### PR TITLE
ci: add per-environment Vertex AI toggle

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -383,7 +383,14 @@ jobs:
         ENV_VARS="$ENV_VARS,SUPABASE_URL=${{ steps.db_env.outputs.SUPABASE_URL }}"
         ENV_VARS="$ENV_VARS,SUPABASE_KEY=${{ steps.db_env.outputs.SUPABASE_KEY }}"
         ENV_VARS="$ENV_VARS,OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}"
-        ENV_VARS="$ENV_VARS,USE_VERTEX_AI=${{ vars.USE_VERTEX_AI || 'false' }}"
+
+        # Per-environment Vertex AI toggle
+        case "${{ steps.env_vars.outputs.ENV_NAME }}" in
+          staging)  _USE_VERTEX_AI="${{ vars.USE_VERTEX_AI_STAGING || 'false' }}" ;;
+          develop)  _USE_VERTEX_AI="${{ vars.USE_VERTEX_AI_STAGING || 'false' }}" ;;
+          *)        _USE_VERTEX_AI="${{ vars.USE_VERTEX_AI || 'false' }}" ;;
+        esac
+        ENV_VARS="$ENV_VARS,USE_VERTEX_AI=${_USE_VERTEX_AI}"
         ENV_VARS="$ENV_VARS,VERTEX_AI_PROJECT_ID=$PROJECT_ID"
         ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=us-central1"
         ENV_VARS="$ENV_VARS,SMTP_HOST=${{ secrets.SMTP_HOST }}"

--- a/.github/workflows/deploy-per-issue.yml
+++ b/.github/workflows/deploy-per-issue.yml
@@ -117,7 +117,7 @@ jobs:
           ENV_VARS="$ENV_VARS,SUPABASE_KEY=${{ secrets.STAGING_SUPABASE_ANON_KEY }}"
           ENV_VARS="$ENV_VARS,FRONTEND_URL=${FRONTEND_URL}"
           ENV_VARS="$ENV_VARS,OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}"
-          ENV_VARS="$ENV_VARS,USE_VERTEX_AI=${{ vars.USE_VERTEX_AI || 'false' }}"
+          ENV_VARS="$ENV_VARS,USE_VERTEX_AI=${{ vars.USE_VERTEX_AI_PREVIEW || 'false' }}"
           ENV_VARS="$ENV_VARS,VERTEX_AI_PROJECT_ID=${PROJECT_ID}"
           ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=us-central1"
           ENV_VARS="$ENV_VARS,SMTP_HOST=${{ secrets.SMTP_HOST }}"


### PR DESCRIPTION
## Summary
- Split `USE_VERTEX_AI` into per-environment GitHub Variables, allowing independent control of Vertex AI on each environment
- `staging` / `develop` → reads `USE_VERTEX_AI_STAGING`
- `per-issue preview` → reads `USE_VERTEX_AI_PREVIEW`
- `production` → reads `USE_VERTEX_AI` (unchanged behavior)

## Variables added
| Variable | Controls | Current value |
|----------|----------|---------------|
| `USE_VERTEX_AI_STAGING` | staging, develop | `false` |
| `USE_VERTEX_AI_PREVIEW` | per-issue environments | `false` |
| `USE_VERTEX_AI` | production (existing) | `false` |

## How to enable
Set the corresponding variable to `true` in GitHub repo Settings → Variables:
```bash
gh variable set USE_VERTEX_AI_STAGING --body "true"   # enable on staging
gh variable set USE_VERTEX_AI_PREVIEW --body "true"   # enable on per-issue
```

## Test plan
- [ ] Verify staging deployment reads `USE_VERTEX_AI_STAGING`
- [ ] Verify per-issue deployment reads `USE_VERTEX_AI_PREVIEW`
- [ ] Verify production still reads `USE_VERTEX_AI` (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)