### PR TITLE
fix: correct gh pr checks fields and review bot user filter

### DIFF
--- a/.github/workflows/automation-auto-approve.yml
+++ b/.github/workflows/automation-auto-approve.yml
@@ -413,7 +413,7 @@ jobs:
             POLL=0
             HAS_CHECKS=false
             while true; do
-              CHECKS=$(gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,status,conclusion 2>/dev/null || echo "[]")
+              CHECKS=$(gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,state 2>/dev/null || echo "[]")
               TOTAL=$(echo "$CHECKS" | jq 'length')
               if [ "$TOTAL" -gt 0 ]; then HAS_CHECKS=true; break; fi
               POLL=$((POLL + 1))
@@ -430,8 +430,8 @@ jobs:
             ```bash
             POLL=0
             while true; do
-              CHECKS=$(gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,status,conclusion 2>/dev/null || echo "[]")
-              PENDING=$(echo "$CHECKS" | jq '[.[] | select(.status != "completed")] | length')
+              CHECKS=$(gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,state 2>/dev/null || echo "[]")
+              PENDING=$(echo "$CHECKS" | jq '[.[] | select(.state == "PENDING")] | length')
               if [ "$PENDING" = "0" ]; then break; fi
               POLL=$((POLL + 1))
               if [ "$POLL" -ge 30 ]; then echo "CI timeout after 15 minutes"; break; fi
@@ -444,7 +444,7 @@ jobs:
 
             Check which CI checks failed:
             ```bash
-            gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,conclusion,status
+            gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,state
             ```
 
             For each failing test check (Test Backend, Test Frontend):
@@ -481,8 +481,8 @@ jobs:
             ```bash
             POLL=0
             while true; do
-              CHECKS=$(gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,status,conclusion 2>/dev/null || echo "[]")
-              REVIEW_PENDING=$(echo "$CHECKS" | jq '[.[] | select(.name | test("claude|review"; "i")) | select(.status != "completed")] | length')
+              CHECKS=$(gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,state 2>/dev/null || echo "[]")
+              REVIEW_PENDING=$(echo "$CHECKS" | jq '[.[] | select(.name | test("claude|review"; "i")) | select(.state == "PENDING")] | length')
               if [ "$REVIEW_PENDING" = "0" ]; then break; fi
               POLL=$((POLL + 1))
               if [ "$POLL" -ge 20 ]; then echo "Review timeout after 10 minutes"; break; fi
@@ -493,17 +493,17 @@ jobs:
 
             ## Phase 4: Fix code review issues
 
-            Fetch the latest review comment from github-actions[bot]:
+            Fetch the latest review comment from claude[bot] (the Code Review bot):
             ```bash
             gh api repos/${{ github.repository }}/issues/${{ needs.create-release-pr.outputs.pr_number }}/comments \
-              --jq '.[] | select(.user.login == "github-actions[bot]") | {body: .body, created_at: .created_at}' \
+              --jq '.[] | select(.user.login == "claude[bot]") | {body: .body, created_at: .created_at}' \
               | jq -s 'sort_by(.created_at) | last'
             ```
 
             Also fetch inline review comments:
             ```bash
             gh api repos/${{ github.repository }}/pulls/${{ needs.create-release-pr.outputs.pr_number }}/comments \
-              --jq '.[] | select(.user.login == "github-actions[bot]") | {path: .path, line: .line, body: .body}'
+              --jq '.[] | select(.user.login == "claude[bot]") | {path: .path, line: .line, body: .body}'
             ```
 
             For each review item:
@@ -554,8 +554,8 @@ jobs:
 
           POLL=0
           while true; do
-            CHECKS=$(gh pr checks "$PR_NUM" --json name,status 2>/dev/null || echo "[]")
-            PENDING=$(echo "$CHECKS" | jq '[.[] | select(.status != "completed")] | length')
+            CHECKS=$(gh pr checks "$PR_NUM" --json name,state 2>/dev/null || echo "[]")
+            PENDING=$(echo "$CHECKS" | jq '[.[] | select(.state == "PENDING")] | length')
             if [ "$PENDING" = "0" ]; then break; fi
             POLL=$((POLL + 1))
             if [ "$POLL" -ge 30 ]; then
@@ -572,12 +572,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUM="${{ needs.create-release-pr.outputs.pr_number }}"
-          CHECKS=$(gh pr checks "$PR_NUM" --json name,conclusion,status 2>/dev/null || echo "[]")
+          CHECKS=$(gh pr checks "$PR_NUM" --json name,state 2>/dev/null || echo "[]")
 
           TOTAL=$(echo "$CHECKS" | jq 'length')
-          FAILED=$(echo "$CHECKS" | jq '[.[] | select(.conclusion == "failure")] | length')
-          PENDING=$(echo "$CHECKS" | jq '[.[] | select(.status != "completed")] | length')
-          FAILED_NAMES=$(echo "$CHECKS" | jq -r '[.[] | select(.conclusion == "failure") | .name] | join(", ")')
+          FAILED=$(echo "$CHECKS" | jq '[.[] | select(.state == "FAILURE")] | length')
+          PENDING=$(echo "$CHECKS" | jq '[.[] | select(.state == "PENDING")] | length')
+          FAILED_NAMES=$(echo "$CHECKS" | jq -r '[.[] | select(.state == "FAILURE") | .name] | join(", ")')
 
           if [ "$TOTAL" = "0" ]; then
             echo "status=needs_human" >> $GITHUB_OUTPUT

--- a/.github/workflows/automation-release-pr.yml
+++ b/.github/workflows/automation-release-pr.yml
@@ -343,7 +343,7 @@ jobs:
             POLL=0
             HAS_CHECKS=false
             while true; do
-              CHECKS=$(gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,status,conclusion 2>/dev/null || echo "[]")
+              CHECKS=$(gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,state 2>/dev/null || echo "[]")
               TOTAL=$(echo "$CHECKS" | jq 'length')
               if [ "$TOTAL" -gt 0 ]; then HAS_CHECKS=true; break; fi
               POLL=$((POLL + 1))
@@ -360,8 +360,8 @@ jobs:
             ```bash
             POLL=0
             while true; do
-              CHECKS=$(gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,status,conclusion 2>/dev/null || echo "[]")
-              PENDING=$(echo "$CHECKS" | jq '[.[] | select(.status != "completed")] | length')
+              CHECKS=$(gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,state 2>/dev/null || echo "[]")
+              PENDING=$(echo "$CHECKS" | jq '[.[] | select(.state == "PENDING")] | length')
               if [ "$PENDING" = "0" ]; then break; fi
               POLL=$((POLL + 1))
               if [ "$POLL" -ge 30 ]; then echo "CI timeout after 15 minutes"; break; fi
@@ -374,7 +374,7 @@ jobs:
 
             Check which CI checks failed:
             ```bash
-            gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,conclusion,status
+            gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,state
             ```
 
             For each failing test check (Test Backend, Test Frontend):
@@ -411,8 +411,8 @@ jobs:
             ```bash
             POLL=0
             while true; do
-              CHECKS=$(gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,status,conclusion 2>/dev/null || echo "[]")
-              REVIEW_PENDING=$(echo "$CHECKS" | jq '[.[] | select(.name | test("claude|review"; "i")) | select(.status != "completed")] | length')
+              CHECKS=$(gh pr checks ${{ needs.create-release-pr.outputs.pr_number }} --json name,state 2>/dev/null || echo "[]")
+              REVIEW_PENDING=$(echo "$CHECKS" | jq '[.[] | select(.name | test("claude|review"; "i")) | select(.state == "PENDING")] | length')
               if [ "$REVIEW_PENDING" = "0" ]; then break; fi
               POLL=$((POLL + 1))
               if [ "$POLL" -ge 20 ]; then echo "Review timeout after 10 minutes"; break; fi
@@ -423,17 +423,17 @@ jobs:
 
             ## Phase 4: Fix code review issues
 
-            Fetch the latest review comment from github-actions[bot]:
+            Fetch the latest review comment from claude[bot] (the Code Review bot):
             ```bash
             gh api repos/${{ github.repository }}/issues/${{ needs.create-release-pr.outputs.pr_number }}/comments \
-              --jq '.[] | select(.user.login == "github-actions[bot]") | {body: .body, created_at: .created_at}' \
+              --jq '.[] | select(.user.login == "claude[bot]") | {body: .body, created_at: .created_at}' \
               | jq -s 'sort_by(.created_at) | last'
             ```
 
             Also fetch inline review comments:
             ```bash
             gh api repos/${{ github.repository }}/pulls/${{ needs.create-release-pr.outputs.pr_number }}/comments \
-              --jq '.[] | select(.user.login == "github-actions[bot]") | {path: .path, line: .line, body: .body}'
+              --jq '.[] | select(.user.login == "claude[bot]") | {path: .path, line: .line, body: .body}'
             ```
 
             For each review item:
@@ -484,8 +484,8 @@ jobs:
 
           POLL=0
           while true; do
-            CHECKS=$(gh pr checks "$PR_NUM" --json name,status 2>/dev/null || echo "[]")
-            PENDING=$(echo "$CHECKS" | jq '[.[] | select(.status != "completed")] | length')
+            CHECKS=$(gh pr checks "$PR_NUM" --json name,state 2>/dev/null || echo "[]")
+            PENDING=$(echo "$CHECKS" | jq '[.[] | select(.state == "PENDING")] | length')
             if [ "$PENDING" = "0" ]; then break; fi
             POLL=$((POLL + 1))
             if [ "$POLL" -ge 30 ]; then
@@ -502,12 +502,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUM="${{ needs.create-release-pr.outputs.pr_number }}"
-          CHECKS=$(gh pr checks "$PR_NUM" --json name,conclusion,status 2>/dev/null || echo "[]")
+          CHECKS=$(gh pr checks "$PR_NUM" --json name,state 2>/dev/null || echo "[]")
 
           TOTAL=$(echo "$CHECKS" | jq 'length')
-          FAILED=$(echo "$CHECKS" | jq '[.[] | select(.conclusion == "failure")] | length')
-          PENDING=$(echo "$CHECKS" | jq '[.[] | select(.status != "completed")] | length')
-          FAILED_NAMES=$(echo "$CHECKS" | jq -r '[.[] | select(.conclusion == "failure") | .name] | join(", ")')
+          FAILED=$(echo "$CHECKS" | jq '[.[] | select(.state == "FAILURE")] | length')
+          PENDING=$(echo "$CHECKS" | jq '[.[] | select(.state == "PENDING")] | length')
+          FAILED_NAMES=$(echo "$CHECKS" | jq -r '[.[] | select(.state == "FAILURE") | .name] | join(", ")')
 
           if [ "$TOTAL" = "0" ]; then
             echo "status=needs_human" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- `gh pr checks --json` 用了無效的欄位 `conclusion`/`status`，導致 `notify-status` 永遠回報 "No CI checks found"（錯誤被 `2>/dev/null` 吞掉）
- 修正為有效欄位 `state`（值：`PENDING`, `SUCCESS`, `FAILURE`）
- Auto-fix prompt 的 review comment filter 從 `github-actions[bot]` 改為 `claude[bot]`，讓 auto-fix 能正確讀取 Code Review 回饋

## Context
- PR #419 的 LINE 通知錯誤說 "No CI checks found" 但實際 checks 都通過
- Auto-fix report 與 Code Review 結果矛盾（auto-fix 說 "no issues" 但 review 有 blocking issues）

## Test plan
- [ ] 觸發 release workflow，確認 LINE 通知正確反映 CI 狀態
- [ ] 確認 auto-fix 能讀取並修復 claude[bot] 的 review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)