### PR TITLE
fix(ci): split backend tests, remove || echo, use pooler URL

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -66,18 +66,25 @@ jobs:
         echo "Running Flake8 linting..."
         flake8 . --config=../.flake8
 
-    - name: Run pytest (Parallel)
+    - name: Run unit tests
+      working-directory: ./backend
+      run: |
+        echo "🧪 Running unit tests (no external dependencies)..."
+        pytest tests/unit/ -n auto -v --tb=short
+
+    - name: Run integration tests
       working-directory: ./backend
       env:
-        DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
-        TEST_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+        DATABASE_URL: ${{ secrets.STAGING_DATABASE_POOLER_URL }}
+        TEST_DATABASE_URL: ${{ secrets.STAGING_DATABASE_POOLER_URL }}
       run: |
-        echo "🧪 Staging: Running full test suite with staging database..."
-        echo "   TEST_DATABASE_URL is set: $TEST_DATABASE_URL"
-        pytest -n auto -v --tb=short || echo "Tests completed with some failures"
+        echo "🧪 Running integration tests with staging database (pooler URL)..."
+        pytest tests/ --ignore=tests/unit/ --ignore=tests/e2e/ --ignore=tests/benchmarks/ --ignore=tests/load_testing/ --ignore=tests/stress/ -n auto -v --tb=short
 
     - name: Test backend import
       working-directory: ./backend
+      env:
+        DATABASE_URL: ${{ secrets.STAGING_DATABASE_POOLER_URL }}
       run: python -c "import main; print('Backend imports successfully')"
 
   deploy-backend:

--- a/.github/workflows/deploy-vm-prod.yml
+++ b/.github/workflows/deploy-vm-prod.yml
@@ -120,11 +120,11 @@ jobs:
         echo "Running Flake8 linting..."
         flake8 . --max-line-length=120 --ignore=E203,W503 --exclude=alembic,__pycache__,.venv
 
-    - name: Run pytest (Unit tests only)
+    - name: Run unit tests
       working-directory: ./backend
       run: |
-        echo "🧪 Running unit tests..."
-        pytest tests/unit/ -v --tb=short || echo "Tests completed with some failures"
+        echo "🧪 Running unit tests (no external dependencies)..."
+        pytest tests/unit/ -v --tb=short
 
   # 🧪 Test frontend before deployment
   test-frontend:


### PR DESCRIPTION
## Summary
- Split single `pytest` step into **unit tests** + **integration tests**, unit tests run first without DB dependency
- Remove `|| echo` that silenced all test failures (507 errors + 258 failures were invisible)
- Switch `DATABASE_URL` from `STAGING_DATABASE_URL` (direct, IPv6) to `STAGING_DATABASE_POOLER_URL` (pooler, IPv4) — fixes GitHub Actions IPv6 unreachable issue
- Sync changes to `deploy-vm-prod.yml`

## Test plan
- [ ] Push to staging triggers `deploy-backend.yml` — verify unit tests and integration tests run as separate steps
- [ ] Unit tests should pass without any `DATABASE_URL` env var
- [ ] Integration tests should connect via pooler URL (no IPv6 timeout errors)
- [ ] Test failures should block deployment (no more `|| echo`)

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)