### PR TITLE
fix(#347): 切換 workspace mode 時自動導向 dashboard

### DIFF
--- a/frontend/src/components/TeacherLayout.tsx
+++ b/frontend/src/components/TeacherLayout.tsx
@@ -79,6 +79,15 @@ function TeacherLayoutInner({
   // Get workspace context
   const { mode, selectedSchool } = useWorkspace();
 
+  // ✅ 切換 workspace mode 時，自動導向 dashboard（避免殘留前一模式的頁面）
+  const prevModeRef = useRef(mode);
+  useEffect(() => {
+    if (prevModeRef.current !== mode) {
+      prevModeRef.current = mode;
+      navigate("/teacher/dashboard");
+    }
+  }, [mode, navigate]);
+
   // Check if user has organization management role
   const hasOrgRole = useMemo(() => {
     const managementRoles = [


### PR DESCRIPTION
## Summary
- 修正從個人教師視圖切換到機構教師視圖時，右側內容殘留前一模式頁面的問題
- 在 `TeacherLayoutInner` 新增 `useEffect` 監聽 `mode` 變化，自動導向 `/teacher/dashboard`
- 使用 `useRef` 記錄前一次 mode，避免初次載入時觸發不必要的跳轉

Fixes #347

## Test plan
- [ ] 個人模式 → 切換機構模式 → 應自動跳轉到 `/teacher/dashboard`
- [ ] 機構模式 → 切換個人模式 → 應自動跳轉到 `/teacher/dashboard`
- [ ] 初次載入（任一模式）→ 不應有非預期的跳轉
- [ ] 同模式內導航 → 不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)