### PR TITLE
feat(#484): 教材內容複製功能

### DIFF
--- a/backend/routers/teachers/content_ops.py
+++ b/backend/routers/teachers/content_ops.py
@@ -729,9 +729,7 @@ async def copy_content(
         db.refresh(new_content)
     except IntegrityError:
         db.rollback()
-        raise HTTPException(
-            status_code=409, detail="複製內容衝突，請重試"
-        )
+        raise HTTPException(status_code=409, detail="複製內容衝突，請重試")
 
     return {
         "id": new_content.id,

--- a/backend/routers/teachers/content_ops.py
+++ b/backend/routers/teachers/content_ops.py
@@ -701,6 +701,13 @@ async def copy_content(
         db, copy_data.target_lesson_id, current_teacher, require_owner=True
     )
 
+    # 防止複製到同一個 lesson
+    if content.lesson_id == copy_data.target_lesson_id:
+        raise HTTPException(
+            status_code=400,
+            detail="無法複製到同一個單元，請選擇不同的目標單元",
+        )
+
     # 計算目標 lesson 中的最大 order_index
     max_order = (
         db.query(func.max(Content.order_index))
@@ -733,8 +740,8 @@ async def copy_content(
         "target_wpm": new_content.target_wpm,
         "target_accuracy": new_content.target_accuracy,
         "order_index": new_content.order_index,
-        "level": new_content.level if hasattr(new_content, "level") else "A1",
-        "tags": new_content.tags if hasattr(new_content, "tags") else [],
+        "level": getattr(new_content, "level", "A1"),
+        "tags": getattr(new_content, "tags", []),
         "source_content_id": content.id,
         "target_lesson_id": copy_data.target_lesson_id,
     }

--- a/backend/routers/teachers/content_ops.py
+++ b/backend/routers/teachers/content_ops.py
@@ -680,6 +680,68 @@ async def delete_content(
     }
 
 
+@router.post("/contents/{content_id}/copy")
+async def copy_content(
+    content_id: int,
+    copy_data: ContentCopy,
+    current_teacher: Teacher = Depends(get_current_teacher),
+    db: Session = Depends(get_db),
+):
+    """複製內容到指定的單元"""
+    from utils.permissions import check_content_access, check_lesson_access
+    from services.program_service import _copy_content_with_items
+
+    # 驗證來源 content 存取權限
+    _program, _lesson, content = check_content_access(
+        db, content_id, current_teacher, require_owner=False
+    )
+
+    # 驗證目標 lesson 存取權限
+    _target_program, target_lesson = check_lesson_access(
+        db, copy_data.target_lesson_id, current_teacher, require_owner=True
+    )
+
+    # 計算目標 lesson 中的最大 order_index
+    max_order = (
+        db.query(func.max(Content.order_index))
+        .filter(
+            Content.lesson_id == copy_data.target_lesson_id,
+            Content.is_active.is_(True),
+        )
+        .scalar()
+    )
+
+    # Eager load content_items
+    db.refresh(content, ["content_items"])
+
+    # 複製 content 及所有 items
+    new_content = _copy_content_with_items(
+        content, copy_data.target_lesson_id, db
+    )
+
+    # 設定複製後的標題和 order_index
+    new_content.title = f"{content.title}(copy)"
+    new_content.order_index = (max_order or 0) + 1
+    new_content.source_content_id = content.id
+
+    db.commit()
+    db.refresh(new_content)
+
+    return {
+        "id": new_content.id,
+        "type": new_content.type.value if new_content.type else "EXAMPLE_SENTENCES",
+        "title": new_content.title,
+        "items_count": len(new_content.content_items),
+        "target_wpm": new_content.target_wpm,
+        "target_accuracy": new_content.target_accuracy,
+        "order_index": new_content.order_index,
+        "level": new_content.level if hasattr(new_content, "level") else "A1",
+        "tags": new_content.tags if hasattr(new_content, "tags") else [],
+        "source_content_id": content.id,
+        "target_lesson_id": copy_data.target_lesson_id,
+    }
+
+
 # ============ Image Upload Endpoints ============
 @router.post("/upload/image")
 async def upload_image(

--- a/backend/routers/teachers/content_ops.py
+++ b/backend/routers/teachers/content_ops.py
@@ -18,7 +18,7 @@ from models import (
     School,
 )
 from .dependencies import get_current_teacher
-from .validators import *
+from .validators import ContentCreate, ContentUpdate, ContentCopy
 from .utils import TEST_SUBSCRIPTION_WHITELIST, parse_birthdate
 from models import ContentType
 
@@ -727,6 +727,7 @@ async def copy_content(
     # 設定複製後的標題和 order_index
     new_content.title = f"{content.title}(copy)"
     new_content.order_index = (max_order or 0) + 1
+    # Teacher-initiated copy: track source but keep is_assignment_copy=False (default)
     new_content.source_content_id = content.id
 
     db.commit()
@@ -810,5 +811,5 @@ async def upload_image(
     except HTTPException as e:
         raise e
     except Exception as e:
-        print(f"Image upload error: {e}")
+        logger.error("Image upload error: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail="Image upload failed")

--- a/backend/routers/teachers/content_ops.py
+++ b/backend/routers/teachers/content_ops.py
@@ -715,9 +715,7 @@ async def copy_content(
     db.refresh(content, ["content_items"])
 
     # 複製 content 及所有 items
-    new_content = _copy_content_with_items(
-        content, copy_data.target_lesson_id, db
-    )
+    new_content = _copy_content_with_items(content, copy_data.target_lesson_id, db)
 
     # 設定複製後的標題和 order_index
     new_content.title = f"{content.title}(copy)"

--- a/backend/routers/teachers/content_ops.py
+++ b/backend/routers/teachers/content_ops.py
@@ -3,6 +3,7 @@ Content Ops operations for teachers.
 """
 from fastapi import APIRouter, Depends, HTTPException, status, File, Form, UploadFile
 from sqlalchemy.orm import Session, selectinload, joinedload
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy import func, text
 from typing import List, Optional, Dict, Any
 from datetime import datetime, timedelta

--- a/backend/routers/teachers/content_ops.py
+++ b/backend/routers/teachers/content_ops.py
@@ -702,13 +702,6 @@ async def copy_content(
         db, copy_data.target_lesson_id, current_teacher, require_owner=True
     )
 
-    # 防止複製到同一個 lesson
-    if content.lesson_id == copy_data.target_lesson_id:
-        raise HTTPException(
-            status_code=400,
-            detail="無法複製到同一個單元，請選擇不同的目標單元",
-        )
-
     # 計算目標 lesson 中的最大 order_index
     max_order = (
         db.query(func.max(Content.order_index))

--- a/backend/routers/teachers/content_ops.py
+++ b/backend/routers/teachers/content_ops.py
@@ -724,8 +724,14 @@ async def copy_content(
     # Teacher-initiated copy: track source but keep is_assignment_copy=False (default)
     new_content.source_content_id = content.id
 
-    db.commit()
-    db.refresh(new_content)
+    try:
+        db.commit()
+        db.refresh(new_content)
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=409, detail="複製內容衝突，請重試"
+        )
 
     return {
         "id": new_content.id,

--- a/backend/routers/teachers/validators.py
+++ b/backend/routers/teachers/validators.py
@@ -190,6 +190,10 @@ class ContentCreate(BaseModel):
     is_public: Optional[bool] = False
 
 
+class ContentCopy(BaseModel):
+    target_lesson_id: int
+
+
 class ContentUpdate(BaseModel):
     title: Optional[str] = None
     items: Optional[List[Dict[str, Any]]] = None

--- a/frontend/src/components/ContentCopyDialog.tsx
+++ b/frontend/src/components/ContentCopyDialog.tsx
@@ -292,10 +292,7 @@ export default function ContentCopyDialog({
           <Button variant="outline" onClick={onClose} disabled={copying}>
             取消
           </Button>
-          <Button
-            onClick={handleCopy}
-            disabled={!selectedLessonId || copying}
-          >
+          <Button onClick={handleCopy} disabled={!selectedLessonId || copying}>
             {copying ? (
               <>
                 <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2" />

--- a/frontend/src/components/ContentCopyDialog.tsx
+++ b/frontend/src/components/ContentCopyDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -35,6 +36,7 @@ export default function ContentCopyDialog({
   currentLessonId,
   programs,
 }: ContentCopyDialogProps) {
+  const { t } = useTranslation();
   const [selectedProgramId, setSelectedProgramId] = useState<number | null>(
     null,
   );
@@ -114,12 +116,14 @@ export default function ContentCopyDialog({
     setCopying(true);
     try {
       await apiClient.copyContent(contentId, selectedLessonId);
-      toast.success(`已複製「${contentTitle}」到目標單元`);
+      toast.success(
+        t("dialogs.contentCopyDialog.success", { title: contentTitle }),
+      );
       onSuccess();
       onClose();
     } catch (error) {
       logError("Failed to copy content:", error);
-      toast.error("複製內容失敗，請重試");
+      toast.error(t("dialogs.contentCopyDialog.error"));
     } finally {
       copyingRef.current = false;
       setCopying(false);
@@ -132,10 +136,12 @@ export default function ContentCopyDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center space-x-2">
             <Copy className="h-5 w-5" />
-            <span>複製內容</span>
+            <span>{t("dialogs.contentCopyDialog.title")}</span>
           </DialogTitle>
           <DialogDescription>
-            將「{contentTitle}」複製到指定的教材單元中
+            {t("dialogs.contentCopyDialog.description", {
+              title: contentTitle,
+            })}
           </DialogDescription>
         </DialogHeader>
 
@@ -143,7 +149,7 @@ export default function ContentCopyDialog({
           {/* Program selector */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
-              目標教材
+              {t("dialogs.contentCopyDialog.targetProgram")}
             </label>
             <div className="relative" ref={programDropdownRef}>
               <button
@@ -159,7 +165,8 @@ export default function ContentCopyDialog({
                     selectedProgram ? "text-gray-900" : "text-gray-400"
                   }
                 >
-                  {selectedProgram?.name || "請選擇教材"}
+                  {selectedProgram?.name ||
+                    t("dialogs.contentCopyDialog.selectProgram")}
                 </span>
                 <ChevronDown className="h-4 w-4 text-gray-400" />
               </button>
@@ -171,7 +178,9 @@ export default function ContentCopyDialog({
                       <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400" />
                       <input
                         type="text"
-                        placeholder="搜尋教材..."
+                        placeholder={t(
+                          "dialogs.contentCopyDialog.searchProgram",
+                        )}
                         value={programSearch}
                         onChange={(e) => setProgramSearch(e.target.value)}
                         className="w-full pl-7 pr-3 py-1.5 text-sm border rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
@@ -182,7 +191,7 @@ export default function ContentCopyDialog({
                   <div className="overflow-y-auto max-h-48">
                     {filteredPrograms.length === 0 ? (
                       <div className="px-3 py-2 text-sm text-gray-500 text-center">
-                        找不到符合的教材
+                        {t("dialogs.contentCopyDialog.noProgramMatch")}
                       </div>
                     ) : (
                       filteredPrograms.map((program) => (
@@ -212,7 +221,7 @@ export default function ContentCopyDialog({
           {/* Lesson selector */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
-              目標單元
+              {t("dialogs.contentCopyDialog.targetLesson")}
             </label>
             <div className="relative" ref={lessonDropdownRef}>
               <button
@@ -237,7 +246,9 @@ export default function ContentCopyDialog({
                   }
                 >
                   {lessons.find((l) => l.id === selectedLessonId)?.name ||
-                    (selectedProgramId ? "請選擇單元" : "請先選擇教材")}
+                    (selectedProgramId
+                      ? t("dialogs.contentCopyDialog.selectLesson")
+                      : t("dialogs.contentCopyDialog.selectProgramFirst"))}
                 </span>
                 <ChevronDown className="h-4 w-4 text-gray-400" />
               </button>
@@ -249,7 +260,9 @@ export default function ContentCopyDialog({
                       <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400" />
                       <input
                         type="text"
-                        placeholder="搜尋單元..."
+                        placeholder={t(
+                          "dialogs.contentCopyDialog.searchLesson",
+                        )}
                         value={lessonSearch}
                         onChange={(e) => setLessonSearch(e.target.value)}
                         className="w-full pl-7 pr-3 py-1.5 text-sm border rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
@@ -261,8 +274,8 @@ export default function ContentCopyDialog({
                     {filteredLessons.length === 0 ? (
                       <div className="px-3 py-2 text-sm text-gray-500 text-center">
                         {lessons.length === 0
-                          ? "此教材沒有單元"
-                          : "找不到符合的單元"}
+                          ? t("dialogs.contentCopyDialog.noLessons")
+                          : t("dialogs.contentCopyDialog.noLessonMatch")}
                       </div>
                     ) : (
                       filteredLessons.map((lesson) => (
@@ -292,18 +305,18 @@ export default function ContentCopyDialog({
 
         <DialogFooter>
           <Button variant="outline" onClick={onClose} disabled={copying}>
-            取消
+            {t("dialogs.contentCopyDialog.cancel")}
           </Button>
           <Button onClick={handleCopy} disabled={!selectedLessonId || copying}>
             {copying ? (
               <>
                 <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2" />
-                複製中...
+                {t("dialogs.contentCopyDialog.copying")}
               </>
             ) : (
               <>
                 <Copy className="h-4 w-4 mr-2" />
-                複製
+                {t("dialogs.contentCopyDialog.copy")}
               </>
             )}
           </Button>

--- a/frontend/src/components/ContentCopyDialog.tsx
+++ b/frontend/src/components/ContentCopyDialog.tsx
@@ -21,8 +21,6 @@ interface ContentCopyDialogProps {
   onSuccess: () => void;
   contentId: number;
   contentTitle: string;
-  /** Current lesson ID (to exclude from target selection) */
-  currentLessonId?: number;
   /** Programs to show in target selection */
   programs: Program[];
 }
@@ -33,7 +31,6 @@ export default function ContentCopyDialog({
   onSuccess,
   contentId,
   contentTitle,
-  currentLessonId,
   programs,
 }: ContentCopyDialogProps) {
   const { t } = useTranslation();
@@ -89,10 +86,8 @@ export default function ContentCopyDialog({
     p.name.toLowerCase().includes(programSearch.toLowerCase()),
   );
 
-  const filteredLessons = lessons.filter(
-    (l) =>
-      l.id !== currentLessonId &&
-      l.name.toLowerCase().includes(lessonSearch.toLowerCase()),
+  const filteredLessons = lessons.filter((l) =>
+    l.name.toLowerCase().includes(lessonSearch.toLowerCase()),
   );
 
   const handleSelectProgram = (programId: number) => {

--- a/frontend/src/components/ContentCopyDialog.tsx
+++ b/frontend/src/components/ContentCopyDialog.tsx
@@ -1,0 +1,315 @@
+import { useState, useEffect, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Copy, Search, ChevronDown, Check } from "lucide-react";
+import { apiClient } from "@/lib/api";
+import { toast } from "sonner";
+import { logError } from "@/utils/errorLogger";
+import { Program, Lesson } from "@/types";
+
+interface ContentCopyDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  contentId: number;
+  contentTitle: string;
+  /** Programs to show in target selection */
+  programs: Program[];
+}
+
+export default function ContentCopyDialog({
+  open,
+  onClose,
+  onSuccess,
+  contentId,
+  contentTitle,
+  programs,
+}: ContentCopyDialogProps) {
+  const [selectedProgramId, setSelectedProgramId] = useState<number | null>(
+    null,
+  );
+  const [selectedLessonId, setSelectedLessonId] = useState<number | null>(null);
+  const [programSearch, setProgramSearch] = useState("");
+  const [lessonSearch, setLessonSearch] = useState("");
+  const [showProgramDropdown, setShowProgramDropdown] = useState(false);
+  const [showLessonDropdown, setShowLessonDropdown] = useState(false);
+  const [copying, setCopying] = useState(false);
+  const copyingRef = useRef(false);
+  const programDropdownRef = useRef<HTMLDivElement>(null);
+  const lessonDropdownRef = useRef<HTMLDivElement>(null);
+
+  // Reset state when dialog opens
+  useEffect(() => {
+    if (open) {
+      setSelectedProgramId(null);
+      setSelectedLessonId(null);
+      setProgramSearch("");
+      setLessonSearch("");
+      setShowProgramDropdown(false);
+      setShowLessonDropdown(false);
+    }
+  }, [open]);
+
+  // Close dropdowns on outside click
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        programDropdownRef.current &&
+        !programDropdownRef.current.contains(event.target as Node)
+      ) {
+        setShowProgramDropdown(false);
+      }
+      if (
+        lessonDropdownRef.current &&
+        !lessonDropdownRef.current.contains(event.target as Node)
+      ) {
+        setShowLessonDropdown(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const selectedProgram = programs.find((p) => p.id === selectedProgramId);
+  const lessons: Lesson[] = selectedProgram?.lessons || [];
+
+  const filteredPrograms = programs.filter((p) =>
+    p.name.toLowerCase().includes(programSearch.toLowerCase()),
+  );
+
+  const filteredLessons = lessons.filter((l) =>
+    l.name.toLowerCase().includes(lessonSearch.toLowerCase()),
+  );
+
+  const handleSelectProgram = (programId: number) => {
+    setSelectedProgramId(programId);
+    setSelectedLessonId(null);
+    setLessonSearch("");
+    setShowProgramDropdown(false);
+    setProgramSearch("");
+  };
+
+  const handleSelectLesson = (lessonId: number) => {
+    setSelectedLessonId(lessonId);
+    setShowLessonDropdown(false);
+    setLessonSearch("");
+  };
+
+  const handleCopy = async () => {
+    if (!selectedLessonId || copyingRef.current) return;
+
+    copyingRef.current = true;
+    setCopying(true);
+    try {
+      await apiClient.copyContent(contentId, selectedLessonId);
+      toast.success(`已複製「${contentTitle}」到目標單元`);
+      onSuccess();
+      onClose();
+    } catch (error) {
+      logError("Failed to copy content:", error);
+      toast.error("複製內容失敗，請重試");
+    } finally {
+      copyingRef.current = false;
+      setCopying(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={() => onClose()}>
+      <DialogContent
+        className="bg-white max-w-md"
+        style={{ backgroundColor: "white" }}
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center space-x-2">
+            <Copy className="h-5 w-5" />
+            <span>複製內容</span>
+          </DialogTitle>
+          <DialogDescription>
+            將「{contentTitle}」複製到指定的教材單元中
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {/* Program selector */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              目標教材
+            </label>
+            <div className="relative" ref={programDropdownRef}>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowProgramDropdown(!showProgramDropdown);
+                  setShowLessonDropdown(false);
+                }}
+                className="w-full flex items-center justify-between px-3 py-2 border rounded-md bg-white hover:bg-gray-50 text-left text-sm"
+              >
+                <span
+                  className={
+                    selectedProgram ? "text-gray-900" : "text-gray-400"
+                  }
+                >
+                  {selectedProgram?.name || "請選擇教材"}
+                </span>
+                <ChevronDown className="h-4 w-4 text-gray-400" />
+              </button>
+
+              {showProgramDropdown && (
+                <div className="absolute z-50 w-full mt-1 bg-white border rounded-md shadow-lg max-h-60 overflow-hidden">
+                  <div className="p-2 border-b">
+                    <div className="relative">
+                      <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400" />
+                      <input
+                        type="text"
+                        placeholder="搜尋教材..."
+                        value={programSearch}
+                        onChange={(e) => setProgramSearch(e.target.value)}
+                        className="w-full pl-7 pr-3 py-1.5 text-sm border rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        autoFocus
+                      />
+                    </div>
+                  </div>
+                  <div className="overflow-y-auto max-h-48">
+                    {filteredPrograms.length === 0 ? (
+                      <div className="px-3 py-2 text-sm text-gray-500 text-center">
+                        找不到符合的教材
+                      </div>
+                    ) : (
+                      filteredPrograms.map((program) => (
+                        <button
+                          key={program.id}
+                          type="button"
+                          onClick={() => handleSelectProgram(program.id)}
+                          className={`w-full flex items-center justify-between px-3 py-2 text-sm text-left hover:bg-gray-100 ${
+                            selectedProgramId === program.id
+                              ? "bg-blue-50 text-blue-700"
+                              : ""
+                          }`}
+                        >
+                          <span className="truncate">{program.name}</span>
+                          {selectedProgramId === program.id && (
+                            <Check className="h-4 w-4 text-blue-600 flex-shrink-0" />
+                          )}
+                        </button>
+                      ))
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Lesson selector */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              目標單元
+            </label>
+            <div className="relative" ref={lessonDropdownRef}>
+              <button
+                type="button"
+                onClick={() => {
+                  if (!selectedProgramId) return;
+                  setShowLessonDropdown(!showLessonDropdown);
+                  setShowProgramDropdown(false);
+                }}
+                disabled={!selectedProgramId}
+                className={`w-full flex items-center justify-between px-3 py-2 border rounded-md text-left text-sm ${
+                  selectedProgramId
+                    ? "bg-white hover:bg-gray-50"
+                    : "bg-gray-100 cursor-not-allowed"
+                }`}
+              >
+                <span
+                  className={
+                    selectedLessonId !== null
+                      ? "text-gray-900"
+                      : "text-gray-400"
+                  }
+                >
+                  {lessons.find((l) => l.id === selectedLessonId)?.name ||
+                    (selectedProgramId ? "請選擇單元" : "請先選擇教材")}
+                </span>
+                <ChevronDown className="h-4 w-4 text-gray-400" />
+              </button>
+
+              {showLessonDropdown && (
+                <div className="absolute z-50 w-full mt-1 bg-white border rounded-md shadow-lg max-h-60 overflow-hidden">
+                  <div className="p-2 border-b">
+                    <div className="relative">
+                      <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400" />
+                      <input
+                        type="text"
+                        placeholder="搜尋單元..."
+                        value={lessonSearch}
+                        onChange={(e) => setLessonSearch(e.target.value)}
+                        className="w-full pl-7 pr-3 py-1.5 text-sm border rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        autoFocus
+                      />
+                    </div>
+                  </div>
+                  <div className="overflow-y-auto max-h-48">
+                    {filteredLessons.length === 0 ? (
+                      <div className="px-3 py-2 text-sm text-gray-500 text-center">
+                        {lessons.length === 0
+                          ? "此教材沒有單元"
+                          : "找不到符合的單元"}
+                      </div>
+                    ) : (
+                      filteredLessons.map((lesson) => (
+                        <button
+                          key={lesson.id}
+                          type="button"
+                          onClick={() => handleSelectLesson(lesson.id)}
+                          className={`w-full flex items-center justify-between px-3 py-2 text-sm text-left hover:bg-gray-100 ${
+                            selectedLessonId === lesson.id
+                              ? "bg-blue-50 text-blue-700"
+                              : ""
+                          }`}
+                        >
+                          <span className="truncate">{lesson.name}</span>
+                          {selectedLessonId === lesson.id && (
+                            <Check className="h-4 w-4 text-blue-600 flex-shrink-0" />
+                          )}
+                        </button>
+                      ))
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={copying}>
+            取消
+          </Button>
+          <Button
+            onClick={handleCopy}
+            disabled={!selectedLessonId || copying}
+          >
+            {copying ? (
+              <>
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2" />
+                複製中...
+              </>
+            ) : (
+              <>
+                <Copy className="h-4 w-4 mr-2" />
+                複製
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/ContentCopyDialog.tsx
+++ b/frontend/src/components/ContentCopyDialog.tsx
@@ -126,7 +126,7 @@ export default function ContentCopyDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={() => onClose()}>
+    <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="bg-white max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center space-x-2">

--- a/frontend/src/components/ContentCopyDialog.tsx
+++ b/frontend/src/components/ContentCopyDialog.tsx
@@ -20,6 +20,8 @@ interface ContentCopyDialogProps {
   onSuccess: () => void;
   contentId: number;
   contentTitle: string;
+  /** Current lesson ID (to exclude from target selection) */
+  currentLessonId?: number;
   /** Programs to show in target selection */
   programs: Program[];
 }
@@ -30,6 +32,7 @@ export default function ContentCopyDialog({
   onSuccess,
   contentId,
   contentTitle,
+  currentLessonId,
   programs,
 }: ContentCopyDialogProps) {
   const [selectedProgramId, setSelectedProgramId] = useState<number | null>(
@@ -84,8 +87,10 @@ export default function ContentCopyDialog({
     p.name.toLowerCase().includes(programSearch.toLowerCase()),
   );
 
-  const filteredLessons = lessons.filter((l) =>
-    l.name.toLowerCase().includes(lessonSearch.toLowerCase()),
+  const filteredLessons = lessons.filter(
+    (l) =>
+      l.id !== currentLessonId &&
+      l.name.toLowerCase().includes(lessonSearch.toLowerCase()),
   );
 
   const handleSelectProgram = (programId: number) => {
@@ -123,10 +128,7 @@ export default function ContentCopyDialog({
 
   return (
     <Dialog open={open} onOpenChange={() => onClose()}>
-      <DialogContent
-        className="bg-white max-w-md"
-        style={{ backgroundColor: "white" }}
-      >
+      <DialogContent className="bg-white max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center space-x-2">
             <Copy className="h-5 w-5" />

--- a/frontend/src/components/shared/RecursiveTreeAccordion.tsx
+++ b/frontend/src/components/shared/RecursiveTreeAccordion.tsx
@@ -564,6 +564,23 @@ function RecursiveTreeNode({
                 </span>
               ))}
 
+              {/* Copy button - hover on desktop, always visible on mobile (icon only) */}
+              {onCopy && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onCopy(data, level, parentId);
+                  }}
+                  className="opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity h-7 w-7 sm:h-auto sm:w-auto sm:px-2.5 sm:py-1 inline-flex items-center justify-center sm:gap-1.5 rounded-md bg-blue-50 hover:bg-blue-100 dark:bg-blue-950/30 dark:hover:bg-blue-900/40 text-blue-600 dark:text-blue-400 border border-blue-200 dark:border-blue-800"
+                  title="複製到..."
+                >
+                  <Copy className="h-3.5 w-3.5 sm:h-3.5 sm:w-3.5" />
+                  <span className="hidden sm:inline text-xs font-medium">
+                    複製到...
+                  </span>
+                </button>
+              )}
+
               {/* Instant practice button - hover on desktop, always visible on mobile (icon only) */}
               {onInstantPractice && (
                 <button
@@ -581,8 +598,8 @@ function RecursiveTreeNode({
                 </button>
               )}
 
-              {/* More menu (⋯) with copy/delete */}
-              {(config.canDelete || onCopy) && (
+              {/* More menu (⋯) with delete */}
+              {config.canDelete && onDelete && (
                 <DropdownMenu>
                   <DropdownMenuTrigger
                     onClick={(e) => e.stopPropagation()}
@@ -594,30 +611,16 @@ function RecursiveTreeNode({
                     align="end"
                     className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700"
                   >
-                    {onCopy && (
-                      <DropdownMenuItem
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onCopy(data, level, parentId);
-                        }}
-                        className="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700"
-                      >
-                        <Copy className="h-4 w-4 mr-2" />
-                        複製到...
-                      </DropdownMenuItem>
-                    )}
-                    {config.canDelete && onDelete && (
-                      <DropdownMenuItem
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onDelete(data, level, parentId);
-                        }}
-                        className="cursor-pointer text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30 focus:text-red-600"
-                      >
-                        <Trash2 className="h-4 w-4 mr-2" />
-                        刪除
-                      </DropdownMenuItem>
-                    )}
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDelete(data, level, parentId);
+                      }}
+                      className="cursor-pointer text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30 focus:text-red-600"
+                    >
+                      <Trash2 className="h-4 w-4 mr-2" />
+                      刪除
+                    </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
               )}

--- a/frontend/src/components/shared/RecursiveTreeAccordion.tsx
+++ b/frontend/src/components/shared/RecursiveTreeAccordion.tsx
@@ -572,11 +572,11 @@ function RecursiveTreeNode({
                     onCopy(data, level, parentId);
                   }}
                   className="opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity h-7 w-7 sm:h-auto sm:w-auto sm:px-2.5 sm:py-1 inline-flex items-center justify-center sm:gap-1.5 rounded-md bg-blue-50 hover:bg-blue-100 dark:bg-blue-950/30 dark:hover:bg-blue-900/40 text-blue-600 dark:text-blue-400 border border-blue-200 dark:border-blue-800"
-                  title="複製到..."
+                  title={t("contentCopy.button")}
                 >
                   <Copy className="h-3.5 w-3.5 sm:h-3.5 sm:w-3.5" />
                   <span className="hidden sm:inline text-xs font-medium">
-                    複製到...
+                    {t("contentCopy.button")}
                   </span>
                 </button>
               )}

--- a/frontend/src/components/shared/RecursiveTreeAccordion.tsx
+++ b/frontend/src/components/shared/RecursiveTreeAccordion.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
+  Copy,
   Edit,
   Trash2,
   GripVertical,
@@ -137,6 +138,8 @@ interface RecursiveTreeNodeProps {
     level: number,
     parentId?: string | number,
   ) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onCopy?: (item: any, level: number, parentId?: string | number) => void;
 
   // Accordion state
   expandedValue: string;
@@ -159,6 +162,7 @@ function RecursiveTreeNode({
   onCreate,
   onReorder,
   onInstantPractice,
+  onCopy,
   disableActions = false,
   disableReason = "",
 }: RecursiveTreeNodeProps) {
@@ -445,6 +449,7 @@ function RecursiveTreeNode({
                               onCreate={onCreate}
                               onReorder={onReorder}
                               onInstantPractice={onInstantPractice}
+                              onCopy={onCopy}
                               expandedValue={childExpandedValue}
                               onExpandedChange={setChildExpandedValue}
                               disableActions={disableActions}
@@ -576,8 +581,8 @@ function RecursiveTreeNode({
                 </button>
               )}
 
-              {/* More menu (⋯) with delete */}
-              {config.canDelete && onDelete && (
+              {/* More menu (⋯) with copy/delete */}
+              {(config.canDelete || onCopy) && (
                 <DropdownMenu>
                   <DropdownMenuTrigger
                     onClick={(e) => e.stopPropagation()}
@@ -589,16 +594,30 @@ function RecursiveTreeNode({
                     align="end"
                     className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700"
                   >
-                    <DropdownMenuItem
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onDelete(data, level, parentId);
-                      }}
-                      className="cursor-pointer text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30 focus:text-red-600"
-                    >
-                      <Trash2 className="h-4 w-4 mr-2" />
-                      刪除
-                    </DropdownMenuItem>
+                    {onCopy && (
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onCopy(data, level, parentId);
+                        }}
+                        className="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700"
+                      >
+                        <Copy className="h-4 w-4 mr-2" />
+                        複製到...
+                      </DropdownMenuItem>
+                    )}
+                    {config.canDelete && onDelete && (
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDelete(data, level, parentId);
+                        }}
+                        className="cursor-pointer text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30 focus:text-red-600"
+                      >
+                        <Trash2 className="h-4 w-4 mr-2" />
+                        刪除
+                      </DropdownMenuItem>
+                    )}
                   </DropdownMenuContent>
                 </DropdownMenu>
               )}
@@ -639,6 +658,8 @@ interface RecursiveTreeAccordionProps {
     level: number,
     parentId?: string | number,
   ) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onCopy?: (item: any, level: number, parentId?: string | number) => void;
   disableActions?: boolean;
   disableReason?: string;
 }
@@ -656,6 +677,7 @@ export function RecursiveTreeAccordion({
   onCreate,
   onReorder,
   onInstantPractice,
+  onCopy,
   disableActions = false,
   disableReason = "",
 }: RecursiveTreeAccordionProps) {
@@ -783,6 +805,7 @@ export function RecursiveTreeAccordion({
                   onCreate={onCreate}
                   onReorder={onReorder}
                   onInstantPractice={onInstantPractice}
+                  onCopy={onCopy}
                   expandedValue={expandedValue}
                   onExpandedChange={setExpandedValue}
                   disableActions={disableActions}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -4664,6 +4664,9 @@
       "copyFailed": "Copy failed. Please try again later."
     }
   },
+  "contentCopy": {
+    "button": "Copy to..."
+  },
   "instantPractice": {
     "title": "Instant Practice",
     "modeLabel": "Practice Mode",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1811,6 +1811,25 @@
       "error": "Copy failed, please try again later",
       "loadError": "Failed to load programs"
     },
+    "contentCopyDialog": {
+      "title": "Copy Content",
+      "description": "Copy \"{{title}}\" to a target lesson",
+      "targetProgram": "Target Program",
+      "targetLesson": "Target Lesson",
+      "selectProgram": "Select a program",
+      "selectLesson": "Select a lesson",
+      "selectProgramFirst": "Select a program first",
+      "searchProgram": "Search programs...",
+      "searchLesson": "Search lessons...",
+      "noProgramMatch": "No matching programs",
+      "noLessons": "No lessons in this program",
+      "noLessonMatch": "No matching lessons",
+      "cancel": "Cancel",
+      "copy": "Copy",
+      "copying": "Copying...",
+      "success": "Copied \"{{title}}\" to target lesson",
+      "error": "Failed to copy content, please try again"
+    },
     "createProgramDialog": {
       "title": "Create Program for \"{{classroomName}}\"",
       "description": "Choose how to create the program",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -1808,6 +1808,25 @@
       "error": "複製失敗，請稍後再試",
       "loadError": "載入課程失敗"
     },
+    "contentCopyDialog": {
+      "title": "複製內容",
+      "description": "將「{{title}}」複製到指定的教材單元中",
+      "targetProgram": "目標教材",
+      "targetLesson": "目標單元",
+      "selectProgram": "請選擇教材",
+      "selectLesson": "請選擇單元",
+      "selectProgramFirst": "請先選擇教材",
+      "searchProgram": "搜尋教材...",
+      "searchLesson": "搜尋單元...",
+      "noProgramMatch": "找不到符合的教材",
+      "noLessons": "此教材沒有單元",
+      "noLessonMatch": "找不到符合的單元",
+      "cancel": "取消",
+      "copy": "複製",
+      "copying": "複製中...",
+      "success": "已複製「{{title}}」到目標單元",
+      "error": "複製內容失敗，請重試"
+    },
     "createProgramDialog": {
       "title": "建立課程到「{{classroomName}}」",
       "description": "選擇建立課程的方式",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -4677,6 +4677,9 @@
       "copyFailed": "複製失敗，請稍後再試"
     }
   },
+  "contentCopy": {
+    "button": "複製到..."
+  },
   "instantPractice": {
     "title": "即刻練習",
     "modeLabel": "練習模式",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1046,6 +1046,13 @@ class ApiClient {
     });
   }
 
+  async copyContent(contentId: number, targetLessonId: number) {
+    return this.request(`/api/teachers/contents/${contentId}/copy`, {
+      method: "POST",
+      body: JSON.stringify({ target_lesson_id: targetLessonId }),
+    });
+  }
+
   // ============ Translation Methods ============
   async translateText(text: string, targetLang: string = "zh-TW") {
     return this.request("/api/teachers/translate", {

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -182,6 +182,7 @@ export default function ClassroomDetail({
   const [copyContentInfo, setCopyContentInfo] = useState<{
     id: number;
     title: string;
+    lessonId: number;
   } | null>(null);
 
   // Instant practice states
@@ -1633,11 +1634,12 @@ export default function ClassroomDetail({
                         }
                       : undefined
                   }
-                  onCopy={(item, level) => {
+                  onCopy={(item, level, parentId) => {
                     if (level === 2) {
                       setCopyContentInfo({
                         id: item.id as number,
                         title: (item.title || item.name) as string,
+                        lessonId: parentId as number,
                       });
                       setShowContentCopyDialog(true);
                     }
@@ -3318,6 +3320,7 @@ export default function ClassroomDetail({
           }}
           contentId={copyContentInfo.id}
           contentTitle={copyContentInfo.title}
+          currentLessonId={copyContentInfo.lessonId}
           programs={programs}
         />
       )}

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -182,7 +182,6 @@ export default function ClassroomDetail({
   const [copyContentInfo, setCopyContentInfo] = useState<{
     id: number;
     title: string;
-    lessonId: number;
   } | null>(null);
 
   // Instant practice states
@@ -1634,12 +1633,11 @@ export default function ClassroomDetail({
                         }
                       : undefined
                   }
-                  onCopy={(item, level, parentId) => {
+                  onCopy={(item, level) => {
                     if (level === 2) {
                       setCopyContentInfo({
                         id: item.id as number,
                         title: (item.title || item.name) as string,
-                        lessonId: parentId as number,
                       });
                       setShowContentCopyDialog(true);
                     }
@@ -3320,7 +3318,6 @@ export default function ClassroomDetail({
           }}
           contentId={copyContentInfo.id}
           contentTitle={copyContentInfo.title}
-          currentLessonId={copyContentInfo.lessonId}
           programs={programs}
         />
       )}

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -21,6 +21,7 @@ import CreateProgramDialog from "@/components/CreateProgramDialog";
 import ContentTypeDialog from "@/components/ContentTypeDialog";
 import ReadingAssessmentPanel from "@/components/ReadingAssessmentPanel";
 import VocabularySetPanel from "@/components/VocabularySetPanel";
+import ContentCopyDialog from "@/components/ContentCopyDialog";
 import { AssignmentDialog } from "@/components/AssignmentDialog";
 import { InstantPracticeDialog } from "@/components/InstantPracticeDialog";
 import BatchGradingModal from "@/components/BatchGradingModal";
@@ -175,6 +176,13 @@ export default function ClassroomDetail({
   const [vocabularySetContentId, setVocabularySetContentId] = useState<
     number | null
   >(null);
+
+  // Content copy dialog state
+  const [showContentCopyDialog, setShowContentCopyDialog] = useState(false);
+  const [copyContentInfo, setCopyContentInfo] = useState<{
+    id: number;
+    title: string;
+  } | null>(null);
 
   // Instant practice states
   const [showInstantPractice, setShowInstantPractice] = useState(false);
@@ -1625,6 +1633,15 @@ export default function ClassroomDetail({
                         }
                       : undefined
                   }
+                  onCopy={(item, level) => {
+                    if (level === 2) {
+                      setCopyContentInfo({
+                        id: item.id as number,
+                        title: (item.title || item.name) as string,
+                      });
+                      setShowContentCopyDialog(true);
+                    }
+                  }}
                 />
               </TabsContent>
 
@@ -3287,6 +3304,23 @@ export default function ClassroomDetail({
         initialAssignmentIndex={stickyNoteModal.assignmentIndex}
         classroomId={Number(id)}
       />
+
+      {/* Content Copy Dialog */}
+      {copyContentInfo && (
+        <ContentCopyDialog
+          open={showContentCopyDialog}
+          onClose={() => {
+            setShowContentCopyDialog(false);
+            setCopyContentInfo(null);
+          }}
+          onSuccess={() => {
+            refreshPrograms();
+          }}
+          contentId={copyContentInfo.id}
+          contentTitle={copyContentInfo.title}
+          programs={programs}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/pages/teacher/OrgMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/OrgMaterialsPage.tsx
@@ -7,6 +7,7 @@ import { LessonDialog } from "@/components/LessonDialog";
 import ContentTypeDialog from "@/components/ContentTypeDialog";
 import ReadingAssessmentPanel from "@/components/ReadingAssessmentPanel";
 import VocabularySetPanel from "@/components/VocabularySetPanel";
+import ContentCopyDialog from "@/components/ContentCopyDialog";
 import { Button } from "@/components/ui/button";
 import { X, AlertCircle } from "lucide-react";
 import { apiClient } from "@/lib/api";
@@ -70,6 +71,13 @@ export default function OrgMaterialsPage() {
   const [vocabularySetContentId, setVocabularySetContentId] = useState<
     number | null
   >(null);
+
+  // Content copy dialog state
+  const [showCopyDialog, setShowCopyDialog] = useState(false);
+  const [copyContentInfo, setCopyContentInfo] = useState<{
+    id: number;
+    title: string;
+  } | null>(null);
 
   useEffect(() => {
     fetchOrgPrograms();
@@ -550,6 +558,15 @@ export default function OrgMaterialsPage() {
               else if (level === 2)
                 handleReorderContents(parentId as number, fromIndex, toIndex);
             }}
+            onCopy={(item, level) => {
+              if (level === 2) {
+                setCopyContentInfo({
+                  id: item.id as number,
+                  title: (item.title || item.name) as string,
+                });
+                setShowCopyDialog(true);
+              }
+            }}
           />
         </div>
 
@@ -967,6 +984,23 @@ export default function OrgMaterialsPage() {
           />
         )}
       </div>
+
+      {/* Content Copy Dialog */}
+      {copyContentInfo && (
+        <ContentCopyDialog
+          open={showCopyDialog}
+          onClose={() => {
+            setShowCopyDialog(false);
+            setCopyContentInfo(null);
+          }}
+          onSuccess={() => {
+            fetchOrgPrograms();
+          }}
+          contentId={copyContentInfo.id}
+          contentTitle={copyContentInfo.title}
+          programs={programs}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/pages/teacher/OrgMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/OrgMaterialsPage.tsx
@@ -77,6 +77,7 @@ export default function OrgMaterialsPage() {
   const [copyContentInfo, setCopyContentInfo] = useState<{
     id: number;
     title: string;
+    lessonId: number;
   } | null>(null);
 
   useEffect(() => {
@@ -558,11 +559,12 @@ export default function OrgMaterialsPage() {
               else if (level === 2)
                 handleReorderContents(parentId as number, fromIndex, toIndex);
             }}
-            onCopy={(item, level) => {
+            onCopy={(item, level, parentId) => {
               if (level === 2) {
                 setCopyContentInfo({
                   id: item.id as number,
                   title: (item.title || item.name) as string,
+                  lessonId: parentId as number,
                 });
                 setShowCopyDialog(true);
               }
@@ -998,6 +1000,7 @@ export default function OrgMaterialsPage() {
           }}
           contentId={copyContentInfo.id}
           contentTitle={copyContentInfo.title}
+          currentLessonId={copyContentInfo.lessonId}
           programs={programs}
         />
       )}

--- a/frontend/src/pages/teacher/OrgMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/OrgMaterialsPage.tsx
@@ -77,7 +77,6 @@ export default function OrgMaterialsPage() {
   const [copyContentInfo, setCopyContentInfo] = useState<{
     id: number;
     title: string;
-    lessonId: number;
   } | null>(null);
 
   useEffect(() => {
@@ -559,12 +558,11 @@ export default function OrgMaterialsPage() {
               else if (level === 2)
                 handleReorderContents(parentId as number, fromIndex, toIndex);
             }}
-            onCopy={(item, level, parentId) => {
+            onCopy={(item, level) => {
               if (level === 2) {
                 setCopyContentInfo({
                   id: item.id as number,
                   title: (item.title || item.name) as string,
-                  lessonId: parentId as number,
                 });
                 setShowCopyDialog(true);
               }
@@ -1000,7 +998,6 @@ export default function OrgMaterialsPage() {
           }}
           contentId={copyContentInfo.id}
           contentTitle={copyContentInfo.title}
-          currentLessonId={copyContentInfo.lessonId}
           programs={programs}
         />
       )}

--- a/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
+++ b/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
@@ -143,7 +143,6 @@ function TeacherTemplateProgramsInner() {
   const [copyContentInfo, setCopyContentInfo] = useState<{
     id: number;
     title: string;
-    lessonId: number;
   } | null>(null);
 
   useEffect(() => {
@@ -601,12 +600,11 @@ function TeacherTemplateProgramsInner() {
               setShowInstantPractice(true);
             }
           }}
-          onCopy={(item, level, parentId) => {
+          onCopy={(item, level) => {
             if (level === 2) {
               setCopyContentInfo({
                 id: item.id as number,
                 title: (item.title || item.name) as string,
-                lessonId: parentId as number,
               });
               setShowCopyDialog(true);
             }
@@ -1074,7 +1072,6 @@ function TeacherTemplateProgramsInner() {
           }}
           contentId={copyContentInfo.id}
           contentTitle={copyContentInfo.title}
-          currentLessonId={copyContentInfo.lessonId}
           programs={programs}
         />
       )}

--- a/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
+++ b/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
@@ -143,6 +143,7 @@ function TeacherTemplateProgramsInner() {
   const [copyContentInfo, setCopyContentInfo] = useState<{
     id: number;
     title: string;
+    lessonId: number;
   } | null>(null);
 
   useEffect(() => {
@@ -600,11 +601,12 @@ function TeacherTemplateProgramsInner() {
               setShowInstantPractice(true);
             }
           }}
-          onCopy={(item, level) => {
+          onCopy={(item, level, parentId) => {
             if (level === 2) {
               setCopyContentInfo({
                 id: item.id as number,
                 title: (item.title || item.name) as string,
+                lessonId: parentId as number,
               });
               setShowCopyDialog(true);
             }
@@ -1072,6 +1074,7 @@ function TeacherTemplateProgramsInner() {
           }}
           contentId={copyContentInfo.id}
           contentTitle={copyContentInfo.title}
+          currentLessonId={copyContentInfo.lessonId}
           programs={programs}
         />
       )}

--- a/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
+++ b/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
@@ -12,6 +12,7 @@ import { LessonDialog } from "@/components/LessonDialog";
 import ContentTypeDialog from "@/components/ContentTypeDialog";
 import ReadingAssessmentPanel from "@/components/ReadingAssessmentPanel";
 import VocabularySetPanel from "@/components/VocabularySetPanel";
+import ContentCopyDialog from "@/components/ContentCopyDialog";
 import { ProgramVisibilitySelector } from "@/components/ProgramVisibilitySelector";
 import { Button } from "@/components/ui/button";
 import { X } from "lucide-react";
@@ -136,6 +137,13 @@ function TeacherTemplateProgramsInner() {
   const [vocabularySetContentId, setVocabularySetContentId] = useState<
     number | null
   >(null);
+
+  // Content copy dialog state
+  const [showCopyDialog, setShowCopyDialog] = useState(false);
+  const [copyContentInfo, setCopyContentInfo] = useState<{
+    id: number;
+    title: string;
+  } | null>(null);
 
   useEffect(() => {
     fetchTemplatePrograms();
@@ -592,6 +600,15 @@ function TeacherTemplateProgramsInner() {
               setShowInstantPractice(true);
             }
           }}
+          onCopy={(item, level) => {
+            if (level === 2) {
+              setCopyContentInfo({
+                id: item.id as number,
+                title: (item.title || item.name) as string,
+              });
+              setShowCopyDialog(true);
+            }
+          }}
         />
       </div>
 
@@ -1039,6 +1056,23 @@ function TeacherTemplateProgramsInner() {
           onStartPractice={(assignmentId) => {
             navigate(`/teacher/assignment/${assignmentId}/preview`);
           }}
+        />
+      )}
+
+      {/* Content Copy Dialog */}
+      {copyContentInfo && (
+        <ContentCopyDialog
+          open={showCopyDialog}
+          onClose={() => {
+            setShowCopyDialog(false);
+            setCopyContentInfo(null);
+          }}
+          onSuccess={() => {
+            fetchTemplatePrograms();
+          }}
+          contentId={copyContentInfo.id}
+          contentTitle={copyContentInfo.title}
+          programs={programs}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- 教材列表的內容 (Content) 新增「複製到...」功能
- 點選內容的 ⋯ 選單中的「複製到...」，選擇目標教材 > 單元後複製
- 下拉選單支援文字搜尋篩選
- 複製後的內容名稱為 `{原名稱}(copy)`
- 支援三個頁面：我的教材、組織教材、班級教材

### Changes
- **Backend**: `POST /api/teachers/contents/{id}/copy` endpoint，複用 `_copy_content_with_items()` 深度複製
- **Frontend**: `RecursiveTreeAccordion` 新增 `onCopy` callback
- **Frontend**: 新增 `ContentCopyDialog` 組件（可搜尋教材/單元下拉選單）
- **Frontend**: 整合至 `TeacherTemplatePrograms`、`OrgMaterialsPage`、`ClassroomDetail`

## Test plan
- [ ] 在「我的教材」頁面測試內容複製到同教材不同單元
- [ ] 在「我的教材」頁面測試內容複製到不同教材的單元
- [ ] 在「組織教材」頁面測試內容複製
- [ ] 在「班級教材」頁面測試內容複製
- [ ] 驗證複製後名稱為 `{原名稱}(copy)`
- [ ] 驗證下拉選單的文字搜尋過濾功能
- [ ] 驗證無權限的單元無法作為複製目標

Fixes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)