### PR TITLE
chore: add demo_config to RLS exclusion list

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -257,6 +257,7 @@ jobs:
               'user_word_progress', 'practice_sessions', 'practice_answers',
               'organizations', 'schools', 'teacher_organizations', 'teacher_schools', 'classroom_schools', 'student_schools',
               'organization_points_log',
+              'demo_config',
               -- n8n 系統表（外部服務，不適用 RLS）
               'annotation_tag_entity', 'auth_identity', 'auth_provider_sync_history', 'binary_data',
               'chat_hub_agents', 'chat_hub_messages', 'chat_hub_sessions', 'credentials_entity',


### PR DESCRIPTION
## Summary
- Add `demo_config` table to the RLS check exclusion list in deploy-backend workflow

## Context
The `demo_config` table was added in PR #210 (Issue #202) for the public demo feature. This table stores demo assignment configuration and is accessed via backend API with JWT auth, not directly through Supabase Auth.

Without this change, future deployments to other environments would fail the RLS check.

## Test plan
- [ ] CI workflow passes
- [ ] Deploy backend succeeds without RLS errors for `demo_config`

Related to #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)