### PR TITLE
chore: update repo owner from Youngger9765 to myduotopia

### DIFF
--- a/.claude/agents/cicd-monitor.md
+++ b/.claude/agents/cicd-monitor.md
@@ -362,7 +362,7 @@ Final Results (285s total):
   ✅ Backend Tests - PASSED (180s)
   ✅ Frontend Build - PASSED (220s)
 
-🚀 PR is ready for review: https://github.com/Youngger9765/duotopia/pull/55
+🚀 PR is ready for review: https://github.com/myduotopia/duotopia/pull/55
 ```
 
 ### Example 2: Handling Failures (Checkpoint 2)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,7 +117,7 @@ repos:
 
       # Flake8 Linting（Python）
       # TODO: Fix pre-existing F401,E402,F821,E722,F403,F405 errors and remove from ignore list
-      # See: https://github.com/Youngger9765/duotopia/issues/112#issuecomment-sync-migration
+      # See: https://github.com/myduotopia/duotopia/issues/112#issuecomment-sync-migration
       - id: flake8-check
         name: Flake8 linting
         entry: bash -c 'cd backend && flake8 . --max-line-length=120 --ignore=E203,W503,F401,E402,F821,E722,F403,F405,E501 --exclude=alembic,__pycache__,.venv,scripts,seed_data || exit 1'

--- a/backend/issue-112-QA.md
+++ b/backend/issue-112-QA.md
@@ -1108,7 +1108,7 @@ organization_info = OrganizationInfo(
 
 **Branch:** `feat/issue-112-org-hierarchy`
 **Deployment:** In progress
-**GitHub Actions:** https://github.com/Youngger9765/duotopia/actions/runs/20621774420
+**GitHub Actions:** https://github.com/myduotopia/duotopia/actions/runs/20621774420
 
 #### Verification Plan
 

--- a/docs/DEVELOP_ENVIRONMENT_SAFETY_CHECK.md
+++ b/docs/DEVELOP_ENVIRONMENT_SAFETY_CHECK.md
@@ -158,13 +158,13 @@ TAPPAY_*                      # ✅ 付款服務（staging/develop 都用 produc
 ### 測試 1: 驗證服務名稱
 ```bash
 # 預期結果：三個環境的服務完全獨立
-gh secret get PRODUCTION_BACKEND_SERVICE --repo Youngger9765/duotopia
+gh secret get PRODUCTION_BACKEND_SERVICE --repo myduotopia/duotopia
 # → duotopia-backend
 
-gh secret get STAGING_BACKEND_SERVICE --repo Youngger9765/duotopia
+gh secret get STAGING_BACKEND_SERVICE --repo myduotopia/duotopia
 # → duotopia-backend-staging
 
-gh secret get DEVELOP_BACKEND_SERVICE --repo Youngger9765/duotopia
+gh secret get DEVELOP_BACKEND_SERVICE --repo myduotopia/duotopia
 # → duotopia-backend-develop
 ```
 

--- a/docs/DEVELOP_ENVIRONMENT_SETUP_GUIDE.md
+++ b/docs/DEVELOP_ENVIRONMENT_SETUP_GUIDE.md
@@ -79,7 +79,7 @@ git push origin develop
 監控部署狀態：
 ```bash
 # 在瀏覽器中查看
-open https://github.com/Youngger9765/duotopia/actions
+open https://github.com/myduotopia/duotopia/actions
 
 # 或使用 CLI
 gh run list --branch develop
@@ -106,8 +106,8 @@ echo "Backend URL:  $BACKEND_URL"
 echo "Frontend URL: $FRONTEND_URL"
 
 # 更新 GitHub Secrets
-gh secret set DEVELOP_BACKEND_URL --body "$BACKEND_URL" --repo Youngger9765/duotopia
-gh secret set DEVELOP_FRONTEND_URL --body "$FRONTEND_URL" --repo Youngger9765/duotopia
+gh secret set DEVELOP_BACKEND_URL --body "$BACKEND_URL" --repo myduotopia/duotopia
+gh secret set DEVELOP_FRONTEND_URL --body "$FRONTEND_URL" --repo myduotopia/duotopia
 ```
 
 ### 步驟 6: 驗證部署
@@ -237,13 +237,13 @@ gcloud artifacts docker images list \
   --quiet
 
 # 3. 刪除 GitHub Secrets（可選）
-gh secret delete DEVELOP_BACKEND_SERVICE --repo Youngger9765/duotopia
-gh secret delete DEVELOP_FRONTEND_SERVICE --repo Youngger9765/duotopia
-gh secret delete DEVELOP_BACKEND_URL --repo Youngger9765/duotopia
-gh secret delete DEVELOP_FRONTEND_URL --repo Youngger9765/duotopia
-gh secret delete DEVELOP_JWT_SECRET --repo Youngger9765/duotopia
-gh secret delete DEVELOP_CRON_SECRET --repo Youngger9765/duotopia
-gh secret delete DEVELOP_ENABLE_PAYMENT --repo Youngger9765/duotopia
+gh secret delete DEVELOP_BACKEND_SERVICE --repo myduotopia/duotopia
+gh secret delete DEVELOP_FRONTEND_SERVICE --repo myduotopia/duotopia
+gh secret delete DEVELOP_BACKEND_URL --repo myduotopia/duotopia
+gh secret delete DEVELOP_FRONTEND_URL --repo myduotopia/duotopia
+gh secret delete DEVELOP_JWT_SECRET --repo myduotopia/duotopia
+gh secret delete DEVELOP_CRON_SECRET --repo myduotopia/duotopia
+gh secret delete DEVELOP_ENABLE_PAYMENT --repo myduotopia/duotopia
 
 # 4. 刪除 develop branch（可選）
 git branch -d develop

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -18,7 +18,7 @@
    backend/.env.staging
 
    # GitHub Secrets
-   https://github.com/Youngger9765/duotopia/settings/secrets/actions
+   https://github.com/myduotopia/duotopia/settings/secrets/actions
    ```
 
 3. **Verify no active breaches**

--- a/frontend/tests/e2e/issue-28-assignment-navigation.spec.ts
+++ b/frontend/tests/e2e/issue-28-assignment-navigation.spec.ts
@@ -6,7 +6,7 @@
  * 2. Submit button in assignment work page → Navigate to assignment list
  * 3. No navigation to assignment detail/confirmation page
  *
- * @see https://github.com/Youngger9765/duotopia/issues/28
+ * @see https://github.com/myduotopia/duotopia/issues/28
  */
 
 import { test, expect } from '@playwright/test';

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -19,7 +19,7 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$BRANCH" == "staging" ]] || [[ "$BRANCH" == "main" ]]; then
     echo "🚀 Deployment triggered for $BRANCH"
     echo "📊 Monitor with: npm run monitor:$BRANCH"
-    echo "🔗 View at: https://github.com/Youngger9765/duotopia/actions"
+    echo "🔗 View at: https://github.com/myduotopia/duotopia/actions"
 
     # Optional: Auto-start monitor (uncomment if desired)
     # (sleep 5 && npm run monitor:$BRANCH 2>/dev/null) &

--- a/scripts/manage-secrets.sh
+++ b/scripts/manage-secrets.sh
@@ -110,7 +110,7 @@ check_git_history() {
 # Function to update GitHub secrets
 update_github_secrets() {
     echo -e "${BLUE}Instructions to update GitHub secrets:${NC}"
-    echo "1. Go to: https://github.com/Youngger9765/duotopia/settings/secrets/actions"
+    echo "1. Go to: https://github.com/myduotopia/duotopia/settings/secrets/actions"
     echo "2. Update the following secrets:"
     echo "   - STAGING_DATABASE_URL"
     echo "   - STAGING_JWT_SECRET"

--- a/scripts/setup_develop_secrets.sh
+++ b/scripts/setup_develop_secrets.sh
@@ -4,7 +4,7 @@
 
 set -e  # Exit on error
 
-REPO="Youngger9765/duotopia"
+REPO="myduotopia/duotopia"
 
 echo "=========================================="
 echo "🔧 Develop Environment Secrets Setup"

--- a/scripts/update_develop_urls.sh
+++ b/scripts/update_develop_urls.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-REPO="Youngger9765/duotopia"
+REPO="myduotopia/duotopia"
 REGION="asia-east1"
 
 echo "=========================================="


### PR DESCRIPTION
## Summary
- Repo ownership transferred from `Youngger9765` to `myduotopia`
- Updated all GitHub URL references and script `REPO` variables across 11 files
- No functional code changes — only URLs, comments, and documentation

## Changed files
- `scripts/setup_develop_secrets.sh` — REPO variable
- `scripts/update_develop_urls.sh` — REPO variable
- `scripts/manage-secrets.sh` — GitHub URL
- `scripts/install-hooks.sh` — GitHub URL
- `docs/SECURITY.md` — GitHub URL
- `docs/DEVELOP_ENVIRONMENT_SETUP_GUIDE.md` — GitHub URLs (9 places)
- `docs/DEVELOP_ENVIRONMENT_SAFETY_CHECK.md` — GitHub URLs (3 places)
- `.pre-commit-config.yaml` — comment URL
- `frontend/tests/e2e/issue-28-assignment-navigation.spec.ts` — comment URL
- `backend/issue-112-QA.md` — record URL
- `.claude/agents/cicd-monitor.md` — example URL

## Test plan
- [x] `grep -r Youngger9765` returns 0 matches
- [ ] CI passes (no functional changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)