### PR TITLE
fix(frontend): 修正批次貼上 Dialog 長文本溢出蓋住按鈕問題

### DIFF
--- a/frontend/src/components/ReadingAssessmentPanel.tsx
+++ b/frontend/src/components/ReadingAssessmentPanel.tsx
@@ -1836,8 +1836,8 @@ export default function ReadingAssessmentPanel({
         open={batchPasteDialogOpen}
         onOpenChange={setBatchPasteDialogOpen}
       >
-        <DialogContent className="max-w-4xl max-h-[90vh]">
-          <DialogHeader className="pb-4">
+        <DialogContent className="max-w-4xl max-h-[90vh] flex flex-col">
+          <DialogHeader className="pb-4 flex-shrink-0">
             <DialogTitle className="text-2xl font-bold text-gray-900">
               批次貼上素材
             </DialogTitle>
@@ -1845,7 +1845,7 @@ export default function ReadingAssessmentPanel({
               每行一個項目，支援自動生成 TTS 與翻譯
             </p>
           </DialogHeader>
-          <div className="space-y-6">
+          <div className="space-y-6 overflow-y-auto flex-1 min-h-0">
             <div>
               <label className="text-base font-semibold text-gray-800 mb-3 block">
                 請貼上內容：
@@ -1854,7 +1854,7 @@ export default function ReadingAssessmentPanel({
                 value={batchPasteText}
                 onChange={(e) => setBatchPasteText(e.target.value)}
                 placeholder="put&#10;Put it away.&#10;It's time to put everything away. Right now."
-                className="w-full h-80 px-4 py-3 border-2 border-gray-300 rounded-lg font-mono text-base focus:border-blue-500 focus:ring-2 focus:ring-blue-200 transition-all resize-none"
+                className="w-full min-h-80 max-h-[60vh] px-4 py-3 border-2 border-gray-300 rounded-lg font-mono text-base focus:border-blue-500 focus:ring-2 focus:ring-blue-200 transition-all resize-y overflow-y-auto"
               />
               <div className="text-xs text-gray-500 mt-2">
                 {batchPasteText.split("\n").filter((line) => line.trim())
@@ -1887,7 +1887,7 @@ export default function ReadingAssessmentPanel({
               </label>
             </div>
           </div>
-          <DialogFooter className="pt-6">
+          <DialogFooter className="pt-6 flex-shrink-0 border-t border-gray-200 mt-4">
             <Button
               variant="outline"
               onClick={() => setBatchPasteDialogOpen(false)}


### PR DESCRIPTION
## 🐛 問題描述
貼上長文本或大量空白行時，批次貼上 Dialog 被撐開超出視窗，導致「確認貼上」和「取消」按鈕被推到視窗外無法點擊。

## ✅ 解決方案

### 1. Dialog 結構改用 Flexbox 三層架構
```tsx
<DialogContent className="flex flex-col max-h-[90vh]">
  <DialogHeader className="flex-shrink-0" />   // 固定不滾動
  <div className="overflow-y-auto flex-1">     // 可滾動內容
    <textarea className="max-h-[60vh]" />      // 獨立滾動
  </div>
  <DialogFooter className="flex-shrink-0" />   // 固定不滾動，永遠可見
</DialogContent>
```

### 2. Textarea 響應式高度
- `min-h-80` (320px) - 舒適的初始高度
- `max-h-[60vh]` - 響應式最大高度，適應 1080p~4K 螢幕
- `overflow-y-auto` - 內容超出時可滾動
- `resize-y` - 允許用戶手動調整高度

### 3. 視覺優化
- DialogFooter 加上 `border-t` 分隔線
- 更清晰的層次結構

## 🎯 修改檔案
- `frontend/src/components/ReadingAssessmentPanel.tsx`

## 🧪 測試狀態
- ✅ Frontend build 成功
- ✅ TypeScript 檢查通過
- ✅ ESLint 檢查通過
- ✅ Pre-commit hooks 通過
- ⚠️ 需手動測試：貼上 100+ 行文字和大量空白行

## 📋 測試步驟
1. 登入 → 素材管理 → 新增朗讀評量
2. 點擊「批次貼上」
3. 貼上 100+ 行文字 → 確認按鈕可見
4. 貼上 200 行空白 (`\n`) → 確認按鈕可見
5. 嘗試 resize textarea → 確認功能正常

## 📊 架構對比

### Before (單層滾動)
```
Dialog (overflow-y-auto)
├─ Header
├─ Textarea (h-80 固定)
└─ Footer (可能被推出視窗)
```

### After (Flexbox 三層)
```
Dialog (flex flex-col)
├─ Header (flex-shrink-0) ← 固定
├─ Content (overflow-y-auto flex-1) ← 可滾動
│  └─ Textarea (max-h-60vh) ← 獨立滾動
└─ Footer (flex-shrink-0) ← 固定可見
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)