### PR TITLE
fix(home): remove border from mobile language switcher icon

### DIFF
--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -25,8 +25,8 @@ export function LanguageSwitcher() {
 
   return (
     <Select value={normalizedLanguage} onValueChange={handleLanguageChange}>
-      <SelectTrigger className="w-9 sm:w-[140px] px-2 sm:px-3 border-0 sm:border bg-transparent sm:bg-background shadow-none sm:shadow-sm">
-        <Globe className="h-4 w-4 text-gray-500 sm:hidden" />
+      <SelectTrigger className="w-9 sm:w-[140px] px-2 sm:px-3 border-0 sm:border bg-transparent sm:bg-background shadow-none sm:shadow-sm [&>svg.opacity-50]:hidden sm:[&>svg.opacity-50]:block">
+        <Globe className="h-5 w-5 text-gray-500 sm:hidden" />
         <div className="hidden sm:flex sm:items-center sm:gap-2">
           <Globe className="h-4 w-4 text-gray-500" />
           <SelectValue placeholder={t("common.selectLanguage")} />


### PR DESCRIPTION
## Summary
- 移除手機版語言切換 icon 的外框，讓它看起來更乾淨
- 桌面版維持原有的完整選單樣式

## Changes
- `LanguageSwitcher.tsx`: 手機版移除 border, background, shadow

## Test plan
- [ ] 手機版（< 640px）：只顯示地球 icon，無外框
- [ ] 桌面版（>= 640px）：顯示完整的選單框 + 地球 icon + 語言名稱
- [ ] 點擊功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)