### PR TITLE
fix: org materials 404 regression in content_ops.py (Fixes #410)

### DIFF
--- a/backend/routers/teachers/content_ops.py
+++ b/backend/routers/teachers/content_ops.py
@@ -36,16 +36,12 @@ async def get_lesson_contents(
     db: Session = Depends(get_db),
 ):
     """取得單元的內容列表"""
-    # Verify the lesson belongs to the teacher
-    lesson = (
-        db.query(Lesson)
-        .join(Program)
-        .filter(Lesson.id == lesson_id, Program.teacher_id == current_teacher.id)
-        .first()
-    )
+    from utils.permissions import check_lesson_access
 
-    if not lesson:
-        raise HTTPException(status_code=404, detail="Lesson not found")
+    # check_lesson_access handles personal, org, and template lesson access
+    _program, lesson = check_lesson_access(
+        db, lesson_id, current_teacher, require_owner=False
+    )
 
     contents = (
         db.query(Content)
@@ -111,26 +107,12 @@ async def create_content(
     db: Session = Depends(get_db),
 ):
     """建立新內容"""
-    # Verify the lesson belongs to the teacher or is a template program
-    lesson = (
-        db.query(Lesson)
-        .join(Program)
-        .filter(
-            Lesson.id == lesson_id,
-            Lesson.is_active.is_(True),
-            Program.is_active.is_(True),
-        )
-        .filter(
-            # Either: lesson belongs to teacher's program
-            # Or: lesson belongs to a template program (公版課程)
-            (Program.teacher_id == current_teacher.id)
-            | (Program.is_template.is_(True))
-        )
-        .first()
-    )
+    from utils.permissions import check_lesson_access
 
-    if not lesson:
-        raise HTTPException(status_code=404, detail="Lesson not found")
+    # check_lesson_access handles personal, org, and template lesson access
+    _program, lesson = check_lesson_access(
+        db, lesson_id, current_teacher, require_owner=True
+    )
 
     # 如果沒有提供 order_index，自動設為最後一個位置
     if content_data.order_index is None:
@@ -307,23 +289,15 @@ async def get_content_detail(
     db: Session = Depends(get_db),
 ):
     """獲取內容詳情"""
-    # Verify the content belongs to the teacher
-    content = (
-        db.query(Content)
-        .join(Lesson)
-        .join(Program)
-        .filter(
-            Content.id == content_id,
-            Program.teacher_id == current_teacher.id,
-            Content.is_active.is_(True),
-            Lesson.is_active.is_(True),
-            Program.is_active.is_(True),
-        )
-        .first()
+    from utils.permissions import check_content_access
+
+    # check_content_access handles personal, org, template, and assignment copy access
+    _program, _lesson, content = check_content_access(
+        db, content_id, current_teacher, require_owner=False
     )
 
-    if not content:
-        raise HTTPException(status_code=404, detail="Content not found")
+    # Eager load content_items to avoid N+1
+    db.refresh(content, ["content_items"])
 
     return {
         "id": content.id,
@@ -408,28 +382,12 @@ async def update_content(
     db: Session = Depends(get_db),
 ):
     """更新內容"""
-    # Verify the content belongs to the teacher or is a template program
-    content = (
-        db.query(Content)
-        .join(Lesson)
-        .join(Program)
-        .filter(
-            Content.id == content_id,
-            Content.is_active.is_(True),
-            Lesson.is_active.is_(True),
-            Program.is_active.is_(True),
-        )
-        .filter(
-            # Either: content belongs to teacher's program
-            # Or: content belongs to a template program (公版課程)
-            (Program.teacher_id == current_teacher.id)
-            | (Program.is_template.is_(True))
-        )
-        .first()
-    )
+    from utils.permissions import check_content_access
 
-    if not content:
-        raise HTTPException(status_code=404, detail="Content not found")
+    # check_content_access handles personal, org, template, and assignment copy access
+    _program, _lesson, content = check_content_access(
+        db, content_id, current_teacher, require_owner=True
+    )
 
     # 引入音檔管理器
     from services.audio_manager import get_audio_manager
@@ -691,23 +649,12 @@ async def delete_content(
     db: Session = Depends(get_db),
 ):
     """刪除內容（軟刪除）"""
-    # Verify the content belongs to the teacher
-    content = (
-        db.query(Content)
-        .join(Lesson)
-        .join(Program)
-        .filter(
-            Content.id == content_id,
-            Program.teacher_id == current_teacher.id,
-            Content.is_active.is_(True),
-            Lesson.is_active.is_(True),
-            Program.is_active.is_(True),
-        )
-        .first()
-    )
+    from utils.permissions import check_content_access
 
-    if not content:
-        raise HTTPException(status_code=404, detail="Content not found")
+    # check_content_access handles personal, org, template, and assignment copy access
+    _program, _lesson, content = check_content_access(
+        db, content_id, current_teacher, require_owner=True, allow_assignment_copy=False
+    )
 
     # 檢查是否有相關的作業
 

--- a/backend/tests/test_e2e_organization_materials.py
+++ b/backend/tests/test_e2e_organization_materials.py
@@ -789,6 +789,89 @@ class TestE2EOrganizationMaterials:
         assert response.json()["title"] == "基本問候語"
         assert len(response.json()["items"]) == 3
 
+    def test_org_member_can_list_lesson_contents(self):
+        """
+        Regression test for issue #410 v2: org member gets 404 on lesson contents listing.
+
+        The old code in GET /api/teachers/lessons/{lesson_id}/contents filtered by
+        Program.teacher_id == current_teacher.id, which excluded org lessons
+        where teacher_id is the org_owner, not the requesting member.
+
+        After the fix, check_lesson_access() handles org membership correctly.
+        """
+        hierarchy = self._create_organization_hierarchy()
+        org = hierarchy["org"]
+        org_owner = hierarchy["org_owner"]
+        teacher = hierarchy["teacher"]
+
+        # Create org material owned by org_owner with organization_id set
+        material = self._create_organization_material(org, org_owner)
+        material.organization_id = org.id
+        self.db.commit()
+        self.db.refresh(material)
+
+        lesson = self.db.query(Lesson).filter(Lesson.program_id == material.id).first()
+        assert lesson is not None
+
+        # org_owner can list lesson contents
+        owner_headers = self._get_auth_headers(org_owner)
+        response = self.client.get(
+            f"/api/teachers/lessons/{lesson.id}/contents",
+            headers=owner_headers,
+        )
+        assert response.status_code == 200
+        assert len(response.json()) == 1  # One content: "基本問候語"
+
+        # Regular org member teacher can also list lesson contents (was 404 before fix)
+        teacher_headers = self._get_auth_headers(teacher)
+        response = self.client.get(
+            f"/api/teachers/lessons/{lesson.id}/contents",
+            headers=teacher_headers,
+        )
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+
+    def test_org_owner_can_update_and_delete_org_content(self):
+        """
+        Regression test for issue #410 v2: org owner gets 404 on content update/delete.
+
+        The old code in PUT/DELETE /api/teachers/contents/{content_id} filtered by
+        Program.teacher_id == current_teacher.id (PUT also allowed templates).
+        After the fix, check_content_access() handles org ownership correctly.
+        """
+        hierarchy = self._create_organization_hierarchy()
+        org = hierarchy["org"]
+        org_owner = hierarchy["org_owner"]
+
+        # Create org material owned by org_owner with organization_id set
+        material = self._create_organization_material(org, org_owner)
+        material.organization_id = org.id
+        self.db.commit()
+        self.db.refresh(material)
+
+        lesson = self.db.query(Lesson).filter(Lesson.program_id == material.id).first()
+        content = self.db.query(Content).filter(Content.lesson_id == lesson.id).first()
+        assert content is not None
+
+        owner_headers = self._get_auth_headers(org_owner)
+
+        # org_owner can update content
+        response = self.client.put(
+            f"/api/teachers/contents/{content.id}",
+            json={"title": "更新後的問候語"},
+            headers=owner_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["title"] == "更新後的問候語"
+
+        # org_owner can delete (soft-delete) content
+        response = self.client.delete(
+            f"/api/teachers/contents/{content.id}",
+            headers=owner_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["details"]["deactivated"] is True
+
 
 # ============================================================================
 # Test Summary


### PR DESCRIPTION
## Summary
- Issue #410 的 404 問題復發，原因是程式碼重構時 `teachers.py` 拆分成模組化結構 (`teachers/content_ops.py`)，但新模組仍使用舊的 `Program.teacher_id` hardcoded filter
- 將 `content_ops.py` 中 5 個 content endpoints 全部改用 `check_content_access()` / `check_lesson_access()`，與之前在 `teachers.py` 的修法一致
- 新增 2 個 regression tests 覆蓋 lesson contents listing 和 content update/delete

## Changes
- **GET** `/lessons/{id}/contents` - 改用 `check_lesson_access(require_owner=False)`
- **POST** `/lessons/{id}/contents` - 改用 `check_lesson_access(require_owner=True)`
- **GET** `/contents/{id}` - 改用 `check_content_access(require_owner=False)`
- **PUT** `/contents/{id}` - 改用 `check_content_access(require_owner=True)`
- **DELETE** `/contents/{id}` - 改用 `check_content_access(require_owner=True, allow_assignment_copy=False)`

## Test plan
- [ ] CI E2E tests pass (test_e2e_organization_materials.py)
- [ ] Org member can view org material content detail (GET /contents/{id})
- [ ] Org member can list org lesson contents (GET /lessons/{id}/contents)
- [ ] Org owner can update/delete org content (PUT/DELETE /contents/{id})
- [ ] Personal materials still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)