### PR TITLE
fix: 資源教材包列表數量不一致 & 組織詳情頁 UI 統一

### DIFF
--- a/backend/services/resource_materials_service.py
+++ b/backend/services/resource_materials_service.py
@@ -121,7 +121,15 @@ def list_resource_materials(
     for program in programs:
         active_lessons = [ls for ls in program.lessons if ls.is_active]
         total_contents = sum(
-            len([c for c in ls.contents if c.is_active]) for ls in active_lessons
+            len(
+                [
+                    c
+                    for c in ls.contents
+                    if c.is_active
+                    and not (hasattr(c, "is_assignment_copy") and c.is_assignment_copy)
+                ]
+            )
+            for ls in active_lessons
         )
         count = copy_counts_today.get(program.id, 0)
 

--- a/frontend/src/pages/organization/OrgResourceMaterialsPage.tsx
+++ b/frontend/src/pages/organization/OrgResourceMaterialsPage.tsx
@@ -37,8 +37,99 @@ import {
   CheckCircle2,
   ArrowLeft,
   Loader2,
+  ListOrdered,
+  Clock,
+  ChevronDown,
 } from "lucide-react";
 import { toast } from "sonner";
+
+/** Expandable content card showing items inside */
+function ContentItemAccordion({
+  content,
+}: {
+  content: ResourceMaterialDetail["lessons"][number]["contents"][number];
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const contentTypeLabel = (type: string | null) => {
+    const labels: Record<string, string> = {
+      reading_assessment: "閱讀評量",
+      example_sentences: "例句集",
+      vocabulary_set: "單字集",
+      sentence_making: "造句",
+    };
+    return type ? (labels[type.toLowerCase()] ?? type) : "";
+  };
+
+  return (
+    <div className="border-l-4 border-l-violet-500 bg-gray-100/60 shadow-sm rounded-[0.15rem] mb-3">
+      <div
+        className="flex items-center justify-between gap-2 px-3 py-2.5 cursor-pointer group"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <div className="flex items-center space-x-2 flex-1 min-w-0">
+          <div className="w-7 h-7 bg-purple-100 rounded-md flex items-center justify-center flex-shrink-0">
+            <FileText className="h-4 w-4 text-purple-600" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="font-medium text-sm truncate">{content.title}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {content.type && (
+            <span className="text-xs text-gray-400">
+              {contentTypeLabel(content.type)}
+            </span>
+          )}
+          <span className="text-xs text-gray-400">
+            {content.item_count} 項目
+          </span>
+          <ChevronDown
+            className={`w-4 h-4 text-gray-400 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
+          />
+        </div>
+      </div>
+      {expanded && content.items && content.items.length > 0 && (
+        <div className="px-3 pb-3">
+          <div className="rounded-md border border-gray-200 bg-white overflow-hidden">
+            {/* Header */}
+            <div className="flex items-center gap-x-2 border-b border-gray-100 bg-gray-50/80 px-3 py-1.5">
+              <span className="w-8 text-xs font-medium text-gray-500 flex-shrink-0">
+                #
+              </span>
+              <span className="text-xs font-medium text-gray-500">內容</span>
+              <span className="text-xs font-medium text-gray-500">/</span>
+              <span className="text-xs font-medium text-gray-500">翻譯</span>
+            </div>
+            {/* Items */}
+            {content.items.map((item, idx) => (
+              <div
+                key={item.id}
+                className="flex flex-wrap items-baseline gap-x-2 px-3 py-2 border-b border-gray-50 last:border-0"
+              >
+                <span className="w-8 text-xs text-gray-400 flex-shrink-0">
+                  {idx + 1}
+                </span>
+                <span className="text-sm text-gray-900 break-all">
+                  {item.text}
+                </span>
+                <span className="text-sm text-gray-400">/</span>
+                <span className="text-sm text-gray-500 break-all">
+                  {item.translation || "—"}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {expanded && (!content.items || content.items.length === 0) && (
+        <div className="px-3 pb-3">
+          <p className="text-sm text-gray-400 text-center py-2">暫無項目</p>
+        </div>
+      )}
+    </div>
+  );
+}
 
 export default function OrgResourceMaterialsPage() {
   const { orgId } = useParams<{ orgId: string }>();
@@ -106,88 +197,207 @@ export default function OrgResourceMaterialsPage() {
     return level ? (colors[level] ?? "bg-gray-100 text-gray-700") : "";
   };
 
+  // Copy dialog — rendered in both detail and list views
+  const copyDialog = (
+    <Dialog open={copyDialogOpen} onOpenChange={setCopyDialogOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>確認複製教材到組織</DialogTitle>
+          <DialogDescription>
+            將「{copyTarget?.name}
+            」複製到組織教材中。複製後組織管理者可以自由編輯內容。
+            <br />
+            <span className="text-xs text-muted-foreground">
+              每個組織每個課程每天最多可複製 1 次
+            </span>
+          </DialogDescription>
+        </DialogHeader>
+        {copyTarget && (
+          <div className="py-2 text-sm space-y-1">
+            <p>
+              <span className="font-medium">課程名稱：</span>
+              {copyTarget.name}
+            </p>
+            <p>
+              <span className="font-medium">包含：</span>
+              {copyTarget.lesson_count} 個單元、{copyTarget.content_count}{" "}
+              個內容
+            </p>
+          </div>
+        )}
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => setCopyDialogOpen(false)}
+            disabled={copying}
+          >
+            取消
+          </Button>
+          <Button onClick={handleConfirmCopy} disabled={copying}>
+            {copying ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                複製中...
+              </>
+            ) : (
+              <>
+                <Copy className="w-4 h-4 mr-1" />
+                確認複製
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+
   if (showDetail && selectedDetail) {
     return (
-      <div className="space-y-6">
-        <div className="flex items-center gap-3">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => {
-              setShowDetail(false);
-              setSelectedDetail(null);
-            }}
-          >
-            <ArrowLeft className="w-4 h-4 mr-1" />
-            返回列表
-          </Button>
-        </div>
+      <div className="p-6 space-y-4 bg-gray-50 min-h-full">
+        {/* Back button */}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            setShowDetail(false);
+            setSelectedDetail(null);
+          }}
+        >
+          <ArrowLeft className="w-4 h-4 mr-1" />
+          返回列表
+        </Button>
 
-        <div className="flex items-start justify-between">
-          <div>
-            <h1 className="text-2xl font-bold">{selectedDetail.name}</h1>
-            {selectedDetail.description && (
-              <p className="text-muted-foreground mt-1">
-                {selectedDetail.description}
-              </p>
-            )}
-            <div className="flex gap-2 mt-2">
-              {selectedDetail.level && (
-                <Badge
-                  className={getLevelBadgeColor(selectedDetail.level)}
-                  variant="secondary"
-                >
-                  {selectedDetail.level}
-                </Badge>
-              )}
-              <Badge variant="outline">
-                <Layers className="w-3 h-3 mr-1" />
-                {selectedDetail.lesson_count} 個單元
-              </Badge>
-            </div>
-          </div>
-        </div>
-
-        <Accordion type="multiple" className="space-y-2">
-          {selectedDetail.lessons.map((lesson) => (
-            <AccordionItem
-              key={lesson.id}
-              value={`lesson-${lesson.id}`}
-              className="border rounded-lg px-4"
-            >
-              <AccordionTrigger className="hover:no-underline">
-                <div className="flex items-center gap-2">
-                  <BookOpen className="w-4 h-4 text-muted-foreground" />
-                  <span className="font-medium">{lesson.name}</span>
-                  <Badge variant="secondary" className="text-xs">
-                    {lesson.content_count} 內容
-                  </Badge>
+        {/* Program-level card */}
+        <div className="border-l-4 border-l-blue-500 bg-white shadow-sm rounded-[0.15rem]">
+          <div className="px-4 py-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-3 flex-1 min-w-0">
+                <div className="w-9 h-9 bg-blue-100 rounded-md flex items-center justify-center flex-shrink-0">
+                  <BookOpen className="h-5 w-5 text-blue-600" />
                 </div>
-              </AccordionTrigger>
-              <AccordionContent>
-                <div className="space-y-2 pl-6">
-                  {lesson.contents.map((content) => (
-                    <div
-                      key={content.id}
-                      className="flex items-center gap-2 py-2 px-3 rounded-md bg-muted/50"
-                    >
-                      <FileText className="w-4 h-4 text-muted-foreground" />
-                      <span className="text-sm">{content.title}</span>
-                      <Badge variant="outline" className="text-xs ml-auto">
-                        {content.item_count} 項目
-                      </Badge>
-                    </div>
-                  ))}
-                  {lesson.contents.length === 0 && (
-                    <p className="text-sm text-muted-foreground py-2">
-                      暫無內容
+                <div className="flex-1 min-w-0">
+                  <h4 className="font-semibold text-base">
+                    {selectedDetail.name}
+                  </h4>
+                  {selectedDetail.description && (
+                    <p className="text-sm text-gray-500 truncate">
+                      {selectedDetail.description}
                     </p>
                   )}
                 </div>
-              </AccordionContent>
-            </AccordionItem>
-          ))}
-        </Accordion>
+              </div>
+              <div className="flex items-center gap-3 flex-shrink-0">
+                {selectedDetail.level && (
+                  <span
+                    className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getLevelBadgeColor(selectedDetail.level)}`}
+                  >
+                    {selectedDetail.level}
+                  </span>
+                )}
+                {selectedDetail.estimated_hours && (
+                  <div className="flex items-center text-sm text-gray-500">
+                    <Clock className="h-4 w-4 mr-1" />
+                    <span>{selectedDetail.estimated_hours} 小時</span>
+                  </div>
+                )}
+              </div>
+            </div>
+            {/* Tags */}
+            {selectedDetail.tags && selectedDetail.tags.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mt-2 pl-12">
+                {selectedDetail.tags.map((tag, index) => (
+                  <span
+                    key={index}
+                    className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-blue-50 text-blue-700 border border-blue-200"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Lessons inside program */}
+          <div className="px-3 pb-3 space-y-0">
+            <Accordion type="multiple">
+              {selectedDetail.lessons.map((lesson) => (
+                <div
+                  key={lesson.id}
+                  className="border-l-4 border-l-emerald-500 bg-gray-50/80 shadow-sm rounded-[0.15rem] mb-3"
+                >
+                  <AccordionItem
+                    value={`lesson-${lesson.id}`}
+                    className="border-none"
+                  >
+                    <AccordionTrigger
+                      hideChevron
+                      className="hover:no-underline px-4 py-3"
+                    >
+                      <div className="flex items-center justify-between w-full gap-2">
+                        <div className="flex items-center space-x-3 flex-1 min-w-0">
+                          <div className="w-9 h-9 bg-green-100 rounded-md flex items-center justify-center flex-shrink-0">
+                            <ListOrdered className="h-5 w-5 text-green-600" />
+                          </div>
+                          <div className="text-left flex-1 min-w-0">
+                            <h4 className="font-semibold text-sm sm:text-base">
+                              {lesson.name}
+                            </h4>
+                            {lesson.description && (
+                              <p className="text-xs sm:text-sm text-gray-500 truncate">
+                                {lesson.description}
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                        <span className="text-xs text-gray-400 flex-shrink-0">
+                          {lesson.content_count} 內容
+                        </span>
+                      </div>
+                    </AccordionTrigger>
+                    <AccordionContent>
+                      <div className="px-3 pb-3 space-y-0">
+                        {lesson.contents.map((content) => (
+                          <ContentItemAccordion
+                            key={content.id}
+                            content={content}
+                          />
+                        ))}
+                        {lesson.contents.length === 0 && (
+                          <p className="text-sm text-gray-500 py-4 text-center">
+                            暫無內容
+                          </p>
+                        )}
+                      </div>
+                    </AccordionContent>
+                  </AccordionItem>
+                </div>
+              ))}
+            </Accordion>
+            {selectedDetail.lessons.length === 0 && (
+              <p className="text-sm text-gray-500 py-4 text-center">暫無單元</p>
+            )}
+          </div>
+        </div>
+
+        {/* Copy button at bottom */}
+        <div className="flex justify-center pt-2">
+          <Button
+            size="lg"
+            onClick={() => {
+              const material = materials.find(
+                (m) => m.id === selectedDetail.id,
+              );
+              if (material) {
+                handleCopyClick(material);
+              }
+            }}
+            className="px-8"
+          >
+            <Copy className="w-4 h-4 mr-2" />
+            複製到組織教材
+          </Button>
+        </div>
+        {copyDialog}
       </div>
     );
   }
@@ -298,57 +508,7 @@ export default function OrgResourceMaterialsPage() {
         ))}
       </div>
 
-      {/* Copy Confirmation Dialog */}
-      <Dialog open={copyDialogOpen} onOpenChange={setCopyDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>確認複製教材到組織</DialogTitle>
-            <DialogDescription>
-              將「{copyTarget?.name}
-              」複製到組織教材中。複製後組織管理者可以自由編輯內容。
-              <br />
-              <span className="text-xs text-muted-foreground">
-                每個組織每個課程每天最多可複製 1 次
-              </span>
-            </DialogDescription>
-          </DialogHeader>
-          {copyTarget && (
-            <div className="py-2 text-sm space-y-1">
-              <p>
-                <span className="font-medium">課程名稱：</span>
-                {copyTarget.name}
-              </p>
-              <p>
-                <span className="font-medium">包含：</span>
-                {copyTarget.lesson_count} 個單元、{copyTarget.content_count}{" "}
-                個內容
-              </p>
-            </div>
-          )}
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setCopyDialogOpen(false)}
-              disabled={copying}
-            >
-              取消
-            </Button>
-            <Button onClick={handleConfirmCopy} disabled={copying}>
-              {copying ? (
-                <>
-                  <Loader2 className="w-4 h-4 mr-1 animate-spin" />
-                  複製中...
-                </>
-              ) : (
-                <>
-                  <Copy className="w-4 h-4 mr-1" />
-                  確認複製
-                </>
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {copyDialog}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **Backend bug fix**: `list_resource_materials` 的 `content_count` 未過濾 `is_assignment_copy` 內容，導致列表顯示的數量比點進詳情頁看到的多。現已加入與 `get_resource_material_detail` 一致的過濾邏輯。
- **Frontend UI 統一**: 組織帳號的資源教材包詳情頁改用與個人版相同的三層色彩邊框風格（藍色課程/綠色單元/紫色內容），加入 `ContentItemAccordion` 可展開查看項目詳情，底部加入「複製到組織教材」按鈕。

## Changes
- `backend/services/resource_materials_service.py`: 在 content 計數中加入 `is_assignment_copy` 過濾
- `frontend/src/pages/organization/OrgResourceMaterialsPage.tsx`: 重寫詳情頁 UI、新增 `ContentItemAccordion` 元件、抽出 `copyDialog` 共用

## Test plan
- [x] Backend resource materials unit tests (11/11 passed)
- [x] TypeScript typecheck passed
- [x] ESLint passed
- [x] Vite build passed
- [x] Prettier formatting passed
- [x] Black + Flake8 formatting passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)