### PR TITLE
fix(#187): restore words_mastered and achieved on assignment re-entry

### DIFF
--- a/backend/routers/students/assignments.py
+++ b/backend/routers/students/assignments.py
@@ -1325,6 +1325,8 @@ async def start_word_selection_practice(
     current_proficiency = (
         float(mastery_result.current_mastery) * 100 if mastery_result else 0
     )
+    words_mastered = int(mastery_result.words_mastered) if mastery_result else 0
+    achieved = bool(mastery_result.achieved) if mastery_result else False
 
     return {
         "session_id": practice_session.id,
@@ -1332,6 +1334,8 @@ async def start_word_selection_practice(
         "total_words": total_words_in_assignment,
         "current_proficiency": current_proficiency,
         "target_proficiency": target_proficiency,
+        "words_mastered": words_mastered,
+        "achieved": achieved,
         "show_word": assignment.show_word if assignment else True,
         "show_image": assignment.show_image if assignment else True,
         "play_audio": assignment.play_audio if assignment else False,

--- a/frontend/src/components/activities/WordSelectionActivity.tsx
+++ b/frontend/src/components/activities/WordSelectionActivity.tsx
@@ -180,6 +180,8 @@ export default function WordSelectionActivity({
         total_words: number;
         current_proficiency: number;
         target_proficiency: number;
+        words_mastered: number;
+        achieved: boolean;
         show_word: boolean;
         show_image: boolean;
         play_audio: boolean;
@@ -196,8 +198,8 @@ export default function WordSelectionActivity({
       setProficiency({
         current_mastery: data.current_proficiency || 0,
         target_mastery: data.target_proficiency || 80,
-        achieved: false,
-        words_mastered: 0,
+        achieved: data.achieved ?? false,
+        words_mastered: data.words_mastered ?? 0,
         total_words: data.total_words || 0,
       });
       setCurrentIndex(0);


### PR DESCRIPTION
## Summary
- `/start` endpoint 新增回傳 `words_mastered` 和 `achieved`（從 `calculate_assignment_mastery()` 取得）
- 前端 `startPractice()` 改用後端回傳值取代硬編碼的 `0` 和 `false`
- 修復學生重新進入單字選擇作業時「已熟練單字數」永遠顯示 0 的問題

## Test plan
- [ ] 學生完成 Round 1 後退出，重新進入確認 words_mastered 和進度條正確還原
- [ ] 學生達標後退出再進入，確認 achieved 狀態正確
- [ ] 預覽模式和 Demo 模式不受影響（使用本地計算）

Fixes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)