### PR TITLE
feat: smart default tab based on student count (Fixes #150)

### DIFF
--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -151,6 +151,7 @@ export default function ClassroomDetail({
   // Assignment states
   const [showAssignmentDialog, setShowAssignmentDialog] = useState(false);
   const [assignments, setAssignments] = useState<Assignment[]>([]);
+  const [assignmentsLoaded, setAssignmentsLoaded] = useState(false);
   const [selectedAssignment] = useState<Assignment | null>(null);
   const [showAssignmentDetails, setShowAssignmentDetails] = useState(false);
   const [batchGradingModal, setBatchGradingModal] = useState({
@@ -189,6 +190,10 @@ export default function ClassroomDetail({
     // Skip if in template mode or already initialized
     if (isTemplateMode || hasInitializedTab || loading) return;
 
+    // Wait for assignments to be loaded before switching tab
+    // (tab is disabled while loading, so switching won't work)
+    if (!assignmentsLoaded) return;
+
     // Skip if URL already specifies a tab
     const searchParams = new URLSearchParams(location.search);
     if (searchParams.get("tab")) return;
@@ -198,7 +203,7 @@ export default function ClassroomDetail({
       setActiveTab("assignments");
     }
     setHasInitializedTab(true);
-  }, [students, loading, isTemplateMode, hasInitializedTab, location.search]);
+  }, [students, loading, isTemplateMode, hasInitializedTab, location.search, assignmentsLoaded]);
 
   const fetchClassroomDetail = async (showLoading = true) => {
     try {
@@ -336,6 +341,8 @@ export default function ClassroomDetail({
     } catch (err) {
       console.error("Failed to fetch assignments:", err);
       setAssignments([]);
+    } finally {
+      setAssignmentsLoaded(true);
     }
   };
 


### PR DESCRIPTION
## Summary
- 當班級沒有學生時，預設顯示「學生列表」標籤
- 當班級已有學生時，預設顯示「作業管理」標籤
- URL 參數優先：若帶有 ?tab= 則使用該參數
- 只在非模板模式下生效

## Changes
- Added `hasInitializedTab` state to track initialization
- Added useEffect to monitor `students` and `loading` state
- Set `activeTab` based on `students.length` after data loads

## Test plan
- [ ] 進入沒有學生的班級，確認預設顯示「學生列表」
- [ ] 進入已有學生的班級，確認預設顯示「作業管理」
- [ ] 使用 URL 參數 `?tab=assignments` 進入，確認參數優先
- [ ] 使用 URL 參數 `?tab=students` 進入，確認參數優先

Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)