### PR TITLE
fix(#230): teacher login uses Identity password for verified students

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -7,6 +7,7 @@ from database import get_db
 from models import (
     Teacher,
     Student,
+    Identity,
     ClassroomStudent,
     ClassroomSchool,
     School,
@@ -349,8 +350,13 @@ async def student_login(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
         )
 
-    # 驗證密碼（老師流程：使用該班級學生的本地密碼）
-    if not verify_password(login_req.password, student.password_hash):
+    # 驗證密碼：已驗證學生用 Identity 統一密碼，未驗證用本地密碼
+    effective_hash = student.password_hash
+    if student.identity_id:
+        identity = db.query(Identity).filter(Identity.id == student.identity_id).first()
+        if identity and identity.password_hash:
+            effective_hash = identity.password_hash
+    if not verify_password(login_req.password, effective_hash):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
         )


### PR DESCRIPTION
## Summary
- Teacher flow login now checks Identity unified password when student has `identity_id` (email verified)
- Unverified students still use local `password_hash` (teacher-set password)
- This ensures verified students use the same password regardless of login flow

## Context
Previously, email login used Identity password while teacher flow used local password. After a student verifies their email and changes password, the teacher flow would still check the old local password, causing login failures.

## Test plan
- [ ] Verified student can login via teacher flow using Identity password
- [ ] Unverified student can login via teacher flow using local password
- [ ] Email login still works with Identity password

Fixes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)