### PR TITLE
feat(#333): toolbar 新增「分享給學生」按鈕

### DIFF
--- a/frontend/src/components/teachingTools/DigitalTeachingToolbar.tsx
+++ b/frontend/src/components/teachingTools/DigitalTeachingToolbar.tsx
@@ -806,9 +806,7 @@ const DigitalTeachingToolbar: React.FC = () => {
       <Dialog open={showShareDialog} onOpenChange={setShowShareDialog}>
         <DialogContent className="sm:max-w-md pointer-events-auto">
           <DialogHeader>
-            <DialogTitle>
-              {t("teacherDashboard.share.title")}
-            </DialogTitle>
+            <DialogTitle>{t("teacherDashboard.share.title")}</DialogTitle>
             <DialogDescription>
               {t("teacherDashboard.share.description")}
             </DialogDescription>
@@ -818,11 +816,7 @@ const DigitalTeachingToolbar: React.FC = () => {
               <QRCodeSVG value={getStudentLoginUrl()} size={200} />
             </div>
             <div className="flex items-center space-x-2">
-              <Input
-                value={getStudentLoginUrl()}
-                readOnly
-                className="flex-1"
-              />
+              <Input value={getStudentLoginUrl()} readOnly className="flex-1" />
               <Button
                 size="sm"
                 onClick={handleCopyUrl}


### PR DESCRIPTION
## Summary
- Toolbar 新增「分享給學生」按鈕，功能與 dashboard 的分享按鈕相同

Closes #333

## Test plan
- [ ] 確認 toolbar 上出現「分享給學生」按鈕
- [ ] 點擊按鈕後功能與 dashboard 分享按鈕一致
- [ ] CI 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)