### PR TITLE
refactor: 統一 Demo 與老師預覽的後端 preview 邏輯 (#492)

### DIFF
--- a/backend/routers/demo.py
+++ b/backend/routers/demo.py
@@ -13,7 +13,6 @@ Includes:
 import logging
 import os
 from typing import Optional
-from pydantic import BaseModel
 from fastapi import (
     APIRouter,
     Depends,
@@ -51,31 +50,12 @@ from services.preview_service import (
     check_rearrangement_answer,
     handle_rearrangement_retry,
     handle_rearrangement_complete,
+    WordSelectionAnswerRequest,
+    RearrangementAnswerRequest,
+    RearrangementCompleteRequest,
 )
 
 logger = logging.getLogger(__name__)
-
-
-# ============================================================================
-# Request Models
-# ============================================================================
-
-
-class WordSelectionAnswerRequest(BaseModel):
-    content_item_id: int
-    selected_answer: str
-
-
-class RearrangementAnswerRequest(BaseModel):
-    content_item_id: int
-    selected_word: str
-    current_position: int = 0
-
-
-class RearrangementCompleteRequest(BaseModel):
-    expected_score: float = 100.0
-    timeout: bool = False
-
 
 router = APIRouter(prefix="/api/demo", tags=["demo"])
 

--- a/backend/routers/teachers/assignment_ops.py
+++ b/backend/routers/teachers/assignment_ops.py
@@ -38,6 +38,9 @@ from services.preview_service import (
     check_rearrangement_answer,
     handle_rearrangement_retry,
     handle_rearrangement_complete,
+    WordSelectionAnswerRequest,
+    RearrangementAnswerRequest,
+    RearrangementCompleteRequest,
 )
 
 logger = logging.getLogger(__name__)
@@ -125,15 +128,15 @@ async def preview_word_selection_start(
 @router.post("/assignments/{assignment_id}/preview/word-selection-answer")
 async def preview_word_selection_answer(
     assignment_id: int,
-    request: dict,
+    data: WordSelectionAnswerRequest,
     current_teacher: Teacher = Depends(get_current_teacher),
     db: Session = Depends(get_db),
 ):
     """Preview mode: Submit word selection answer (not saved)."""
     assignment = _get_teacher_assignment(assignment_id, current_teacher, db)
     return check_word_selection_answer(
-        request.get("content_item_id"),
-        request.get("selected_answer"),
+        data.content_item_id,
+        data.selected_answer,
         assignment,
         db,
     )
@@ -153,16 +156,16 @@ async def preview_rearrangement_questions(
 @router.post("/assignments/{assignment_id}/preview/rearrangement-answer")
 async def preview_rearrangement_answer(
     assignment_id: int,
-    request: dict,
+    data: RearrangementAnswerRequest,
     current_teacher: Teacher = Depends(get_current_teacher),
     db: Session = Depends(get_db),
 ):
     """Preview mode: Submit rearrangement answer (not saved)."""
     _get_teacher_assignment(assignment_id, current_teacher, db)
     return check_rearrangement_answer(
-        request.get("content_item_id"),
-        request.get("selected_word", ""),
-        request.get("current_position", 0),
+        data.content_item_id,
+        data.selected_word,
+        data.current_position,
         db,
     )
 
@@ -170,7 +173,6 @@ async def preview_rearrangement_answer(
 @router.post("/assignments/{assignment_id}/preview/rearrangement-retry")
 async def preview_rearrangement_retry(
     assignment_id: int,
-    request: dict,
     current_teacher: Teacher = Depends(get_current_teacher),
     db: Session = Depends(get_db),
 ):
@@ -182,13 +184,13 @@ async def preview_rearrangement_retry(
 @router.post("/assignments/{assignment_id}/preview/rearrangement-complete")
 async def preview_rearrangement_complete(
     assignment_id: int,
-    request: dict,
+    data: RearrangementCompleteRequest,
     current_teacher: Teacher = Depends(get_current_teacher),
     db: Session = Depends(get_db),
 ):
     """Preview mode: Complete rearrangement question (simulated)."""
     _get_teacher_assignment(assignment_id, current_teacher, db)
     return handle_rearrangement_complete(
-        expected_score=request.get("expected_score", 100.0),
-        timeout=request.get("timeout", False),
+        expected_score=data.expected_score,
+        timeout=data.timeout,
     )

--- a/backend/services/preview_service.py
+++ b/backend/services/preview_service.py
@@ -8,9 +8,11 @@ code are affected by this refactoring.
 
 import logging
 import random
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from fastapi import HTTPException, UploadFile
+from pydantic import BaseModel
 from sqlalchemy.orm import Session, selectinload
 
 from models import (
@@ -20,6 +22,28 @@ from models import (
     ContentItem,
     ContentType,
 )
+
+
+# ---------------------------------------------------------------------------
+# Shared Pydantic request models (used by both demo.py and assignment_ops.py)
+# ---------------------------------------------------------------------------
+
+
+class WordSelectionAnswerRequest(BaseModel):
+    content_item_id: int
+    selected_answer: str
+
+
+class RearrangementAnswerRequest(BaseModel):
+    content_item_id: int
+    selected_word: str
+    current_position: int = 0
+
+
+class RearrangementCompleteRequest(BaseModel):
+    expected_score: float = 100.0
+    timeout: bool = False
+
 
 logger = logging.getLogger(__name__)
 
@@ -507,11 +531,9 @@ def handle_rearrangement_complete(
     timeout: bool = False,
 ) -> dict:
     """Return a simulated completion response (preview — no DB writes)."""
-    from datetime import datetime
-
     return {
         "success": True,
         "final_score": expected_score,
         "timeout": timeout,
-        "completed_at": datetime.now().isoformat(),
+        "completed_at": datetime.now(timezone.utc).isoformat(),
     }

--- a/backend/tests/unit/test_preview_service.py
+++ b/backend/tests/unit/test_preview_service.py
@@ -5,6 +5,9 @@ Verifies that the shared preview service functions produce the expected
 output structure, so that both demo.py and assignment_ops.py stay in sync.
 """
 
+import io
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 from datetime import datetime, timedelta
 
@@ -21,6 +24,7 @@ from models import (
 )
 from auth import get_password_hash
 from services.preview_service import (
+    assess_speech_preview,
     build_assignment_preview,
     get_vocabulary_activities,
     get_word_selection_start,
@@ -30,6 +34,8 @@ from services.preview_service import (
     handle_rearrangement_retry,
     handle_rearrangement_complete,
     _parse_exclude_ids,
+    ALLOWED_AUDIO_FORMATS,
+    MAX_AUDIO_FILE_SIZE,
 )
 
 
@@ -459,3 +465,48 @@ class TestRearrangementRetryAndComplete:
         assert result["final_score"] == 75.0
         assert result["timeout"] is True
         assert "completed_at" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: assess_speech_preview validation guards
+# ---------------------------------------------------------------------------
+
+
+class TestAssessSpeechPreview:
+    @pytest.mark.asyncio
+    async def test_rejects_unsupported_audio_format(self):
+        mock_file = MagicMock()
+        mock_file.content_type = "text/plain"
+        mock_file.read = AsyncMock(return_value=b"not audio")
+
+        with pytest.raises(Exception) as exc_info:
+            await assess_speech_preview(mock_file, "hello")
+        assert exc_info.value.status_code == 400
+        assert "Unsupported audio format" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_file(self):
+        mock_file = MagicMock()
+        mock_file.content_type = "audio/wav"
+        # Return data larger than MAX_AUDIO_FILE_SIZE
+        mock_file.read = AsyncMock(return_value=b"x" * (MAX_AUDIO_FILE_SIZE + 1))
+
+        with pytest.raises(Exception) as exc_info:
+            await assess_speech_preview(mock_file, "hello")
+        assert exc_info.value.status_code == 413
+        assert "File too large" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_accepts_valid_audio_formats(self):
+        """Verify all declared formats pass the content-type check."""
+        for fmt in ALLOWED_AUDIO_FORMATS:
+            mock_file = MagicMock()
+            mock_file.content_type = fmt
+            # Return oversized data so we hit the *size* guard, not the format guard.
+            # This proves the format guard passed.
+            mock_file.read = AsyncMock(return_value=b"x" * (MAX_AUDIO_FILE_SIZE + 1))
+
+            with pytest.raises(Exception) as exc_info:
+                await assess_speech_preview(mock_file, "hello")
+            # If we get 413 (too large), that means format check passed
+            assert exc_info.value.status_code == 413


### PR DESCRIPTION
## Summary
- 建立 `backend/services/preview_service.py`，將 Demo 與老師預覽共 9 個 endpoint 的核心邏輯抽成共用函式
- `demo.py` 和 `assignment_ops.py` 改為薄 wrapper，只保留認證/rate-limit 層
- 總行數從 1,714 行降至 1,146 行（-33%），未來修改只需改一處
- **不動 API 路徑、不動前端**，純後端重構

## Changes
| File | Before | After |
|------|--------|-------|
| `backend/services/preview_service.py` | (new) | 519 行 |
| `backend/routers/demo.py` | 976 行 | 433 行 (-56%) |
| `backend/routers/teachers/assignment_ops.py` | 738 行 | 194 行 (-74%) |

## Phase 2 統一項目（一併完成）
- `word-selection-answer`: 統一 request key 為 `content_item_id`/`selected_answer`（前端 preview/demo 模式不呼叫此 endpoint，無影響）
- `rearrangement-answer`: 統一為逐字驗證（前端不呼叫此 endpoint，為 dead code）
- `word-selection-start`: 統一為優先使用 `item.distractors`（行為更優）

## Test plan
- [x] 19 個新增 `test_preview_service.py` 單元測試全部通過
- [x] 現有 unit tests 583 個通過（失敗為 pre-existing issues）
- [ ] CI/CD pipeline 通過
- [ ] Staging 部署後手動驗證 Demo 頁面與老師預覽功能正常

Related to #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)