### PR TITLE
fix: Resolve 503 error in /api/organizations endpoint (#157)

### DIFF
--- a/backend/routers/organizations.py
+++ b/backend/routers/organizations.py
@@ -624,9 +624,14 @@ async def list_organization_teachers(
     check_org_permission(teacher.id, org_id, db)
 
     # Get all teacher relationships with eager loading (eliminates N+1 query)
+    # ✅ FIX #157: Use selectinload + load_only (same fix as list_organizations)
     teacher_orgs = (
         db.query(TeacherOrganization)
-        .options(joinedload(TeacherOrganization.teacher))
+        .options(
+            selectinload(TeacherOrganization.teacher).load_only(
+                Teacher.id, Teacher.name, Teacher.email
+            )
+        )
         .filter(
             TeacherOrganization.organization_id == org_id,
             TeacherOrganization.is_active.is_(True),


### PR DESCRIPTION
## Summary
Fixes #157 - /api/organizations endpoint returning 503 in Preview environment

## Problem
- `GET /api/organizations` returns 503 Service Unavailable
- `GET /api/organizations/stats` works correctly (returns 200)
- Issue occurs in Preview environment (issue #112)
- Symptoms: Organization sidebar shows "尚無組織資料", tree chart shows empty state

## Root Cause Analysis
1. **Line 310** in `backend/routers/organizations.py` uses `joinedload(TeacherOrganization.teacher)`
2. **Teacher model** has 10+ relationships defined:
   - classrooms
   - programs
   - assignments
   - subscription_transactions
   - subscription_periods
   - point_usage_logs
   - teacher_organizations
   - teacher_schools
3. **SQLAlchemy** tries to eagerly load all these relationships, creating a massive JOIN query
4. **Query timeout**: Exceeds 30-second `statement_timeout` in `database.py:52`
5. **Result**: 503 error returned to client

## Solution
Replace `joinedload` with `selectinload` + `load_only`:

```python
# BEFORE (caused timeout)
.options(joinedload(TeacherOrganization.teacher))

# AFTER (efficient)
.options(
    selectinload(TeacherOrganization.teacher).load_only(
        Teacher.id, Teacher.name, Teacher.email
    )
)
```

**Why this works**:
- `selectinload`: Uses separate SELECT query instead of complex JOINs
- `load_only`: Limits columns loaded from Teacher table
- Prevents cascade loading of Teacher relationships

## Testing Strategy
- [x] Syntax verified: Module imports successfully
- [ ] Verify in Preview environment (waiting for deployment)
- [ ] Test organization list endpoint returns 200
- [ ] Verify organization sidebar shows correct data
- [ ] Verify organization tree chart displays properly

## Technical Details
**Query pattern before**:
```sql
SELECT ... FROM teacher_organizations 
LEFT OUTER JOIN teachers ON ... 
LEFT OUTER JOIN classrooms ON ...
LEFT OUTER JOIN programs ON ...
-- (10+ more joins)
```

**Query pattern after**:
```sql
-- Query 1: Get teacher-organization relationships
SELECT ... FROM teacher_organizations WHERE ...

-- Query 2: Get only required teacher data
SELECT id, name, email FROM teachers WHERE id IN (...)
```

## Related Changes
- Modified: `backend/routers/organizations.py`
  - Added imports: `selectinload`, `load_only`
  - Updated query in `list_organizations()` function (line 310-323)

## References
- Issue: https://github.com/Youngger9765/duotopia/issues/157
- Database timeout config: `backend/database.py:52`
- SQLAlchemy docs: https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#select-in-loading

## Deployment Plan
1. PR creates per-issue Preview environment
2. Test endpoint in Preview environment
3. If successful, merge to staging
4. After staging verification, release to production

Generated with [Claude Code](https://claude.com/claude-code)