### PR TITLE
feat(#514): 教材活動 TTS 口音與性別新增 Random 選項

### DIFF
--- a/backend/services/tts.py
+++ b/backend/services/tts.py
@@ -26,6 +26,7 @@ class TTSService:
             },
             "en-GB": {"male": "en-GB-RyanNeural", "female": "en-GB-SoniaNeural"},
             "en-AU": {"male": "en-AU-WilliamNeural", "female": "en-AU-NatashaNeural"},
+            "en-IN": {"male": "en-IN-PrabhatNeural", "female": "en-IN-NeerjaNeural"},
         }
 
         # Azure Speech 設定
@@ -370,6 +371,18 @@ class TTSService:
                 "display_name": "William (AU Male)",
                 "gender": "Male",
                 "locale": "en-AU",
+            },
+            {
+                "name": "en-IN-NeerjaNeural",
+                "display_name": "Neerja (IN Female)",
+                "gender": "Female",
+                "locale": "en-IN",
+            },
+            {
+                "name": "en-IN-PrabhatNeural",
+                "display_name": "Prabhat (IN Male)",
+                "gender": "Male",
+                "locale": "en-IN",
             },
         ]
 

--- a/frontend/src/components/ReadingAssessmentPanel.tsx
+++ b/frontend/src/components/ReadingAssessmentPanel.tsx
@@ -1159,6 +1159,8 @@ export default function ReadingAssessmentPanel({
   }, []);
 
   // Save TTS settings to localStorage (Issue #121)
+  // Note: "Random" is intentionally persisted as the user's preference,
+  // so re-opening the panel preserves their intent to randomize.
   const saveBatchTTSSettings = () => {
     localStorage.setItem(
       "duotopia_batch_tts_settings",

--- a/frontend/src/components/ReadingAssessmentPanel.tsx
+++ b/frontend/src/components/ReadingAssessmentPanel.tsx
@@ -134,13 +134,37 @@ const TTSModal = ({
   const recordingDurationRef = useRef<number>(0);
 
   const accents = [
+    "Random",
     "American English",
     "British English",
     "Indian English",
     "Australian English",
   ];
-  const genders = ["Male", "Female"];
+  const genders = ["Random", "Male", "Female"];
   const speeds = ["Slow x0.75", "Normal x1", "Fast x1.5"];
+
+  // 解析 Random 選項，回傳實際的 accent/gender（每次呼叫都重新隨機）
+  const resolveRandomOptions = (
+    accentVal: string,
+    genderVal: string,
+  ): { resolvedAccent: string; resolvedGender: string } => {
+    const accentChoices = [
+      "American English",
+      "British English",
+      "Indian English",
+      "Australian English",
+    ];
+    const genderChoices = ["Male", "Female"];
+    const resolvedAccent =
+      accentVal === "Random"
+        ? accentChoices[Math.floor(Math.random() * accentChoices.length)]
+        : accentVal;
+    const resolvedGender =
+      genderVal === "Random"
+        ? genderChoices[Math.floor(Math.random() * genderChoices.length)]
+        : genderVal;
+    return { resolvedAccent, resolvedGender };
+  };
 
   // 當 modal 打開或 row.text 改變時，更新 text state
   useEffect(() => {
@@ -152,17 +176,33 @@ const TTSModal = ({
   const handleGenerate = async () => {
     setIsGenerating(true);
     try {
+      const { resolvedAccent, resolvedGender } = resolveRandomOptions(
+        accent,
+        gender,
+      );
       // 根據選擇的口音和性別選擇適當的語音
       let voice = "en-US-JennyNeural"; // 預設美國女聲
 
-      if (accent === "American English") {
+      if (resolvedAccent === "American English") {
         voice =
-          gender === "Male" ? "en-US-ChristopherNeural" : "en-US-JennyNeural";
-      } else if (accent === "British English") {
-        voice = gender === "Male" ? "en-GB-RyanNeural" : "en-GB-SoniaNeural";
-      } else if (accent === "Australian English") {
+          resolvedGender === "Male"
+            ? "en-US-ChristopherNeural"
+            : "en-US-JennyNeural";
+      } else if (resolvedAccent === "British English") {
         voice =
-          gender === "Male" ? "en-AU-WilliamNeural" : "en-AU-NatashaNeural";
+          resolvedGender === "Male"
+            ? "en-GB-RyanNeural"
+            : "en-GB-SoniaNeural";
+      } else if (resolvedAccent === "Indian English") {
+        voice =
+          resolvedGender === "Male"
+            ? "en-IN-PrabhatNeural"
+            : "en-IN-NeerjaNeural";
+      } else if (resolvedAccent === "Australian English") {
+        voice =
+          resolvedGender === "Male"
+            ? "en-AU-WilliamNeural"
+            : "en-AU-NatashaNeural";
       }
 
       // 轉換速度設定
@@ -1147,12 +1187,13 @@ export default function ReadingAssessmentPanel({
 
   // TTS options for batch paste (Issue #121)
   const batchTTSAccents = [
+    "Random",
     "American English",
     "British English",
     "Indian English",
     "Australian English",
   ];
-  const batchTTSGenders = ["Male", "Female"];
+  const batchTTSGenders = ["Random", "Male", "Female"];
   const batchTTSSpeeds = ["Slow x0.75", "Normal x1", "Fast x1.5"];
 
   // Load saved TTS settings from localStorage (Issue #121)
@@ -1171,18 +1212,46 @@ export default function ReadingAssessmentPanel({
   }, []);
 
   // Helper function to get voice and rate from TTS settings (Issue #121)
+  // 每次呼叫都會重新解析 Random，確保批次中每題不同
   const getVoiceAndRate = (accent: string, gender: string, speed: string) => {
+    const accentChoices = [
+      "American English",
+      "British English",
+      "Indian English",
+      "Australian English",
+    ];
+    const genderChoices = ["Male", "Female"];
+    const resolvedAccent =
+      accent === "Random"
+        ? accentChoices[Math.floor(Math.random() * accentChoices.length)]
+        : accent;
+    const resolvedGender =
+      gender === "Random"
+        ? genderChoices[Math.floor(Math.random() * genderChoices.length)]
+        : gender;
+
     let voice = "en-US-JennyNeural"; // default
 
-    if (accent === "American English") {
+    if (resolvedAccent === "American English") {
       voice =
-        gender === "Male" ? "en-US-ChristopherNeural" : "en-US-JennyNeural";
-    } else if (accent === "British English") {
-      voice = gender === "Male" ? "en-GB-RyanNeural" : "en-GB-SoniaNeural";
-    } else if (accent === "Indian English") {
-      voice = gender === "Male" ? "en-IN-PrabhatNeural" : "en-IN-NeerjaNeural";
-    } else if (accent === "Australian English") {
-      voice = gender === "Male" ? "en-AU-WilliamNeural" : "en-AU-NatashaNeural";
+        resolvedGender === "Male"
+          ? "en-US-ChristopherNeural"
+          : "en-US-JennyNeural";
+    } else if (resolvedAccent === "British English") {
+      voice =
+        resolvedGender === "Male"
+          ? "en-GB-RyanNeural"
+          : "en-GB-SoniaNeural";
+    } else if (resolvedAccent === "Indian English") {
+      voice =
+        resolvedGender === "Male"
+          ? "en-IN-PrabhatNeural"
+          : "en-IN-NeerjaNeural";
+    } else if (resolvedAccent === "Australian English") {
+      voice =
+        resolvedGender === "Male"
+          ? "en-AU-WilliamNeural"
+          : "en-AU-NatashaNeural";
     }
 
     let rate = "+0%";
@@ -1905,37 +1974,66 @@ export default function ReadingAssessmentPanel({
     if (autoTTS || autoTranslate) {
       try {
         if (autoTTS) {
-          // Get voice and rate from selected TTS settings (Issue #121)
-          const { voice, rate } = getVoiceAndRate(
-            batchTTSAccent,
-            batchTTSGender,
-            batchTTSSpeed,
-          );
-          // Save settings for next time
           saveBatchTTSSettings();
 
-          const ttsResult = await apiClient.batchGenerateTTS(
-            lines,
-            voice,
-            rate,
-            "+0%",
-          );
-          if (
-            ttsResult &&
-            typeof ttsResult === "object" &&
-            "audio_urls" in ttsResult
-          ) {
-            const audioUrls = (ttsResult as { audio_urls: string[] })
-              .audio_urls;
-            newItems = newItems.map((item, i) => ({
-              ...item,
-              audioUrl: audioUrls[i]?.startsWith("http")
-                ? audioUrls[i]
-                : `${import.meta.env.VITE_API_URL}${audioUrls[i]}`,
-              audio_url: audioUrls[i]?.startsWith("http")
-                ? audioUrls[i]
-                : `${import.meta.env.VITE_API_URL}${audioUrls[i]}`,
-            }));
+          const isRandom =
+            batchTTSAccent === "Random" || batchTTSGender === "Random";
+
+          if (isRandom) {
+            // Random 模式：每題個別生成，確保口音/性別不同
+            for (let i = 0; i < newItems.length; i++) {
+              const { voice, rate } = getVoiceAndRate(
+                batchTTSAccent,
+                batchTTSGender,
+                batchTTSSpeed,
+              );
+              const ttsResult = await apiClient.generateTTS(
+                newItems[i].text,
+                voice,
+                rate,
+                "+0%",
+              );
+              if (ttsResult?.audio_url) {
+                const fullUrl = ttsResult.audio_url.startsWith("http")
+                  ? ttsResult.audio_url
+                  : `${import.meta.env.VITE_API_URL}${ttsResult.audio_url}`;
+                newItems[i] = {
+                  ...newItems[i],
+                  audioUrl: fullUrl,
+                  audio_url: fullUrl,
+                };
+              }
+            }
+          } else {
+            // 固定口音/性別：批次生成
+            const { voice, rate } = getVoiceAndRate(
+              batchTTSAccent,
+              batchTTSGender,
+              batchTTSSpeed,
+            );
+            const ttsResult = await apiClient.batchGenerateTTS(
+              lines,
+              voice,
+              rate,
+              "+0%",
+            );
+            if (
+              ttsResult &&
+              typeof ttsResult === "object" &&
+              "audio_urls" in ttsResult
+            ) {
+              const audioUrls = (ttsResult as { audio_urls: string[] })
+                .audio_urls;
+              newItems = newItems.map((item, i) => ({
+                ...item,
+                audioUrl: audioUrls[i]?.startsWith("http")
+                  ? audioUrls[i]
+                  : `${import.meta.env.VITE_API_URL}${audioUrls[i]}`,
+                audio_url: audioUrls[i]?.startsWith("http")
+                  ? audioUrls[i]
+                  : `${import.meta.env.VITE_API_URL}${audioUrls[i]}`,
+              }));
+            }
           }
         }
 

--- a/frontend/src/components/ReadingAssessmentPanel.tsx
+++ b/frontend/src/components/ReadingAssessmentPanel.tsx
@@ -190,9 +190,7 @@ const TTSModal = ({
             : "en-US-JennyNeural";
       } else if (resolvedAccent === "British English") {
         voice =
-          resolvedGender === "Male"
-            ? "en-GB-RyanNeural"
-            : "en-GB-SoniaNeural";
+          resolvedGender === "Male" ? "en-GB-RyanNeural" : "en-GB-SoniaNeural";
       } else if (resolvedAccent === "Indian English") {
         voice =
           resolvedGender === "Male"
@@ -1239,9 +1237,7 @@ export default function ReadingAssessmentPanel({
           : "en-US-JennyNeural";
     } else if (resolvedAccent === "British English") {
       voice =
-        resolvedGender === "Male"
-          ? "en-GB-RyanNeural"
-          : "en-GB-SoniaNeural";
+        resolvedGender === "Male" ? "en-GB-RyanNeural" : "en-GB-SoniaNeural";
     } else if (resolvedAccent === "Indian English") {
       voice =
         resolvedGender === "Male"

--- a/frontend/src/components/ReadingAssessmentPanel.tsx
+++ b/frontend/src/components/ReadingAssessmentPanel.tsx
@@ -26,6 +26,12 @@ import {
 import { toast } from "sonner";
 import { apiClient, ApiError } from "@/lib/api";
 import { retryAudioUpload } from "@/utils/retryHelper";
+import {
+  TTS_ACCENTS,
+  TTS_GENDERS,
+  TTS_SPEEDS,
+  getVoiceAndRate,
+} from "@/utils/ttsVoiceResolver";
 // dnd-kit imports
 import {
   DndContext,
@@ -133,38 +139,9 @@ const TTSModal = ({
   const audioBlobRef = useRef<Blob | null>(null);
   const recordingDurationRef = useRef<number>(0);
 
-  const accents = [
-    "Random",
-    "American English",
-    "British English",
-    "Indian English",
-    "Australian English",
-  ];
-  const genders = ["Random", "Male", "Female"];
-  const speeds = ["Slow x0.75", "Normal x1", "Fast x1.5"];
-
-  // 解析 Random 選項，回傳實際的 accent/gender（每次呼叫都重新隨機）
-  const resolveRandomOptions = (
-    accentVal: string,
-    genderVal: string,
-  ): { resolvedAccent: string; resolvedGender: string } => {
-    const accentChoices = [
-      "American English",
-      "British English",
-      "Indian English",
-      "Australian English",
-    ];
-    const genderChoices = ["Male", "Female"];
-    const resolvedAccent =
-      accentVal === "Random"
-        ? accentChoices[Math.floor(Math.random() * accentChoices.length)]
-        : accentVal;
-    const resolvedGender =
-      genderVal === "Random"
-        ? genderChoices[Math.floor(Math.random() * genderChoices.length)]
-        : genderVal;
-    return { resolvedAccent, resolvedGender };
-  };
+  const accents = TTS_ACCENTS;
+  const genders = TTS_GENDERS;
+  const speeds = TTS_SPEEDS;
 
   // 當 modal 打開或 row.text 改變時，更新 text state
   useEffect(() => {
@@ -176,37 +153,7 @@ const TTSModal = ({
   const handleGenerate = async () => {
     setIsGenerating(true);
     try {
-      const { resolvedAccent, resolvedGender } = resolveRandomOptions(
-        accent,
-        gender,
-      );
-      // 根據選擇的口音和性別選擇適當的語音
-      let voice = "en-US-JennyNeural"; // 預設美國女聲
-
-      if (resolvedAccent === "American English") {
-        voice =
-          resolvedGender === "Male"
-            ? "en-US-ChristopherNeural"
-            : "en-US-JennyNeural";
-      } else if (resolvedAccent === "British English") {
-        voice =
-          resolvedGender === "Male" ? "en-GB-RyanNeural" : "en-GB-SoniaNeural";
-      } else if (resolvedAccent === "Indian English") {
-        voice =
-          resolvedGender === "Male"
-            ? "en-IN-PrabhatNeural"
-            : "en-IN-NeerjaNeural";
-      } else if (resolvedAccent === "Australian English") {
-        voice =
-          resolvedGender === "Male"
-            ? "en-AU-WilliamNeural"
-            : "en-AU-NatashaNeural";
-      }
-
-      // 轉換速度設定
-      let rate = "+0%";
-      if (speed === "Slow x0.75") rate = "-25%";
-      else if (speed === "Fast x1.5") rate = "+50%";
+      const { voice, rate } = getVoiceAndRate(accent, gender, speed);
 
       const result = await apiClient.generateTTS(text, voice, rate, "+0%");
 
@@ -536,7 +483,9 @@ const TTSModal = ({
             </div>
 
             <div>
-              <label className="text-sm font-medium">Accent</label>
+              <label className="text-sm font-medium">
+                {t("contentEditor.generate.accent")}
+              </label>
               <select
                 value={accent}
                 onChange={(e) => setAccent(e.target.value)}
@@ -552,7 +501,9 @@ const TTSModal = ({
 
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label className="text-sm font-medium">Gender</label>
+                <label className="text-sm font-medium">
+                  {t("contentEditor.generate.gender")}
+                </label>
                 <select
                   value={gender}
                   onChange={(e) => setGender(e.target.value)}
@@ -567,7 +518,9 @@ const TTSModal = ({
               </div>
 
               <div>
-                <label className="text-sm font-medium">Speed</label>
+                <label className="text-sm font-medium">
+                  {t("contentEditor.generate.speed")}
+                </label>
                 <select
                   value={speed}
                   onChange={(e) => setSpeed(e.target.value)}
@@ -589,7 +542,9 @@ const TTSModal = ({
                 className="flex-1 bg-yellow-500 hover:bg-yellow-600 dark:bg-yellow-400 dark:hover:bg-yellow-500 text-black"
                 title={t("contentEditor.tooltips.ttsMicrosoftEdge")}
               >
-                {isGenerating ? "Generating..." : "Generate"}
+                {isGenerating
+                  ? t("contentEditor.generate.generating")
+                  : t("contentEditor.generate.generate")}
               </Button>
               {audioUrl && (
                 <Button
@@ -1184,15 +1139,9 @@ export default function ReadingAssessmentPanel({
   );
 
   // TTS options for batch paste (Issue #121)
-  const batchTTSAccents = [
-    "Random",
-    "American English",
-    "British English",
-    "Indian English",
-    "Australian English",
-  ];
-  const batchTTSGenders = ["Random", "Male", "Female"];
-  const batchTTSSpeeds = ["Slow x0.75", "Normal x1", "Fast x1.5"];
+  const batchTTSAccents = TTS_ACCENTS;
+  const batchTTSGenders = TTS_GENDERS;
+  const batchTTSSpeeds = TTS_SPEEDS;
 
   // Load saved TTS settings from localStorage (Issue #121)
   useEffect(() => {
@@ -1208,54 +1157,6 @@ export default function ReadingAssessmentPanel({
       }
     }
   }, []);
-
-  // Helper function to get voice and rate from TTS settings (Issue #121)
-  // 每次呼叫都會重新解析 Random，確保批次中每題不同
-  const getVoiceAndRate = (accent: string, gender: string, speed: string) => {
-    const accentChoices = [
-      "American English",
-      "British English",
-      "Indian English",
-      "Australian English",
-    ];
-    const genderChoices = ["Male", "Female"];
-    const resolvedAccent =
-      accent === "Random"
-        ? accentChoices[Math.floor(Math.random() * accentChoices.length)]
-        : accent;
-    const resolvedGender =
-      gender === "Random"
-        ? genderChoices[Math.floor(Math.random() * genderChoices.length)]
-        : gender;
-
-    let voice = "en-US-JennyNeural"; // default
-
-    if (resolvedAccent === "American English") {
-      voice =
-        resolvedGender === "Male"
-          ? "en-US-ChristopherNeural"
-          : "en-US-JennyNeural";
-    } else if (resolvedAccent === "British English") {
-      voice =
-        resolvedGender === "Male" ? "en-GB-RyanNeural" : "en-GB-SoniaNeural";
-    } else if (resolvedAccent === "Indian English") {
-      voice =
-        resolvedGender === "Male"
-          ? "en-IN-PrabhatNeural"
-          : "en-IN-NeerjaNeural";
-    } else if (resolvedAccent === "Australian English") {
-      voice =
-        resolvedGender === "Male"
-          ? "en-AU-WilliamNeural"
-          : "en-AU-NatashaNeural";
-    }
-
-    let rate = "+0%";
-    if (speed === "Slow x0.75") rate = "-25%";
-    else if (speed === "Fast x1.5") rate = "+50%";
-
-    return { voice, rate };
-  };
 
   // Save TTS settings to localStorage (Issue #121)
   const saveBatchTTSSettings = () => {

--- a/frontend/src/components/ReadingAssessmentPanel.tsx
+++ b/frontend/src/components/ReadingAssessmentPanel.tsx
@@ -1114,8 +1114,8 @@ export default function ReadingAssessmentPanel({
   const [isInitialLoad, setIsInitialLoad] = useState(true); // 🔥 標記是否為初始載入
 
   // TTS settings for batch paste (Issue #121)
-  const [batchTTSAccent, setBatchTTSAccent] = useState("American English");
-  const [batchTTSGender, setBatchTTSGender] = useState("Male");
+  const [batchTTSAccent, setBatchTTSAccent] = useState("Random");
+  const [batchTTSGender, setBatchTTSGender] = useState("Random");
   const [batchTTSSpeed, setBatchTTSSpeed] = useState("Normal x1");
   const [isBatchGeneratingTTS, setIsBatchGeneratingTTS] = useState(false); // 批次生成 TTS 中
   const [isBatchGeneratingTranslation, setIsBatchGeneratingTranslation] =
@@ -1567,51 +1567,109 @@ export default function ReadingAssessmentPanel({
         }),
       );
 
-      // 批次生成 TTS
-      const result = await apiClient.batchGenerateTTS(
-        textsToGenerate,
-        "en-US-JennyNeural", // 預設使用美國女聲
-        "+0%",
-        "+0%",
-      );
+      // 批次生成 TTS — Random 時每題不同語音
+      const isRandom =
+        batchTTSAccent === "Random" || batchTTSGender === "Random";
+      const newRows = [...rows];
 
-      if (
-        result &&
-        typeof result === "object" &&
-        "audio_urls" in result &&
-        Array.isArray(result.audio_urls)
-      ) {
-        // 更新 rows 的 audioUrl
-        const newRows = [...rows];
-        let audioIndex = 0;
-
+      if (isRandom) {
+        // Per-item TTS with different random voices
         for (let i = 0; i < newRows.length; i++) {
           if (newRows[i].text && !newRows[i].audioUrl) {
-            const audioUrl = (result as { audio_urls: string[] }).audio_urls[
-              audioIndex
-            ];
-            // 如果是相對路徑，加上 API base URL
-            newRows[i].audioUrl = audioUrl.startsWith("http")
-              ? audioUrl
-              : `${import.meta.env.VITE_API_URL}${audioUrl}`;
-            audioIndex++;
+            const { voice, rate } = getVoiceAndRate(
+              batchTTSAccent,
+              batchTTSGender,
+              batchTTSSpeed,
+            );
+            const ttsResult = await apiClient.generateTTS(
+              newRows[i].text,
+              voice,
+              rate,
+              "+0%",
+            );
+            if (
+              ttsResult &&
+              typeof ttsResult === "object" &&
+              "audio_url" in ttsResult
+            ) {
+              const audioUrl = (ttsResult as { audio_url: string }).audio_url;
+              newRows[i].audioUrl = audioUrl.startsWith("http")
+                ? audioUrl
+                : `${import.meta.env.VITE_API_URL}${audioUrl}`;
+            }
           }
         }
+      } else {
+        // Batch TTS with single voice
+        const { voice, rate } = getVoiceAndRate(
+          batchTTSAccent,
+          batchTTSGender,
+          batchTTSSpeed,
+        );
+        const result = await apiClient.batchGenerateTTS(
+          textsToGenerate,
+          voice,
+          rate,
+          "+0%",
+        );
 
-        setRows(newRows);
+        if (
+          result &&
+          typeof result === "object" &&
+          "audio_urls" in result &&
+          Array.isArray(result.audio_urls)
+        ) {
+          let audioIndex = 0;
+          for (let i = 0; i < newRows.length; i++) {
+            if (newRows[i].text && !newRows[i].audioUrl) {
+              const audioUrl = (result as { audio_urls: string[] }).audio_urls[
+                audioIndex
+              ];
+              newRows[i].audioUrl = audioUrl.startsWith("http")
+                ? audioUrl
+                : `${import.meta.env.VITE_API_URL}${audioUrl}`;
+              audioIndex++;
+            }
+          }
+        }
+      }
 
-        // 立即更新 content 並儲存到後端（不要用 onSave 避免關閉 panel）
-        const items = newRows.map((row) => ({
-          text: row.text,
-          definition: row.definition, // 中文翻譯
-          translation: row.translation, // 英文釋義
-          audio_url: row.audioUrl || "",
-          selectedLanguage: row.selectedLanguage, // 記錄最後選擇的語言
-        }));
+      setRows(newRows);
 
-        // 新增模式：只更新本地狀態，不呼叫 API
-        if (isCreating) {
-          // 更新本地狀態
+      // 立即更新 content 並儲存到後端（不要用 onSave 避免關閉 panel）
+      const items = newRows.map((row) => ({
+        text: row.text,
+        definition: row.definition, // 中文翻譯
+        translation: row.translation, // 英文釋義
+        audio_url: row.audioUrl || "",
+        selectedLanguage: row.selectedLanguage, // 記錄最後選擇的語言
+      }));
+
+      // 新增模式：只更新本地狀態，不呼叫 API
+      if (isCreating) {
+        if (onUpdateContent) {
+          onUpdateContent({
+            ...editingContent,
+            title,
+            items,
+          });
+        }
+
+        toast.success(
+          t("contentEditor.messages.audioGeneratedSuccessfully", {
+            count: textsToGenerate.length,
+          }),
+        );
+      } else if (editingContent?.id) {
+        // 編輯模式：直接呼叫 API 更新
+        try {
+          const updateData = {
+            title: title || editingContent?.title,
+            items,
+          };
+
+          await apiClient.updateContent(editingContent.id, updateData);
+
           if (onUpdateContent) {
             onUpdateContent({
               ...editingContent,
@@ -1621,65 +1679,38 @@ export default function ReadingAssessmentPanel({
           }
 
           toast.success(
-            t("contentEditor.messages.audioGeneratedSuccessfully", {
+            t("contentEditor.messages.audioGeneratedAndSaved", {
               count: textsToGenerate.length,
             }),
           );
-        } else if (editingContent?.id) {
-          // 編輯模式：直接呼叫 API 更新
-          try {
-            const updateData = {
-              title: title || editingContent?.title,
-              items,
-            };
-
-            await apiClient.updateContent(editingContent.id, updateData);
-
-            // 更新本地狀態
-            if (onUpdateContent) {
-              onUpdateContent({
-                ...editingContent,
-                title,
-                items,
-              });
-            }
-
-            toast.success(
-              t("contentEditor.messages.audioGeneratedAndSaved", {
-                count: textsToGenerate.length,
-              }),
-            );
-          } catch (error: unknown) {
-            console.error("Failed to save TTS:", error);
-            // 解析 ApiError 的結構化錯誤訊息
-            if (error instanceof ApiError) {
-              const detail = error.detail;
-              const errorMessage =
-                typeof detail === "object" &&
-                !Array.isArray(detail) &&
-                detail?.message
-                  ? detail.message
-                  : typeof detail === "string"
-                    ? detail
-                    : null;
-              toast.error(
-                errorMessage ||
-                  t("contentEditor.messages.savingFailedButAudioGenerated"),
-              );
-            } else {
-              toast.error(
+        } catch (error: unknown) {
+          console.error("Failed to save TTS:", error);
+          if (error instanceof ApiError) {
+            const detail = error.detail;
+            const errorMessage =
+              typeof detail === "object" &&
+              !Array.isArray(detail) &&
+              detail?.message
+                ? detail.message
+                : typeof detail === "string"
+                  ? detail
+                  : null;
+            toast.error(
+              errorMessage ||
                 t("contentEditor.messages.savingFailedButAudioGenerated"),
-              );
-            }
+            );
+          } else {
+            toast.error(
+              t("contentEditor.messages.savingFailedButAudioGenerated"),
+            );
           }
-        } else {
-          // 沒有 content ID，只是本地更新
-          toast.success(
-            t("contentEditor.messages.audioGeneratedSuccessfully", {
-              count: textsToGenerate.length,
-            }),
-          );
         }
+      } else {
+        toast.success(
+          t("contentEditor.messages.audioGeneratedSuccessfully", {
+            count: textsToGenerate.length,
+          }),
+        );
       }
     } catch (error) {
       console.error("Batch TTS generation failed:", error);

--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -312,12 +312,13 @@ const TTSModal = ({
   const recordingDurationRef = useRef<number>(0);
 
   const accents = [
+    "Random",
     "American English",
     "British English",
     "Indian English",
     "Australian English",
   ];
-  const genders = ["Male", "Female"];
+  const genders = ["Random", "Male", "Female"];
   const speeds = ["Slow x0.75", "Normal x1", "Fast x1.5"];
 
   // 當 modal 打開或 row.text 改變時，更新 text state
@@ -327,20 +328,59 @@ const TTSModal = ({
     }
   }, [open, row.text]);
 
+  // 解析 Random 選項，回傳實際的 accent/gender（每次呼叫都重新隨機）
+  const resolveRandomOptions = (
+    accentVal: string,
+    genderVal: string,
+  ): { resolvedAccent: string; resolvedGender: string } => {
+    const accentChoices = [
+      "American English",
+      "British English",
+      "Indian English",
+      "Australian English",
+    ];
+    const genderChoices = ["Male", "Female"];
+    const resolvedAccent =
+      accentVal === "Random"
+        ? accentChoices[Math.floor(Math.random() * accentChoices.length)]
+        : accentVal;
+    const resolvedGender =
+      genderVal === "Random"
+        ? genderChoices[Math.floor(Math.random() * genderChoices.length)]
+        : genderVal;
+    return { resolvedAccent, resolvedGender };
+  };
+
   const handleGenerate = async () => {
     setIsGenerating(true);
     try {
+      const { resolvedAccent, resolvedGender } = resolveRandomOptions(
+        accent,
+        gender,
+      );
       // 根據選擇的口音和性別選擇適當的語音
       let voice = "en-US-JennyNeural"; // 預設美國女聲
 
-      if (accent === "American English") {
+      if (resolvedAccent === "American English") {
         voice =
-          gender === "Male" ? "en-US-ChristopherNeural" : "en-US-JennyNeural";
-      } else if (accent === "British English") {
-        voice = gender === "Male" ? "en-GB-RyanNeural" : "en-GB-SoniaNeural";
-      } else if (accent === "Australian English") {
+          resolvedGender === "Male"
+            ? "en-US-ChristopherNeural"
+            : "en-US-JennyNeural";
+      } else if (resolvedAccent === "British English") {
         voice =
-          gender === "Male" ? "en-AU-WilliamNeural" : "en-AU-NatashaNeural";
+          resolvedGender === "Male"
+            ? "en-GB-RyanNeural"
+            : "en-GB-SoniaNeural";
+      } else if (resolvedAccent === "Indian English") {
+        voice =
+          resolvedGender === "Male"
+            ? "en-IN-PrabhatNeural"
+            : "en-IN-NeerjaNeural";
+      } else if (resolvedAccent === "Australian English") {
+        voice =
+          resolvedGender === "Male"
+            ? "en-AU-WilliamNeural"
+            : "en-AU-NatashaNeural";
       }
 
       // 轉換速度設定
@@ -1623,12 +1663,13 @@ export default function VocabularySetPanel({
 
   // TTS options for batch paste (Issue #121)
   const batchTTSAccents = [
+    "Random",
     "American English",
     "British English",
     "Indian English",
     "Australian English",
   ];
-  const batchTTSGenders = ["Male", "Female"];
+  const batchTTSGenders = ["Random", "Male", "Female"];
   const batchTTSSpeeds = ["Slow x0.75", "Normal x1", "Fast x1.5"];
 
   // Load saved TTS settings from localStorage (Issue #121)
@@ -1647,18 +1688,46 @@ export default function VocabularySetPanel({
   }, []);
 
   // Helper function to get voice and rate from TTS settings (Issue #121)
+  // 每次呼叫都會重新解析 Random，確保批次中每題不同
   const getVoiceAndRate = (accent: string, gender: string, speed: string) => {
+    const accentChoices = [
+      "American English",
+      "British English",
+      "Indian English",
+      "Australian English",
+    ];
+    const genderChoices = ["Male", "Female"];
+    const resolvedAccent =
+      accent === "Random"
+        ? accentChoices[Math.floor(Math.random() * accentChoices.length)]
+        : accent;
+    const resolvedGender =
+      gender === "Random"
+        ? genderChoices[Math.floor(Math.random() * genderChoices.length)]
+        : gender;
+
     let voice = "en-US-JennyNeural"; // default
 
-    if (accent === "American English") {
+    if (resolvedAccent === "American English") {
       voice =
-        gender === "Male" ? "en-US-ChristopherNeural" : "en-US-JennyNeural";
-    } else if (accent === "British English") {
-      voice = gender === "Male" ? "en-GB-RyanNeural" : "en-GB-SoniaNeural";
-    } else if (accent === "Indian English") {
-      voice = gender === "Male" ? "en-IN-PrabhatNeural" : "en-IN-NeerjaNeural";
-    } else if (accent === "Australian English") {
-      voice = gender === "Male" ? "en-AU-WilliamNeural" : "en-AU-NatashaNeural";
+        resolvedGender === "Male"
+          ? "en-US-ChristopherNeural"
+          : "en-US-JennyNeural";
+    } else if (resolvedAccent === "British English") {
+      voice =
+        resolvedGender === "Male"
+          ? "en-GB-RyanNeural"
+          : "en-GB-SoniaNeural";
+    } else if (resolvedAccent === "Indian English") {
+      voice =
+        resolvedGender === "Male"
+          ? "en-IN-PrabhatNeural"
+          : "en-IN-NeerjaNeural";
+    } else if (resolvedAccent === "Australian English") {
+      voice =
+        resolvedGender === "Male"
+          ? "en-AU-WilliamNeural"
+          : "en-AU-NatashaNeural";
     }
 
     let rate = "+0%";
@@ -3149,16 +3218,7 @@ export default function VocabularySetPanel({
             : WORD_TRANSLATION_LANGUAGES.find((l) => l.value === batchLang)
                 ?.code || "zh-TW";
 
-        let voice = "";
-        let rate = "";
         if (autoTTS) {
-          const ttsSettings = getVoiceAndRate(
-            batchTTSAccent,
-            batchTTSGender,
-            batchTTSSpeed,
-          );
-          voice = ttsSettings.voice;
-          rate = ttsSettings.rate;
           saveBatchTTSSettings();
         }
 
@@ -3309,8 +3369,13 @@ export default function VocabularySetPanel({
               }
             }
 
-            // 補齊 TTS（如果缺少）
+            // 補齊 TTS（如果缺少）— 每題重新解析 Random
             if (autoTTS && !row.audioUrl && !row.audio_url) {
+              const { voice, rate } = getVoiceAndRate(
+                batchTTSAccent,
+                batchTTSGender,
+                batchTTSSpeed,
+              );
               const ttsResult = await apiClient.generateTTS(
                 text,
                 voice,
@@ -3426,17 +3491,8 @@ export default function VocabularySetPanel({
           : WORD_TRANSLATION_LANGUAGES.find((l) => l.value === batchLang)
               ?.code || "zh-TW";
 
-      // TTS settings
-      let voice = "";
-      let rate = "";
+      // TTS settings — 每題在迴圈內重新解析 Random
       if (autoTTS) {
-        const ttsSettings = getVoiceAndRate(
-          batchTTSAccent,
-          batchTTSGender,
-          batchTTSSpeed,
-        );
-        voice = ttsSettings.voice;
-        rate = ttsSettings.rate;
         saveBatchTTSSettings();
       }
 
@@ -3560,8 +3616,13 @@ export default function VocabularySetPanel({
             });
           }
 
-          // Step 2: TTS
+          // Step 2: TTS — 每題重新解析 Random
           if (autoTTS) {
+            const { voice, rate } = getVoiceAndRate(
+              batchTTSAccent,
+              batchTTSGender,
+              batchTTSSpeed,
+            );
             const ttsResult = await apiClient.generateTTS(
               text,
               voice,

--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -368,9 +368,7 @@ const TTSModal = ({
             : "en-US-JennyNeural";
       } else if (resolvedAccent === "British English") {
         voice =
-          resolvedGender === "Male"
-            ? "en-GB-RyanNeural"
-            : "en-GB-SoniaNeural";
+          resolvedGender === "Male" ? "en-GB-RyanNeural" : "en-GB-SoniaNeural";
       } else if (resolvedAccent === "Indian English") {
         voice =
           resolvedGender === "Male"
@@ -1715,9 +1713,7 @@ export default function VocabularySetPanel({
           : "en-US-JennyNeural";
     } else if (resolvedAccent === "British English") {
       voice =
-        resolvedGender === "Male"
-          ? "en-GB-RyanNeural"
-          : "en-GB-SoniaNeural";
+        resolvedGender === "Male" ? "en-GB-RyanNeural" : "en-GB-SoniaNeural";
     } else if (resolvedAccent === "Indian English") {
       voice =
         resolvedGender === "Male"

--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -30,6 +30,12 @@ import {
 import { toast } from "sonner";
 import { apiClient } from "@/lib/api";
 import { retryAudioUpload } from "@/utils/retryHelper";
+import {
+  TTS_ACCENTS,
+  TTS_GENDERS,
+  TTS_SPEEDS,
+  getVoiceAndRate,
+} from "@/utils/ttsVoiceResolver";
 // dnd-kit imports
 import {
   DndContext,
@@ -311,15 +317,9 @@ const TTSModal = ({
   const audioBlobRef = useRef<Blob | null>(null);
   const recordingDurationRef = useRef<number>(0);
 
-  const accents = [
-    "Random",
-    "American English",
-    "British English",
-    "Indian English",
-    "Australian English",
-  ];
-  const genders = ["Random", "Male", "Female"];
-  const speeds = ["Slow x0.75", "Normal x1", "Fast x1.5"];
+  const accents = TTS_ACCENTS;
+  const genders = TTS_GENDERS;
+  const speeds = TTS_SPEEDS;
 
   // 當 modal 打開或 row.text 改變時，更新 text state
   useEffect(() => {
@@ -328,63 +328,10 @@ const TTSModal = ({
     }
   }, [open, row.text]);
 
-  // 解析 Random 選項，回傳實際的 accent/gender（每次呼叫都重新隨機）
-  const resolveRandomOptions = (
-    accentVal: string,
-    genderVal: string,
-  ): { resolvedAccent: string; resolvedGender: string } => {
-    const accentChoices = [
-      "American English",
-      "British English",
-      "Indian English",
-      "Australian English",
-    ];
-    const genderChoices = ["Male", "Female"];
-    const resolvedAccent =
-      accentVal === "Random"
-        ? accentChoices[Math.floor(Math.random() * accentChoices.length)]
-        : accentVal;
-    const resolvedGender =
-      genderVal === "Random"
-        ? genderChoices[Math.floor(Math.random() * genderChoices.length)]
-        : genderVal;
-    return { resolvedAccent, resolvedGender };
-  };
-
   const handleGenerate = async () => {
     setIsGenerating(true);
     try {
-      const { resolvedAccent, resolvedGender } = resolveRandomOptions(
-        accent,
-        gender,
-      );
-      // 根據選擇的口音和性別選擇適當的語音
-      let voice = "en-US-JennyNeural"; // 預設美國女聲
-
-      if (resolvedAccent === "American English") {
-        voice =
-          resolvedGender === "Male"
-            ? "en-US-ChristopherNeural"
-            : "en-US-JennyNeural";
-      } else if (resolvedAccent === "British English") {
-        voice =
-          resolvedGender === "Male" ? "en-GB-RyanNeural" : "en-GB-SoniaNeural";
-      } else if (resolvedAccent === "Indian English") {
-        voice =
-          resolvedGender === "Male"
-            ? "en-IN-PrabhatNeural"
-            : "en-IN-NeerjaNeural";
-      } else if (resolvedAccent === "Australian English") {
-        voice =
-          resolvedGender === "Male"
-            ? "en-AU-WilliamNeural"
-            : "en-AU-NatashaNeural";
-      }
-
-      // 轉換速度設定
-      let rate = "+0%";
-      if (speed === "Slow x0.75") rate = "-25%";
-      else if (speed === "Fast x1.5") rate = "+50%";
+      const { voice, rate } = getVoiceAndRate(accent, gender, speed);
 
       const result = await apiClient.generateTTS(text, voice, rate, "+0%");
 
@@ -714,7 +661,9 @@ const TTSModal = ({
             </div>
 
             <div>
-              <label className="text-sm font-medium">Accent</label>
+              <label className="text-sm font-medium">
+                {t("contentEditor.generate.accent")}
+              </label>
               <select
                 value={accent}
                 onChange={(e) => setAccent(e.target.value)}
@@ -730,7 +679,9 @@ const TTSModal = ({
 
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label className="text-sm font-medium">Gender</label>
+                <label className="text-sm font-medium">
+                  {t("contentEditor.generate.gender")}
+                </label>
                 <select
                   value={gender}
                   onChange={(e) => setGender(e.target.value)}
@@ -745,7 +696,9 @@ const TTSModal = ({
               </div>
 
               <div>
-                <label className="text-sm font-medium">Speed</label>
+                <label className="text-sm font-medium">
+                  {t("contentEditor.generate.speed")}
+                </label>
                 <select
                   value={speed}
                   onChange={(e) => setSpeed(e.target.value)}
@@ -767,7 +720,9 @@ const TTSModal = ({
                 className="flex-1 bg-yellow-500 hover:bg-yellow-600 dark:bg-yellow-400 dark:hover:bg-yellow-500 text-black"
                 title={t("contentEditor.tooltips.ttsMicrosoftEdge")}
               >
-                {isGenerating ? "Generating..." : "Generate"}
+                {isGenerating
+                  ? t("contentEditor.generate.generating")
+                  : t("contentEditor.generate.generate")}
               </Button>
               {audioUrl && (
                 <Button
@@ -1660,15 +1615,9 @@ export default function VocabularySetPanel({
   );
 
   // TTS options for batch paste (Issue #121)
-  const batchTTSAccents = [
-    "Random",
-    "American English",
-    "British English",
-    "Indian English",
-    "Australian English",
-  ];
-  const batchTTSGenders = ["Random", "Male", "Female"];
-  const batchTTSSpeeds = ["Slow x0.75", "Normal x1", "Fast x1.5"];
+  const batchTTSAccents = TTS_ACCENTS;
+  const batchTTSGenders = TTS_GENDERS;
+  const batchTTSSpeeds = TTS_SPEEDS;
 
   // Load saved TTS settings from localStorage (Issue #121)
   useEffect(() => {
@@ -1684,54 +1633,6 @@ export default function VocabularySetPanel({
       }
     }
   }, []);
-
-  // Helper function to get voice and rate from TTS settings (Issue #121)
-  // 每次呼叫都會重新解析 Random，確保批次中每題不同
-  const getVoiceAndRate = (accent: string, gender: string, speed: string) => {
-    const accentChoices = [
-      "American English",
-      "British English",
-      "Indian English",
-      "Australian English",
-    ];
-    const genderChoices = ["Male", "Female"];
-    const resolvedAccent =
-      accent === "Random"
-        ? accentChoices[Math.floor(Math.random() * accentChoices.length)]
-        : accent;
-    const resolvedGender =
-      gender === "Random"
-        ? genderChoices[Math.floor(Math.random() * genderChoices.length)]
-        : gender;
-
-    let voice = "en-US-JennyNeural"; // default
-
-    if (resolvedAccent === "American English") {
-      voice =
-        resolvedGender === "Male"
-          ? "en-US-ChristopherNeural"
-          : "en-US-JennyNeural";
-    } else if (resolvedAccent === "British English") {
-      voice =
-        resolvedGender === "Male" ? "en-GB-RyanNeural" : "en-GB-SoniaNeural";
-    } else if (resolvedAccent === "Indian English") {
-      voice =
-        resolvedGender === "Male"
-          ? "en-IN-PrabhatNeural"
-          : "en-IN-NeerjaNeural";
-    } else if (resolvedAccent === "Australian English") {
-      voice =
-        resolvedGender === "Male"
-          ? "en-AU-WilliamNeural"
-          : "en-AU-NatashaNeural";
-    }
-
-    let rate = "+0%";
-    if (speed === "Slow x0.75") rate = "-25%";
-    else if (speed === "Fast x1.5") rate = "+50%";
-
-    return { voice, rate };
-  };
 
   // Save TTS settings to localStorage (Issue #121)
   const saveBatchTTSSettings = () => {
@@ -3648,11 +3549,6 @@ export default function VocabularySetPanel({
 
           // Step 3: AI 例句
           if (shouldGenerateExamples) {
-            console.log("[Do the Magic] AI例句參數:", {
-              exampleTargetLang,
-              aiGenerateTranslateLang,
-              lessonId,
-            });
             const response = await apiClient.generateSentences({
               words: [text],
               definitions: [newItem.definition || ""],

--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -1574,8 +1574,8 @@ export default function VocabularySetPanel({
   }, [rows]);
 
   // TTS settings for batch paste (Issue #121)
-  const [batchTTSAccent, setBatchTTSAccent] = useState("American English");
-  const [batchTTSGender, setBatchTTSGender] = useState("Male");
+  const [batchTTSAccent, setBatchTTSAccent] = useState("Random");
+  const [batchTTSGender, setBatchTTSGender] = useState("Random");
   const [batchTTSSpeed, setBatchTTSSpeed] = useState("Normal x1");
 
   // 多義 Picker 狀態（英英釋義 / 中文翻譯皆可）
@@ -2348,43 +2348,81 @@ export default function VocabularySetPanel({
     }
 
     try {
-      // 批次生成 TTS（使用預設美國女聲）
-      const result = await apiClient.batchGenerateTTS(
-        textsToGenerate,
-        "en-US-JennyNeural",
-        "+0%",
-        "+0%",
-      );
+      const isRandom =
+        batchTTSAccent === "Random" || batchTTSGender === "Random";
+      const newRows = [...currentRows];
 
-      if (
-        result &&
-        typeof result === "object" &&
-        "audio_urls" in result &&
-        Array.isArray(result.audio_urls)
-      ) {
-        const newRows = [...currentRows];
-        let audioIndex = 0;
-
+      if (isRandom) {
+        // Per-item TTS with different random voices
         for (let i = 0; i < newRows.length; i++) {
           if (
             newRows[i].text &&
             newRows[i].text.trim() &&
             !newRows[i].audioUrl
           ) {
-            const audioUrl = (result as { audio_urls: string[] }).audio_urls[
-              audioIndex
-            ];
-            newRows[i].audioUrl = audioUrl.startsWith("http")
-              ? audioUrl
-              : `${import.meta.env.VITE_API_URL}${audioUrl}`;
-            audioIndex++;
+            const { voice, rate } = getVoiceAndRate(
+              batchTTSAccent,
+              batchTTSGender,
+              batchTTSSpeed,
+            );
+            const ttsResult = await apiClient.generateTTS(
+              newRows[i].text.trim(),
+              voice,
+              rate,
+              "+0%",
+            );
+            if (
+              ttsResult &&
+              typeof ttsResult === "object" &&
+              "audio_url" in ttsResult
+            ) {
+              const audioUrl = (ttsResult as { audio_url: string }).audio_url;
+              newRows[i].audioUrl = audioUrl.startsWith("http")
+                ? audioUrl
+                : `${import.meta.env.VITE_API_URL}${audioUrl}`;
+            }
           }
         }
+      } else {
+        // Batch TTS with single voice
+        const { voice, rate } = getVoiceAndRate(
+          batchTTSAccent,
+          batchTTSGender,
+          batchTTSSpeed,
+        );
+        const result = await apiClient.batchGenerateTTS(
+          textsToGenerate,
+          voice,
+          rate,
+          "+0%",
+        );
 
-        return { success: true, updatedRows: newRows };
+        if (
+          result &&
+          typeof result === "object" &&
+          "audio_urls" in result &&
+          Array.isArray(result.audio_urls)
+        ) {
+          let audioIndex = 0;
+          for (let i = 0; i < newRows.length; i++) {
+            if (
+              newRows[i].text &&
+              newRows[i].text.trim() &&
+              !newRows[i].audioUrl
+            ) {
+              const audioUrl = (result as { audio_urls: string[] }).audio_urls[
+                audioIndex
+              ];
+              newRows[i].audioUrl = audioUrl.startsWith("http")
+                ? audioUrl
+                : `${import.meta.env.VITE_API_URL}${audioUrl}`;
+              audioIndex++;
+            }
+          }
+        }
       }
 
-      return { success: true, updatedRows: currentRows };
+      return { success: true, updatedRows: newRows };
     } catch (error) {
       console.error("Auto TTS generation failed:", error);
       toast.error(t("contentEditor.messages.batchGenerationFailed"));
@@ -2412,49 +2450,111 @@ export default function VocabularySetPanel({
         }),
       );
 
-      // 批次生成 TTS
-      const result = await apiClient.batchGenerateTTS(
-        textsToGenerate,
-        "en-US-JennyNeural", // 預設使用美國女聲
-        "+0%",
-        "+0%",
-      );
+      // 批次生成 TTS — Random 時每題不同語音
+      const isRandom =
+        batchTTSAccent === "Random" || batchTTSGender === "Random";
+      const newRows = [...rows];
 
-      if (
-        result &&
-        typeof result === "object" &&
-        "audio_urls" in result &&
-        Array.isArray(result.audio_urls)
-      ) {
-        // 更新 rows 的 audioUrl（單字音檔）
-        const newRows = [...rows];
-        let audioIndex = 0;
-
+      if (isRandom) {
+        // Per-item TTS with different random voices
         for (let i = 0; i < newRows.length; i++) {
           if (
             newRows[i].text &&
             newRows[i].text.trim() &&
             !newRows[i].audioUrl
           ) {
-            const audioUrl = (result as { audio_urls: string[] }).audio_urls[
-              audioIndex
-            ];
-            // 如果是相對路徑，加上 API base URL
-            newRows[i].audioUrl = audioUrl.startsWith("http")
-              ? audioUrl
-              : `${import.meta.env.VITE_API_URL}${audioUrl}`;
-            audioIndex++;
+            const { voice, rate } = getVoiceAndRate(
+              batchTTSAccent,
+              batchTTSGender,
+              batchTTSSpeed,
+            );
+            const ttsResult = await apiClient.generateTTS(
+              newRows[i].text.trim(),
+              voice,
+              rate,
+              "+0%",
+            );
+            if (
+              ttsResult &&
+              typeof ttsResult === "object" &&
+              "audio_url" in ttsResult
+            ) {
+              const audioUrl = (ttsResult as { audio_url: string }).audio_url;
+              newRows[i].audioUrl = audioUrl.startsWith("http")
+                ? audioUrl
+                : `${import.meta.env.VITE_API_URL}${audioUrl}`;
+            }
           }
         }
+      } else {
+        // Batch TTS with single voice
+        const { voice, rate } = getVoiceAndRate(
+          batchTTSAccent,
+          batchTTSGender,
+          batchTTSSpeed,
+        );
+        const result = await apiClient.batchGenerateTTS(
+          textsToGenerate,
+          voice,
+          rate,
+          "+0%",
+        );
 
-        setRows(newRows);
+        if (
+          result &&
+          typeof result === "object" &&
+          "audio_urls" in result &&
+          Array.isArray(result.audio_urls)
+        ) {
+          let audioIndex = 0;
+          for (let i = 0; i < newRows.length; i++) {
+            if (
+              newRows[i].text &&
+              newRows[i].text.trim() &&
+              !newRows[i].audioUrl
+            ) {
+              const audioUrl = (result as { audio_urls: string[] }).audio_urls[
+                audioIndex
+              ];
+              newRows[i].audioUrl = audioUrl.startsWith("http")
+                ? audioUrl
+                : `${import.meta.env.VITE_API_URL}${audioUrl}`;
+              audioIndex++;
+            }
+          }
+        }
+      }
 
-        // 立即更新 content 並儲存到後端（不要用 onSave 避免關閉 panel）
-        const items = newRows.map(buildItemPayload);
+      setRows(newRows);
 
-        // 新增模式：只更新本地狀態，不呼叫 API
-        if (isCreating) {
-          // 更新本地狀態
+      // 立即更新 content 並儲存到後端（不要用 onSave 避免關閉 panel）
+      const items = newRows.map(buildItemPayload);
+
+      // 新增模式：只更新本地狀態，不呼叫 API
+      if (isCreating) {
+        if (onUpdateContent) {
+          onUpdateContent({
+            ...editingContent,
+            title,
+            items,
+          });
+        }
+
+        toast.success(
+          t("contentEditor.messages.audioGeneratedSuccessfully", {
+            count: textsToGenerate.length,
+          }),
+        );
+      } else if (editingContent?.id) {
+        // 編輯模式：直接呼叫 API 更新
+        try {
+          const updateData = {
+            title: title || editingContent?.title,
+            items,
+          };
+
+          await apiClient.updateContent(editingContent.id, updateData);
+
           if (onUpdateContent) {
             onUpdateContent({
               ...editingContent,
@@ -2464,48 +2564,22 @@ export default function VocabularySetPanel({
           }
 
           toast.success(
-            t("contentEditor.messages.audioGeneratedSuccessfully", {
+            t("contentEditor.messages.audioGeneratedAndSaved", {
               count: textsToGenerate.length,
             }),
           );
-        } else if (editingContent?.id) {
-          // 編輯模式：直接呼叫 API 更新
-          try {
-            const updateData = {
-              title: title || editingContent?.title,
-              items,
-            };
-
-            await apiClient.updateContent(editingContent.id, updateData);
-
-            // 更新本地狀態
-            if (onUpdateContent) {
-              onUpdateContent({
-                ...editingContent,
-                title,
-                items,
-              });
-            }
-
-            toast.success(
-              t("contentEditor.messages.audioGeneratedAndSaved", {
-                count: textsToGenerate.length,
-              }),
-            );
-          } catch (error) {
-            console.error("Failed to save TTS:", error);
-            toast.error(
-              t("contentEditor.messages.savingFailedButAudioGenerated"),
-            );
-          }
-        } else {
-          // 沒有 content ID，只是本地更新
-          toast.success(
-            t("contentEditor.messages.audioGeneratedSuccessfully", {
-              count: textsToGenerate.length,
-            }),
+        } catch (error) {
+          console.error("Failed to save TTS:", error);
+          toast.error(
+            t("contentEditor.messages.savingFailedButAudioGenerated"),
           );
         }
+      } else {
+        toast.success(
+          t("contentEditor.messages.audioGeneratedSuccessfully", {
+            count: textsToGenerate.length,
+          }),
+        );
       }
     } catch (error) {
       console.error("Batch TTS generation failed:", error);

--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -1635,6 +1635,8 @@ export default function VocabularySetPanel({
   }, []);
 
   // Save TTS settings to localStorage (Issue #121)
+  // Note: "Random" is intentionally persisted as the user's preference,
+  // so re-opening the panel preserves their intent to randomize.
   const saveBatchTTSSettings = () => {
     localStorage.setItem(
       "duotopia_batch_tts_settings",

--- a/frontend/src/utils/__tests__/ttsVoiceResolver.test.ts
+++ b/frontend/src/utils/__tests__/ttsVoiceResolver.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   TTS_ACCENTS,
   TTS_GENDERS,
@@ -151,6 +151,26 @@ describe("ttsVoiceResolver", () => {
       }
       // With 50 iterations, we should see more than 1 unique voice
       expect(voices.size).toBeGreaterThan(1);
+    });
+
+    describe("deterministic Random resolution (spied Math.random)", () => {
+      afterEach(() => {
+        vi.restoreAllMocks();
+      });
+
+      it("picks first accent and Male when Math.random returns 0", () => {
+        vi.spyOn(Math, "random").mockReturnValue(0);
+        const { voice } = getVoiceAndRate("Random", "Random", "Normal x1");
+        // ACCENT_CHOICES[0] = "American English", GENDER_CHOICES[0] = "Male"
+        expect(voice).toBe("en-US-ChristopherNeural");
+      });
+
+      it("picks last accent and Female when Math.random returns 0.9999", () => {
+        vi.spyOn(Math, "random").mockReturnValue(0.9999);
+        const { voice } = getVoiceAndRate("Random", "Random", "Normal x1");
+        // ACCENT_CHOICES[3] = "Australian English", GENDER_CHOICES[1] = "Female"
+        expect(voice).toBe("en-AU-NatashaNeural");
+      });
     });
   });
 });

--- a/frontend/src/utils/__tests__/ttsVoiceResolver.test.ts
+++ b/frontend/src/utils/__tests__/ttsVoiceResolver.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import {
+  TTS_ACCENTS,
+  TTS_GENDERS,
+  TTS_SPEEDS,
+  resolveRandomOptions,
+  getVoiceAndRate,
+} from "../ttsVoiceResolver";
+
+describe("ttsVoiceResolver", () => {
+  describe("constants", () => {
+    it("TTS_ACCENTS includes Random as first option", () => {
+      expect(TTS_ACCENTS[0]).toBe("Random");
+      expect(TTS_ACCENTS.length).toBeGreaterThan(1);
+    });
+
+    it("TTS_GENDERS includes Random as first option", () => {
+      expect(TTS_GENDERS[0]).toBe("Random");
+      expect(TTS_GENDERS.length).toBeGreaterThan(1);
+    });
+
+    it("TTS_SPEEDS has expected values", () => {
+      expect(TTS_SPEEDS).toContain("Normal x1");
+    });
+  });
+
+  describe("resolveRandomOptions", () => {
+    it("passes through non-Random accent and gender", () => {
+      const result = resolveRandomOptions("American English", "Male");
+      expect(result.resolvedAccent).toBe("American English");
+      expect(result.resolvedGender).toBe("Male");
+    });
+
+    it("resolves Random accent to a valid concrete accent", () => {
+      const validAccents = TTS_ACCENTS.filter((a) => a !== "Random");
+      for (let i = 0; i < 20; i++) {
+        const { resolvedAccent } = resolveRandomOptions("Random", "Male");
+        expect(validAccents).toContain(resolvedAccent);
+      }
+    });
+
+    it("resolves Random gender to Male or Female", () => {
+      const validGenders = ["Male", "Female"];
+      for (let i = 0; i < 20; i++) {
+        const { resolvedGender } = resolveRandomOptions(
+          "American English",
+          "Random",
+        );
+        expect(validGenders).toContain(resolvedGender);
+      }
+    });
+
+    it("resolves both Random accent and gender", () => {
+      const validAccents = TTS_ACCENTS.filter((a) => a !== "Random");
+      const validGenders = ["Male", "Female"];
+      for (let i = 0; i < 20; i++) {
+        const { resolvedAccent, resolvedGender } = resolveRandomOptions(
+          "Random",
+          "Random",
+        );
+        expect(validAccents).toContain(resolvedAccent);
+        expect(validGenders).toContain(resolvedGender);
+      }
+    });
+  });
+
+  describe("getVoiceAndRate", () => {
+    it("returns correct voice for American English Male", () => {
+      const { voice, rate } = getVoiceAndRate(
+        "American English",
+        "Male",
+        "Normal x1",
+      );
+      expect(voice).toBe("en-US-ChristopherNeural");
+      expect(rate).toBe("+0%");
+    });
+
+    it("returns correct voice for American English Female", () => {
+      const { voice } = getVoiceAndRate(
+        "American English",
+        "Female",
+        "Normal x1",
+      );
+      expect(voice).toBe("en-US-JennyNeural");
+    });
+
+    it("returns correct voice for British English", () => {
+      expect(
+        getVoiceAndRate("British English", "Male", "Normal x1").voice,
+      ).toBe("en-GB-RyanNeural");
+      expect(
+        getVoiceAndRate("British English", "Female", "Normal x1").voice,
+      ).toBe("en-GB-SoniaNeural");
+    });
+
+    it("returns correct voice for Indian English", () => {
+      expect(getVoiceAndRate("Indian English", "Male", "Normal x1").voice).toBe(
+        "en-IN-PrabhatNeural",
+      );
+      expect(
+        getVoiceAndRate("Indian English", "Female", "Normal x1").voice,
+      ).toBe("en-IN-NeerjaNeural");
+    });
+
+    it("returns correct voice for Australian English", () => {
+      expect(
+        getVoiceAndRate("Australian English", "Male", "Normal x1").voice,
+      ).toBe("en-AU-WilliamNeural");
+      expect(
+        getVoiceAndRate("Australian English", "Female", "Normal x1").voice,
+      ).toBe("en-AU-NatashaNeural");
+    });
+
+    it("falls back to en-US-JennyNeural for unknown accent", () => {
+      const { voice } = getVoiceAndRate("Unknown Accent", "Male", "Normal x1");
+      expect(voice).toBe("en-US-JennyNeural");
+    });
+
+    it("falls back to en-US-JennyNeural for unknown gender", () => {
+      const { voice } = getVoiceAndRate(
+        "American English",
+        "Unknown",
+        "Normal x1",
+      );
+      expect(voice).toBe("en-US-JennyNeural");
+    });
+
+    it("returns correct rate for each speed option", () => {
+      expect(
+        getVoiceAndRate("American English", "Female", "Slow x0.75").rate,
+      ).toBe("-25%");
+      expect(
+        getVoiceAndRate("American English", "Female", "Normal x1").rate,
+      ).toBe("+0%");
+      expect(
+        getVoiceAndRate("American English", "Female", "Fast x1.5").rate,
+      ).toBe("+50%");
+    });
+
+    it("falls back to +0% for unknown speed", () => {
+      const { rate } = getVoiceAndRate("American English", "Female", "Unknown");
+      expect(rate).toBe("+0%");
+    });
+
+    it("resolves Random to a valid voice on each call", () => {
+      const voices = new Set<string>();
+      for (let i = 0; i < 50; i++) {
+        const { voice } = getVoiceAndRate("Random", "Random", "Normal x1");
+        voices.add(voice);
+        expect(voice).toMatch(/Neural$/);
+      }
+      // With 50 iterations, we should see more than 1 unique voice
+      expect(voices.size).toBeGreaterThan(1);
+    });
+  });
+});

--- a/frontend/src/utils/ttsVoiceResolver.ts
+++ b/frontend/src/utils/ttsVoiceResolver.ts
@@ -13,14 +13,9 @@ export const TTS_GENDERS = ["Random", "Male", "Female"] as const;
 /** TTS speed options */
 export const TTS_SPEEDS = ["Slow x0.75", "Normal x1", "Fast x1.5"] as const;
 
-const ACCENT_CHOICES = [
-  "American English",
-  "British English",
-  "Indian English",
-  "Australian English",
-] as const;
-
-const GENDER_CHOICES = ["Male", "Female"] as const;
+// Derived from TTS_ACCENTS/TTS_GENDERS — no manual sync needed
+const ACCENT_CHOICES = TTS_ACCENTS.filter((a) => a !== "Random");
+const GENDER_CHOICES = TTS_GENDERS.filter((g) => g !== "Random");
 
 const VOICE_MAP: Record<string, Record<string, string>> = {
   "American English": {

--- a/frontend/src/utils/ttsVoiceResolver.ts
+++ b/frontend/src/utils/ttsVoiceResolver.ts
@@ -1,0 +1,86 @@
+/** TTS accent options */
+export const TTS_ACCENTS = [
+  "Random",
+  "American English",
+  "British English",
+  "Indian English",
+  "Australian English",
+] as const;
+
+/** TTS gender options */
+export const TTS_GENDERS = ["Random", "Male", "Female"] as const;
+
+/** TTS speed options */
+export const TTS_SPEEDS = ["Slow x0.75", "Normal x1", "Fast x1.5"] as const;
+
+const ACCENT_CHOICES = [
+  "American English",
+  "British English",
+  "Indian English",
+  "Australian English",
+] as const;
+
+const GENDER_CHOICES = ["Male", "Female"] as const;
+
+const VOICE_MAP: Record<string, Record<string, string>> = {
+  "American English": {
+    Male: "en-US-ChristopherNeural",
+    Female: "en-US-JennyNeural",
+  },
+  "British English": {
+    Male: "en-GB-RyanNeural",
+    Female: "en-GB-SoniaNeural",
+  },
+  "Indian English": {
+    Male: "en-IN-PrabhatNeural",
+    Female: "en-IN-NeerjaNeural",
+  },
+  "Australian English": {
+    Male: "en-AU-WilliamNeural",
+    Female: "en-AU-NatashaNeural",
+  },
+};
+
+const RATE_MAP: Record<string, string> = {
+  "Slow x0.75": "-25%",
+  "Normal x1": "+0%",
+  "Fast x1.5": "+50%",
+};
+
+/**
+ * Resolve Random accent/gender to concrete values.
+ * Each call re-randomizes, so batch loops get different values per item.
+ */
+export function resolveRandomOptions(
+  accent: string,
+  gender: string,
+): { resolvedAccent: string; resolvedGender: string } {
+  const resolvedAccent =
+    accent === "Random"
+      ? ACCENT_CHOICES[Math.floor(Math.random() * ACCENT_CHOICES.length)]
+      : accent;
+  const resolvedGender =
+    gender === "Random"
+      ? GENDER_CHOICES[Math.floor(Math.random() * GENDER_CHOICES.length)]
+      : gender;
+  return { resolvedAccent, resolvedGender };
+}
+
+/**
+ * Get Azure TTS voice name and rate from accent/gender/speed settings.
+ * Resolves "Random" on each call, ensuring batch items get different voices.
+ */
+export function getVoiceAndRate(
+  accent: string,
+  gender: string,
+  speed: string,
+): { voice: string; rate: string } {
+  const { resolvedAccent, resolvedGender } = resolveRandomOptions(
+    accent,
+    gender,
+  );
+  const voice =
+    VOICE_MAP[resolvedAccent]?.[resolvedGender] ?? "en-US-JennyNeural";
+  const rate = RATE_MAP[speed] ?? "+0%";
+  return { voice, rate };
+}


### PR DESCRIPTION
## Summary
- Accent 與 Gender 下拉選單新增 **Random** 選項
- Random 模式下，批次中**每一題都重新隨機**挑選口音/性別，確保 10 題各自不同
- ReadingAssessmentPanel 的批次 TTS 在 Random 模式改為逐題 `generateTTS`（非統一 `batchGenerateTTS`），非 Random 仍用批次 API
- 同步更新 VocabularySetPanel 與 ReadingAssessmentPanel

## Test plan
- [ ] 單題 TTS Modal 選 Random accent/gender → 生成語音，確認每次可能不同
- [ ] 批次貼上 10 個單字，選 Random accent + Random gender → 確認各題語音不同
- [ ] 批次貼上選固定 accent/gender（如 American English + Male）→ 確認行為不變
- [ ] 補齊模式（backfill）選 Random → 確認各題語音不同
- [ ] ReadingAssessmentPanel 同樣測試 Random 批次

Fixes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)