### PR TITLE
fix(ui): 區分單字集與例句集的 icon 顯示 (#251)

### DIFF
--- a/frontend/src/components/shared/RecursiveTreeAccordion.tsx
+++ b/frontend/src/components/shared/RecursiveTreeAccordion.tsx
@@ -64,7 +64,8 @@ import { CSS } from "@dnd-kit/utilities";
 
 export interface TreeNodeConfig {
   // Display config
-  icon: LucideIcon;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  icon: LucideIcon | ((item: any) => LucideIcon);
   colorScheme: {
     bg: string;
     text: string;
@@ -238,9 +239,23 @@ function RecursiveTreeNode({
                     <div
                       className={`w-7 h-7 sm:w-9 sm:h-9 ${config.colorScheme.iconBg} rounded-md flex items-center justify-center flex-shrink-0`}
                     >
-                      <config.icon
-                        className={`h-4 w-4 sm:h-5 sm:w-5 ${config.colorScheme.iconText}`}
-                      />
+                      {(() => {
+                        const IconComponent =
+                          typeof config.icon === "function" &&
+                          !("render" in config.icon)
+                            ? (
+                                config.icon as (
+                                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                                  item: any,
+                                ) => LucideIcon
+                              )(data)
+                            : (config.icon as LucideIcon);
+                        return (
+                          <IconComponent
+                            className={`h-4 w-4 sm:h-5 sm:w-5 ${config.colorScheme.iconText}`}
+                          />
+                        );
+                      })()}
                     </div>
 
                     {/* Name and description */}
@@ -489,9 +504,23 @@ function RecursiveTreeNode({
               <div
                 className={`w-6 h-6 sm:w-7 sm:h-7 ${config.colorScheme.iconBg} rounded-md flex items-center justify-center flex-shrink-0`}
               >
-                <config.icon
-                  className={`h-3.5 w-3.5 sm:h-4 sm:w-4 ${config.colorScheme.iconText}`}
-                />
+                {(() => {
+                  const IconComponent =
+                    typeof config.icon === "function" &&
+                    !("render" in config.icon)
+                      ? (
+                          config.icon as (
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            item: any,
+                          ) => LucideIcon
+                        )(data)
+                      : (config.icon as LucideIcon);
+                  return (
+                    <IconComponent
+                      className={`h-3.5 w-3.5 sm:h-4 sm:w-4 ${config.colorScheme.iconText}`}
+                    />
+                  );
+                })()}
               </div>
               <div className="flex-1 min-w-0">
                 <p

--- a/frontend/src/components/shared/programTreeConfig.tsx
+++ b/frontend/src/components/shared/programTreeConfig.tsx
@@ -1,12 +1,13 @@
 import { TreeNodeConfig } from "./RecursiveTreeAccordion";
-import { BookOpen, ListOrdered, FileText, Clock } from "lucide-react";
+import { BookOpen, ListOrdered, Clock } from "lucide-react";
+import { getContentTypeIcon } from "@/lib/contentTypeIcon";
 
 // Content types to hide (legacy types that are no longer used)
 const HIDDEN_CONTENT_TYPES = ["sentence_making"];
 
 // Content layer config (leaf nodes)
 const contentConfig: TreeNodeConfig = {
-  icon: FileText,
+  icon: (item: { type?: string }) => getContentTypeIcon(item.type),
   colorScheme: {
     bg: "bg-gray-50",
     text: "text-gray-900",

--- a/frontend/src/lib/contentTypeIcon.ts
+++ b/frontend/src/lib/contentTypeIcon.ts
@@ -1,0 +1,19 @@
+import { BookA, BookText, FileText, type LucideIcon } from "lucide-react";
+
+/**
+ * Returns the appropriate Lucide icon for a given content type.
+ *
+ * - VOCABULARY_SET → BookA
+ * - EXAMPLE_SENTENCES → BookText
+ * - Others → FileText (default)
+ */
+export function getContentTypeIcon(type?: string | null): LucideIcon {
+  switch (type?.toUpperCase()) {
+    case "VOCABULARY_SET":
+      return BookA;
+    case "EXAMPLE_SENTENCES":
+      return BookText;
+    default:
+      return FileText;
+  }
+}

--- a/frontend/src/pages/organization/OrgResourceMaterialsPage.tsx
+++ b/frontend/src/pages/organization/OrgResourceMaterialsPage.tsx
@@ -41,6 +41,7 @@ import {
   Clock,
   ChevronDown,
 } from "lucide-react";
+import { getContentTypeIcon } from "@/lib/contentTypeIcon";
 import { toast } from "sonner";
 
 /** Expandable content card showing items inside */
@@ -69,7 +70,10 @@ function ContentItemAccordion({
       >
         <div className="flex items-center space-x-2 flex-1 min-w-0">
           <div className="w-7 h-7 bg-purple-100 rounded-md flex items-center justify-center flex-shrink-0">
-            <FileText className="h-4 w-4 text-purple-600" />
+            {(() => {
+              const Icon = getContentTypeIcon(content.type);
+              return <Icon className="h-4 w-4 text-purple-600" />;
+            })()}
           </div>
           <div className="flex-1 min-w-0">
             <p className="font-medium text-sm truncate">{content.title}</p>

--- a/frontend/src/pages/student/StudentAssignmentDetail.tsx
+++ b/frontend/src/pages/student/StudentAssignmentDetail.tsx
@@ -16,10 +16,10 @@ import {
   CheckCircle,
   AlertCircle,
   BarChart3,
-  FileText,
   Headphones,
   Mic,
 } from "lucide-react";
+import { getContentTypeIcon } from "@/lib/contentTypeIcon";
 import {
   StudentAssignment,
   StudentContentProgress,
@@ -243,14 +243,16 @@ export default function StudentAssignmentDetail() {
     }
   };
 
-  const getContentTypeIcon = (type?: string) => {
+  const getContentTypeIconElement = (type?: string) => {
     switch (type) {
       case "reading_assessment":
         return <Mic className="h-4 w-4" />;
       case "listening":
         return <Headphones className="h-4 w-4" />;
-      default:
-        return <FileText className="h-4 w-4" />;
+      default: {
+        const Icon = getContentTypeIcon(type);
+        return <Icon className="h-4 w-4" />;
+      }
     }
   };
 
@@ -298,7 +300,7 @@ export default function StudentAssignmentDetail() {
 
   const renderContentProgress = (progress: StudentContentProgress) => {
     const statusDisplay = getStatusDisplay(progress.status);
-    const contentTypeIcon = getContentTypeIcon(progress.content?.type);
+    const contentTypeIcon = getContentTypeIconElement(progress.content?.type);
 
     // 檢查題目的評分狀態
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -37,6 +37,7 @@ import {
   Trash2,
   Sparkles,
 } from "lucide-react";
+import { getContentTypeIcon } from "@/lib/contentTypeIcon";
 import { apiClient, ApiError } from "@/lib/api";
 import { toast } from "sonner";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
@@ -1999,7 +2000,10 @@ export default function ClassroomDetail({
                     {/* Content Type Badge */}
                     <div className="flex items-center space-x-2">
                       <div className="w-8 h-8 bg-purple-100 rounded-lg flex items-center justify-center">
-                        <FileText className="h-4 w-4 text-purple-600" />
+                        {(() => {
+                          const Icon = getContentTypeIcon(selectedContent.type);
+                          return <Icon className="h-4 w-4 text-purple-600" />;
+                        })()}
                       </div>
                       <div>
                         <p className="font-medium">{selectedContent.type}</p>

--- a/frontend/src/pages/teacher/ResourceMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/ResourceMaterialsPage.tsx
@@ -40,6 +40,7 @@ import {
   Clock,
   ChevronDown,
 } from "lucide-react";
+import { getContentTypeIcon } from "@/lib/contentTypeIcon";
 import { toast } from "sonner";
 
 export default function ResourceMaterialsPage() {
@@ -76,7 +77,10 @@ function ContentItemAccordion({
       >
         <div className="flex items-center space-x-2 flex-1 min-w-0">
           <div className="w-7 h-7 bg-purple-100 rounded-md flex items-center justify-center flex-shrink-0">
-            <FileText className="h-4 w-4 text-purple-600" />
+            {(() => {
+              const Icon = getContentTypeIcon(content.type);
+              return <Icon className="h-4 w-4 text-purple-600" />;
+            })()}
           </div>
           <div className="flex-1 min-w-0">
             <p className="font-medium text-sm truncate">{content.title}</p>


### PR DESCRIPTION
## Summary
- 新增共用 `getContentTypeIcon` helper，根據 content type 回傳對應 icon
  - `VOCABULARY_SET` → BookA
  - `EXAMPLE_SENTENCES` → BookText
  - 其他 → FileText（預設）
- 擴充 `RecursiveTreeAccordion` 的 `TreeNodeConfig.icon` 支援動態 icon function
- 更新所有 6 處使用 content type icon 的頁面，統一使用共用 helper

## Files Changed
- `frontend/src/lib/contentTypeIcon.ts` — **新增** 共用 icon helper
- `frontend/src/components/shared/RecursiveTreeAccordion.tsx` — 支援動態 icon
- `frontend/src/components/shared/programTreeConfig.tsx` — 使用動態 icon
- `frontend/src/pages/student/StudentAssignmentDetail.tsx` — 使用共用 helper
- `frontend/src/pages/teacher/ClassroomDetail.tsx` — 使用動態 icon
- `frontend/src/pages/teacher/ResourceMaterialsPage.tsx` — 使用動態 icon
- `frontend/src/pages/organization/OrgResourceMaterialsPage.tsx` — 使用動態 icon

## Test Plan
- [x] TypeScript typecheck passes
- [x] Prettier format check passes
- [x] Production build succeeds
- [ ] 確認教材列表中單字集顯示 BookA icon
- [ ] 確認教材列表中例句集顯示 BookText icon
- [ ] 確認其他類型仍顯示 FileText icon

Fixes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)