### PR TITLE
hotfix: cherry-pick migration 20260225_1000 to fix staging Alembic

### DIFF
--- a/backend/alembic/versions/20260225_1000_rename_trial_plan_to_free_trial.py
+++ b/backend/alembic/versions/20260225_1000_rename_trial_plan_to_free_trial.py
@@ -1,0 +1,36 @@
+"""Rename 30-Day Trial plan to Free Trial
+
+Revision ID: 20260225_1000
+Revises: 20260206_1000
+Create Date: 2026-02-25 10:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260225_1000"
+down_revision = "20260206_1000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Rename "30-Day Trial" to "Free Trial" in subscription_periods (idempotent)
+    op.execute(
+        """
+        UPDATE subscription_periods
+        SET plan_name = 'Free Trial'
+        WHERE plan_name = '30-Day Trial'
+    """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE subscription_periods
+        SET plan_name = '30-Day Trial'
+        WHERE plan_name = 'Free Trial'
+    """
+    )


### PR DESCRIPTION
## Summary
- Cherry-pick `20260225_1000_rename_trial_plan_to_free_trial.py` migration from `fix/issue-228-teacher-credits-plan` branch
- This migration was applied to staging DB during a per-issue deployment, but the file only exists on the issue-228 branch
- Without this file in staging, **all other branches** fail with: `Can't locate revision identified by '20260225_1000'`

## Root Cause
Per-issue 環境部署時共用 staging DB 跑 Alembic migration，導致 staging DB 的 `alembic_version` 被更新到 `20260225_1000`，但這個 migration 檔案不在 staging branch 上。

## Impact
- Fixes CI failures for all PRs that deploy backend (including #343)
- No schema changes - this migration only renames a plan name string

## Test plan
- [ ] CI passes
- [ ] Other PRs can successfully run Alembic migrations after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)