### PR TITLE
fix: 修正 cleanup-per-issue-on-close workflow YAML 語法錯誤

### DIFF
--- a/.github/workflows/cleanup-per-issue-on-close.yml
+++ b/.github/workflows/cleanup-per-issue-on-close.yml
@@ -123,18 +123,22 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const body = [
+              '## 🧹 Per-Issue Test Environment Cleaned Up',
+              '',
+              '✅ Cloud Run services deleted',
+              '✅ Container images cleaned',
+              `✅ All related branches deleted (智能檢測 issue-${context.issue.number})`,
+              '💰 Billing stopped',
+              '',
+              `**Note**: All branches containing \`issue-${context.issue.number}\` pattern have been removed.`
+            ].join('\n');
+
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## 🧹 Per-Issue Test Environment Cleaned Up
-
-✅ Cloud Run services deleted
-✅ Container images cleaned
-✅ All related branches deleted (智能檢測 issue-${context.issue.number})
-💰 Billing stopped
-
-**Note**: All branches containing \`issue-${context.issue.number}\` pattern have been removed.`
+              body: body
             })
 
   cleanup-on-pr-merge:
@@ -245,18 +249,23 @@ jobs:
         with:
           script: |
             const issueNumber = ${{ steps.extract.outputs.issue_number }};
+            const prNumber = ${{ github.event.pull_request.number }};
+            const body = [
+              '## 🧹 Per-Issue Test Environment Cleaned Up',
+              '',
+              `PR #${prNumber} merged, cleaning up resources.`,
+              '',
+              '✅ Cloud Run services deleted',
+              '✅ Container images cleaned',
+              `✅ All related branches deleted (智能檢測 issue-${issueNumber})`,
+              '💰 Billing stopped',
+              '',
+              `**Note**: All branches containing \`issue-${issueNumber}\` pattern have been removed.`
+            ].join('\n');
+
             github.rest.issues.createComment({
               issue_number: issueNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## 🧹 Per-Issue Test Environment Cleaned Up
-
-PR #${{ github.event.pull_request.number }} merged, cleaning up resources.
-
-✅ Cloud Run services deleted
-✅ Container images cleaned
-✅ All related branches deleted (智能檢測 issue-${issueNumber})
-💰 Billing stopped
-
-**Note**: All branches containing \`issue-${issueNumber}\` pattern have been removed.`
+              body: body
             })


### PR DESCRIPTION
## Summary
- 修正 GitHub Actions workflow YAML 語法錯誤（line 132）
- 將多行 JavaScript template literal 改為 array + `join('\n')` 格式

## 問題原因
YAML 無法正確解析 JavaScript 的多行 template literal（含有 backticks）

## 修復方式
```javascript
// Before (導致 YAML 語法錯誤)
body: `多行
字串`

// After (正確)
const body = ['line1', 'line2'].join('\n');
```

## Test plan
- [ ] Merge 此 PR 到 main
- [ ] 關閉一個 Issue 確認 cleanup workflow 正常執行

🤖 Generated with [Claude Code](https://claude.com/claude-code)