### PR TITLE
fix(ci): handle commas in env var values for Cloud Run deploy

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -399,6 +399,11 @@ jobs:
           MAX_INSTANCES=1      # Staging 流量低，降為 1 節省成本
         fi
 
+        # Use @ as custom delimiter instead of , because env var values contain commas
+        # (e.g. DEMO_ALLOWED_ORIGINS=https://duotopia.co,https://www.duotopia.net)
+        # sed replaces only commas followed by KEY= pattern, preserving commas inside values
+        ENV_VARS_ESCAPED=$(echo "$ENV_VARS" | sed 's/,\([A-Z_][A-Z_0-9]*=\)/@\1/g')
+
         gcloud run deploy ${{ steps.env_vars.outputs.BACKEND_SERVICE }} \
           --image $REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/${{ steps.env_vars.outputs.BACKEND_SERVICE }}:$GITHUB_SHA \
           --platform managed \
@@ -412,7 +417,7 @@ jobs:
           --cpu-throttling \
           --concurrency $CONCURRENCY \
           --no-cpu-boost \
-          --set-env-vars="$ENV_VARS"
+          --set-env-vars="^@^$ENV_VARS_ESCAPED"
 
     - name: 🧹 Cleanup Old Backend Images
       run: |


### PR DESCRIPTION
## Summary

- Fix `gcloud run deploy --set-env-vars` failing with `Bad syntax for dict arg: [https://www.duotopia.net]`
- `DEMO_ALLOWED_ORIGINS` contains comma-separated URLs (`https://duotopia.co,https://www.duotopia.net`) which conflicts with gcloud's default `,` delimiter
- Use `^@^` custom delimiter syntax so commas inside values are preserved

## Test plan

- [ ] Merge and verify production backend deploy succeeds
- [ ] Verify `DEMO_ALLOWED_ORIGINS` is correctly set on Cloud Run with both URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)