### PR TITLE
feat(#513): 派發作業 UI 從 Dialog 改為右側 Sheet

### DIFF
--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -1085,6 +1085,7 @@ export function AssignmentDialog({
     <Sheet open={open} onOpenChange={handleClose}>
       <SheetContent
         side="right"
+        aria-describedby={undefined}
         className="!w-full !max-w-5xl h-full flex flex-col p-0 sm:!max-w-5xl"
       >
         {/* Compact Header with Clear Steps - 響應式方案 C */}


### PR DESCRIPTION
## Summary
- 將「派發作業」的 `AssignmentDialog` 外層容器從 `Dialog`（置中彈窗）改為 `Sheet`（右側滑入面板）
- 內部 4 步驟精靈內容完全不變，僅替換外層包裝元件
- 寬度維持 `max-w-5xl`，高度改為 `h-full` 配合 Sheet 全高特性

## Test plan
- [ ] 點擊「派發新作業」按鈕，Sheet 從右側滑入
- [ ] 4 個步驟（選擇內容 → 練習模式 → 選擇學生 → 作業詳情）流程正常
- [ ] 點擊遮罩或 X 按鈕可正確關閉 Sheet
- [ ] 手機版 RWD 顯示正常
- [ ] TypeScript 編譯通過、Build 成功

Fixes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)