### PR TITLE
feat: 跨 Tab 登入狀態同步 (Fixes #472)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,6 +44,7 @@ import PricingPage from "./pages/PricingPage";
 import TestSubscription from "./pages/TestSubscription";
 import DemoAssignmentPage from "./pages/DemoAssignmentPage";
 import { Toaster } from "sonner";
+import { useCrossTabAuthSync } from "./hooks/useCrossTabAuthSync";
 
 /**
  * Custom hook to detect mobile screen size
@@ -73,6 +74,8 @@ function useIsMobile() {
 function App() {
   // Issue #142: Use bottom-center on mobile to avoid blocking question numbers
   const isMobile = useIsMobile();
+  // Issue #472: Cross-tab auth sync
+  useCrossTabAuthSync();
 
   return (
     <>

--- a/frontend/src/hooks/useCrossTabAuthSync.ts
+++ b/frontend/src/hooks/useCrossTabAuthSync.ts
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+
+/**
+ * 跨 Tab 登入狀態同步
+ * 當其他 Tab 修改 auth localStorage 時，自動跳轉首頁
+ * Issue #472
+ */
+export function useCrossTabAuthSync() {
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (
+        e.key === "teacher-auth-storage" ||
+        e.key === "student-auth-storage"
+      ) {
+        window.location.href = "/";
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+}


### PR DESCRIPTION
## Summary
- 新增 `useCrossTabAuthSync` hook，監聽瀏覽器 `storage` event
- 當其他 Tab 變更登入狀態（登出/切換身份）時，自動跳轉首頁 `/`
- 防止使用者在過期 token 的 Tab 上操作導致 API 錯誤

## Test plan
- [x] Tab A 登入老師 → Tab B 登出再登入學生 → Tab A 自動跳轉首頁
- [x] Tab A 登入學生 → Tab B 登出再登入老師 → Tab A 自動跳轉首頁
- [ ] 同一 Tab 內正常登入登出不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)