### PR TITLE
fix(api): add parts_of_speech to GET content detail endpoint

### DIFF
--- a/backend/routers/teachers/content_ops.py
+++ b/backend/routers/teachers/content_ops.py
@@ -313,12 +313,27 @@ async def get_content_detail(
                 )
                 if item.item_metadata
                 else "chinese",  # 選擇的語言
+                # 新的統一欄位格式（vocabulary_translation）
+                "vocabulary_translation": item.item_metadata.get("chinese_translation")
+                or item.translation
+                if item.item_metadata
+                else item.translation,
+                "vocabulary_translation_lang": item.item_metadata.get(
+                    "vocabulary_translation_lang", "chinese"
+                )
+                if item.item_metadata
+                else "chinese",
                 "audio_url": item.audio_url,
                 # 單字集相關欄位
                 "example_sentence": item.example_sentence,
                 "example_sentence_translation": item.example_sentence_translation,
                 "image_url": item.image_url,
                 "part_of_speech": item.part_of_speech,
+                # 前端使用 parts_of_speech (plural, array)
+                # 優先從 metadata 讀取完整陣列，否則用 DB 欄位的單一值
+                "parts_of_speech": item.item_metadata.get("parts_of_speech", [])
+                if item.item_metadata and item.item_metadata.get("parts_of_speech")
+                else ([item.part_of_speech] if item.part_of_speech else []),
                 "distractors": item.distractors,
                 # 時間戳記
                 "created_at": item.created_at.isoformat() if item.created_at else None,


### PR DESCRIPTION
## Summary
- Add `parts_of_speech` array field to GET `/api/teachers/contents/{id}` response
- Add `vocabulary_translation` and `vocabulary_translation_lang` fields
- Reads `parts_of_speech` from `item_metadata` first (full array), falls back to DB column

## Problem
The PUT endpoint was correctly storing `parts_of_speech` array in `item_metadata`, but the GET endpoint was not returning it. This caused the frontend to not display parts of speech after reloading.

## Fix
Added the missing fields to the GET endpoint response, with proper priority:
1. First try `item_metadata.parts_of_speech` (contains full array)
2. Fall back to `[part_of_speech]` from DB column (single value as array)
3. Return empty array if neither exists

## Test plan
- [x] Black formatting passes
- [x] Flake8 linting passes
- [x] Pytest passes (6/6 tests)
- [ ] Backend deploy tests pass
- [ ] Frontend deploy tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)