### PR TITLE
fix: 修正 Claude Code Automation workflow 認證參數

### DIFF
--- a/.github/workflows/automation-claude-pdca.yml
+++ b/.github/workflows/automation-claude-pdca.yml
@@ -18,6 +18,12 @@ jobs:
       (github.event.action == 'labeled' && github.event.label.name == '🤖 claude: auto-implement') ||
       (github.event.action == 'created' && contains(github.event.comment.body, '@claude'))
 
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,7 +34,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             # 🤖 Claude Code - Duotopia Issue 自動化處理
 


### PR DESCRIPTION
## Summary
- 將 `anthropic_api_key` 改為 `claude_code_oauth_token`（正確的 OAuth 認證參數）
- 新增 `permissions` 區塊授予 write 權限

## 問題原因
原本 workflow 使用錯誤的參數名 `anthropic_api_key` 傳入 OAuth token，導致 Claude Code 無法正常認證。

## 修復內容
```yaml
# Before
anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

# After  
claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)