### PR TITLE
fix: 修復學生登入 Step 1 的錯誤訊息閃現和 loading 狀態問題

### DIFF
--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -837,6 +837,7 @@
       "title": "Enter Teacher's Email",
       "placeholder": "teacher@example.com",
       "next": "Next",
+      "validating": "Validating...",
       "demoTeacher": "🎯 Use Demo Teacher (demo@duotopia.com)",
       "quickTest": "Quick Test:",
       "recentTeachers": "Or select a recently used teacher:"

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -837,6 +837,7 @@
       "title": "請輸入老師 Email",
       "placeholder": "teacher@example.com",
       "next": "下一步",
+      "validating": "驗證中...",
       "demoTeacher": "🎯 使用 Demo 教師 (demo@duotopia.com)",
       "quickTest": "快速測試：",
       "recentTeachers": "或選擇最近使用過的老師："

--- a/frontend/src/pages/StudentLogin.tsx
+++ b/frontend/src/pages/StudentLogin.tsx
@@ -261,9 +261,20 @@ export default function StudentLogin() {
                   disabled={!teacherEmail || loading}
                   className="w-full py-6 text-lg bg-gradient-to-r from-blue-500 to-cyan-500 hover:from-blue-600 hover:to-cyan-600"
                 >
-                  {t("studentLogin.step1.next")}
+                  {loading ? (
+                    <>
+                      <span className="animate-spin mr-2">⏳</span>
+                      {t("studentLogin.step1.validating")}
+                    </>
+                  ) : (
+                    t("studentLogin.step1.next")
+                  )}
                 </Button>
               </div>
+
+              {error && (
+                <p className="text-red-500 text-center mt-4">{error}</p>
+              )}
 
               {/* Demo 教師快捷鍵 - 只在非 production 或有 ?is_demo=true 時顯示 */}
               {showDemoBlocks && (
@@ -309,8 +320,6 @@ export default function StudentLogin() {
                   </div>
                 </div>
               )}
-
-              {error && <p className="text-red-500 text-center">{error}</p>}
             </div>
           )}
 


### PR DESCRIPTION
## 🐛 修復 Issue
Fixes #7

## 📝 問題描述
學生登入時存在兩個體驗問題：
1. 輸入老師 Email 時會閃現紅字錯誤訊息
2. 點擊「下一步」按鈕需要等待，但沒有任何 loading 提示

## ✅ 修復內容

### 1. 修復錯誤訊息閃現
**問題根因**: 錯誤訊息 (`error`) 顯示在 Step 1 區塊外部，當切換 step 時會短暫顯示舊的錯誤訊息

**修復方式**:
- 將 `{error && <p>...</p>}` 移到 Step 1 內部 (Line 275)
- 移除原本在 Step 1 外部的錯誤訊息顯示 (原 Line 313)
- 現在錯誤訊息只在 Step 1 內顯示，切換 step 時不會閃現

### 2. 加入 Loading 狀態提示
**問題根因**: 按鈕只有 `disabled={loading}` 但沒有視覺反饋

**修復方式**:
- 按鈕文字根據 `loading` 狀態動態切換 (Line 264-271)
- Loading 時顯示：`⏳ 驗證中...` (動畫 emoji)
- 正常時顯示：`下一步`
- 讓使用者明確知道需要等待 API 回應

### 3. 更新翻譯檔案
- 中文：加入 `"validating": "驗證中..."`
- 英文：加入 `"validating": "Validating..."`

## 📁 變更檔案
- `frontend/src/pages/StudentLogin.tsx` - 修復 UI 邏輯
- `frontend/src/i18n/locales/zh-TW/translation.json` - 中文翻譯
- `frontend/src/i18n/locales/en/translation.json` - 英文翻譯

## 🧪 測試計劃

### Staging 測試 URL
https://duotopia-staging.web.app/student/login

### 測試案例

#### 1. 錯誤訊息不閃現
- [ ] 輸入不存在的老師 Email（如 `test@example.com`）
- [ ] 確認錯誤訊息「找不到此教師帳號」顯示在 Step 1 內
- [ ] 重新輸入正確 Email，確認錯誤訊息消失
- [ ] 切換到其他 step 再返回，確認不會看到錯誤閃現

#### 2. Loading 狀態正確顯示
- [ ] 輸入 `demo@duotopia.com`
- [ ] 點擊「下一步」
- [ ] 確認按鈕立即顯示「⏳ 驗證中...」
- [ ] 確認 loading 期間按鈕不可點擊（`disabled` 狀態）
- [ ] 驗證完成後自動進入 Step 2

#### 3. 完整登入流程
- [ ] 使用 demo@duotopia.com 完整走一次登入流程
- [ ] 確認所有 step 切換正常
- [ ] 確認沒有其他 UI 異常

## 📸 截圖/影片
（測試後補充）

## ✅ Checklist
- [x] 程式碼已通過 TypeScript 編譯檢查
- [x] 程式碼已通過 ESLint 檢查
- [x] 程式碼已通過 Prettier 格式化
- [x] 已在 Staging 環境部署
- [ ] 已完成 UI 功能測試
- [ ] 已獲得 reviewer approve

## 🔗 相關連結
- Issue: #7
- Staging 部署: https://duotopia-staging.web.app/student/login
- CI/CD Run: https://github.com/Youngger9765/duotopia/actions/runs/19631787005