### PR TITLE
feat(#487): add example_sentence_audio_url migration

### DIFF
--- a/backend/alembic/versions/20260326_1000_add_example_sentence_audio_url.py
+++ b/backend/alembic/versions/20260326_1000_add_example_sentence_audio_url.py
@@ -1,0 +1,30 @@
+"""Add example_sentence_audio_url to content_items
+
+Revision ID: 20260326_1000
+"""
+
+from alembic import op
+
+revision = "20260326_1000"
+down_revision = "20260325_1400"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add example_sentence_audio_url column (idempotent)
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                          WHERE table_name = 'content_items'
+                          AND column_name = 'example_sentence_audio_url') THEN
+                ALTER TABLE content_items ADD COLUMN example_sentence_audio_url TEXT;
+            END IF;
+        END $$;
+    """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/models/program.py
+++ b/backend/models/program.py
@@ -212,6 +212,9 @@ class ContentItem(Base):
     example_sentence_definition = Column(
         Text, nullable=True
     )  # English definition of example
+    example_sentence_audio_url = Column(
+        Text, nullable=True
+    )  # TTS audio for example sentence
 
     # ===== 例句重組相關欄位 =====
     # 單字數量（建立時自動計算）


### PR DESCRIPTION
## Summary
- Idempotent migration adding `example_sentence_audio_url TEXT` column to `content_items` table
- Model definition updated with corresponding SQLAlchemy column
- Part of #487, split out so the DB migration can land first while the feature PR continues

## Test plan
- [ ] Migration applies cleanly on staging (`alembic upgrade head`)
- [ ] Column exists: `SELECT column_name FROM information_schema.columns WHERE table_name='content_items' AND column_name='example_sentence_audio_url'`
- [ ] Migration is idempotent (safe to re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)