### PR TITLE
fix(home): show language switcher on mobile with icon-only mode

### DIFF
--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -24,20 +24,21 @@ export function LanguageSwitcher() {
   const normalizedLanguage = i18n.language.startsWith("zh") ? "zh-TW" : "en";
 
   return (
-    <div className="flex items-center gap-2">
-      <Globe className="h-4 w-4 text-gray-500" />
-      <Select value={normalizedLanguage} onValueChange={handleLanguageChange}>
-        <SelectTrigger className="w-[140px]">
+    <Select value={normalizedLanguage} onValueChange={handleLanguageChange}>
+      <SelectTrigger className="w-9 sm:w-[140px] px-2 sm:px-3">
+        <Globe className="h-4 w-4 text-gray-500 sm:hidden" />
+        <div className="hidden sm:flex sm:items-center sm:gap-2">
+          <Globe className="h-4 w-4 text-gray-500" />
           <SelectValue placeholder={t("common.selectLanguage")} />
-        </SelectTrigger>
-        <SelectContent>
-          {languages.map((lang) => (
-            <SelectItem key={lang.code} value={lang.code}>
-              {lang.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+        </div>
+      </SelectTrigger>
+      <SelectContent>
+        {languages.map((lang) => (
+          <SelectItem key={lang.code} value={lang.code}>
+            {lang.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -114,9 +114,7 @@ export default function Home() {
               {t("home.header.studentLogin")}
             </Button>
           </Link>
-          <div className="hidden sm:block">
-            <LanguageSwitcher />
-          </div>
+          <LanguageSwitcher />
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- 修復手機版首頁語言切換選單不見的問題
- 手機版顯示精簡的地球 icon，點擊後開啟下拉選單
- 桌面版維持原有的完整顯示（地球 icon + 語言名稱）

## Changes
- `LanguageSwitcher.tsx`: 新增響應式設計，手機版只顯示 icon
- `Home.tsx`: 移除 `hidden sm:block` wrapper

## Test plan
- [ ] 手機版（< 640px）：只顯示地球 icon，點擊可開啟語言選單
- [ ] 桌面版（>= 640px）：顯示完整的地球 icon + 語言名稱
- [ ] 切換語言功能正常運作

🤖 Generated with [Claude Code](https://claude.com/claude-code)