### PR TITLE
fix(#298): 手機版編輯面板寬度過窄修正

### DIFF
--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -1461,6 +1461,7 @@ export default function VocabularySetPanel({
   const [batchPasteText, setBatchPasteText] = useState("");
   const [batchPasteAutoTTS, setBatchPasteAutoTTS] = useState(true);
   const [batchPasteAutoTranslate, setBatchPasteAutoTranslate] = useState(true);
+  const [isBatchPasting, setIsBatchPasting] = useState(false);
 
   // TTS settings for batch paste (Issue #121)
   const [batchTTSAccent, setBatchTTSAccent] = useState("American English");
@@ -2874,10 +2875,13 @@ export default function VocabularySetPanel({
       return;
     }
 
+    setIsBatchPasting(true);
+
     toast.info(
       t("contentEditor.messages.processingItems", { count: lines.length }),
     );
 
+    try {
     // 清除空白 items
     const nonEmptyRows = rows.filter((row) => row.text && row.text.trim());
 
@@ -3006,6 +3010,9 @@ export default function VocabularySetPanel({
 
     setBatchPasteDialogOpen(false);
     setBatchPasteText("");
+    } finally {
+      setIsBatchPasting(false);
+    }
   };
 
   if (isLoading) {
@@ -3340,6 +3347,7 @@ export default function VocabularySetPanel({
             <Button
               variant="outline"
               onClick={() => setBatchPasteDialogOpen(false)}
+              disabled={isBatchPasting}
               className="px-6 py-2 text-base"
             >
               {t("contentEditor.buttons.cancel")}
@@ -3348,9 +3356,12 @@ export default function VocabularySetPanel({
               onClick={() =>
                 handleBatchPaste(batchPasteAutoTTS, batchPasteAutoTranslate)
               }
+              disabled={isBatchPasting}
               className="px-6 py-2 text-base bg-blue-600 hover:bg-blue-700"
             >
-              {t("contentEditor.buttons.confirmPaste")}
+              {isBatchPasting
+                ? "Working... 工作中"
+                : t("contentEditor.buttons.confirmPaste")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/components/shared/ProgramTreeView.tsx
+++ b/frontend/src/components/shared/ProgramTreeView.tsx
@@ -725,7 +725,7 @@ export function ProgramTreeView({
               className="fixed inset-0 bg-black bg-opacity-20 z-40 transition-opacity"
               onClick={closeReadingEditor}
             />
-            <div className="fixed top-0 right-0 h-screen w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 flex flex-col">
+            <div className="fixed top-0 right-0 h-screen w-full md:w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 flex flex-col">
               {/* Header */}
               <div className="flex items-center justify-between p-6 border-b border-gray-200 flex-shrink-0">
                 <h2 className="text-xl font-semibold text-gray-900">
@@ -843,7 +843,7 @@ export function ProgramTreeView({
               className="fixed inset-0 bg-black bg-opacity-20 z-40 transition-opacity"
               onClick={closeSentenceMakingEditor}
             />
-            <div className="fixed top-0 right-0 h-screen w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 flex flex-col">
+            <div className="fixed top-0 right-0 h-screen w-full md:w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 flex flex-col">
               {/* Header */}
               <div className="flex items-center justify-between p-6 border-b border-gray-200 flex-shrink-0">
                 <h2 className="text-xl font-semibold text-gray-900">
@@ -931,7 +931,7 @@ export function ProgramTreeView({
               className="fixed inset-0 bg-black bg-opacity-20 z-40 transition-opacity"
               onClick={closeVocabularySetEditor}
             />
-            <div className="fixed top-0 right-0 h-screen w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 flex flex-col">
+            <div className="fixed top-0 right-0 h-screen w-full md:w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 flex flex-col">
               {/* Header */}
               <div className="flex items-center justify-between p-6 border-b border-gray-200 flex-shrink-0">
                 <h2 className="text-xl font-semibold text-gray-900">

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -1932,7 +1932,7 @@ export default function ClassroomDetail({
 
         {/* Right Sliding Panel */}
         <div
-          className={`fixed right-0 top-0 h-full w-1/2 bg-white shadow-xl border-l transform transition-transform duration-300 z-50 ${
+          className={`fixed right-0 top-0 h-full w-full md:w-1/2 bg-white shadow-xl border-l transform transition-transform duration-300 z-50 ${
             isPanelOpen ? "translate-x-0" : "translate-x-full"
           }`}
         >

--- a/frontend/src/pages/teacher/OrgMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/OrgMaterialsPage.tsx
@@ -644,7 +644,7 @@ export default function OrgMaterialsPage() {
               />
 
               {/* Panel */}
-              <div className="fixed top-0 right-0 h-screen w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 overflow-auto animate-in slide-in-from-right duration-300">
+              <div className="fixed top-0 right-0 h-screen w-full md:w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 overflow-auto animate-in slide-in-from-right duration-300">
                 <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between z-10">
                   <h2 className="text-lg font-semibold text-gray-900">
                     {t("teacherTemplatePrograms.dialogs.editContentTitle")}
@@ -786,7 +786,7 @@ export default function OrgMaterialsPage() {
               />
 
               {/* Panel */}
-              <div className="fixed top-0 right-0 h-screen w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 overflow-auto animate-in slide-in-from-right duration-300">
+              <div className="fixed top-0 right-0 h-screen w-full md:w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 overflow-auto animate-in slide-in-from-right duration-300">
                 <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between z-10">
                   <h2 className="text-lg font-semibold text-gray-900">
                     {t("vocabularySet.editTitle")}

--- a/frontend/src/pages/teacher/SchoolMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/SchoolMaterialsPage.tsx
@@ -655,7 +655,7 @@ export default function SchoolMaterialsPage() {
               />
 
               {/* Panel */}
-              <div className="fixed top-0 right-0 h-screen w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 overflow-auto animate-in slide-in-from-right duration-300">
+              <div className="fixed top-0 right-0 h-screen w-full md:w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 overflow-auto animate-in slide-in-from-right duration-300">
                 <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between z-10">
                   <h2 className="text-lg font-semibold text-gray-900">
                     {t("teacherTemplatePrograms.dialogs.editContentTitle")}
@@ -799,7 +799,7 @@ export default function SchoolMaterialsPage() {
               />
 
               {/* Panel */}
-              <div className="fixed top-0 right-0 h-screen w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 overflow-auto animate-in slide-in-from-right duration-300">
+              <div className="fixed top-0 right-0 h-screen w-full md:w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 overflow-auto animate-in slide-in-from-right duration-300">
                 <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between z-10">
                   <h2 className="text-lg font-semibold text-gray-900">
                     {t("vocabularySet.editTitle")}

--- a/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
+++ b/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
@@ -674,7 +674,7 @@ function TeacherTemplateProgramsInner() {
             />
 
             {/* Panel */}
-            <div className="fixed top-0 right-0 h-screen w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 overflow-auto animate-in slide-in-from-right duration-300">
+            <div className="fixed top-0 right-0 h-screen w-full md:w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 overflow-auto animate-in slide-in-from-right duration-300">
               <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between z-10">
                 <h2 className="text-lg font-semibold text-gray-900">
                   {t("teacherTemplatePrograms.dialogs.editContentTitle")}
@@ -824,7 +824,7 @@ function TeacherTemplateProgramsInner() {
             />
 
             {/* Panel */}
-            <div className="fixed top-0 right-0 h-screen w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 overflow-auto animate-in slide-in-from-right duration-300">
+            <div className="fixed top-0 right-0 h-screen w-full md:w-1/2 bg-white shadow-2xl border-l border-gray-200 z-50 overflow-auto animate-in slide-in-from-right duration-300">
               <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between z-10">
                 <h2 className="text-lg font-semibold text-gray-900">
                   {t("vocabularySet.editTitle")}


### PR DESCRIPTION
## Summary
- 修正單字集、例句集等編輯面板在手機版寬度僅 50%（`w-1/2`）的問題，改為 `w-full md:w-1/2`，手機全寬、桌面半寬
- 批次貼上按鈕新增 loading 狀態（`isBatchPasting`），防止重複點擊並顯示工作中提示

## Changes
- **ProgramTreeView.tsx** — 閱讀編輯器、造句編輯器、單字集編輯器面板：`w-1/2` → `w-full md:w-1/2`
- **ClassroomDetail.tsx** — 右側滑動面板：`w-1/2` → `w-full md:w-1/2`
- **OrgMaterialsPage.tsx** — 機構教材編輯面板（x2）：`w-1/2` → `w-full md:w-1/2`
- **SchoolMaterialsPage.tsx** — 學校教材編輯面板（x2）：`w-1/2` → `w-full md:w-1/2`
- **TeacherTemplatePrograms.tsx** — 範本教材編輯面板（x2）：`w-1/2` → `w-full md:w-1/2`
- **VocabularySetPanel.tsx** — 批次貼上新增 `isBatchPasting` 狀態，按鈕 disabled 及 loading 文字

## Test plan
- [ ] 手機版（< 768px）開啟單字集/例句集編輯面板，確認面板寬度為 100%
- [ ] 桌面版（>= 768px）開啟編輯面板，確認寬度仍為 50%
- [ ] 批次貼上時確認按鈕 disabled 並顯示 "Working... 工作中"

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)