### PR TITLE
feat(ui): collapse sidebar bottom into account popup menu

### DIFF
--- a/frontend/src/components/TeacherLayout.tsx
+++ b/frontend/src/components/TeacherLayout.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useMemo, useCallback, useRef } from "react";
-import { useNavigate, useLocation, Link } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import DigitalTeachingToolbar from "@/components/teachingTools/DigitalTeachingToolbar";
 import {
@@ -11,6 +11,9 @@ import {
   User,
   CreditCard,
   Building2,
+  Globe,
+  ChevronUp,
+  Check,
 } from "lucide-react";
 import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
 import { apiClient } from "@/lib/api";
@@ -18,6 +21,17 @@ import { useState, useEffect } from "react";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { useTranslation } from "react-i18next";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { getSidebarGroups } from "@/config/sidebarConfig";
 import { useSidebarRoles } from "@/hooks/useSidebarRoles";
 import { SidebarGroup } from "@/components/sidebar/SidebarGroup";
@@ -54,7 +68,7 @@ function TeacherLayoutInner({
 }: TeacherLayoutInnerProps) {
   const navigate = useNavigate();
   const location = useLocation();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [config, setConfig] = useState<SystemConfig | null>(null);
 
@@ -222,131 +236,143 @@ function TeacherLayoutInner({
             </ul>
           </nav>
 
-          {/* User Info & Logout */}
-          <div className="p-4 border-t dark:border-gray-700">
-            {/* 語言切換器 */}
-            {!sidebarCollapsed && (
-              <div className="mb-4">
-                <LanguageSwitcher />
-              </div>
-            )}
-
-            {teacherProfile && (
-              <div className="mb-4">
-                {sidebarCollapsed ? (
-                  <div className="flex justify-center">
-                    <div className="w-8 h-8 bg-blue-100 dark:bg-blue-900 rounded-full flex items-center justify-center">
-                      <span className="text-sm font-medium text-blue-600 dark:text-blue-400">
-                        {teacherProfile.name?.charAt(0) || "T"}
-                      </span>
-                    </div>
+          {/* Account Menu */}
+          <div className="p-2 border-t dark:border-gray-700">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  className={`w-full flex items-center gap-3 rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer ${sidebarCollapsed ? "justify-center" : ""}`}
+                >
+                  <div className="w-8 h-8 bg-blue-100 dark:bg-blue-900 rounded-full flex items-center justify-center flex-shrink-0">
+                    <span className="text-sm font-medium text-blue-600 dark:text-blue-400">
+                      {teacherProfile?.name?.charAt(0) || "T"}
+                    </span>
                   </div>
-                ) : (
-                  <div>
-                    <div className="flex items-center space-x-3 mb-2">
-                      <div className="w-10 h-10 bg-blue-100 dark:bg-blue-900 rounded-full flex items-center justify-center">
-                        <span className="text-lg font-medium text-blue-600 dark:text-blue-400">
-                          {teacherProfile.name?.charAt(0) || "T"}
-                        </span>
-                      </div>
-                      <div className="flex-1">
-                        <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                          {teacherProfile.name}
+                  {!sidebarCollapsed && (
+                    <>
+                      <div className="flex-1 text-left min-w-0">
+                        <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                          {teacherProfile?.name}
                         </p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400">
-                          {teacherProfile.email}
+                        <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                          {teacherProfile?.email}
                         </p>
                       </div>
-                    </div>
+                      <ChevronUp className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                    </>
+                  )}
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                side="top"
+                align="start"
+                className="w-56 mb-1"
+              >
+                <DropdownMenuLabel className="font-normal">
+                  <div className="flex flex-col space-y-1">
+                    <p className="text-sm font-medium">
+                      {teacherProfile?.name}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {teacherProfile?.email}
+                    </p>
                   </div>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  className="cursor-pointer"
+                  onClick={() => {
+                    navigate("/teacher/profile");
+                    onNavigate?.();
+                  }}
+                >
+                  <User className="mr-2 h-4 w-4" />
+                  {t("teacherLayout.nav.profile")}
+                </DropdownMenuItem>
+                {teacherProfile?.is_admin && (
+                  <DropdownMenuItem
+                    className="cursor-pointer"
+                    onClick={() => {
+                      navigate("/admin");
+                      onNavigate?.();
+                    }}
+                  >
+                    <Crown className="mr-2 h-4 w-4 text-yellow-500" />
+                    {t("teacherLayout.nav.systemAdmin")}
+                  </DropdownMenuItem>
                 )}
-              </div>
-            )}
-            {teacherProfile?.is_admin && (
-              <Link to="/admin" className="block mb-2" onClick={onNavigate}>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className={`w-full justify-start h-12 min-h-12 ${sidebarCollapsed ? "px-3" : "px-4"}`}
-                >
-                  <Crown className="h-4 w-4 text-yellow-500" />
-                  {!sidebarCollapsed && (
-                    <span className="ml-2">
-                      {t("teacherLayout.nav.systemAdmin")}
-                    </span>
-                  )}
-                </Button>
-              </Link>
-            )}
-            <Link
-              to="/teacher/profile"
-              className="block mb-2"
-              onClick={onNavigate}
-            >
-              <Button
-                variant="ghost"
-                size="sm"
-                className={`w-full justify-start h-12 min-h-12 ${sidebarCollapsed ? "px-3" : "px-4"}`}
-              >
-                <User className="h-4 w-4" />
-                {!sidebarCollapsed && (
-                  <span className="ml-2">{t("teacherLayout.nav.profile")}</span>
+                {config?.enablePayment && (
+                  <DropdownMenuItem
+                    className="cursor-pointer"
+                    onClick={() => {
+                      navigate("/teacher/subscription");
+                      onNavigate?.();
+                    }}
+                  >
+                    <CreditCard className="mr-2 h-4 w-4" />
+                    {t("teacherLayout.nav.subscription")}
+                  </DropdownMenuItem>
                 )}
-              </Button>
-            </Link>
-            {config?.enablePayment && (
-              <Link
-                to="/teacher/subscription"
-                className="block mb-2"
-                onClick={onNavigate}
-              >
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className={`w-full justify-start h-12 min-h-12 ${sidebarCollapsed ? "px-3" : "px-4"}`}
+                {hasOrgRole && (
+                  <DropdownMenuItem
+                    className="cursor-pointer"
+                    onClick={() => {
+                      navigate("/organization/dashboard");
+                      onNavigate?.();
+                    }}
+                  >
+                    <Building2 className="mr-2 h-4 w-4 text-blue-600" />
+                    {t("teacherLayout.nav.orgManagement")}
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuSeparator />
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger className="cursor-pointer">
+                    <Globe className="mr-2 h-4 w-4" />
+                    {t("teacherLayout.nav.language")}
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    <DropdownMenuItem
+                      className="cursor-pointer"
+                      onClick={() => i18n.changeLanguage("zh-TW")}
+                    >
+                      繁體中文
+                      {i18n.language.startsWith("zh") && (
+                        <Check className="ml-auto h-4 w-4" />
+                      )}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="cursor-pointer"
+                      onClick={() => i18n.changeLanguage("en")}
+                    >
+                      English
+                      {!i18n.language.startsWith("zh") && (
+                        <Check className="ml-auto h-4 w-4" />
+                      )}
+                    </DropdownMenuItem>
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  className="cursor-pointer text-red-600 focus:text-red-600 focus:bg-red-50 dark:focus:bg-red-900/20"
+                  onClick={() => {
+                    handleLogout();
+                    onNavigate?.();
+                  }}
                 >
-                  <CreditCard className="h-4 w-4" />
-                  {!sidebarCollapsed && (
-                    <span className="ml-2">
-                      {t("teacherLayout.nav.subscription")}
-                    </span>
-                  )}
-                </Button>
-              </Link>
-            )}
-            {hasOrgRole && (
-              <Link
-                to="/organization/dashboard"
-                className="block mb-2"
-                onClick={onNavigate}
-              >
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className={`w-full justify-start h-12 min-h-12 ${sidebarCollapsed ? "px-3" : "px-4"}`}
-                >
-                  <Building2 className="h-4 w-4 text-blue-600" />
-                  {!sidebarCollapsed && <span className="ml-2">組織管理</span>}
-                </Button>
-              </Link>
-            )}
-            <Button
-              variant="ghost"
-              size="sm"
-              className={`w-full justify-start h-12 min-h-12 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 ${sidebarCollapsed ? "px-3" : "px-4"}`}
-              onClick={handleLogout}
-            >
-              <LogOut className="h-4 w-4" />
-              {!sidebarCollapsed && (
-                <span className="ml-2">{t("nav.logout")}</span>
-              )}
-            </Button>
+                  <LogOut className="mr-2 h-4 w-4" />
+                  {t("nav.logout")}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </>
       ),
     [
       sidebarCollapsed,
       t,
+      i18n,
+      navigate,
       setSidebarCollapsed,
       filteredGroups,
       isActive,

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1954,7 +1954,9 @@
       "publicPrograms": "My Teaching Materials",
       "subscription": "Subscription",
       "systemAdmin": "System Admin",
-      "profile": "Profile"
+      "profile": "Profile",
+      "orgManagement": "Organization",
+      "language": "Language"
     }
   },
   "teacherProfile": {

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -1953,7 +1953,9 @@
       "publicPrograms": "我的教材",
       "subscription": "訂閱管理",
       "systemAdmin": "系統管理",
-      "profile": "個人資料"
+      "profile": "個人資料",
+      "orgManagement": "組織管理",
+      "language": "語言"
     }
   },
   "teacherProfile": {


### PR DESCRIPTION
## Summary
- 將教師後台左側選單底部的展開式按鈕（語言切換、個人資料、系統管理、訂閱管理、組織管理、登出）收合成一個帳號 popup menu
- 點擊左下角的使用者頭像+名稱即可開啟 DropdownMenu，類似 Claude 的帳號選單設計
- 大幅減少底部區域佔用空間，讓上方導航功能（資源教材包、我的教材等）有更多顯示空間
- 語言切換整合為子選單，帶有勾選標記顯示當前語言
- 支援 sidebar 收合模式（僅顯示頭像）
- 新增 i18n 翻譯鍵：`orgManagement`、`language`

## Test plan
- [ ] 桌面版：點擊左下角帳號區域，popup menu 正確向上展開
- [ ] 桌面版：各項功能（個人資料、系統管理、訂閱管理、組織管理）點擊後正確導航
- [ ] 桌面版：語言切換子選單正確切換語言，勾選標記顯示當前語言
- [ ] 桌面版：登出按鈕正確執行登出
- [ ] 桌面版：sidebar 收合模式下僅顯示頭像，點擊後 popup 正常運作
- [ ] 桌面版：非 admin 使用者不顯示系統管理選項
- [ ] 桌面版：無組織角色使用者不顯示組織管理選項
- [ ] 手機版：mobile header 的語言切換器不受影響，正常運作
- [ ] 確認 TypeScript、ESLint、Prettier、Build 均通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)