### PR TITLE
fix: context-aware token selection to prevent org admin 403 errors

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -140,14 +140,24 @@ class ApiClient {
   }
 
   private getToken(): string | null {
-    // 動態獲取 token，優先學生 token
     const studentToken = useStudentAuthStore.getState().token;
-    if (studentToken) return studentToken;
-
     const teacherToken = useTeacherAuthStore.getState().token;
-    if (teacherToken) return teacherToken;
 
-    return null;
+    // Context-aware token selection based on current page
+    const path = window.location.pathname;
+    const isTeacherContext =
+      path.startsWith("/teacher") || path.startsWith("/organization");
+    const isStudentContext = path.startsWith("/student");
+
+    if (isTeacherContext) {
+      return teacherToken || studentToken || null;
+    }
+    if (isStudentContext) {
+      return studentToken || teacherToken || null;
+    }
+
+    // Default: prefer whichever token exists (teacher first for API compatibility)
+    return teacherToken || studentToken || null;
   }
 
   private async request<T>(


### PR DESCRIPTION
## Summary

- 機構帳號（teacher id=24）在組織管理後台建立班級時出現「建立班級失敗，請稍後再試」
- GCP Cloud Run logs 確認 `POST /api/schools/.../classrooms` 回傳 **403 Forbidden**，`query_count: 0`（token 驗證階段就被擋）
- 根因：`apiClient.getToken()` 無條件優先使用 student token，當 localStorage 同時有 student + teacher token 時，機構後台的 API 會送出 student token，後端因 `type != "teacher"` 回 403

## Changes

- `frontend/src/lib/api.ts` - `getToken()` 改為 context-aware token selection：
  - `/teacher/*`, `/organization/*` 頁面 → 優先 teacher token
  - `/student/*` 頁面 → 優先 student token
  - 其他頁面 → 預設 teacher token first

## Test plan

- [ ] 機構帳號登入後，在組織管理後台建立班級應成功
- [ ] 學生登入後，學生端 API 仍正常運作
- [ ] 同時有 teacher + student token 殘留時，各頁面使用正確的 token

🤖 Generated with [Claude Code](https://claude.com/claude-code)