### PR TITLE
fix(ui): sidebar account menu - white submenu bg & clear stale roles on login

### DIFF
--- a/frontend/src/components/TeacherLayout.tsx
+++ b/frontend/src/components/TeacherLayout.tsx
@@ -89,16 +89,8 @@ function TeacherLayoutInner({
     ];
 
     // Check if user has any management role in their roles array
-    const hasRole = userRoles.some((role) => managementRoles.includes(role));
-
-    // Debug logging
-    console.log("🔍 TeacherLayout Debug:");
-    console.log("  userRoles:", userRoles);
-    console.log("  hasOrgRole:", hasRole);
-    console.log("  user.role (single):", user?.role);
-
-    return hasRole;
-  }, [userRoles, user?.role]);
+    return userRoles.some((role) => managementRoles.includes(role));
+  }, [userRoles]);
 
   // Determine which sidebar items are read-only
   const readOnlyItemIds = useMemo(() => {
@@ -331,7 +323,7 @@ function TeacherLayoutInner({
                     <Globe className="mr-2 h-4 w-4" />
                     {t("teacherLayout.nav.language")}
                   </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent>
+                  <DropdownMenuSubContent className="bg-white dark:bg-gray-800">
                     <DropdownMenuItem
                       className="cursor-pointer"
                       onClick={() => i18n.changeLanguage("zh-TW")}

--- a/frontend/src/stores/teacherAuthStore.ts
+++ b/frontend/src/stores/teacherAuthStore.ts
@@ -40,6 +40,8 @@ export const useTeacherAuthStore = create<TeacherAuthState>()(
           token,
           user,
           isAuthenticated: true,
+          userRoles: [],
+          rolesLoading: false,
         });
       },
 


### PR DESCRIPTION
## Summary
- **Language sub-menu background**: Added `bg-white dark:bg-gray-800` to `DropdownMenuSubContent` so the language selection flyout has a solid white background instead of transparent
- **Stale roles on login**: Fixed `login()` action in `teacherAuthStore` to clear `userRoles` and `rolesLoading`, preventing stale org roles from a previous session from carrying over (this caused Demo teacher to incorrectly see "組織管理")
- **Cleanup**: Removed debug `console.log` statements from `hasOrgRole` check

## Root Cause Analysis
The `teacherAuthStore` uses Zustand `persist` middleware which saves `userRoles` to localStorage. The `login()` action was NOT clearing `userRoles`, so if a user previously logged in with org roles (e.g., org_admin), then logged in as Demo teacher, the stale roles persisted. The `useSidebarRoles` hook skips fetching when `userRoles.length > 0`, so fresh roles were never loaded.

## Test plan
- [ ] Login as Demo teacher on staging → verify "組織管理" does NOT appear in account menu
- [ ] Login as org admin → verify "組織管理" DOES appear
- [ ] Click language sub-menu → verify white background on the flyout
- [ ] Switch language → verify language changes correctly
- [ ] Logout then login as different user → verify roles are refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)