### PR TITLE
hotfix: add student_identities to RLS exclusion list

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -311,6 +311,7 @@ jobs:
               'organization_points_log',
               'program_copy_logs',
               'demo_config',
+              'student_identities',
               -- n8n 系統表（外部服務，不適用 RLS）
               'annotation_tag_entity', 'auth_identity', 'auth_provider_sync_history', 'binary_data',
               'chat_hub_agents', 'chat_hub_messages', 'chat_hub_sessions', 'credentials_entity',


### PR DESCRIPTION
## Summary

- Add `student_identities` table to the RLS exclusion list in `deploy-backend.yml`
- Fixes the staging deploy failure from PR #357 merge

## Context

Staging deploy failed at the RLS verification step because `student_identities` (created by migration `20260225_1600`) was not in the exclusion list. Since Duotopia uses JWT auth (not Supabase Auth), all business tables are excluded from the RLS check.

```
❌ ERROR: The following tables do not have RLS enabled:
   - student_identities
```

Related to #349

## Test plan

- [ ] Staging deploy passes the RLS verification step
- [ ] `student_identities` is excluded alongside other business tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)