### PR TITLE
feat(#297): 訂閱頁面改版（3-tab layout）

### DIFF
--- a/backend/seed_data/stage_01_users.py
+++ b/backend/seed_data/stage_01_users.py
@@ -60,10 +60,10 @@ def seed_users_and_organizations(db: Session):
     print("   - trial@duotopia.com (30天試用期)")
 
     # ============ 1.4 創建對應的 subscription_periods ============
-    # Demo 老師的訂閱週期（300天，大配額）
+    # Demo 老師的訂閱週期（300天，大配額）— 模擬 School 方案
     demo_period = SubscriptionPeriod(
         teacher_id=demo_teacher.id,
-        plan_name="Demo Unlimited Plan",
+        plan_name="School Teachers",
         amount_paid=0,
         quota_total=999999999,  # 無限配額
         quota_used=0,

--- a/frontend/src/components/SubscriptionProgressBanner.tsx
+++ b/frontend/src/components/SubscriptionProgressBanner.tsx
@@ -5,11 +5,13 @@ import { useTranslation } from "react-i18next";
 interface SubscriptionProgressBannerProps {
   currentStep: "select-plan" | "login" | "payment" | "complete";
   selectedPlan?: string;
+  vertical?: boolean;
 }
 
 export default function SubscriptionProgressBanner({
   currentStep,
   selectedPlan,
+  vertical = false,
 }: SubscriptionProgressBannerProps) {
   const { t } = useTranslation();
 
@@ -44,6 +46,70 @@ export default function SubscriptionProgressBanner({
     if (stepIndex === currentIndex) return "active";
     return "pending";
   };
+
+  if (vertical) {
+    return (
+      <div className="flex flex-col py-2">
+        {steps.map((step, index) => {
+          const status = getStepStatus(step.id);
+          const isLast = index === steps.length - 1;
+
+          return (
+            <React.Fragment key={step.id}>
+              <div className="flex items-center gap-2.5">
+                <div
+                  className={`
+                    w-7 h-7 rounded-full flex items-center justify-center font-semibold text-xs flex-shrink-0
+                    ${
+                      status === "completed"
+                        ? "bg-green-500 text-white"
+                        : status === "active"
+                          ? "bg-blue-600 text-white ring-3 ring-blue-200"
+                          : "bg-gray-300 text-gray-600"
+                    }
+                  `}
+                >
+                  {status === "completed" ? (
+                    <Check className="w-3.5 h-3.5" />
+                  ) : (
+                    <span>{step.icon}</span>
+                  )}
+                </div>
+                <span
+                  className={`
+                    text-xs font-medium whitespace-nowrap
+                    ${
+                      status === "active"
+                        ? "text-blue-700"
+                        : status === "completed"
+                          ? "text-green-700"
+                          : "text-gray-500"
+                    }
+                  `}
+                >
+                  {step.label}
+                </span>
+              </div>
+
+              {!isLast && (
+                <div className="ml-3.5 my-1">
+                  <div className="w-0.5 h-5 bg-gray-300 rounded">
+                    <div
+                      className={`w-full rounded transition-all duration-500 ${
+                        status === "completed"
+                          ? "bg-green-500 h-full"
+                          : "h-0"
+                      }`}
+                    />
+                  </div>
+                </div>
+              )}
+            </React.Fragment>
+          );
+        })}
+      </div>
+    );
+  }
 
   return (
     <div className="bg-blue-50 border-b border-blue-200 px-4 py-3">

--- a/frontend/src/components/payment/TapPayPayment.tsx
+++ b/frontend/src/components/payment/TapPayPayment.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Loader2, CreditCard, Shield } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Loader2, Shield } from "lucide-react";
 import { toast } from "sonner";
 import SubscriptionProgressBanner from "../SubscriptionProgressBanner";
 import { analyticsService } from "@/services/analyticsService";
@@ -366,31 +366,23 @@ const TapPayPayment: React.FC<TapPayPaymentProps> = ({
   };
 
   return (
-    <div className="space-y-4">
-      <SubscriptionProgressBanner
-        currentStep="payment"
-        selectedPlan={planName}
-      />
+    <div className="flex gap-4 p-2 sm:p-4">
+      {/* Vertical stepper sidebar — hidden on mobile */}
+      <div className="hidden sm:block flex-shrink-0 pr-4">
+        <SubscriptionProgressBanner
+          currentStep="payment"
+          selectedPlan={planName}
+          vertical
+        />
+      </div>
 
-      <Card className="w-full max-w-lg mx-auto">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <CreditCard className="h-5 w-5" />
-            信用卡付款
-          </CardTitle>
-          <div className="flex items-center justify-between mt-2">
-            <span className="text-sm text-gray-600">方案: {planName}</span>
-            <span className="text-lg font-semibold">
-              NT$ {amount.toLocaleString()}
-            </span>
-          </div>
-        </CardHeader>
-
-        <CardContent className="space-y-4">
+      {/* Payment form */}
+      <Card className="w-full">
+        <CardContent className="space-y-3 pt-5">
           {/* Security Badge */}
-          <div className="flex items-center gap-2 p-3 bg-green-50 rounded-lg border border-green-200">
-            <Shield className="h-4 w-4 text-green-600" />
-            <span className="text-sm text-green-800">
+          <div className="flex items-center gap-2">
+            <Shield className="h-4 w-4 text-green-600 flex-shrink-0" />
+            <span className="text-sm text-green-700">
               使用 TapPay 安全加密技術保護您的付款資訊
             </span>
           </div>
@@ -495,18 +487,6 @@ const TapPayPayment: React.FC<TapPayPaymentProps> = ({
             />
           </div>
 
-          {/* Prorated Payment Notice - 移至底部 */}
-          {!isCardUpdate && (
-            <div className="p-3 bg-blue-50 rounded-lg border border-blue-200 mt-4">
-              <p className="text-sm text-blue-800 font-medium mb-1">
-                💡 首月比例計費
-              </p>
-              <p className="text-xs text-blue-700">
-                本次付款按本月剩餘天數比例計算。下個月 1 號起，將以全額 (NT${" "}
-                {planName === "Tutor Teachers" ? "230" : "330"}) 自動續訂。
-              </p>
-            </div>
-          )}
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/components/pricing/PointPackageCard.tsx
+++ b/frontend/src/components/pricing/PointPackageCard.tsx
@@ -1,0 +1,126 @@
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Gift, ShoppingCart } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+export interface PointPackage {
+  id: string;
+  points: number;
+  price: number;
+  bonusPoints: number;
+  unitCost: number;
+  bestValue?: boolean;
+}
+
+interface PointPackageCardProps {
+  pkg: PointPackage;
+  onSelect?: (pkg: PointPackage) => void;
+  disabled?: boolean;
+  ctaText: string;
+  baseUnitCost: number; // highest unit cost for discount calculation
+}
+
+export function PointPackageCard({
+  pkg,
+  onSelect,
+  disabled,
+  ctaText,
+  baseUnitCost,
+}: PointPackageCardProps) {
+  const { t } = useTranslation();
+  const discountPercent =
+    baseUnitCost > pkg.unitCost
+      ? Math.round(((baseUnitCost - pkg.unitCost) / baseUnitCost) * 100)
+      : 0;
+
+  const greenGradient =
+    "linear-gradient(145deg, #15803d, #22c55e, #6ee7a0, #22c55e, #15803d)";
+
+  const cardStyle = pkg.bestValue
+    ? {
+        backgroundImage: `linear-gradient(white, white), ${greenGradient}`,
+        backgroundOrigin: "border-box" as const,
+        backgroundClip: "padding-box, border-box",
+        boxShadow: "0 0 18px rgba(34,197,94,0.35)",
+      }
+    : undefined;
+
+  return (
+    <Card
+      className={`relative p-6 hover:shadow-xl transition-all duration-300 flex flex-col ${
+        pkg.bestValue ? "border-2 border-transparent" : ""
+      }`}
+      style={cardStyle}
+    >
+      {pkg.bestValue && (
+        <Badge className="absolute -top-3 left-1/2 transform -translate-x-1/2 bg-green-500 text-white">
+          {t("pricing.pointPackages.bestValue")}
+        </Badge>
+      )}
+
+      <div className="text-center flex-1 flex flex-col">
+        {/* Points */}
+        <h3 className="text-xl font-bold text-gray-900 mb-1">
+          {pkg.points.toLocaleString()} {t("pricing.pointPackages.points")}
+        </h3>
+
+        {/* Bonus */}
+        {pkg.bonusPoints > 0 && (
+          <div className="flex items-center justify-center gap-1 text-green-600 text-sm font-medium mb-3">
+            <Gift className="w-4 h-4" />
+            <span>{t("pricing.pointPackages.bonusPoints", { count: pkg.bonusPoints })}</span>
+          </div>
+        )}
+        {pkg.bonusPoints === 0 && (
+          <div className="flex items-center justify-center gap-1 text-transparent text-sm font-medium mb-3">
+            <Gift className="w-4 h-4" />
+            <span>&nbsp;</span>
+          </div>
+        )}
+
+        {/* Price */}
+        <div className="bg-gray-50 rounded-lg p-3 mb-3">
+          <div className="text-2xl font-bold text-gray-900">
+            NT$ {pkg.price.toLocaleString()}
+          </div>
+          <div className="text-xs text-gray-500 mt-1">
+            {pkg.unitCost} {t("pricing.pointPackages.unitCost")}
+          </div>
+        </div>
+
+        {/* Discount Badge */}
+        {discountPercent > 0 && (
+          <div className="mb-3">
+            <Badge
+              variant="outline"
+              className="text-orange-600 border-orange-300"
+            >
+              {t("pricing.pointPackages.discount", { percent: discountPercent })}
+            </Badge>
+          </div>
+        )}
+
+        {/* Spacer to push button to bottom */}
+        <div className="flex-1" />
+
+        {/* Validity */}
+        <p className="text-xs text-gray-400 mb-4">{t("pricing.pointPackages.validity")}</p>
+
+        <Button
+          onClick={() => onSelect?.(pkg)}
+          disabled={disabled}
+          variant={pkg.bestValue ? "default" : "outline"}
+          className={`w-full ${
+            pkg.bestValue
+              ? "bg-green-600 hover:bg-green-700 text-white"
+              : ""
+          }`}
+        >
+          <ShoppingCart className="mr-2 h-4 w-4" />
+          {ctaText}
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/pricing/SubscriptionPlanCard.tsx
+++ b/frontend/src/components/pricing/SubscriptionPlanCard.tsx
@@ -1,0 +1,142 @@
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Check, CheckCircle, Star, Users, CreditCard } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+export interface SubscriptionPlan {
+  id: string;
+  name: string;
+  description: string;
+  monthlyPrice: number;
+  pointsPerMonth: number;
+  pointsLabel?: string; // override default "X 點/月" display
+  studentCapacity: string;
+  features: string[];
+  popular?: boolean;
+}
+
+interface SubscriptionPlanCardProps {
+  plan: SubscriptionPlan;
+  onSelect?: (plan: SubscriptionPlan) => void;
+  disabled?: boolean;
+  disabledText?: string;
+  ctaText: string;
+  isCurrent?: boolean;
+}
+
+export function SubscriptionPlanCard({
+  plan,
+  onSelect,
+  disabled,
+  disabledText,
+  ctaText,
+  isCurrent,
+}: SubscriptionPlanCardProps) {
+  const { t } = useTranslation();
+
+  const hasGradientBorder = isCurrent || (plan.popular && !isCurrent);
+
+  const cardClassName = [
+    "relative p-5 hover:shadow-xl transition-all duration-300 flex flex-col",
+    hasGradientBorder ? "border-2 border-transparent" : "",
+    plan.popular && !isCurrent ? "scale-105" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const blueGradient =
+    "linear-gradient(145deg, #101f6b, #204dc0, #5b8def, #204dc0, #101f6b)";
+  const goldGradient =
+    "linear-gradient(145deg, #b8860b, #daa520, #ffd700, #daa520, #b8860b)";
+
+  const cardStyle = isCurrent
+    ? {
+        backgroundImage: `linear-gradient(white, white), ${blueGradient}`,
+        backgroundOrigin: "border-box" as const,
+        backgroundClip: "padding-box, border-box",
+        boxShadow: "0 0 18px rgba(32,77,192,0.35)",
+      }
+    : plan.popular
+      ? {
+          backgroundImage: `linear-gradient(white, white), ${goldGradient}`,
+          backgroundOrigin: "border-box" as const,
+          backgroundClip: "padding-box, border-box",
+          boxShadow: "0 0 18px rgba(218,165,32,0.35)",
+        }
+      : undefined;
+
+  return (
+    <Card className={cardClassName} style={cardStyle}>
+      {isCurrent && (
+        <Badge
+          className="absolute -top-3 left-1/2 transform -translate-x-1/2 text-white"
+          style={{ backgroundColor: "#204dc0" }}
+        >
+          <CheckCircle className="w-3 h-3 mr-1" />
+          {t("pricing.actions.currentPlan")}
+        </Badge>
+      )}
+      {plan.popular && !isCurrent && (
+        <Badge className="absolute -top-3 left-1/2 transform -translate-x-1/2 bg-amber-500 text-white">
+          <Star className="w-3 h-3 mr-1" />
+          {t("pricing.card.popular")}
+        </Badge>
+      )}
+
+      <div className="text-center mb-4">
+        <h3 className="text-xl font-bold text-gray-900 mb-1">{plan.name}</h3>
+        <p className="text-sm text-gray-600">{plan.description}</p>
+        <div className="flex items-center justify-center mt-2 text-sm text-gray-500">
+          <Users className="w-4 h-4 mr-1.5" />
+          <span>{plan.studentCapacity}</span>
+        </div>
+      </div>
+
+      {/* Price Block */}
+      <div className="mb-5">
+        <div className="bg-blue-50 rounded-lg p-3">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-gray-600">{t("pricing.billing.monthly")}</span>
+            <div className="text-right">
+              <span className="text-2xl font-bold text-gray-900">
+                NT$ {plan.monthlyPrice}
+              </span>
+              <span className="text-gray-600 ml-1">{t("pricing.billing.perMonth")}</span>
+            </div>
+          </div>
+          <div className="mt-1 text-sm text-blue-700 font-medium">
+            {plan.pointsLabel || `${plan.pointsPerMonth.toLocaleString()} ${t("pricing.billing.pointsPerMonth")}`}
+          </div>
+        </div>
+      </div>
+
+      <ul className="space-y-2 mb-5">
+        {plan.features.map((feature, idx) => (
+          <li key={idx} className="flex items-start">
+            <Check className="w-5 h-5 text-green-500 mr-3 flex-shrink-0 mt-0.5" />
+            <span className="text-gray-700">{feature}</span>
+          </li>
+        ))}
+      </ul>
+
+      {/* Spacer to push button to bottom */}
+      <div className="flex-1" />
+
+      <Button
+        onClick={() => onSelect?.(plan)}
+        disabled={disabled}
+        className={`w-full ${
+          disabled
+            ? "bg-gray-300 cursor-not-allowed text-gray-500"
+            : plan.popular
+              ? "bg-amber-500 hover:bg-amber-600 text-white"
+              : "bg-gray-800 hover:bg-gray-900 text-white"
+        }`}
+      >
+        <CreditCard className="mr-2 h-4 w-4" />
+        {disabled ? disabledText : ctaText}
+      </Button>
+    </Card>
+  );
+}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -399,10 +399,90 @@
     "billing": {
       "monthly": "Monthly Plan",
       "perMonth": "/month",
+      "pointsPerMonth": "pts/mo",
       "description": "Monthly billing, flexible adjustments, upgrade or change your plan anytime"
+    },
+    "card": {
+      "popular": "Popular"
+    },
+    "tabs": {
+      "subscription": "Monthly Plans",
+      "pointPackages": "Point Packages"
+    },
+    "trialBanner": {
+      "title": "Get 2,000 Free AI Points on Sign Up"
+    },
+    "pointPackages": {
+      "description": "Purchase points on-demand. Buy more, save more! (Points valid for 1 year)",
+      "buy": "Buy",
+      "comingSoon": "Point package purchase coming soon",
+      "bestValue": "Best Value",
+      "points": "pts",
+      "bonusPoints": "+{{count, number}} bonus pts",
+      "unitCost": "NTD/pt",
+      "discount": "Save {{percent}}%",
+      "validity": "Valid for 1 year"
+    },
+    "plans": {
+      "free": {
+        "name": "Free Plan",
+        "description": "Try AI teaching features for free",
+        "studentCapacity": "Unlimited students",
+        "pointsLabel": "2,000 points (valid 1 year, until depleted)",
+        "features": {
+          "assignments": "Unlimited assignments",
+          "aiUntilDepleted": "AI grading available until points run out",
+          "semiAutoGrading": "Semi-auto grading for reading tasks (no points needed)"
+        }
+      },
+      "tutor": {
+        "name": "Tutor Teachers",
+        "description": "Small Tutoring ESL Teachers",
+        "studentCapacity": "Ideal for ~10 students",
+        "features": {
+          "assignments": "All Free Plan features",
+          "aiEvaluation": "AI lesson prep & grading",
+          "workshop": "Free online workshops"
+        }
+      },
+      "school": {
+        "name": "School Teachers",
+        "description": "Campus ESL Teachers",
+        "studentCapacity": "Ideal for ~30 students",
+        "features": {
+          "allTutor": "All Tutor Teacher features",
+          "report": "Student learning reports (coming soon)"
+        }
+      }
+    },
+    "fallback": {
+      "teacher": "Teacher",
+      "student": "Student {{id}}"
+    },
+    "faq": {
+      "title": "FAQ",
+      "q1": "Should I choose Tutor Teachers or School Teachers?",
+      "a1": "Tutor Teachers (NT$299/mo) is ideal for tutors with up to 30 students. School Teachers (NT$599/mo) is for school-based teachers with around 100 students. The School plan offers 33% lower per-point cost. We recommend upgrading when you have 30+ students.",
+      "q2": "How do new users get started?",
+      "a2": "New users enjoy an unlimited free trial with 2,000 AI points valid for one year. After upgrading, the remaining free points stay in your account until they expire.",
+      "q3": "What are points and how are they used?",
+      "a3": "Points are used for AI features: (1) AI analysis of student speaking recordings, (2) Fully automated AI assignment grading, (3) AI-assisted material conversion, (4) Student learning data analysis.",
+      "q4": "Do points expire?",
+      "a4": "Subscription points are valid for one month and reset at the start of each billing cycle. Purchased point packages are valid for one year.",
+      "q5": "What happens when subscription points run out?",
+      "a5": "When points are depleted, AI features become unavailable. You can purchase point packages or upgrade your plan.",
+      "q6": "How do I purchase additional points?",
+      "a6": "Point prices vary by volume: 1,000 pts = NT$180, 2,000 pts = NT$320, 5,000 pts = NT$700 (+200 bonus), 10,000 pts = NT$1,200 (+500 bonus), 20,000 pts = NT$2,000 (+800 bonus). The more you buy, the lower the unit price.",
+      "q7": "Does the subscription auto-renew?",
+      "a7": "Yes, subscriptions auto-renew every 30 days.",
+      "q8": "How do I cancel? What happens after cancellation?",
+      "a8": "You can cancel anytime in account settings. You won't be charged the following month. Remaining points can be used until they expire."
     },
     "actions": {
       "subscribe": "Subscribe Now",
+      "freeRegister": "Free Sign Up",
+      "currentPlan": "Current Plan",
+      "upgradePlan": "Upgrade Plan",
       "studentCannotSubscribe": "Students Cannot Subscribe",
       "loginRequired": "Please login to subscribe",
       "studentAccountWarning": "Student accounts cannot subscribe to teacher plans, please use a teacher account",
@@ -2817,7 +2897,10 @@
     "tabs": {
       "overview": "Overview",
       "analytics": "Usage Analytics",
-      "paymentHistory": "Payment History"
+      "paymentHistory": "Payment History",
+      "plans": "Plans",
+      "pointPackages": "Point Packages",
+      "management": "Subscription"
     },
     "status": {
       "success": "Success",
@@ -2853,7 +2936,8 @@
       "enableRenewal": "Enable Auto-Renewal",
       "goBack": "Go Back",
       "confirmCancel": "Confirm Cancellation",
-      "selectPlan": "Select This Plan"
+      "selectPlan": "Select This Plan",
+      "viewUsageDetail": "View Usage Details"
     },
     "messages": {
       "pleaseLogin": "Please log in with a teacher account",
@@ -2867,7 +2951,8 @@
       "reactivateSuccess": "Successfully reactivated auto-renewal",
       "reactivateFailed": "Failed to reactivate",
       "pleaseBindCard": "Please bind a credit card in 'Payment Method Management' below",
-      "pleaseBindCardIcon": "💳 Please bind a credit card in 'Payment Method Management' below"
+      "pleaseBindCardIcon": "💳 Please bind a credit card in 'Payment Method Management' below",
+      "usageDetailComingSoon": "Usage details feature coming soon"
     },
     "warnings": {
       "renewalCancelled": "⚠️ Auto-renewal cancelled. Your subscription will expire on {{date}}",
@@ -2898,6 +2983,22 @@
       "remainsValidUntil": "Subscription remains valid until {{date}}",
       "loseAccess": "You will lose access to premium features after expiry",
       "canReactivate": "You can reactivate auto-renewal anytime"
+    },
+    "usageDetail": {
+      "title": "Usage Details",
+      "description": "View your points consumption history",
+      "tabs": {
+        "summary": "Summary",
+        "students": "Top Students",
+        "assignments": "Top Assignments"
+      },
+      "totalQuota": "Total Quota",
+      "used": "Used",
+      "usageRate": "Usage Rate",
+      "remaining": "{{points}} pts remaining",
+      "dailyTrend": "Daily Usage Trend",
+      "pointsUsed": "Points Used",
+      "noData": "No usage data available"
     },
     "plans": {
       "title": "Choose Subscription Plan",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -399,10 +399,90 @@
     "billing": {
       "monthly": "月付方案",
       "perMonth": "/月",
+      "pointsPerMonth": "點/月",
       "description": "按月計費，彈性調整，隨時升級或調整您的方案"
+    },
+    "card": {
+      "popular": "熱門選擇"
+    },
+    "tabs": {
+      "subscription": "月訂閱方案",
+      "pointPackages": "點數包加購"
+    },
+    "trialBanner": {
+      "title": "註冊即享 2,000 免費 AI 點數"
+    },
+    "pointPackages": {
+      "description": "依需求彈性加購點數，購買越多越划算（點數效期 1 年）",
+      "buy": "購買",
+      "comingSoon": "點數包購買功能即將開放，敬請期待",
+      "bestValue": "最划算",
+      "points": "點",
+      "bonusPoints": "+{{count, number}} 點贈送",
+      "unitCost": "元/點",
+      "discount": "省 {{percent}}%",
+      "validity": "有效期限：1 年"
+    },
+    "plans": {
+      "free": {
+        "name": "免費方案",
+        "description": "免費體驗 AI 教學功能",
+        "studentCapacity": "不限學生人數",
+        "pointsLabel": "2,000 點（效期 1 年，用完為止）",
+        "features": {
+          "assignments": "無限制派發作業",
+          "aiUntilDepleted": "AI 批改功能用到點數用完為止",
+          "semiAutoGrading": "朗讀作業半自動批改（免點數）"
+        }
+      },
+      "tutor": {
+        "name": "Tutor Teachers",
+        "description": "小型家教 ESL 教師",
+        "studentCapacity": "適合約 10 位學生",
+        "features": {
+          "assignments": "免費方案全功能",
+          "aiEvaluation": "AI 備課與批改",
+          "workshop": "免費線上研習"
+        }
+      },
+      "school": {
+        "name": "School Teachers",
+        "description": "校園 ESL 教師",
+        "studentCapacity": "適合約 30 位學生",
+        "features": {
+          "allTutor": "Tutor 教師全功能",
+          "report": "學生學習報表（即將推出）"
+        }
+      }
+    },
+    "fallback": {
+      "teacher": "教師",
+      "student": "學生 {{id}}"
+    },
+    "faq": {
+      "title": "常見問題",
+      "q1": "我適合 Tutor Teachers 或 School Teachers 方案？",
+      "a1": "Tutor Teachers (NT$299/月) 適合學生人數在 30 人以內的家教教師；School Teachers (NT$599/月) 適合學生 100 人左右或任職於學校的教師。School Teachers 方案點數更多，點數成本平均優惠 33%，建議學生人數達 30 人以上時升級。",
+      "q2": "新用戶如何開始使用？",
+      "a2": "新用戶可享不限期免費試用，並獲得 AI 點數 2,000 點，期限為一年；升級後 2,000 點額度會保留在帳號中，直到到期。",
+      "q3": "點數是什麼？用途是什麼？",
+      "a3": "點數用於 AI 功能計費，包含：(1) 學生口說錄音作業 AI 分析，(2) 全自動 AI 作業批改，(3) AI 協作教材轉換，(4) 學生學習數據分析。",
+      "q4": "點數會過期嗎？",
+      "a4": "訂閱方案點數有效期限為一個月，每個月開始時重新計算。點數包購買點數使用期限為一年。",
+      "q5": "訂閱方案內的點數用完了怎麼辦？",
+      "a5": "點數用完後無法使用 AI 功能，可加購點數包補充或升級方案。",
+      "q6": "如何購買額外的點數？",
+      "a6": "點數價格依購買量級而定：1,000 點 = 180 元、2,000 點 = 320 元、5,000 點 = 700 元（+200 贈送）、10,000 點 = 1,200 元（+500 贈送）、20,000 點 = 2,000 元（+800 贈送）。購買量越多單價越便宜。",
+      "q7": "訂閱會自動續費嗎？",
+      "a7": "是的，訂閱自動續費。每 30 天扣款一次。",
+      "q8": "如何取消訂閱？取消後會怎樣？",
+      "a8": "可隨時透過帳戶設定取消訂閱，下個月將不再扣款。未使用完的點數於點數期限內可使用，直到到期歸零。"
     },
     "actions": {
       "subscribe": "立即訂閱",
+      "freeRegister": "免費註冊",
+      "currentPlan": "目前方案",
+      "upgradePlan": "升級方案",
       "studentCannotSubscribe": "學生無法訂閱",
       "loginRequired": "請先登入才能訂閱方案",
       "studentAccountWarning": "學生帳號無法訂閱教師方案，請使用教師帳號登入",
@@ -2818,7 +2898,10 @@
     "tabs": {
       "overview": "訂閱總覽",
       "analytics": "使用統計",
-      "paymentHistory": "付款歷史"
+      "paymentHistory": "付款歷史",
+      "plans": "方案",
+      "pointPackages": "點數包",
+      "management": "訂閱管理"
     },
     "status": {
       "success": "成功",
@@ -2854,7 +2937,8 @@
       "enableRenewal": "啟用續訂",
       "goBack": "返回",
       "confirmCancel": "確認取消",
-      "selectPlan": "選擇此方案"
+      "selectPlan": "選擇此方案",
+      "viewUsageDetail": "查看使用明細"
     },
     "messages": {
       "pleaseLogin": "請先登入教師帳號",
@@ -2868,7 +2952,8 @@
       "reactivateSuccess": "已重新啟用自動續訂",
       "reactivateFailed": "啟用失敗",
       "pleaseBindCard": "請先在下方「付款方式管理」綁定信用卡",
-      "pleaseBindCardIcon": "💳 請先在下方「付款方式管理」綁定信用卡"
+      "pleaseBindCardIcon": "💳 請先在下方「付款方式管理」綁定信用卡",
+      "usageDetailComingSoon": "點數使用明細功能即將開放"
     },
     "warnings": {
       "renewalCancelled": "⚠️ 您已取消自動續訂，訂閱將於 {{date}} 到期後失效",
@@ -2899,6 +2984,22 @@
       "remainsValidUntil": "訂閱繼續有效至 {{date}}",
       "loseAccess": "到期後將無法使用進階功能",
       "canReactivate": "您可以隨時重新啟用自動續訂"
+    },
+    "usageDetail": {
+      "title": "點數使用明細",
+      "description": "查看您的點數消耗紀錄",
+      "tabs": {
+        "summary": "摘要",
+        "students": "學生排行",
+        "assignments": "作業排行"
+      },
+      "totalQuota": "總配額",
+      "used": "已使用",
+      "usageRate": "使用率",
+      "remaining": "剩餘 {{points}} 點",
+      "dailyTrend": "每日使用趨勢",
+      "pointsUsed": "使用點數",
+      "noData": "暫無使用資料"
     },
     "plans": {
       "title": "選擇訂閱方案",

--- a/frontend/src/pages/teacher/TeacherSubscription.tsx
+++ b/frontend/src/pages/teacher/TeacherSubscription.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from "react-i18next";
 import {
   Card,
   CardContent,
-  CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
@@ -21,14 +20,14 @@ import {
 import {
   CreditCard,
   Calendar,
-  DollarSign,
   CheckCircle,
   XCircle,
-  Clock,
   RefreshCw,
   ArrowRight,
-  Gauge,
   TrendingUp,
+  Gauge,
+  Package,
+  Settings,
   Users,
   FileText,
 } from "lucide-react";
@@ -42,12 +41,21 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip as RechartsTooltip,
-  Legend,
   ResponsiveContainer,
 } from "recharts";
 import TeacherLayout from "@/components/TeacherLayout";
 import TapPayPayment from "@/components/payment/TapPayPayment";
 import { SubscriptionCardManagement } from "@/components/payment/SubscriptionCardManagement";
+import TeacherLoginModal from "@/components/TeacherLoginModal";
+import {
+  SubscriptionPlanCard,
+  type SubscriptionPlan,
+} from "@/components/pricing/SubscriptionPlanCard";
+import {
+  PointPackageCard,
+  type PointPackage,
+} from "@/components/pricing/PointPackageCard";
+import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
 import { apiClient } from "@/lib/api";
 
 interface SubscriptionInfo {
@@ -72,17 +80,6 @@ interface SavedCardInfo {
   } | null;
 }
 
-interface Transaction {
-  id: number;
-  type: string;
-  amount: number;
-  currency: string;
-  status: string;
-  months: number;
-  created_at: string;
-  subscription_type: string;
-}
-
 interface QuotaUsageAnalytics {
   summary: {
     total_used: number;
@@ -105,29 +102,132 @@ interface QuotaUsageAnalytics {
   feature_breakdown: Record<string, number>;
 }
 
+function getSubscriptionPlans(
+  t: (key: string) => string,
+): SubscriptionPlan[] {
+  return [
+    {
+      id: "free",
+      name: t("pricing.plans.free.name"),
+      description: t("pricing.plans.free.description"),
+      monthlyPrice: 0,
+      pointsPerMonth: 2000,
+      pointsLabel: t("pricing.plans.free.pointsLabel"),
+      studentCapacity: t("pricing.plans.free.studentCapacity"),
+      features: [
+        t("pricing.plans.free.features.assignments"),
+        t("pricing.plans.free.features.aiUntilDepleted"),
+        t("pricing.plans.free.features.semiAutoGrading"),
+      ],
+    },
+    {
+      id: "tutor",
+      name: t("pricing.plans.tutor.name"),
+      description: t("pricing.plans.tutor.description"),
+      monthlyPrice: 299,
+      pointsPerMonth: 2000,
+      studentCapacity: t("pricing.plans.tutor.studentCapacity"),
+      features: [
+        t("pricing.plans.tutor.features.assignments"),
+        t("pricing.plans.tutor.features.aiEvaluation"),
+        t("pricing.plans.tutor.features.workshop"),
+      ],
+    },
+    {
+      id: "school",
+      name: t("pricing.plans.school.name"),
+      description: t("pricing.plans.school.description"),
+      monthlyPrice: 599,
+      pointsPerMonth: 6000,
+      studentCapacity: t("pricing.plans.school.studentCapacity"),
+      features: [
+        t("pricing.plans.school.features.allTutor"),
+        t("pricing.plans.school.features.report"),
+      ],
+      popular: true,
+    },
+  ];
+}
+
+const pointPackages: PointPackage[] = [
+  {
+    id: "pkg-1000",
+    points: 1000,
+    price: 180,
+    bonusPoints: 0,
+    unitCost: 0.18,
+  },
+  {
+    id: "pkg-2000",
+    points: 2000,
+    price: 320,
+    bonusPoints: 0,
+    unitCost: 0.16,
+  },
+  {
+    id: "pkg-5000",
+    points: 5000,
+    price: 700,
+    bonusPoints: 200,
+    unitCost: 0.1346,
+  },
+  {
+    id: "pkg-10000",
+    points: 10000,
+    price: 1200,
+    bonusPoints: 500,
+    unitCost: 0.1143,
+  },
+  {
+    id: "pkg-20000",
+    points: 20000,
+    price: 2000,
+    bonusPoints: 800,
+    unitCost: 0.0962,
+    bestValue: true,
+  },
+];
+
+const BASE_UNIT_COST = 0.18;
+
 export default function TeacherSubscription() {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(true);
   const [subscription, setSubscription] = useState<SubscriptionInfo | null>(
     null,
   );
-  const [transactions, setTransactions] = useState<Transaction[]>([]);
-  const [analytics, setAnalytics] = useState<QuotaUsageAnalytics | null>(null);
-  const [analyticsLoading, setAnalyticsLoading] = useState(false);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
-  const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
-  const [selectedUpgradePlan, setSelectedUpgradePlan] = useState<{
-    name: string;
-    price: number;
-  } | null>(null);
+  const [showPaymentDialog, setShowPaymentDialog] = useState(false);
+  const [showUsageDetailDialog, setShowUsageDetailDialog] = useState(false);
+  const [selectedPlan, setSelectedPlan] = useState<SubscriptionPlan | null>(
+    null,
+  );
   const [savedCardInfo, setSavedCardInfo] = useState<SavedCardInfo | null>(
     null,
   );
+  const [analytics, setAnalytics] = useState<QuotaUsageAnalytics | null>(null);
+  const [analyticsLoading, setAnalyticsLoading] = useState(false);
+  const [showLoginModal, setShowLoginModal] = useState(false);
+
+  const { isAuthenticated } = useTeacherAuthStore();
+  const subscriptionPlans = getSubscriptionPlans(t);
+
+  // Determine current plan ID from subscription data
+  const getCurrentPlanId = (): string | null => {
+    if (!subscription || !subscription.is_active) return null;
+    const plan = subscription.plan;
+    if (!plan) return null;
+    if (plan === "30-Day Trial") return "free";
+    if (plan.toLowerCase().includes("tutor")) return "tutor";
+    if (plan.toLowerCase().includes("school")) return "school";
+    return "free";
+  };
+
+  const currentPlanId = getCurrentPlanId();
 
   useEffect(() => {
     fetchSubscriptionData();
 
-    // 🔴 PRD Rule 2: 監聽信用卡刪除事件，重新載入訂閱狀態（auto_renew 會被關閉）
     const handleSubscriptionChanged = () => {
       fetchSubscriptionData();
     };
@@ -149,7 +249,6 @@ export default function TeacherSubscription() {
     try {
       setLoading(true);
 
-      // 獲取訂閱狀態
       try {
         const subData = await apiClient.get<SubscriptionInfo>(
           "/api/subscription/status",
@@ -157,7 +256,6 @@ export default function TeacherSubscription() {
         setSubscription(subData);
       } catch (error) {
         console.error("Failed to fetch subscription:", error);
-        // If 401, user is not logged in - show appropriate message
         if (error && typeof error === "object" && "status" in error) {
           if (error.status === 401) {
             toast.error(t("teacherSubscription.messages.pleaseLogin"));
@@ -173,7 +271,6 @@ export default function TeacherSubscription() {
         }
       }
 
-      // 🔴 獲取綁卡狀態（用於判斷是否能啟用自動續訂）
       try {
         const cardData = await apiClient.get<SavedCardInfo>(
           "/api/payment/saved-card",
@@ -182,16 +279,6 @@ export default function TeacherSubscription() {
       } catch (error) {
         console.error("Failed to fetch card info:", error);
         setSavedCardInfo(null);
-      }
-
-      // 獲取付款歷史
-      try {
-        const txnData = await apiClient.get<{ transactions: Transaction[] }>(
-          "/api/payment/history",
-        );
-        setTransactions(txnData.transactions || []);
-      } catch (error) {
-        console.error("Failed to fetch transactions:", error);
       }
     } catch (error) {
       console.error("Failed to fetch subscription data:", error);
@@ -216,46 +303,40 @@ export default function TeacherSubscription() {
     }
   };
 
-  const handleUpgrade = () => {
-    setShowUpgradeDialog(true);
+  const handleOpenUsageDetail = () => {
+    setShowUsageDetailDialog(true);
+    if (!analytics) {
+      fetchAnalytics();
+    }
   };
 
-  // 計算首月比例付款金額
-  const calculateProratedAmount = (fullPrice: number): number => {
-    const now = new Date();
-    const currentYear = now.getFullYear();
-    const currentMonth = now.getMonth(); // 0-11
-
-    // 計算當月天數
-    const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate();
-
-    // 計算到月底的剩餘天數（包含今天）
-    const currentDay = now.getDate();
-    const remainingDays = daysInMonth - currentDay + 1;
-
-    // 按比例計算（四捨五入）
-    return Math.round(fullPrice * (remainingDays / daysInMonth));
+  const handleSelectPlan = (plan: SubscriptionPlan) => {
+    setSelectedPlan(plan);
+    setShowPaymentDialog(true);
   };
 
-  const handleSelectUpgradePlan = (planName: string, price: number) => {
-    // 計算首月比例金額
-    const proratedAmount = calculateProratedAmount(price);
-    setSelectedUpgradePlan({ name: planName, price: proratedAmount });
+  const handleSelectPointPackage = (_pkg: PointPackage) => {
+    toast.info(t("pricing.pointPackages.comingSoon"));
   };
 
-  const handleUpgradeSuccess = async (transactionId: string) => {
+  const handlePaymentSuccess = async (transactionId: string) => {
     toast.success(
       t("teacherSubscription.messages.subscriptionSuccess", { transactionId }),
     );
-    setShowUpgradeDialog(false);
-    setSelectedUpgradePlan(null);
+    setShowPaymentDialog(false);
+    setSelectedPlan(null);
     await fetchSubscriptionData();
   };
 
-  const handleUpgradeError = (error: string) => {
-    toast.error(
-      t("teacherSubscription.messages.subscriptionFailed", { error }),
-    );
+  const handlePaymentError = (error: string) => {
+    if (error.includes("免費優惠期間") || error.includes("未來將會開放儲值")) {
+      toast.info(error, { duration: 6000 });
+      setShowPaymentDialog(false);
+    } else {
+      toast.error(
+        t("teacherSubscription.messages.subscriptionFailed", { error }),
+      );
+    }
   };
 
   const handleCancelSubscription = async () => {
@@ -297,34 +378,6 @@ export default function TeacherSubscription() {
     });
   };
 
-  const getStatusBadge = (status: string) => {
-    switch (status) {
-      case "SUCCESS":
-        return (
-          <Badge className="bg-green-500">
-            <CheckCircle className="w-3 h-3 mr-1" />
-            {t("teacherSubscription.status.success")}
-          </Badge>
-        );
-      case "FAILED":
-        return (
-          <Badge variant="destructive">
-            <XCircle className="w-3 h-3 mr-1" />
-            {t("teacherSubscription.status.failed")}
-          </Badge>
-        );
-      case "PENDING":
-        return (
-          <Badge variant="secondary">
-            <Clock className="w-3 h-3 mr-1" />
-            {t("teacherSubscription.status.pending")}
-          </Badge>
-        );
-      default:
-        return <Badge variant="outline">{status}</Badge>;
-    }
-  };
-
   if (loading) {
     return (
       <div className="container mx-auto p-6">
@@ -337,7 +390,7 @@ export default function TeacherSubscription() {
 
   return (
     <TeacherLayout>
-      <div className="container mx-auto p-6 max-w-6xl">
+      <div>
         <div className="mb-6">
           <h1 className="text-3xl font-bold text-gray-900">
             {t("teacherSubscription.title")}
@@ -347,36 +400,113 @@ export default function TeacherSubscription() {
           </p>
         </div>
 
-        <Tabs defaultValue="overview" className="w-full">
+        <Tabs defaultValue="plans" className="w-full">
           <TabsList className="grid w-full grid-cols-3 mb-6 h-auto p-1 bg-gray-100">
             <TabsTrigger
-              value="overview"
-              className="flex items-center gap-2 py-3 text-base font-medium data-[state=active]:bg-white data-[state=active]:shadow-sm"
+              value="plans"
+              className="flex items-center gap-2 py-3 text-base font-medium text-gray-600 data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=active]:shadow-sm"
             >
               <CreditCard className="w-5 h-5" />
-              {t("teacherSubscription.tabs.overview")}
+              {t("teacherSubscription.tabs.plans")}
             </TabsTrigger>
             <TabsTrigger
-              value="analytics"
-              className="flex items-center gap-2 py-3 text-base font-medium data-[state=active]:bg-white data-[state=active]:shadow-sm"
-              onClick={() => {
-                if (!analytics) fetchAnalytics();
-              }}
+              value="pointPackages"
+              className="flex items-center gap-2 py-3 text-base font-medium text-gray-600 data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=active]:shadow-sm"
             >
-              <TrendingUp className="w-5 h-5" />
-              {t("teacherSubscription.tabs.analytics")}
+              <Package className="w-5 h-5" />
+              {t("teacherSubscription.tabs.pointPackages")}
             </TabsTrigger>
             <TabsTrigger
-              value="history"
-              className="flex items-center gap-2 py-3 text-base font-medium data-[state=active]:bg-white data-[state=active]:shadow-sm"
+              value="management"
+              className="flex items-center gap-2 py-3 text-base font-medium text-gray-600 data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=active]:shadow-sm"
             >
-              <DollarSign className="w-5 h-5" />
-              {t("teacherSubscription.tabs.paymentHistory")}
+              <Settings className="w-5 h-5" />
+              {t("teacherSubscription.tabs.management")}
             </TabsTrigger>
           </TabsList>
 
-          <TabsContent value="overview" className="space-y-6">
-            {/* 訂閱狀態卡片 */}
+          {/* Tab 1: Plans */}
+          <TabsContent value="plans">
+            <div>
+              <div className="grid md:grid-cols-3 gap-6">
+                {subscriptionPlans.map((plan) => {
+                  const isCurrentPlan = currentPlanId === plan.id;
+                  const planRank = { free: 0, tutor: 1, school: 2 };
+                  const currentRank = currentPlanId
+                    ? (planRank[currentPlanId as keyof typeof planRank] ?? -1)
+                    : -1;
+                  const thisRank =
+                    planRank[plan.id as keyof typeof planRank] ?? 0;
+
+                  let ctaText: string;
+                  let disabled = false;
+                  let onSelect: ((plan: SubscriptionPlan) => void) | undefined =
+                    handleSelectPlan;
+
+                  if (!isAuthenticated) {
+                    // Not logged in
+                    if (plan.id === "free") {
+                      ctaText = t("pricing.actions.freeRegister");
+                      onSelect = () => setShowLoginModal(true);
+                    } else {
+                      ctaText = t("pricing.actions.subscribe");
+                    }
+                  } else if (isCurrentPlan) {
+                    ctaText = t("pricing.actions.currentPlan");
+                    disabled = true;
+                  } else if (currentRank >= 0 && thisRank > currentRank) {
+                    ctaText = t("pricing.actions.upgradePlan");
+                  } else if (plan.id === "free") {
+                    // Logged in user viewing free plan (they have a higher plan)
+                    ctaText = t("pricing.actions.currentPlan");
+                    disabled = true;
+                    // If user is on a paid plan, free card just shows disabled
+                    if (currentRank > 0) {
+                      ctaText = t("pricing.plans.free.name");
+                      disabled = true;
+                    }
+                  } else {
+                    ctaText = t("pricing.actions.subscribe");
+                  }
+
+                  return (
+                    <SubscriptionPlanCard
+                      key={plan.id}
+                      plan={plan}
+                      onSelect={onSelect}
+                      disabled={disabled}
+                      disabledText={ctaText}
+                      ctaText={ctaText}
+                      isCurrent={isCurrentPlan}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          </TabsContent>
+
+          {/* Tab 2: Point Packages */}
+          <TabsContent value="pointPackages">
+            <div className="text-center mb-6">
+              <p className="text-gray-600">
+                {t("pricing.pointPackages.description")}
+              </p>
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+              {pointPackages.map((pkg) => (
+                <PointPackageCard
+                  key={pkg.id}
+                  pkg={pkg}
+                  onSelect={handleSelectPointPackage}
+                  ctaText={t("pricing.pointPackages.buy")}
+                  baseUnitCost={BASE_UNIT_COST}
+                />
+              ))}
+            </div>
+          </TabsContent>
+
+          {/* Tab 3: Subscription Management */}
+          <TabsContent value="management" className="space-y-6">
             <Card className="mb-6">
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
@@ -427,7 +557,12 @@ export default function TeacherSubscription() {
                       {subscription.plan === "30-Day Trial" && (
                         <div className="flex-shrink-0">
                           <Button
-                            onClick={handleUpgrade}
+                            onClick={() => {
+                              const tabsTrigger = document.querySelector(
+                                '[value="plans"]',
+                              ) as HTMLElement;
+                              tabsTrigger?.click();
+                            }}
                             className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white"
                           >
                             <TrendingUp className="w-4 h-4 mr-2" />
@@ -509,6 +644,15 @@ export default function TeacherSubscription() {
                             {(subscription.quota_total || 0).toLocaleString()}{" "}
                             {t("teacherSubscription.labels.points")}
                           </p>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            className="text-blue-600 hover:text-blue-700 h-auto px-0 py-1 text-xs"
+                            onClick={handleOpenUsageDetail}
+                          >
+                            {t("teacherSubscription.buttons.viewUsageDetail")}
+                            <ArrowRight className="w-3 h-3 ml-1" />
+                          </Button>
                         </div>
                       </div>
 
@@ -572,7 +716,6 @@ export default function TeacherSubscription() {
                       </div>
                     </div>
 
-                    {/* 取消續訂警告提示 */}
                     {!subscription.auto_renew && (
                       <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
                         <p className="text-orange-800 text-sm">
@@ -604,7 +747,14 @@ export default function TeacherSubscription() {
                     <p className="text-gray-600 mb-4">
                       {t("teacherSubscription.subscription.choosePlan")}
                     </p>
-                    <Button onClick={handleUpgrade}>
+                    <Button
+                      onClick={() => {
+                        const tabsTrigger = document.querySelector(
+                          '[value="plans"]',
+                        ) as HTMLElement;
+                        tabsTrigger?.click();
+                      }}
+                    >
                       {t("teacherSubscription.buttons.viewPlans")}
                       <ArrowRight className="w-4 h-4 ml-2" />
                     </Button>
@@ -613,229 +763,14 @@ export default function TeacherSubscription() {
               </CardContent>
             </Card>
 
-            {/* 💳 信用卡管理 */}
             <div data-card-management>
               <SubscriptionCardManagement />
             </div>
           </TabsContent>
-
-          <TabsContent value="analytics" className="space-y-6">
-            {analyticsLoading ? (
-              <div className="flex items-center justify-center h-64">
-                <RefreshCw className="w-8 h-8 animate-spin text-blue-600" />
-              </div>
-            ) : analytics ? (
-              <>
-                {/* 配額使用摘要 */}
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <Gauge className="w-5 h-5" />
-                      {t("teacherSubscription.analytics.quotaSummary")}
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                      <div className="text-center p-4 bg-blue-50 rounded-lg">
-                        <p className="text-sm text-gray-600 mb-1">
-                          {t("teacherSubscription.analytics.totalQuota")}
-                        </p>
-                        <p className="text-3xl font-bold text-blue-600">
-                          {analytics.summary.total_quota}
-                        </p>
-                        <p className="text-xs text-gray-500">
-                          {t("teacherSubscription.labels.points")}
-                        </p>
-                      </div>
-                      <div className="text-center p-4 bg-orange-50 rounded-lg">
-                        <p className="text-sm text-gray-600 mb-1">
-                          {t("teacherSubscription.analytics.used")}
-                        </p>
-                        <p className="text-3xl font-bold text-orange-600">
-                          {analytics.summary.total_used}
-                        </p>
-                        <p className="text-xs text-gray-500">
-                          {t("teacherSubscription.labels.points")}
-                        </p>
-                      </div>
-                      <div className="text-center p-4 bg-green-50 rounded-lg">
-                        <p className="text-sm text-gray-600 mb-1">
-                          {t("teacherSubscription.analytics.usageRate")}
-                        </p>
-                        <p className="text-3xl font-bold text-green-600">
-                          {analytics.summary.percentage}%
-                        </p>
-                        <p className="text-xs text-gray-500">
-                          {t("teacherSubscription.analytics.remaining", {
-                            points:
-                              analytics.summary.total_quota -
-                              analytics.summary.total_used,
-                          })}
-                        </p>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-
-                {/* 每日使用趨勢 */}
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <TrendingUp className="w-5 h-5" />
-                      {t("teacherSubscription.analytics.dailyTrend")}
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <LineChart data={analytics.daily_usage}>
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis dataKey="date" />
-                        <YAxis />
-                        <RechartsTooltip />
-                        <Legend />
-                        <Line
-                          type="monotone"
-                          dataKey="seconds"
-                          stroke="#3b82f6"
-                          name={t("teacherSubscription.analytics.usageSeconds")}
-                        />
-                      </LineChart>
-                    </ResponsiveContainer>
-                  </CardContent>
-                </Card>
-
-                {/* 學生使用排行 & 作業使用排行 */}
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                  <Card>
-                    <CardHeader>
-                      <CardTitle className="flex items-center gap-2">
-                        <Users className="w-5 h-5" />
-                        {t("teacherSubscription.analytics.topStudents")}
-                      </CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      <ResponsiveContainer width="100%" height={300}>
-                        <BarChart data={analytics.top_students}>
-                          <CartesianGrid strokeDasharray="3 3" />
-                          <XAxis dataKey="name" />
-                          <YAxis />
-                          <RechartsTooltip />
-                          <Bar
-                            dataKey="seconds"
-                            fill="#10b981"
-                            name={t(
-                              "teacherSubscription.analytics.usageSeconds",
-                            )}
-                          />
-                        </BarChart>
-                      </ResponsiveContainer>
-                    </CardContent>
-                  </Card>
-
-                  <Card>
-                    <CardHeader>
-                      <CardTitle className="flex items-center gap-2">
-                        <FileText className="w-5 h-5" />
-                        {t("teacherSubscription.analytics.topAssignments")}
-                      </CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      <ResponsiveContainer width="100%" height={300}>
-                        <BarChart data={analytics.top_assignments}>
-                          <CartesianGrid strokeDasharray="3 3" />
-                          <XAxis dataKey="title" />
-                          <YAxis />
-                          <RechartsTooltip />
-                          <Bar
-                            dataKey="seconds"
-                            fill="#f59e0b"
-                            name={t(
-                              "teacherSubscription.analytics.usageSeconds",
-                            )}
-                          />
-                        </BarChart>
-                      </ResponsiveContainer>
-                    </CardContent>
-                  </Card>
-                </div>
-              </>
-            ) : (
-              <div className="text-center py-12">
-                <TrendingUp className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                <p className="text-gray-600">
-                  {t("teacherSubscription.analytics.noData")}
-                </p>
-              </div>
-            )}
-          </TabsContent>
-
-          <TabsContent value="history">
-            {/* 付款歷史 */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <DollarSign className="w-5 h-5" />
-                  {t("teacherSubscription.history.title")}
-                </CardTitle>
-                <CardDescription>
-                  {t("teacherSubscription.history.description")}
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                {transactions.length === 0 ? (
-                  <div className="text-center py-8 text-gray-500">
-                    <DollarSign className="w-12 h-12 mx-auto mb-4 text-gray-300" />
-                    <p>{t("teacherSubscription.history.noTransactions")}</p>
-                  </div>
-                ) : (
-                  <div className="space-y-4">
-                    {transactions.map((txn) => (
-                      <div
-                        key={txn.id}
-                        className="flex flex-col sm:flex-row sm:items-center sm:justify-between p-4 border dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors gap-4"
-                      >
-                        <div className="flex items-start gap-4">
-                          <div className="w-10 h-10 bg-blue-100 dark:bg-blue-900 rounded-full flex items-center justify-center flex-shrink-0">
-                            <CreditCard className="w-5 h-5 text-blue-600 dark:text-blue-400" />
-                          </div>
-                          <div>
-                            <h4 className="font-semibold dark:text-gray-100">
-                              {txn.subscription_type}
-                            </h4>
-                            <p className="text-sm text-gray-600 dark:text-gray-300">
-                              {formatDate(txn.created_at)}
-                            </p>
-                            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                              {t(
-                                "teacherSubscription.history.subscriptionMonths",
-                                { months: txn.months },
-                              )}
-                            </p>
-                          </div>
-                        </div>
-
-                        <div className="flex items-center justify-between sm:justify-end gap-4">
-                          <div className="text-left sm:text-right">
-                            <p className="font-semibold text-lg dark:text-gray-100">
-                              {txn.currency} ${txn.amount}
-                            </p>
-                            <p className="text-xs text-gray-500 dark:text-gray-400">
-                              {txn.type}
-                            </p>
-                          </div>
-                          {getStatusBadge(txn.status)}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          </TabsContent>
         </Tabs>
       </div>
 
-      {/* 取消續訂確認對話框 */}
+      {/* Cancel Renewal Dialog */}
       <Dialog open={showCancelDialog} onOpenChange={setShowCancelDialog}>
         <DialogContent className="max-w-md">
           <DialogHeader>
@@ -894,162 +829,226 @@ export default function TeacherSubscription() {
         </DialogContent>
       </Dialog>
 
-      {/* 訂閱方案選擇對話框 */}
-      <Dialog open={showUpgradeDialog} onOpenChange={setShowUpgradeDialog}>
-        <DialogContent className="max-w-4xl">
-          <DialogHeader>
-            <DialogTitle>{t("teacherSubscription.plans.title")}</DialogTitle>
+      {/* Payment Dialog */}
+      <Dialog open={showPaymentDialog} onOpenChange={setShowPaymentDialog}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader className="sr-only">
+            <DialogTitle>{t("pricing.payment.title")}</DialogTitle>
             <DialogDescription>
-              {t("teacherSubscription.plans.description")}
+              {t("pricing.payment.selectedPlan", {
+                planName: selectedPlan?.name,
+              })}
             </DialogDescription>
           </DialogHeader>
 
-          {!selectedUpgradePlan ? (
-            <div className="grid md:grid-cols-2 gap-6 py-4">
-              {/* Tutor Teachers 方案 */}
-              <Card className="border-2 hover:border-blue-500 transition-colors">
-                <CardHeader>
-                  <CardTitle>Tutor Teachers</CardTitle>
-                  <CardDescription>
-                    {t("teacherSubscription.plans.tutorDescription")}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div>
-                    <div className="flex items-baseline gap-2">
-                      <span className="text-3xl font-bold">NT$ 330</span>
-                      <span className="text-gray-600">
-                        {t("teacherSubscription.plans.perMonth")}
-                      </span>
-                    </div>
-                    <div className="mt-2 p-2 bg-blue-50 rounded text-sm">
-                      <span className="text-blue-700">
-                        {t("teacherSubscription.plans.firstMonth", {
-                          amount: calculateProratedAmount(330),
-                        })}
-                      </span>
-                      <span className="text-gray-500 text-xs ml-1">
-                        {t("teacherSubscription.plans.prorated")}
-                      </span>
-                    </div>
-                  </div>
-                  <ul className="space-y-2 text-sm">
-                    <li className="flex items-start gap-2">
-                      <CheckCircle className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
-                      <span>
-                        {t("teacherSubscription.plans.tutorFeature1")}
-                      </span>
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <CheckCircle className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
-                      <span>
-                        {t("teacherSubscription.plans.tutorFeature2")}
-                      </span>
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <CheckCircle className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
-                      <span>
-                        {t("teacherSubscription.plans.tutorFeature3")}
-                      </span>
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <CheckCircle className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
-                      <span>
-                        {t("teacherSubscription.plans.tutorFeature4")}
-                      </span>
-                    </li>
-                  </ul>
-                  <Button
-                    onClick={() =>
-                      handleSelectUpgradePlan("Tutor Teachers", 330)
-                    }
-                    className="w-full"
-                  >
-                    {t("teacherSubscription.buttons.selectPlan")}
-                  </Button>
-                </CardContent>
-              </Card>
+          {selectedPlan && (
+            <TapPayPayment
+              amount={selectedPlan.monthlyPrice}
+              planName={selectedPlan.name}
+              onPaymentSuccess={handlePaymentSuccess}
+              onPaymentError={handlePaymentError}
+              onCancel={() => setShowPaymentDialog(false)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
 
-              {/* School Teachers 方案 */}
-              <Card className="border-2 border-blue-500 relative">
-                <div className="absolute -top-3 left-1/2 -translate-x-1/2">
-                  <Badge className="bg-blue-500">
-                    {t("teacherSubscription.plans.recommended")}
-                  </Badge>
-                </div>
-                <CardHeader>
-                  <CardTitle>School Teachers</CardTitle>
-                  <CardDescription>
-                    {t("teacherSubscription.plans.schoolDescription")}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div>
-                    <div className="flex items-baseline gap-2">
-                      <span className="text-3xl font-bold">NT$ 660</span>
-                      <span className="text-gray-600">
-                        {t("teacherSubscription.plans.perMonth")}
-                      </span>
-                    </div>
-                    <div className="mt-2 p-2 bg-blue-50 rounded text-sm">
-                      <span className="text-blue-700">
-                        {t("teacherSubscription.plans.firstMonth", {
-                          amount: calculateProratedAmount(660),
-                        })}
-                      </span>
-                      <span className="text-gray-500 text-xs ml-1">
-                        {t("teacherSubscription.plans.prorated")}
-                      </span>
-                    </div>
-                  </div>
-                  <ul className="space-y-2 text-sm">
-                    <li className="flex items-start gap-2">
-                      <CheckCircle className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
-                      <span>
-                        {t("teacherSubscription.plans.schoolFeature1")}
-                      </span>
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <CheckCircle className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
-                      <span>
-                        {t("teacherSubscription.plans.schoolFeature2")}
-                      </span>
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <CheckCircle className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
-                      <span>
-                        {t("teacherSubscription.plans.schoolFeature3")}
-                      </span>
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <CheckCircle className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
-                      <span>
-                        {t("teacherSubscription.plans.schoolFeature4")}
-                      </span>
-                    </li>
-                  </ul>
-                  <Button
-                    onClick={() =>
-                      handleSelectUpgradePlan("School Teachers", 660)
-                    }
-                    className="w-full"
-                  >
-                    {t("teacherSubscription.buttons.selectPlan")}
-                  </Button>
-                </CardContent>
-              </Card>
+      {/* Login / Register Modal */}
+      <TeacherLoginModal
+        isOpen={showLoginModal}
+        onClose={() => setShowLoginModal(false)}
+        onLoginSuccess={() => {
+          setShowLoginModal(false);
+          fetchSubscriptionData();
+        }}
+      />
+
+      {/* Usage Detail Dialog */}
+      <Dialog
+        open={showUsageDetailDialog}
+        onOpenChange={setShowUsageDetailDialog}
+      >
+        <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>
+              {t("teacherSubscription.usageDetail.title")}
+            </DialogTitle>
+            <DialogDescription>
+              {t("teacherSubscription.usageDetail.description")}
+            </DialogDescription>
+          </DialogHeader>
+
+          {analyticsLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <RefreshCw className="w-8 h-8 animate-spin text-blue-600" />
             </div>
+          ) : analytics ? (
+            <Tabs defaultValue="summary" className="w-full">
+              <TabsList className="grid w-full grid-cols-3 h-auto p-1">
+                <TabsTrigger
+                  value="summary"
+                  className="text-sm py-2"
+                >
+                  <Gauge className="w-4 h-4 mr-1.5" />
+                  {t("teacherSubscription.usageDetail.tabs.summary")}
+                </TabsTrigger>
+                <TabsTrigger
+                  value="students"
+                  className="text-sm py-2"
+                >
+                  <Users className="w-4 h-4 mr-1.5" />
+                  {t("teacherSubscription.usageDetail.tabs.students")}
+                </TabsTrigger>
+                <TabsTrigger
+                  value="assignments"
+                  className="text-sm py-2"
+                >
+                  <FileText className="w-4 h-4 mr-1.5" />
+                  {t("teacherSubscription.usageDetail.tabs.assignments")}
+                </TabsTrigger>
+              </TabsList>
+
+              {/* Summary Tab */}
+              <TabsContent value="summary" className="space-y-4 mt-4">
+                <div className="grid grid-cols-3 gap-3">
+                  <div className="text-center p-3 bg-blue-50 rounded-lg">
+                    <p className="text-xs text-gray-600 mb-1">
+                      {t("teacherSubscription.usageDetail.totalQuota")}
+                    </p>
+                    <p className="text-2xl font-bold text-blue-600">
+                      {analytics.summary.total_quota.toLocaleString()}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {t("teacherSubscription.labels.points")}
+                    </p>
+                  </div>
+                  <div className="text-center p-3 bg-orange-50 rounded-lg">
+                    <p className="text-xs text-gray-600 mb-1">
+                      {t("teacherSubscription.usageDetail.used")}
+                    </p>
+                    <p className="text-2xl font-bold text-orange-600">
+                      {analytics.summary.total_used.toLocaleString()}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {t("teacherSubscription.labels.points")}
+                    </p>
+                  </div>
+                  <div className="text-center p-3 bg-green-50 rounded-lg">
+                    <p className="text-xs text-gray-600 mb-1">
+                      {t("teacherSubscription.usageDetail.usageRate")}
+                    </p>
+                    <p className="text-2xl font-bold text-green-600">
+                      {analytics.summary.percentage}%
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {t("teacherSubscription.usageDetail.remaining", {
+                        points:
+                          analytics.summary.total_quota -
+                          analytics.summary.total_used,
+                      })}
+                    </p>
+                  </div>
+                </div>
+
+                {analytics.daily_usage.length > 0 ? (
+                  <div>
+                    <h4 className="text-sm font-medium text-gray-700 mb-2">
+                      {t("teacherSubscription.usageDetail.dailyTrend")}
+                    </h4>
+                    <ResponsiveContainer width="100%" height={220}>
+                      <LineChart data={analytics.daily_usage}>
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+                        <YAxis tick={{ fontSize: 11 }} />
+                        <RechartsTooltip />
+                        <Line
+                          type="monotone"
+                          dataKey="seconds"
+                          stroke="#3b82f6"
+                          name={t("teacherSubscription.usageDetail.pointsUsed")}
+                          strokeWidth={2}
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  </div>
+                ) : (
+                  <div className="text-center py-6 text-gray-400 text-sm">
+                    {t("teacherSubscription.usageDetail.noData")}
+                  </div>
+                )}
+              </TabsContent>
+
+              {/* Students Tab */}
+              <TabsContent value="students" className="mt-4">
+                {analytics.top_students.length > 0 ? (
+                  <div>
+                    <ResponsiveContainer width="100%" height={300}>
+                      <BarChart data={analytics.top_students} layout="vertical">
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis type="number" tick={{ fontSize: 11 }} />
+                        <YAxis
+                          dataKey="name"
+                          type="category"
+                          width={80}
+                          tick={{ fontSize: 11 }}
+                        />
+                        <RechartsTooltip />
+                        <Bar
+                          dataKey="seconds"
+                          fill="#10b981"
+                          name={t("teacherSubscription.usageDetail.pointsUsed")}
+                          radius={[0, 4, 4, 0]}
+                        />
+                      </BarChart>
+                    </ResponsiveContainer>
+                  </div>
+                ) : (
+                  <div className="text-center py-12 text-gray-400 text-sm">
+                    <Users className="w-10 h-10 mx-auto mb-3 text-gray-300" />
+                    {t("teacherSubscription.usageDetail.noData")}
+                  </div>
+                )}
+              </TabsContent>
+
+              {/* Assignments Tab */}
+              <TabsContent value="assignments" className="mt-4">
+                {analytics.top_assignments.length > 0 ? (
+                  <div>
+                    <ResponsiveContainer width="100%" height={300}>
+                      <BarChart
+                        data={analytics.top_assignments}
+                        layout="vertical"
+                      >
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis type="number" tick={{ fontSize: 11 }} />
+                        <YAxis
+                          dataKey="title"
+                          type="category"
+                          width={100}
+                          tick={{ fontSize: 11 }}
+                        />
+                        <RechartsTooltip />
+                        <Bar
+                          dataKey="seconds"
+                          fill="#f59e0b"
+                          name={t("teacherSubscription.usageDetail.pointsUsed")}
+                          radius={[0, 4, 4, 0]}
+                        />
+                      </BarChart>
+                    </ResponsiveContainer>
+                  </div>
+                ) : (
+                  <div className="text-center py-12 text-gray-400 text-sm">
+                    <FileText className="w-10 h-10 mx-auto mb-3 text-gray-300" />
+                    {t("teacherSubscription.usageDetail.noData")}
+                  </div>
+                )}
+              </TabsContent>
+            </Tabs>
           ) : (
-            <div className="py-4">
-              <TapPayPayment
-                planName={selectedUpgradePlan.name}
-                amount={selectedUpgradePlan.price}
-                onPaymentSuccess={handleUpgradeSuccess}
-                onPaymentError={handleUpgradeError}
-                onCancel={() => {
-                  setSelectedUpgradePlan(null);
-                }}
-              />
+            <div className="py-8 text-center text-gray-500">
+              <Gauge className="w-12 h-12 mx-auto mb-4 text-gray-300" />
+              <p>{t("teacherSubscription.usageDetail.noData")}</p>
             </div>
           )}
         </DialogContent>


### PR DESCRIPTION
## Summary
- Redesign TeacherSubscription page with new 3-tab layout
- Add shared `SubscriptionPlanCard` component
- Update i18n translations for subscription page

Closes #297

## Test plan
- [ ] Verify 3-tab layout renders correctly
- [ ] Check tab switching behavior
- [ ] Verify subscription plan cards display correct info
- [ ] Test responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)