### PR TITLE
chore(#341): migration - make students.password_hash nullable

### DIFF
--- a/backend/alembic/versions/20260323_1100_make_student_password_hash_nullable.py
+++ b/backend/alembic/versions/20260323_1100_make_student_password_hash_nullable.py
@@ -1,0 +1,36 @@
+"""Make students.password_hash nullable for SSO-only accounts.
+
+Revision ID: 20260323_1100
+Revises: 20260323_1000
+Create Date: 2026-03-23
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260323_1100"
+down_revision = "20260323_1000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'students'
+                AND column_name = 'password_hash'
+                AND is_nullable = 'NO'
+            ) THEN
+                ALTER TABLE students ALTER COLUMN password_hash DROP NOT NULL;
+            END IF;
+        END $$;
+    """
+    )
+
+
+def downgrade() -> None:
+    # Intentional no-op: making nullable→not-null could fail if NULLs exist
+    pass

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -318,7 +318,7 @@ class Student(Base):
     name = Column(String(100), nullable=False)
     student_number = Column(String(50))
     email = Column(String(255), nullable=True, index=True)
-    password_hash = Column(String(255), nullable=False)
+    password_hash = Column(String(255), nullable=True)  # nullable for SSO-only accounts
     birthdate = Column(Date, nullable=True)
     password_changed = Column(Boolean, default=False)
     email_verified = Column(Boolean, default=False)


### PR DESCRIPTION
## Summary
- Make `students.password_hash` column nullable to support SSO-only accounts (1Campus)
- Update Student model `nullable=False` → `nullable=True`
- Migration follows idempotency rules (`DO $$ BEGIN IF EXISTS`)

## Why separate PR
This migration needs to land on staging first so that other per-issue environments (which depend on staging's migration chain) can run properly.

Parent PR: #523 (1Campus SSO integration)

## Test plan
- [ ] Migration runs without error on staging
- [ ] Existing students with passwords are unaffected
- [ ] Per-issue environments can run migrations without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)