### PR TITLE
ci: allow claude[bot] in claude-review workflow

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -38,6 +38,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude[bot]'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- Add `allowed_bots: 'claude[bot]'` to the Claude Code Review workflow
- Fixes claude-review CI failures on PRs where `claude[bot]` pushes auto-fix commits
- Unblocks PR #457 (and future bot-triggered PRs)

## Test plan
- [ ] Merge this PR to main
- [ ] Re-trigger claude-review on PR #457 — should no longer fail with bot-actor error

🤖 Generated with [Claude Code](https://claude.com/claude-code)