### PR TITLE
Fix: Skip assignment confirmation screen

### DIFF
--- a/frontend/src/pages/StudentDashboard.tsx
+++ b/frontend/src/pages/StudentDashboard.tsx
@@ -182,7 +182,8 @@ export default function StudentDashboard() {
   };
 
   const handleStartAssignment = (assignmentId: number) => {
-    navigate(`/student/assignment/${assignmentId}/detail`);
+    // Navigate directly to activity page, skipping the confirmation screen (Issue #28)
+    navigate(`/student/assignment/${assignmentId}/activity`);
   };
 
   const handleViewAllAssignments = () => {

--- a/frontend/src/pages/student/StudentAssignmentList.tsx
+++ b/frontend/src/pages/student/StudentAssignmentList.tsx
@@ -250,7 +250,8 @@ export default function StudentAssignmentList() {
   };
 
   const handleStartAssignment = (assignmentId: number) => {
-    navigate(`/student/assignment/${assignmentId}/detail`);
+    // Navigate directly to activity page, skipping the confirmation screen (Issue #28)
+    navigate(`/student/assignment/${assignmentId}/activity`);
   };
 
   const renderAssignmentCard = (assignment: StudentAssignmentCard) => {


### PR DESCRIPTION
Related to #28

## 🎯 Purpose
Remove unnecessary confirmation screen before students start assignments

## 🔍 Problem Analysis
When students clicked "Start Assignment" from the list, they were taken to an intermediate confirmation screen showing activity details. Students didn't read this screen and found it confusing - they just wanted to start working immediately.

## ✅ Solution
Changed navigation flow to skip the confirmation screen:

**Before**:
1. Assignment List → Click "開始作業"
2. Assignment Detail (confirmation screen) → Click "開始作業" again
3. Activity Page (actual work)

**After**:
1. Assignment List → Click "開始作業"
2. Activity Page (actual work) ✅ Direct!

## 🧪 Testing
- ✅ TypeScript compilation passed
- ✅ Prettier formatting passed
- ✅ ESLint passed
- ✅ Frontend build test passed

## 📝 Files Changed
1. `StudentDashboard.tsx` - Navigate to /activity instead of /detail
2. `StudentAssignmentList.tsx` - Navigate to /activity instead of /detail

## 🌐 Per-Issue Test Environment
Will be available at:
- Frontend: https://duotopia-preview-issue-28-frontend.run.app
- Backend: https://duotopia-preview-issue-28-backend.run.app