### PR TITLE
fix(i18n): update teacher interface terminology for clarity

### DIFF
--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1905,7 +1905,7 @@
       "dashboard": "Dashboard",
       "myClassrooms": "My Classrooms",
       "allStudents": "All Students",
-      "publicPrograms": "Public Programs",
+      "publicPrograms": "My Teaching Materials",
       "subscription": "Subscription",
       "systemAdmin": "System Admin",
       "profile": "Profile"
@@ -2198,7 +2198,7 @@
       "students": "Students",
       "studentList": "Student List",
       "programs": "Programs",
-      "programList": "Program List",
+      "programList": "Class Materials",
       "assignments": "Assignments",
       "assignmentManagement": "Assignment Management"
     },
@@ -2630,9 +2630,9 @@
     }
   },
   "teacherTemplatePrograms": {
-    "title": "Template Programs",
+    "title": "My Teaching Materials",
     "buttons": {
-      "addProgram": "Add Program"
+      "addProgram": "Add Resource Pack"
     },
     "messages": {
       "loadFailed": "Failed to load template programs",
@@ -3140,7 +3140,7 @@
     }
   },
   "createProgramDialog": {
-    "title": "Add Program - {{classroom}}",
+    "title": "Add Class Materials - {{classroom}}",
     "description": "Choose creation method: copy from template, copy from other classroom, or create custom",
     "tabs": {
       "template": "Copy from Template",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -1910,7 +1910,7 @@
       "dashboard": "儀表板",
       "myClassrooms": "我的班級",
       "allStudents": "所有學生",
-      "publicPrograms": "公版課程",
+      "publicPrograms": "我的教材",
       "subscription": "訂閱管理",
       "systemAdmin": "系統管理",
       "profile": "個人資料"
@@ -2204,7 +2204,7 @@
       "students": "學生",
       "studentList": "學生列表",
       "programs": "課程",
-      "programList": "課程列表",
+      "programList": "班級教材",
       "assignments": "作業",
       "assignmentManagement": "作業管理"
     },
@@ -2637,9 +2637,9 @@
     }
   },
   "teacherTemplatePrograms": {
-    "title": "公版課程",
+    "title": "我的教材",
     "buttons": {
-      "addProgram": "新增課程"
+      "addProgram": "新增教材資源包"
     },
     "messages": {
       "loadFailed": "載入公版課程失敗",
@@ -3147,7 +3147,7 @@
     }
   },
   "createProgramDialog": {
-    "title": "新增課程 - {{classroom}}",
+    "title": "新增班級教材 - {{classroom}}",
     "description": "選擇建立方式：從公版複製、從其他班級複製，或自建課程",
     "tabs": {
       "template": "從公版複製",


### PR DESCRIPTION
## Summary
- 更新老師操作介面用語，解決用語混淆問題
- 同步更新繁體中文和英文語系

## Changes
| Location | Before (zh-TW) | After (zh-TW) | Before (en) | After (en) |
|----------|----------------|---------------|-------------|------------|
| Side Navigation | 公版課程 | 我的教材 | Public Programs | My Teaching Materials |
| Classroom Detail Tab | 課程列表 | 班級教材 | Program List | Class Materials |
| Template Programs Title | 公版課程 | 我的教材 | Template Programs | My Teaching Materials |
| Add Button | 新增課程 | 新增教材資源包 | Add Program | Add Resource Pack |
| Create Dialog Title | 新增課程 | 新增班級教材 | Add Program | Add Class Materials |

## Test plan
- [ ] Verify Chinese labels display correctly in teacher interface
- [ ] Verify English labels display correctly when switching language
- [ ] Check side navigation menu shows "我的教材" / "My Teaching Materials"
- [ ] Check classroom detail page shows "班級教材" / "Class Materials" tab
- [ ] Check create program dialog shows "新增班級教材" / "Add Class Materials"

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)