### PR TITLE
chore(#341): migration - add 1Campus SSO fields

### DIFF
--- a/backend/alembic/versions/20260322_1000_add_1campus_identity_fields.py
+++ b/backend/alembic/versions/20260322_1000_add_1campus_identity_fields.py
@@ -18,7 +18,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "20260322_1000"
-down_revision = "20260320_1000"
+down_revision = "20260321_1000"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/20260322_1000_add_1campus_identity_fields.py
+++ b/backend/alembic/versions/20260322_1000_add_1campus_identity_fields.py
@@ -1,0 +1,141 @@
+"""Add 1Campus SSO fields to identities and oauth_identities tables
+
+Revision ID: 20260322_1000
+Revises: 20260320_1000
+Create Date: 2026-03-22 10:00:00.000000
+
+Adds fields for 1Campus SSO integration:
+- identities.one_campus_student_id: 1Campus studentID for identity matching
+- identities.one_campus_account: 1Campus account (e.g. dev.j.s20101@1campus.net)
+- identities.national_id_hash: SHA256 hash of national ID for cross-school matching
+- identities.email nullable: Allow SSO-only accounts without email
+- oauth_identities.identity_id: Extend OAuth to support Identity-level linking
+
+Related: #341
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260322_1000"
+down_revision = "20260320_1000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- identities table: make email nullable for SSO-only accounts ---
+    op.execute(
+        """
+        DO $$ BEGIN
+            -- Allow null email for SSO-only accounts (1Campus students may not have email)
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'identities'
+                AND column_name = 'email'
+                AND is_nullable = 'NO'
+            ) THEN
+                ALTER TABLE identities ALTER COLUMN email DROP NOT NULL;
+            END IF;
+        END $$;
+        """
+    )
+
+    # --- identities table: add 1Campus fields ---
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'identities'
+                AND column_name = 'one_campus_student_id'
+            ) THEN
+                ALTER TABLE identities
+                ADD COLUMN one_campus_student_id VARCHAR(100);
+            END IF;
+        END $$;
+        """
+    )
+
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'identities'
+                AND column_name = 'one_campus_account'
+            ) THEN
+                ALTER TABLE identities
+                ADD COLUMN one_campus_account VARCHAR(255);
+            END IF;
+        END $$;
+        """
+    )
+
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'identities'
+                AND column_name = 'national_id_hash'
+            ) THEN
+                ALTER TABLE identities
+                ADD COLUMN national_id_hash VARCHAR(64);
+            END IF;
+        END $$;
+        """
+    )
+
+    # --- identities table: indexes ---
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_identities_one_campus_student_id "
+        "ON identities (one_campus_student_id)"
+    )
+
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_identities_national_id_hash "
+        "ON identities (national_id_hash)"
+    )
+
+    # --- oauth_identities table: add identity_id FK ---
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'oauth_identities'
+                AND column_name = 'identity_id'
+            ) THEN
+                ALTER TABLE oauth_identities
+                ADD COLUMN identity_id INTEGER;
+            END IF;
+        END $$;
+        """
+    )
+
+    # Add FK constraint for identity_id
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'fk_oauth_identities_identity_id'
+            ) THEN
+                ALTER TABLE oauth_identities
+                ADD CONSTRAINT fk_oauth_identities_identity_id
+                FOREIGN KEY (identity_id) REFERENCES identities(id)
+                ON DELETE SET NULL;
+            END IF;
+        END $$;
+        """
+    )
+
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_oauth_identity_identity "
+        "ON oauth_identities (identity_id)"
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/20260322_1000_add_1campus_identity_fields.py
+++ b/backend/alembic/versions/20260322_1000_add_1campus_identity_fields.py
@@ -138,4 +138,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Intentional no-op: email NOT NULL cannot be safely restored because
+    # SSO-only accounts may have been created with email=NULL after this
+    # migration runs. Reverting would violate those rows.
     pass

--- a/backend/models/oauth_identity.py
+++ b/backend/models/oauth_identity.py
@@ -29,6 +29,9 @@ class OAuthIdentity(Base):
     teacher_id = Column(
         Integer, ForeignKey("teachers.id", ondelete="CASCADE"), nullable=False
     )
+    identity_id = Column(
+        Integer, ForeignKey("identities.id", ondelete="SET NULL"), nullable=True
+    )
 
     # OAuth provider info
     provider = Column(String(50), nullable=False)
@@ -52,12 +55,14 @@ class OAuthIdentity(Base):
 
     # Relationships
     teacher = relationship("Teacher", back_populates="oauth_identities")
+    identity = relationship("Identity", backref="oauth_identities")
 
     __table_args__ = (
         UniqueConstraint("provider", "provider_user_id", name="uq_oauth_provider_user"),
         UniqueConstraint("teacher_id", "provider", name="uq_oauth_teacher_provider"),
         Index("ix_oauth_identity_teacher", "teacher_id"),
         Index("ix_oauth_identity_lookup", "provider", "provider_user_id"),
+        Index("ix_oauth_identity_identity", "identity_id"),
     )
 
     def __repr__(self):

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -23,14 +23,15 @@ class Identity(Base):
 
     統一管理老師和學生的登入身分，
     以 email 為唯一識別，支援密碼統一管理和 OAuth 擴展。
+    1Campus SSO 帳號可能沒有 email，此時 email 為 null。
     """
 
     __tablename__ = "identities"
 
     id = Column(Integer, primary_key=True, index=True)
 
-    # 統一 Email（唯一）
-    email = Column(String(255), unique=True, nullable=False, index=True)
+    # 統一 Email（唯一，SSO-only 帳號可為 null）
+    email = Column(String(255), unique=True, nullable=True, index=True)
 
     # 密碼管理
     password_hash = Column(String(255), nullable=True)
@@ -40,6 +41,11 @@ class Identity(Base):
     # Email 驗證
     email_verified = Column(Boolean, default=False, nullable=False)
     email_verified_at = Column(DateTime(timezone=True), nullable=True)
+
+    # 1Campus SSO 欄位
+    one_campus_student_id = Column(String(100), nullable=True, index=True)
+    one_campus_account = Column(String(255), nullable=True)
+    national_id_hash = Column(String(64), nullable=True, index=True)
 
     is_active = Column(Boolean, default=True, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -13,9 +13,13 @@ from sqlalchemy import (
     Float,
     select,
 )
-from sqlalchemy.orm import relationship, Session
+import re
+
+from sqlalchemy.orm import relationship, Session, validates
 from sqlalchemy.sql import func
 from database import Base
+
+_SHA256_HEX_RE = re.compile(r"^[a-f0-9]{64}$")
 
 
 class Identity(Base):
@@ -62,6 +66,14 @@ class Identity(Base):
         back_populates="identity",
         foreign_keys="Teacher.identity_id",
     )
+
+    @validates("national_id_hash")
+    def _validate_national_id_hash(self, key, value):
+        if value is not None and not _SHA256_HEX_RE.match(value):
+            raise ValueError(
+                "national_id_hash must be a 64-char lowercase hex SHA256 digest"
+            )
+        return value
 
     def __repr__(self):
         return f"<Identity {self.email}>"

--- a/backend/services/oauth_service.py
+++ b/backend/services/oauth_service.py
@@ -67,6 +67,9 @@ class OAuthService:
 
         Creates a new OAuthIdentity record linking the external
         provider account to the specified teacher.
+
+        Note: identity_id is not set here — it will be wired in
+        the 1Campus SSO follow-up PR (#341).
         """
         identity = OAuthIdentity(
             teacher_id=teacher_id,


### PR DESCRIPTION
## Summary
- Add `one_campus_student_id`, `one_campus_account`, `national_id_hash` columns to `identities` table
- Make `identities.email` nullable to support SSO-only accounts (1Campus students may not have email)
- Add `identity_id` FK to `oauth_identities` table for Identity-level OAuth linking
- All migration statements are idempotent (`IF NOT EXISTS`)

This is the database preparation for #341 (1Campus SSO integration). No application logic changes — only schema + model updates.

## Changes
| File | Change |
|------|--------|
| `backend/alembic/versions/20260322_1000_add_1campus_identity_fields.py` | New migration |
| `backend/models/user.py` | Identity model: add 3 columns, email nullable |
| `backend/models/oauth_identity.py` | Add `identity_id` FK + relationship |

## Migration Checklist
- [x] `ADD COLUMN IF NOT EXISTS` (DO $$ block)
- [x] `CREATE INDEX IF NOT EXISTS`
- [x] Constraint uses `pg_constraint` check
- [x] New columns are `nullable=True`
- [x] No DROP, RENAME, ALTER TYPE
- [x] Idempotent — safe to re-run

## Test plan
- [ ] Migration runs successfully on staging DB
- [ ] Existing Identity records unaffected (email stays populated)
- [ ] New columns default to NULL
- [ ] `oauth_identities.identity_id` FK constraint works

Related: #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)