### PR TITLE
feat(#255): add is_instant_practice flag to assignments

### DIFF
--- a/backend/alembic/versions/20260309_1000_add_instant_practice_flag.py
+++ b/backend/alembic/versions/20260309_1000_add_instant_practice_flag.py
@@ -1,0 +1,48 @@
+"""Add is_instant_practice flag to assignments
+
+Revision ID: 20260309_1000
+Revises: 20260306_1200
+Create Date: 2026-03-09 10:00:00.000000
+
+Adds is_instant_practice boolean flag to assignments table.
+Instant practice assignments are temporary, created when teachers
+use the "instant practice" feature to self-practice content without
+assigning to students. Lazy cleanup: old instant practice assignments
+are deleted when a new one is created.
+
+Related: #255
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260309_1000"
+down_revision = "20260306_1200"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add is_instant_practice column (idempotent)
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                          WHERE table_schema = 'public' AND table_name = 'assignments' AND column_name = 'is_instant_practice') THEN
+                ALTER TABLE assignments ADD COLUMN is_instant_practice BOOLEAN NOT NULL DEFAULT FALSE;
+            END IF;
+        END $$;
+    """
+    )
+
+    # Add index for filtering out instant practice assignments in list queries (idempotent)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_assignments_not_instant_practice"
+        " ON assignments (teacher_id, classroom_id)"
+        " WHERE is_instant_practice = FALSE"
+    )
+
+
+def downgrade() -> None:
+    # No-op: follows idempotent-only migration approach (see CLAUDE.md)
+    pass

--- a/backend/models/assignment.py
+++ b/backend/models/assignment.py
@@ -85,6 +85,9 @@ class Assignment(Base):
     is_archived = Column(Boolean, default=False)
     archived_at = Column(DateTime(timezone=True), nullable=True)
 
+    # 即刻練習標記（暫時資料，懶清理：建立新的時刪除舊的）
+    is_instant_practice = Column(Boolean, default=False)
+
     # Relationships
     classroom = relationship("Classroom", back_populates="assignments")
     teacher = relationship("Teacher", back_populates="assignments")

--- a/backend/routers/assignments/crud.py
+++ b/backend/routers/assignments/crud.py
@@ -382,9 +382,11 @@ async def get_assignments(
     - 可依班級和狀態篩選
     - 預設只顯示未封存作業，is_archived=true 顯示封存作業
     """
-    # 建立查詢
+    # 建立查詢（排除即刻練習暫時作業）
     query = db.query(Assignment).filter(
-        Assignment.teacher_id == current_teacher.id, Assignment.is_active.is_(True)
+        Assignment.teacher_id == current_teacher.id,
+        Assignment.is_active.is_(True),
+        Assignment.is_instant_practice.is_(False),
     )
 
     # 封存篩選


### PR DESCRIPTION
## Summary
- Add `is_instant_practice` boolean column to `assignments` table (idempotent migration)
- Update Assignment model with new field
- Filter out instant practice assignments from regular assignment list queries
- Add partial index for efficient filtering

This is the DB migration prerequisite for #255 (教材即刻練習). The instant practice feature will reuse the existing assignment + preview infrastructure, with a lazy cleanup mechanism (delete old instant practice assignments when creating new ones).

## Migration Details
- **File**: `20260309_1000_add_instant_practice_flag.py`
- **Column**: `is_instant_practice BOOLEAN NOT NULL DEFAULT FALSE`
- **Index**: `idx_assignments_not_instant_practice` (partial index on `teacher_id, classroom_id` where `is_instant_practice = FALSE`)
- **Idempotent**: Yes (uses `DO $$ IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`)

## Test plan
- [ ] Migration runs successfully on staging
- [ ] Existing assignment list queries unaffected (default FALSE)
- [ ] No breaking changes to existing APIs

Related: #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)