### PR TITLE
fix: 修正單字集內容類型開啟錯誤的 Modal

### DIFF
--- a/frontend/src/components/shared/ProgramTreeView.tsx
+++ b/frontend/src/components/shared/ProgramTreeView.tsx
@@ -3,6 +3,7 @@ import { RecursiveTreeAccordion } from "./RecursiveTreeAccordion";
 import { programTreeConfig } from "./programTreeConfig";
 import ReadingAssessmentPanel from "@/components/ReadingAssessmentPanel";
 import SentenceMakingPanel from "@/components/activities/SentenceMakingActivity";
+import VocabularySetPanel from "@/components/VocabularySetPanel";
 import ContentTypeDialog from "@/components/ContentTypeDialog";
 import {
   ProgramTreeLesson,
@@ -168,11 +169,16 @@ export function ProgramTreeView({
     showSentenceMakingEditor,
     sentenceMakingLessonId,
     sentenceMakingContentId,
+    showVocabularySetEditor,
+    vocabularySetLessonId,
+    vocabularySetContentId,
     openContentEditor,
     openReadingCreateEditor,
     openSentenceMakingCreateEditor,
+    openVocabularySetCreateEditor,
     closeReadingEditor,
     closeSentenceMakingEditor,
+    closeVocabularySetEditor,
   } = useContentEditor();
 
   const [showContentTypeDialog, setShowContentTypeDialog] = useState(false);
@@ -879,6 +885,84 @@ export function ProgramTreeView({
           </>
         )}
 
+      {/* Vocabulary Set Modal - Create Mode */}
+      {showVocabularySetEditor &&
+        vocabularySetLessonId &&
+        vocabularySetContentId === null && (
+          <Dialog
+            open={true}
+            onOpenChange={() => closeVocabularySetEditor()}
+          >
+            <DialogContent className="max-w-7xl max-h-[90vh] overflow-y-auto">
+              <DialogHeader>
+                <DialogTitle>新增單字集</DialogTitle>
+              </DialogHeader>
+              <VocabularySetPanel
+                lessonId={vocabularySetLessonId}
+                isCreating={true}
+                onSave={async () => {
+                  closeVocabularySetEditor();
+                  toast.success("內容已儲存");
+                  if (onRefresh) onRefresh();
+                }}
+              />
+            </DialogContent>
+          </Dialog>
+        )}
+
+      {/* Vocabulary Set Panel - Edit Mode */}
+      {showVocabularySetEditor &&
+        vocabularySetLessonId &&
+        vocabularySetContentId !== null && (
+          <>
+            <div
+              className="fixed inset-0 bg-black bg-opacity-20 z-40 transition-opacity"
+              onClick={closeVocabularySetEditor}
+            />
+            <div className="fixed top-0 right-0 h-screen w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 flex flex-col">
+              {/* Header */}
+              <div className="flex items-center justify-between p-6 border-b border-gray-200 flex-shrink-0">
+                <h2 className="text-xl font-semibold text-gray-900">
+                  編輯單字集
+                </h2>
+                <button
+                  onClick={closeVocabularySetEditor}
+                  className="text-gray-400 hover:text-gray-600 transition-colors"
+                >
+                  <svg
+                    className="h-6 w-6"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              </div>
+              {/* Content */}
+              <div className="flex-1 overflow-hidden flex flex-col">
+                <div className="flex-1 overflow-auto p-6 min-h-0">
+                  <VocabularySetPanel
+                    lessonId={vocabularySetLessonId}
+                    contentId={vocabularySetContentId}
+                    isCreating={false}
+                    onSave={async () => {
+                      closeVocabularySetEditor();
+                      toast.success("內容已儲存");
+                      if (onRefresh) onRefresh();
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+
       {contentLessonInfo && (
         <ContentTypeDialog
           open={showContentTypeDialog}
@@ -899,11 +983,14 @@ export function ProgramTreeView({
               openReadingCreateEditor(selection.lessonId);
             } else if (
               selection.type === "SENTENCE_MAKING" ||
-              selection.type === "sentence_making" ||
+              selection.type === "sentence_making"
+            ) {
+              openSentenceMakingCreateEditor(selection.lessonId);
+            } else if (
               selection.type === "vocabulary_set" ||
               selection.type === "VOCABULARY_SET"
             ) {
-              openSentenceMakingCreateEditor(selection.lessonId);
+              openVocabularySetCreateEditor(selection.lessonId);
             } else {
               toast.info("此內容類型仍在開發中");
             }

--- a/frontend/src/hooks/useContentEditor.ts
+++ b/frontend/src/hooks/useContentEditor.ts
@@ -18,6 +18,15 @@ export function useContentEditor() {
     number | null
   >(null);
 
+  // Vocabulary Set Editor
+  const [showVocabularySetEditor, setShowVocabularySetEditor] = useState(false);
+  const [vocabularySetLessonId, setVocabularySetLessonId] = useState<
+    number | null
+  >(null);
+  const [vocabularySetContentId, setVocabularySetContentId] = useState<
+    number | null
+  >(null);
+
   const openContentEditor = (
     content: Content & {
       lessonName?: string;
@@ -35,13 +44,14 @@ export function useContentEditor() {
       setEditorLessonId(content.lesson_id || null);
       setEditorContentId(content.id);
       setShowReadingEditor(true);
-    } else if (
-      contentType === "sentence_making" ||
-      contentType === "vocabulary_set"
-    ) {
+    } else if (contentType === "sentence_making") {
       setSentenceMakingLessonId(content.lesson_id || null);
       setSentenceMakingContentId(content.id);
       setShowSentenceMakingEditor(true);
+    } else if (contentType === "vocabulary_set") {
+      setVocabularySetLessonId(content.lesson_id || null);
+      setVocabularySetContentId(content.id);
+      setShowVocabularySetEditor(true);
     }
   };
 
@@ -58,6 +68,12 @@ export function useContentEditor() {
     setShowSentenceMakingEditor(true);
   };
 
+  const openVocabularySetCreateEditor = (lessonId: number) => {
+    setVocabularySetLessonId(lessonId);
+    setVocabularySetContentId(null);
+    setShowVocabularySetEditor(true);
+  };
+
   const closeReadingEditor = () => {
     setShowReadingEditor(false);
     setEditorLessonId(null);
@@ -69,6 +85,12 @@ export function useContentEditor() {
     setShowSentenceMakingEditor(false);
     setSentenceMakingLessonId(null);
     setSentenceMakingContentId(null);
+  };
+
+  const closeVocabularySetEditor = () => {
+    setShowVocabularySetEditor(false);
+    setVocabularySetLessonId(null);
+    setVocabularySetContentId(null);
   };
 
   return {
@@ -83,11 +105,18 @@ export function useContentEditor() {
     sentenceMakingLessonId,
     sentenceMakingContentId,
 
+    // Vocabulary Set Editor State
+    showVocabularySetEditor,
+    vocabularySetLessonId,
+    vocabularySetContentId,
+
     // Actions
     openContentEditor,
     openReadingCreateEditor,
     openSentenceMakingCreateEditor,
+    openVocabularySetCreateEditor,
     closeReadingEditor,
     closeSentenceMakingEditor,
+    closeVocabularySetEditor,
   };
 }


### PR DESCRIPTION
## Summary
- 修正在教材頁面新增「單字集」內容時，錯誤地開啟「句子模組設定」Modal 而非正確的「新增單字集」Modal
- 新增 VocabularySetPanel 專用的 state 管理，將 vocabulary_set 類型從 sentence_making 分離

## Changes
- `useContentEditor.ts`: 新增 vocabulary set editor 的 state 和 actions
- `ProgramTreeView.tsx`: 新增 VocabularySetPanel 的 create/edit modals，修正 onSelect handler

## Test plan
- [ ] 在教材頁面點擊「+ 新增內容」
- [ ] 選擇「單字集」類型
- [ ] 確認顯示「新增單字集」Modal（而非句子模組設定）
- [ ] 確認編輯既有單字集內容正常運作

🤖 Generated with [Claude Code](https://claude.ai/code)