### PR TITLE
fix(#353): backfill distractors for existing word_selection assignments

### DIFF
--- a/backend/alembic/versions/20260302_1000_backfill_word_selection_distractors.py
+++ b/backend/alembic/versions/20260302_1000_backfill_word_selection_distractors.py
@@ -41,6 +41,8 @@ def upgrade() -> None:
             JOIN word_selection_contents wsc ON wsc.content_id = ci.content_id
             WHERE ci.translation IS NOT NULL
               AND ci.translation != ''
+              -- NULL: never set; '[]': empty array;
+              -- 'null': JSON null keyword; '"null"': JSONB-serialised string
               AND (
                   ci.distractors IS NULL
                   OR ci.distractors::text = '[]'


### PR DESCRIPTION
## Summary

- 一次性 data migration：為所有 `word_selection` 類型的作業補齊缺失的干擾項
- 從同 content 的其他單字翻譯中隨機取最多 3 個作為干擾項
- 處理 `NULL`、`[]`（空 array）、`"null"`（字串）三種情況

## Migration 邏輯

1. 找到所有 `practice_mode = 'word_selection'` 的 assignments
2. 透過 `assignment_contents` 找到對應的 content copies
3. 篩選需要補干擾項的 `content_items`（distractors 為 NULL / 空 / "null"）
4. 從同 content 其他 items 的 translation 隨機取 3 個填入

## 注意事項

- **Idempotent**：只更新缺失的干擾項，已有干擾項的 items 不受影響
- **先 merge 這個 PR**，再 merge PR #371，避免 migration revision 衝突
- merge 後其他 feature branches 需要 rebase staging 同步 migration

## Test plan

- [ ] Staging deploy 後確認 word_selection 作業的干擾項已補齊
- [ ] 確認已有干擾項的 items 不受影響
- [ ] Production deploy 後確認同樣效果

Related to #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)