### PR TITLE
style: fix Prettier formatting in VocabularySetPanel

### DIFF
--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -2161,7 +2161,11 @@ export default function VocabularySetPanel({
         let audioIndex = 0;
 
         for (let i = 0; i < newRows.length; i++) {
-          if (newRows[i].text && newRows[i].text.trim() && !newRows[i].audioUrl) {
+          if (
+            newRows[i].text &&
+            newRows[i].text.trim() &&
+            !newRows[i].audioUrl
+          ) {
             const audioUrl = (result as { audio_urls: string[] }).audio_urls[
               audioIndex
             ];


### PR DESCRIPTION
## Summary
- Fix Prettier formatting issue in VocabularySetPanel.tsx

## Problem
CI failed with Prettier formatting check error after PR #184 was merged.

## Solution
Run `npx prettier --write` to fix the formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)