### PR TITLE
feat(#256): 作業管理頁面 + 即刻練習永久保存

### DIFF
--- a/backend/alembic/versions/20260327_1000_instant_practice_student_assignment.py
+++ b/backend/alembic/versions/20260327_1000_instant_practice_student_assignment.py
@@ -1,0 +1,97 @@
+"""Make student_assignments compatible with instant practice (teacher as answerer)
+
+Revision ID: 20260327_1000
+Revises: 20260326_1100
+Create Date: 2026-03-27
+
+- Make student_id nullable (teacher instant practice has no student)
+- Make classroom_id nullable (instant practice without classroom)
+- Add teacher_id column (tracks which teacher answered)
+
+Related: #256
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260327_1000"
+down_revision = "20260326_1100"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Make student_id nullable for instant practice (teacher as answerer)
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'student_assignments'
+                AND column_name = 'student_id'
+                AND is_nullable = 'NO'
+            ) THEN
+                ALTER TABLE student_assignments ALTER COLUMN student_id DROP NOT NULL;
+            END IF;
+        END $$;
+    """
+    )
+
+    # Make classroom_id nullable for instant practice without classroom
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'student_assignments'
+                AND column_name = 'classroom_id'
+                AND is_nullable = 'NO'
+            ) THEN
+                ALTER TABLE student_assignments ALTER COLUMN classroom_id DROP NOT NULL;
+            END IF;
+        END $$;
+    """
+    )
+
+    # Make title nullable for instant practice (title comes from assignment)
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'student_assignments'
+                AND column_name = 'title'
+                AND is_nullable = 'NO'
+            ) THEN
+                ALTER TABLE student_assignments ALTER COLUMN title DROP NOT NULL;
+            END IF;
+        END $$;
+    """
+    )
+
+    # Add teacher_id column to track teacher as answerer in instant practice
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                          WHERE table_schema = 'public'
+                          AND table_name = 'student_assignments'
+                          AND column_name = 'teacher_id') THEN
+                ALTER TABLE student_assignments
+                ADD COLUMN teacher_id INTEGER REFERENCES teachers(id) DEFAULT NULL;
+            END IF;
+        END $$;
+    """
+    )
+
+    # Index for querying teacher's instant practice assignments
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_student_assignments_teacher_id"
+        " ON student_assignments (teacher_id)"
+        " WHERE teacher_id IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    # No-op: follows idempotent-only migration approach (see CLAUDE.md)
+    pass

--- a/backend/models/assignment.py
+++ b/backend/models/assignment.py
@@ -87,7 +87,7 @@ class Assignment(Base):
     is_archived = Column(Boolean, default=False)
     archived_at = Column(DateTime(timezone=True), nullable=True)
 
-    # 即刻練習標記（暫時資料，懶清理：建立新的時刪除舊的）
+    # 即刻練習標記（永久保存，不再自動清理）
     is_instant_practice = Column(Boolean, default=False)
 
     # Relationships
@@ -138,14 +138,19 @@ class StudentAssignment(Base):
     assignment_id = Column(
         Integer, ForeignKey("assignments.id"), nullable=True
     )  # nullable 暫時為 True 以兼容舊資料
-    student_id = Column(Integer, ForeignKey("students.id"), nullable=False)
+    student_id = Column(
+        Integer, ForeignKey("students.id"), nullable=True
+    )  # nullable: 即刻練習由老師作答，無 student
+    teacher_id = Column(
+        Integer, ForeignKey("teachers.id"), nullable=True
+    )  # 即刻練習時記錄作答的老師
 
     # TODO: Phase 2 - 移除以下舊欄位（等資料遷移完成）
     # 這些欄位應該從 Assignment 取得，不需要重複儲存
     classroom_id = Column(
-        Integer, ForeignKey("classrooms.id"), nullable=False
-    )  # 可從 assignment.classroom_id 取得
-    title = Column(String(200), nullable=False)  # 可從 assignment.title 取得
+        Integer, ForeignKey("classrooms.id"), nullable=True
+    )  # 可從 assignment.classroom_id 取得；即刻練習可為 NULL
+    title = Column(String(200), nullable=True)  # 可從 assignment.title 取得
     instructions = Column(Text)  # 可從 assignment.description 取得
     due_date = Column(DateTime(timezone=True))  # 可從 assignment.due_date 取得
 

--- a/backend/routers/assignments/crud.py
+++ b/backend/routers/assignments/crud.py
@@ -424,21 +424,32 @@ async def get_assignments(
     classroom_id: Optional[int] = Query(None, description="Filter by classroom"),
     status: Optional[str] = Query(None, description="Filter by status"),
     is_archived: Optional[bool] = Query(False, description="Filter by archive status"),
+    is_instant_practice: Optional[bool] = Query(
+        None, description="Filter by instant practice (None=all, True=only, False=exclude)"
+    ),
     db: Session = Depends(get_db),
     current_teacher: Teacher = Depends(get_current_teacher),
 ):
     """
     取得作業列表（新架構）
     - 教師看到自己建立的作業
-    - 可依班級和狀態篩選
+    - 可依班級、狀態、即刻練習篩選
     - 預設只顯示未封存作業，is_archived=true 顯示封存作業
+    - is_instant_practice=None 顯示所有，True 只顯示即刻練習，False 排除即刻練習
+    - 不帶 classroom_id 時回傳所有班級的作業（跨班級查詢）
     """
-    # 建立查詢（排除即刻練習暫時作業）
+    # 建立查詢
     query = db.query(Assignment).filter(
         Assignment.teacher_id == current_teacher.id,
         Assignment.is_active.is_(True),
-        Assignment.is_instant_practice.is_(False),
     )
+
+    # 即刻練習篩選（預設 None = 顯示所有）
+    if is_instant_practice is True:
+        query = query.filter(Assignment.is_instant_practice.is_(True))
+    elif is_instant_practice is False:
+        query = query.filter(Assignment.is_instant_practice.is_(False))
+    # is_instant_practice=None → 不篩選，回傳全部
 
     # 封存篩選
     if is_archived:
@@ -451,6 +462,17 @@ async def get_assignments(
         query = query.filter(Assignment.classroom_id == classroom_id)
 
     assignments = query.order_by(Assignment.created_at.desc()).all()
+
+    # Batch-load classroom names (avoid N+1)
+    classroom_ids = list({a.classroom_id for a in assignments if a.classroom_id})
+    classrooms = (
+        db.query(Classroom.id, Classroom.name)
+        .filter(Classroom.id.in_(classroom_ids))
+        .all()
+        if classroom_ids
+        else []
+    )
+    classroom_name_map = {c.id: c.name for c in classrooms}
 
     # Batch-load assignment content counts (avoid N+1)
     assignment_ids = [a.id for a in assignments]
@@ -533,6 +555,8 @@ async def get_assignments(
                 "title": assignment.title,
                 "description": assignment.description,
                 "classroom_id": assignment.classroom_id,
+                "classroom_name": classroom_name_map.get(assignment.classroom_id),
+                "is_instant_practice": assignment.is_instant_practice or False,
                 "content_count": content_count,
                 "student_count": total_students,
                 "due_date": (

--- a/backend/routers/assignments/crud.py
+++ b/backend/routers/assignments/crud.py
@@ -425,7 +425,8 @@ async def get_assignments(
     status: Optional[str] = Query(None, description="Filter by status"),
     is_archived: Optional[bool] = Query(False, description="Filter by archive status"),
     is_instant_practice: Optional[bool] = Query(
-        None, description="Filter by instant practice (None=all, True=only, False=exclude)"
+        None,
+        description="Filter by instant practice (None=all, True=only, False=exclude)",
     ),
     db: Session = Depends(get_db),
     current_teacher: Teacher = Depends(get_current_teacher),

--- a/backend/routers/teachers/assignment_ops.py
+++ b/backend/routers/teachers/assignment_ops.py
@@ -2,6 +2,8 @@
 Assignment Ops operations for teachers.
 """
 import logging
+from datetime import datetime, timezone
+
 from fastapi import (
     APIRouter,
     Depends,
@@ -24,6 +26,10 @@ from models import (
     TeacherSchool,
     Organization,
     School,
+    StudentAssignment,
+    StudentItemProgress,
+    StudentContentProgress,
+    AssignmentStatus,
 )
 from .dependencies import get_current_teacher
 from .validators import *
@@ -73,8 +79,40 @@ def _get_teacher_assignment(
     return assignment
 
 
+def _get_instant_practice_student_assignment(
+    assignment: Assignment, db: Session
+) -> Optional[StudentAssignment]:
+    """Get the teacher's StudentAssignment for an instant practice assignment."""
+    if not assignment.is_instant_practice:
+        return None
+    return (
+        db.query(StudentAssignment)
+        .filter(
+            StudentAssignment.assignment_id == assignment.id,
+            StudentAssignment.teacher_id == assignment.teacher_id,
+            StudentAssignment.is_active.is_(True),
+        )
+        .first()
+    )
+
+
+def _get_item_progress(
+    student_assignment_id: int, content_item_id: int, db: Session
+) -> Optional[StudentItemProgress]:
+    """Get StudentItemProgress for a specific item."""
+    return (
+        db.query(StudentItemProgress)
+        .filter(
+            StudentItemProgress.student_assignment_id == student_assignment_id,
+            StudentItemProgress.content_item_id == content_item_id,
+        )
+        .first()
+    )
+
+
 # ============================================================================
 # Preview Endpoints — thin wrappers around preview_service
+# For instant practice assignments, also saves progress to DB
 # ============================================================================
 
 
@@ -86,7 +124,16 @@ async def get_assignment_preview(
 ):
     """取得作業的預覽內容（供老師示範用）"""
     assignment = _get_teacher_assignment(assignment_id, current_teacher, db)
-    return build_assignment_preview(assignment, db)
+    result = build_assignment_preview(assignment, db)
+
+    # 即刻練習：加入 student_assignment_id 供前端使用
+    if assignment.is_instant_practice:
+        sa = _get_instant_practice_student_assignment(assignment, db)
+        if sa:
+            result["student_assignment_id"] = sa.id
+            result["is_instant_practice"] = True
+
+    return result
 
 
 @router.post("/assignments/preview/assess-speech")
@@ -131,14 +178,50 @@ async def preview_word_selection_answer(
     current_teacher: Teacher = Depends(get_current_teacher),
     db: Session = Depends(get_db),
 ):
-    """Preview mode: Submit word selection answer (not saved)."""
+    """Preview mode: Submit word selection answer.
+    For instant practice: also saves progress to StudentItemProgress.
+    """
     assignment = _get_teacher_assignment(assignment_id, current_teacher, db)
-    return check_word_selection_answer(
+    result = check_word_selection_answer(
         data.content_item_id,
         data.selected_answer,
         assignment,
         db,
     )
+
+    # 即刻練習：儲存答題進度
+    if assignment.is_instant_practice:
+        sa = _get_instant_practice_student_assignment(assignment, db)
+        if sa:
+            item_progress = _get_item_progress(sa.id, data.content_item_id, db)
+            if item_progress:
+                now = datetime.now(timezone.utc)
+                item_progress.status = "COMPLETED"
+                item_progress.submitted_at = now
+                item_progress.attempts = (item_progress.attempts or 0) + 1
+
+                # 累計答題紀錄到 word_selection_data
+                history = item_progress.word_selection_data or {}
+                answers = history.get("answers", [])
+                answers.append(
+                    {
+                        "selected": data.selected_answer,
+                        "is_correct": result["is_correct"],
+                        "answered_at": now.isoformat(),
+                    }
+                )
+                history["answers"] = answers
+                history["last_correct"] = result["is_correct"]
+                item_progress.word_selection_data = history
+
+                # 更新 StudentAssignment 狀態
+                if sa.status == AssignmentStatus.NOT_STARTED:
+                    sa.status = AssignmentStatus.IN_PROGRESS
+                    sa.started_at = now
+
+                db.commit()
+
+    return result
 
 
 @router.get("/assignments/{assignment_id}/preview/rearrangement-questions")
@@ -159,14 +242,42 @@ async def preview_rearrangement_answer(
     current_teacher: Teacher = Depends(get_current_teacher),
     db: Session = Depends(get_db),
 ):
-    """Preview mode: Submit rearrangement answer (not saved)."""
-    _get_teacher_assignment(assignment_id, current_teacher, db)
-    return check_rearrangement_answer(
+    """Preview mode: Submit rearrangement answer.
+    For instant practice: also saves progress to StudentItemProgress.
+    """
+    assignment = _get_teacher_assignment(assignment_id, current_teacher, db)
+    result = check_rearrangement_answer(
         data.content_item_id,
         data.selected_word,
         data.current_position,
         db,
     )
+
+    # 即刻練習：儲存答題進度
+    if assignment.is_instant_practice:
+        sa = _get_instant_practice_student_assignment(assignment, db)
+        if sa:
+            item_progress = _get_item_progress(sa.id, data.content_item_id, db)
+            if item_progress:
+                now = datetime.now(timezone.utc)
+                if not result["is_correct"]:
+                    item_progress.error_count = (item_progress.error_count or 0) + 1
+                item_progress.correct_word_count = result["correct_word_count"]
+                item_progress.expected_score = result["expected_score"]
+                item_progress.status = "IN_PROGRESS"
+
+                if result.get("completed"):
+                    item_progress.status = "COMPLETED"
+                    item_progress.submitted_at = now
+
+                # 更新 StudentAssignment 狀態
+                if sa.status == AssignmentStatus.NOT_STARTED:
+                    sa.status = AssignmentStatus.IN_PROGRESS
+                    sa.started_at = now
+
+                db.commit()
+
+    return result
 
 
 @router.post("/assignments/{assignment_id}/preview/rearrangement-retry")
@@ -175,8 +286,23 @@ async def preview_rearrangement_retry(
     current_teacher: Teacher = Depends(get_current_teacher),
     db: Session = Depends(get_db),
 ):
-    """Preview mode: Retry rearrangement question (simulated)."""
-    _get_teacher_assignment(assignment_id, current_teacher, db)
+    """Preview mode: Retry rearrangement question."""
+    assignment = _get_teacher_assignment(assignment_id, current_teacher, db)
+
+    # 即刻練習：記錄重試
+    if assignment.is_instant_practice:
+        sa = _get_instant_practice_student_assignment(assignment, db)
+        if sa:
+            # Increment retry count on all in-progress items
+            db.query(StudentItemProgress).filter(
+                StudentItemProgress.student_assignment_id == sa.id,
+                StudentItemProgress.status == "IN_PROGRESS",
+            ).update(
+                {"retry_count": StudentItemProgress.retry_count + 1},
+                synchronize_session=False,
+            )
+            db.commit()
+
     return handle_rearrangement_retry()
 
 
@@ -187,8 +313,31 @@ async def preview_rearrangement_complete(
     current_teacher: Teacher = Depends(get_current_teacher),
     db: Session = Depends(get_db),
 ):
-    """Preview mode: Complete rearrangement question (simulated)."""
-    _get_teacher_assignment(assignment_id, current_teacher, db)
+    """Preview mode: Complete rearrangement question.
+    For instant practice: updates StudentAssignment status to SUBMITTED.
+    """
+    assignment = _get_teacher_assignment(assignment_id, current_teacher, db)
+
+    # 即刻練習：標記完成
+    if assignment.is_instant_practice:
+        sa = _get_instant_practice_student_assignment(assignment, db)
+        if sa:
+            now = datetime.now(timezone.utc)
+            sa.status = AssignmentStatus.SUBMITTED
+            sa.submitted_at = now
+
+            # 更新 StudentContentProgress
+            db.query(StudentContentProgress).filter(
+                StudentContentProgress.student_assignment_id == sa.id,
+            ).update(
+                {
+                    "status": AssignmentStatus.SUBMITTED,
+                    "completed_at": now,
+                },
+                synchronize_session=False,
+            )
+            db.commit()
+
     return handle_rearrangement_complete(
         expected_score=data.expected_score,
         timeout=data.timeout,

--- a/backend/routers/teachers/instant_practice.py
+++ b/backend/routers/teachers/instant_practice.py
@@ -1,11 +1,12 @@
 """
 Instant Practice API - 即刻練習
 
-Allows teachers to quickly practice content without creating a full assignment.
-Creates a lightweight assignment marked as is_instant_practice=True.
-Uses lazy cleanup: deletes old instant practice assignments before creating new ones.
+Allows teachers to quickly practice content as if they were a student.
+Creates an assignment marked as is_instant_practice=True with a
+StudentAssignment record (teacher_id set, student_id=NULL) so that
+answering progress is persisted permanently.
 
-Reuses all existing preview APIs for the actual practice experience.
+All records are kept for review in the assignment management page.
 """
 
 import logging
@@ -27,6 +28,7 @@ from models import (
     StudentAssignment,
     StudentContentProgress,
     StudentItemProgress,
+    AssignmentStatus,
 )
 from utils.permissions import check_content_access
 from .dependencies import get_current_teacher
@@ -62,11 +64,12 @@ async def create_instant_practice(
     """
     建立即刻練習作業
 
-    - 懶清理：先刪除該老師的舊即刻練習作業
-    - 建立新的 assignment (is_instant_practice=True)
+    - 建立 assignment (is_instant_practice=True)
     - 複製 content（重用既有邏輯）
-    - 不建立 StudentAssignment（老師使用 preview API 練習）
-    - 回傳 assignment_id，前端導向 preview 頁面
+    - 建立 StudentAssignment（teacher_id = 老師，student_id = NULL）
+    - 建立 StudentContentProgress + StudentItemProgress
+    - 回傳 assignment_id + student_assignment_id，前端導向作答頁面
+    - 所有記錄永久保存，不再自動清理
     """
     # 驗證班級存在且教師有權限（classroom_id 為 optional，我的教材不需要班級）
     if request.classroom_id:
@@ -88,7 +91,7 @@ async def create_instant_practice(
                 detail="You don't have permission for this classroom",
             )
 
-    # 驗證 Content 存在且教師有權限存取（permission side-effect，回傳值不直接使用）
+    # 驗證 Content 存在且教師有權限存取
     check_content_access(db, request.content_id, current_teacher, require_owner=False)
     # Re-query with eagerly loaded content_items for copying
     content = (
@@ -99,57 +102,6 @@ async def create_instant_practice(
     )
     if not content:
         raise HTTPException(status_code=404, detail="Content not found")
-
-    # 懶清理：刪除該老師的舊即刻練習作業及相關資料
-    old_assignments = (
-        db.query(Assignment)
-        .filter(
-            Assignment.teacher_id == current_teacher.id,
-            Assignment.is_instant_practice.is_(True),
-        )
-        .all()
-    )
-
-    for old_assignment in old_assignments:
-        # Delete related student assignments and progress (cascade should handle this,
-        # but be explicit for safety)
-        old_student_assignments = (
-            db.query(StudentAssignment)
-            .filter(StudentAssignment.assignment_id == old_assignment.id)
-            .all()
-        )
-        for sa in old_student_assignments:
-            db.query(StudentContentProgress).filter(
-                StudentContentProgress.student_assignment_id == sa.id
-            ).delete()
-            db.query(StudentItemProgress).filter(
-                StudentItemProgress.student_assignment_id == sa.id
-            ).delete()
-            db.delete(sa)
-
-        # Collect copied content IDs before deleting AssignmentContent
-        old_ac_contents = (
-            db.query(AssignmentContent)
-            .filter(AssignmentContent.assignment_id == old_assignment.id)
-            .all()
-        )
-        copied_content_ids = [ac.content_id for ac in old_ac_contents]
-
-        # Delete assignment contents
-        db.query(AssignmentContent).filter(
-            AssignmentContent.assignment_id == old_assignment.id
-        ).delete()
-
-        # Delete copied content and items (only copies, not originals)
-        for content_id in copied_content_ids:
-            db.query(ContentItem).filter(ContentItem.content_id == content_id).delete()
-            db.query(Content).filter(
-                Content.id == content_id, Content.is_assignment_copy.is_(True)
-            ).delete()
-
-        db.delete(old_assignment)
-
-    db.flush()
 
     # 複製 Content 和 ContentItem（重用既有邏輯）
     content_copy = Content(
@@ -251,12 +203,53 @@ async def create_instant_practice(
         order_index=1,
     )
     db.add(assignment_content)
+    db.flush()
+
+    # 建立 StudentAssignment（老師作為作答者）
+    student_assignment = StudentAssignment(
+        assignment_id=assignment.id,
+        student_id=None,  # 老師作答，非學生
+        teacher_id=current_teacher.id,  # 記錄作答的老師
+        classroom_id=request.classroom_id,  # 可為 None
+        title=assignment.title,
+        status=AssignmentStatus.NOT_STARTED,
+        is_active=True,
+    )
+    db.add(student_assignment)
+    db.flush()
+
+    # 建立 StudentContentProgress
+    content_progress = StudentContentProgress(
+        student_assignment_id=student_assignment.id,
+        content_id=content_copy.id,
+        status=AssignmentStatus.NOT_STARTED,
+        order_index=1,
+        is_locked=False,
+    )
+    db.add(content_progress)
+    db.flush()
+
+    # 建立 StudentItemProgress（每個 ContentItem 一筆）
+    copy_items = (
+        db.query(ContentItem)
+        .filter(ContentItem.content_id == content_copy.id)
+        .order_by(ContentItem.order_index)
+        .all()
+    )
+    for item in copy_items:
+        item_progress = StudentItemProgress(
+            student_assignment_id=student_assignment.id,
+            content_item_id=item.id,
+            status="NOT_STARTED",
+        )
+        db.add(item_progress)
 
     db.commit()
 
     return {
         "success": True,
         "assignment_id": assignment.id,
+        "student_assignment_id": student_assignment.id,
         "content_title": content.title,
         "practice_mode": request.practice_mode,
     }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import TeacherResetPassword from "./pages/TeacherResetPassword";
 import TeacherSetupPassword from "./pages/TeacherSetupPassword";
 import TeacherDashboard from "./pages/teacher/TeacherDashboard";
 import TeacherClassrooms from "./pages/teacher/TeacherClassrooms";
+import AssignmentManagementPage from "./pages/teacher/AssignmentManagementPage";
 import TeacherStudents from "./pages/teacher/TeacherStudents";
 import ClassroomDetail from "./pages/teacher/ClassroomDetail";
 import TeacherAssignmentDetailPage from "./pages/teacher/TeacherAssignmentDetailPage";
@@ -148,6 +149,16 @@ function App() {
             <ProtectedRoute>
               <TeacherLayout>
                 <TeacherClassrooms />
+              </TeacherLayout>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/teacher/assignments"
+          element={
+            <ProtectedRoute>
+              <TeacherLayout>
+                <AssignmentManagementPage />
               </TeacherLayout>
             </ProtectedRoute>
           }

--- a/frontend/src/config/sidebarConfig.tsx
+++ b/frontend/src/config/sidebarConfig.tsx
@@ -9,6 +9,7 @@ import {
   Users,
   BookOpen,
   Package,
+  ClipboardList,
 } from "lucide-react";
 import { SidebarGroup } from "@/types/sidebar";
 
@@ -47,6 +48,12 @@ export const getSidebarGroups = (
         label: t("teacherLayout.nav.myClassrooms"),
         icon: GraduationCap,
         path: "/teacher/classrooms",
+      },
+      {
+        id: "assignments",
+        label: t("assignmentManagement.title"),
+        icon: ClipboardList,
+        path: "/teacher/assignments",
       },
       {
         id: "students",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -4830,5 +4830,52 @@
       "generatedAt": "Generated: ",
       "pointsUsed": "Points Used: "
     }
+  },
+  "assignmentManagement": {
+    "title": "Assignment Management",
+    "fetchError": "Failed to load assignments",
+    "empty": "No assignments yet",
+    "filters": {
+      "allClassrooms": "All Classes",
+      "noClassroom": "No Class",
+      "allTypes": "All Types",
+      "regularOnly": "Regular Only",
+      "instantOnly": "Instant Practice Only"
+    },
+    "columns": {
+      "title": "Title",
+      "classroom": "Class",
+      "type": "Type",
+      "mode": "Practice Mode",
+      "students": "Students",
+      "completion": "Completion",
+      "createdAt": "Created",
+      "dueDate": "Due Date"
+    },
+    "labels": {
+      "instantPractice": "Instant Practice",
+      "regular": "Regular",
+      "noClassroom": "No Class"
+    },
+    "actions": {
+      "view": "View Details",
+      "archive": "Archive",
+      "unarchive": "Unarchive",
+      "delete": "Delete"
+    },
+    "confirm": {
+      "archiveTitle": "Confirm Archive",
+      "archiveDescription": "Are you sure you want to archive \"{{title}}\"? You can find it in the archive.",
+      "unarchiveTitle": "Confirm Unarchive",
+      "unarchiveDescription": "Are you sure you want to unarchive \"{{title}}\"?",
+      "deleteTitle": "Confirm Delete",
+      "deleteDescription": "Are you sure you want to delete \"{{title}}\"? This action cannot be undone."
+    },
+    "archiveSuccess": "Assignment archived",
+    "archiveError": "Failed to archive",
+    "unarchiveSuccess": "Assignment unarchived",
+    "unarchiveError": "Failed to unarchive",
+    "deleteSuccess": "Assignment deleted",
+    "deleteError": "Failed to delete"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -4849,5 +4849,52 @@
       "generatedAt": "生成時間：",
       "pointsUsed": "消耗點數："
     }
+  },
+  "assignmentManagement": {
+    "title": "作業管理",
+    "fetchError": "載入作業列表失敗",
+    "empty": "目前沒有作業",
+    "filters": {
+      "allClassrooms": "所有班級",
+      "noClassroom": "無班級",
+      "allTypes": "所有類型",
+      "regularOnly": "一般作業",
+      "instantOnly": "即刻練習"
+    },
+    "columns": {
+      "title": "標題",
+      "classroom": "班級",
+      "type": "類型",
+      "mode": "練習模式",
+      "students": "學生數",
+      "completion": "完成率",
+      "createdAt": "建立日期",
+      "dueDate": "截止日期"
+    },
+    "labels": {
+      "instantPractice": "即刻練習",
+      "regular": "一般作業",
+      "noClassroom": "無班級"
+    },
+    "actions": {
+      "view": "查看詳情",
+      "archive": "封存",
+      "unarchive": "取消封存",
+      "delete": "刪除"
+    },
+    "confirm": {
+      "archiveTitle": "確認封存",
+      "archiveDescription": "確定要封存「{{title}}」嗎？封存後可在封存區找到。",
+      "unarchiveTitle": "確認取消封存",
+      "unarchiveDescription": "確定要取消封存「{{title}}」嗎？",
+      "deleteTitle": "確認刪除",
+      "deleteDescription": "確定要刪除「{{title}}」嗎？此操作無法復原。"
+    },
+    "archiveSuccess": "作業已封存",
+    "archiveError": "封存失敗",
+    "unarchiveSuccess": "作業已取消封存",
+    "unarchiveError": "取消封存失敗",
+    "deleteSuccess": "作業已刪除",
+    "deleteError": "刪除失敗"
   }
 }

--- a/frontend/src/pages/teacher/AssignmentManagementPage.tsx
+++ b/frontend/src/pages/teacher/AssignmentManagementPage.tsx
@@ -1,0 +1,715 @@
+/**
+ * AssignmentManagementPage - 作業管理頁面
+ *
+ * 跨班級的作業總覽，包含一般作業和即刻練習。
+ * 支援篩選：班級、類型（一般/即刻練習）、練習模式、日期。
+ * 管理操作：查看詳情、封存/取消封存、刪除。
+ */
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  ClipboardList,
+  Search,
+  Archive,
+  ArchiveRestore,
+  Trash2,
+  MoreHorizontal,
+  Eye,
+  Zap,
+  RefreshCw,
+  X,
+  Loader2,
+} from "lucide-react";
+import { apiClient } from "@/lib/api";
+import { toast } from "sonner";
+
+interface Assignment {
+  id: number;
+  title: string;
+  description?: string;
+  classroom_id?: number;
+  classroom_name?: string;
+  is_instant_practice: boolean;
+  content_count: number;
+  student_count: number;
+  due_date?: string;
+  start_date?: string;
+  created_at?: string;
+  completion_rate: number;
+  status_distribution: Record<string, number>;
+  content_type?: string;
+  practice_mode?: string;
+  answer_mode?: string;
+  is_archived: boolean;
+  archived_at?: string;
+}
+
+interface Classroom {
+  id: number;
+  name: string;
+}
+
+export default function AssignmentManagementPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  // Data
+  const [assignments, setAssignments] = useState<Assignment[]>([]);
+  const [archivedAssignments, setArchivedAssignments] = useState<Assignment[]>(
+    [],
+  );
+  const [classrooms, setClassrooms] = useState<Classroom[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // View toggle
+  const [showArchived, setShowArchived] = useState(false);
+
+  // Filters
+  const [filterClassroom, setFilterClassroom] = useState<string>("");
+  const [filterType, setFilterType] = useState<string>(""); // "" | "regular" | "instant"
+  const [filterPracticeMode, setFilterPracticeMode] = useState<string>("");
+  const [filterKeyword, setFilterKeyword] = useState("");
+  const [filterDateFrom, setFilterDateFrom] = useState("");
+  const [filterDateTo, setFilterDateTo] = useState("");
+
+  const fetchAssignments = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [activeRes, archivedRes] = await Promise.all([
+        apiClient.get<Assignment[]>("/api/teachers/assignments/"),
+        apiClient.get<Assignment[]>(
+          "/api/teachers/assignments/?is_archived=true",
+        ),
+      ]);
+      setAssignments(activeRes);
+      setArchivedAssignments(archivedRes);
+    } catch (error) {
+      console.error("Failed to fetch assignments:", error);
+      toast.error(t("assignmentManagement.fetchError"));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  const fetchClassrooms = useCallback(async () => {
+    try {
+      const res = await apiClient.get<Classroom[]>("/api/classrooms/");
+      setClassrooms(res);
+    } catch {
+      // Non-critical, silently fail
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAssignments();
+    fetchClassrooms();
+  }, [fetchAssignments, fetchClassrooms]);
+
+  // Derive unique classrooms from assignments for filter
+  const classroomOptions = useMemo(() => {
+    const all = [...assignments, ...archivedAssignments];
+    const map = new Map<number, string>();
+    for (const a of all) {
+      if (a.classroom_id && a.classroom_name) {
+        map.set(a.classroom_id, a.classroom_name);
+      }
+    }
+    // Merge with fetched classrooms
+    for (const c of classrooms) {
+      if (!map.has(c.id)) map.set(c.id, c.name);
+    }
+    return Array.from(map.entries()).map(([id, name]) => ({ id, name }));
+  }, [assignments, archivedAssignments, classrooms]);
+
+  // Filter logic
+  const filteredAssignments = useMemo(() => {
+    const source = showArchived ? archivedAssignments : assignments;
+    return source.filter((a) => {
+      if (filterClassroom) {
+        if (filterClassroom === "none") {
+          if (a.classroom_id) return false;
+        } else if (a.classroom_id !== Number(filterClassroom)) {
+          return false;
+        }
+      }
+      if (filterType === "regular" && a.is_instant_practice) return false;
+      if (filterType === "instant" && !a.is_instant_practice) return false;
+      if (
+        filterPracticeMode &&
+        a.practice_mode !== filterPracticeMode
+      )
+        return false;
+      if (
+        filterKeyword &&
+        !a.title.toLowerCase().includes(filterKeyword.toLowerCase())
+      )
+        return false;
+      if (filterDateFrom && a.created_at) {
+        if (a.created_at.slice(0, 10) < filterDateFrom) return false;
+      }
+      if (filterDateTo && a.created_at) {
+        if (a.created_at.slice(0, 10) > filterDateTo) return false;
+      }
+      return true;
+    });
+  }, [
+    showArchived,
+    assignments,
+    archivedAssignments,
+    filterClassroom,
+    filterType,
+    filterPracticeMode,
+    filterKeyword,
+    filterDateFrom,
+    filterDateTo,
+  ]);
+
+  const hasActiveFilters =
+    filterClassroom ||
+    filterType ||
+    filterPracticeMode ||
+    filterKeyword ||
+    filterDateFrom ||
+    filterDateTo;
+
+  const clearFilters = () => {
+    setFilterClassroom("");
+    setFilterType("");
+    setFilterPracticeMode("");
+    setFilterKeyword("");
+    setFilterDateFrom("");
+    setFilterDateTo("");
+  };
+
+  // Actions
+  const handleArchive = async (assignment: Assignment) => {
+    if (
+      !confirm(
+        t("assignmentManagement.confirm.archiveDescription", {
+          title: assignment.title,
+        }),
+      )
+    )
+      return;
+    try {
+      await apiClient.patch(
+        `/api/teachers/assignments/${assignment.id}/archive`,
+      );
+      toast.success(t("assignmentManagement.archiveSuccess"));
+      fetchAssignments();
+    } catch {
+      toast.error(t("assignmentManagement.archiveError"));
+    }
+  };
+
+  const handleUnarchive = async (assignment: Assignment) => {
+    if (
+      !confirm(
+        t("assignmentManagement.confirm.unarchiveDescription", {
+          title: assignment.title,
+        }),
+      )
+    )
+      return;
+    try {
+      await apiClient.patch(
+        `/api/teachers/assignments/${assignment.id}/unarchive`,
+      );
+      toast.success(t("assignmentManagement.unarchiveSuccess"));
+      fetchAssignments();
+    } catch {
+      toast.error(t("assignmentManagement.unarchiveError"));
+    }
+  };
+
+  const handleDelete = async (assignment: Assignment) => {
+    if (
+      !confirm(
+        t("assignmentManagement.confirm.deleteDescription", {
+          title: assignment.title,
+        }),
+      )
+    )
+      return;
+    try {
+      await apiClient.delete(`/api/teachers/assignments/${assignment.id}`);
+      toast.success(t("assignmentManagement.deleteSuccess"));
+      fetchAssignments();
+    } catch {
+      toast.error(t("assignmentManagement.deleteError"));
+    }
+  };
+
+  const handleViewDetails = (assignment: Assignment) => {
+    if (assignment.classroom_id) {
+      navigate(
+        `/teacher/classroom/${assignment.classroom_id}/assignment/${assignment.id}/preview`,
+      );
+    } else {
+      navigate(`/teacher/assignment/${assignment.id}/preview`);
+    }
+  };
+
+  const getPracticeModeLabel = (mode?: string) => {
+    switch (mode) {
+      case "reading":
+        return t("classroomDetail.contentTypes.SPEAKING");
+      case "rearrangement":
+        return t("classroomDetail.contentTypes.REARRANGEMENT");
+      case "word_reading":
+        return t("classroomDetail.contentTypes.WORD_READING");
+      case "word_selection":
+        return t("classroomDetail.contentTypes.WORD_SELECTION");
+      default:
+        return mode || "—";
+    }
+  };
+
+  const getPracticeModeBadgeColor = (mode?: string) => {
+    switch (mode) {
+      case "reading":
+        return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
+      case "rearrangement":
+        return "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300";
+      case "word_reading":
+        return "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300";
+      case "word_selection":
+        return "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300";
+      default:
+        return "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300";
+    }
+  };
+
+  const formatDate = (dateStr?: string) => {
+    if (!dateStr) return "—";
+    return new Date(dateStr).toLocaleDateString("zh-TW", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+  };
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4 sm:space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <ClipboardList className="h-6 w-6 text-blue-500" />
+          <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-gray-100">
+            {t("assignmentManagement.title")}
+          </h1>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={fetchAssignments}
+          disabled={loading}
+        >
+          <RefreshCw
+            className={`h-4 w-4 mr-1 ${loading ? "animate-spin" : ""}`}
+          />
+          {t("common.refresh")}
+        </Button>
+      </div>
+
+      {/* Active/Archived Toggle */}
+      <div className="flex">
+        <button
+          onClick={() => setShowArchived(false)}
+          className={`px-4 py-2 text-sm font-medium rounded-l-lg border ${
+            !showArchived
+              ? "bg-blue-500 text-white border-blue-500"
+              : "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+          }`}
+        >
+          {t("classroomDetail.tabs.activeAssignments")}
+          {assignments.length > 0 && (
+            <span className="ml-1.5 text-xs">({assignments.length})</span>
+          )}
+        </button>
+        <button
+          onClick={() => setShowArchived(true)}
+          className={`px-4 py-2 text-sm font-medium rounded-r-lg border-t border-r border-b ${
+            showArchived
+              ? "bg-blue-500 text-white border-blue-500"
+              : "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+          }`}
+        >
+          <Archive className="inline-block w-4 h-4 mr-1 -mt-0.5" />
+          {t("classroomDetail.tabs.archivedAssignments")}
+          {archivedAssignments.length > 0 && (
+            <span className="ml-1.5 text-xs">
+              ({archivedAssignments.length})
+            </span>
+          )}
+        </button>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-2">
+        <select
+          value={filterClassroom}
+          onChange={(e) => setFilterClassroom(e.target.value)}
+          className="h-9 rounded-md border border-input bg-background px-3 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200"
+        >
+          <option value="">{t("assignmentManagement.filters.allClassrooms")}</option>
+          <option value="none">{t("assignmentManagement.filters.noClassroom")}</option>
+          {classroomOptions.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={filterType}
+          onChange={(e) => setFilterType(e.target.value)}
+          className="h-9 rounded-md border border-input bg-background px-3 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200"
+        >
+          <option value="">{t("assignmentManagement.filters.allTypes")}</option>
+          <option value="regular">{t("assignmentManagement.filters.regularOnly")}</option>
+          <option value="instant">{t("assignmentManagement.filters.instantOnly")}</option>
+        </select>
+
+        <select
+          value={filterPracticeMode}
+          onChange={(e) => setFilterPracticeMode(e.target.value)}
+          className="h-9 rounded-md border border-input bg-background px-3 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200"
+        >
+          <option value="">{t("classroomDetail.filters.allTypes")}</option>
+          <option value="reading">
+            {t("classroomDetail.contentTypes.SPEAKING")}
+          </option>
+          <option value="rearrangement">
+            {t("classroomDetail.contentTypes.REARRANGEMENT")}
+          </option>
+          <option value="word_reading">
+            {t("classroomDetail.contentTypes.WORD_READING")}
+          </option>
+          <option value="word_selection">
+            {t("classroomDetail.contentTypes.WORD_SELECTION")}
+          </option>
+        </select>
+
+        <div className="relative w-full md:w-[250px]">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Input
+            placeholder={t("classroomDetail.filters.searchPlaceholder")}
+            value={filterKeyword}
+            onChange={(e) => setFilterKeyword(e.target.value)}
+            className="pl-9 h-9"
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input
+            type="date"
+            value={filterDateFrom}
+            onChange={(e) => setFilterDateFrom(e.target.value)}
+            className="h-9 rounded-md border border-input bg-background px-2 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200"
+          />
+          <span className="text-gray-400 text-sm">~</span>
+          <input
+            type="date"
+            value={filterDateTo}
+            onChange={(e) => setFilterDateTo(e.target.value)}
+            className="h-9 rounded-md border border-input bg-background px-2 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200"
+          />
+        </div>
+
+        {hasActiveFilters && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-9 text-gray-500"
+            onClick={clearFilters}
+          >
+            <X className="h-3.5 w-3.5 mr-1" />
+            {t("classroomDetail.filters.clearAll")}
+          </Button>
+        )}
+      </div>
+
+      {/* Assignment Table */}
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+        </div>
+      ) : filteredAssignments.length === 0 ? (
+        <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+          <ClipboardList className="h-12 w-12 mx-auto mb-3 opacity-30" />
+          <p>{t("assignmentManagement.empty")}</p>
+        </div>
+      ) : (
+        <>
+          {/* Desktop Table */}
+          <div className="hidden md:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("assignmentManagement.columns.title")}</TableHead>
+                  <TableHead>{t("assignmentManagement.columns.classroom")}</TableHead>
+                  <TableHead>{t("assignmentManagement.columns.type")}</TableHead>
+                  <TableHead>{t("assignmentManagement.columns.mode")}</TableHead>
+                  <TableHead>{t("assignmentManagement.columns.students")}</TableHead>
+                  <TableHead>{t("assignmentManagement.columns.completion")}</TableHead>
+                  <TableHead>{t("assignmentManagement.columns.createdAt")}</TableHead>
+                  <TableHead>{t("assignmentManagement.columns.dueDate")}</TableHead>
+                  <TableHead className="w-[50px]"></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredAssignments.map((assignment) => (
+                  <TableRow
+                    key={assignment.id}
+                    className="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                    onClick={() => handleViewDetails(assignment)}
+                  >
+                    <TableCell className="font-medium max-w-[200px] truncate">
+                      {assignment.title}
+                    </TableCell>
+                    <TableCell className="text-sm text-gray-500">
+                      {assignment.classroom_name || "—"}
+                    </TableCell>
+                    <TableCell>
+                      {assignment.is_instant_practice ? (
+                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+                          <Zap className="h-3 w-3" />
+                          {t("assignmentManagement.labels.instantPractice")}
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+                          {t("assignmentManagement.labels.regular")}
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${getPracticeModeBadgeColor(assignment.practice_mode)}`}
+                      >
+                        {getPracticeModeLabel(assignment.practice_mode)}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {assignment.is_instant_practice
+                        ? "—"
+                        : assignment.student_count}
+                    </TableCell>
+                    <TableCell>
+                      {assignment.is_instant_practice ? (
+                        "—"
+                      ) : (
+                        <div className="flex items-center gap-2">
+                          <div className="w-16 h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+                            <div
+                              className="h-full bg-green-500 rounded-full"
+                              style={{
+                                width: `${assignment.completion_rate}%`,
+                              }}
+                            />
+                          </div>
+                          <span className="text-xs text-gray-500">
+                            {assignment.completion_rate}%
+                          </span>
+                        </div>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-sm text-gray-500">
+                      {formatDate(assignment.created_at)}
+                    </TableCell>
+                    <TableCell className="text-sm text-gray-500">
+                      {formatDate(assignment.due_date)}
+                    </TableCell>
+                    <TableCell>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 w-8 p-0"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleViewDetails(assignment);
+                            }}
+                          >
+                            <Eye className="h-4 w-4 mr-2" />
+                            {t("assignmentManagement.actions.view")}
+                          </DropdownMenuItem>
+                          {showArchived ? (
+                            <DropdownMenuItem
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleUnarchive(assignment);
+                              }}
+                            >
+                              <ArchiveRestore className="h-4 w-4 mr-2" />
+                              {t("assignmentManagement.actions.unarchive")}
+                            </DropdownMenuItem>
+                          ) : (
+                            <DropdownMenuItem
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleArchive(assignment);
+                              }}
+                            >
+                              <Archive className="h-4 w-4 mr-2" />
+                              {t("assignmentManagement.actions.archive")}
+                            </DropdownMenuItem>
+                          )}
+                          <DropdownMenuItem
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleDelete(assignment);
+                            }}
+                            className="text-red-600 dark:text-red-400"
+                          >
+                            <Trash2 className="h-4 w-4 mr-2" />
+                            {t("assignmentManagement.actions.delete")}
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          {/* Mobile Card Layout */}
+          <div className="md:hidden space-y-3">
+            {filteredAssignments.map((assignment) => (
+              <div
+                key={assignment.id}
+                className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg p-4 space-y-2 cursor-pointer"
+                onClick={() => handleViewDetails(assignment)}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex-1 min-w-0">
+                    <h4 className="font-medium text-gray-900 dark:text-gray-100 truncate">
+                      {assignment.title}
+                    </h4>
+                    <div className="flex items-center gap-2 mt-1 flex-wrap">
+                      {assignment.is_instant_practice && (
+                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+                          <Zap className="h-3 w-3" />
+                          {t("assignmentManagement.labels.instantPractice")}
+                        </span>
+                      )}
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${getPracticeModeBadgeColor(assignment.practice_mode)}`}
+                      >
+                        {getPracticeModeLabel(assignment.practice_mode)}
+                      </span>
+                    </div>
+                  </div>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <MoreHorizontal className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleViewDetails(assignment);
+                        }}
+                      >
+                        <Eye className="h-4 w-4 mr-2" />
+                        {t("assignmentManagement.actions.view")}
+                      </DropdownMenuItem>
+                      {showArchived ? (
+                        <DropdownMenuItem
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleUnarchive(assignment);
+                          }}
+                        >
+                          <ArchiveRestore className="h-4 w-4 mr-2" />
+                          {t("assignmentManagement.actions.unarchive")}
+                        </DropdownMenuItem>
+                      ) : (
+                        <DropdownMenuItem
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleArchive(assignment);
+                          }}
+                        >
+                          <Archive className="h-4 w-4 mr-2" />
+                          {t("assignmentManagement.actions.archive")}
+                        </DropdownMenuItem>
+                      )}
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDelete(assignment);
+                        }}
+                        className="text-red-600 dark:text-red-400"
+                      >
+                        <Trash2 className="h-4 w-4 mr-2" />
+                        {t("assignmentManagement.actions.delete")}
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+                <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+                  <span>
+                    {assignment.classroom_name ||
+                      t("assignmentManagement.labels.noClassroom")}
+                  </span>
+                  <span>{formatDate(assignment.created_at)}</span>
+                </div>
+                {!assignment.is_instant_practice && (
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1 h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+                      <div
+                        className="h-full bg-green-500 rounded-full"
+                        style={{
+                          width: `${assignment.completion_rate}%`,
+                        }}
+                      />
+                    </div>
+                    <span className="text-xs text-gray-500">
+                      {assignment.completion_rate}%
+                    </span>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+    </div>
+  );
+}

--- a/frontend/src/pages/teacher/AssignmentManagementPage.tsx
+++ b/frontend/src/pages/teacher/AssignmentManagementPage.tsx
@@ -152,10 +152,7 @@ export default function AssignmentManagementPage() {
       }
       if (filterType === "regular" && a.is_instant_practice) return false;
       if (filterType === "instant" && !a.is_instant_practice) return false;
-      if (
-        filterPracticeMode &&
-        a.practice_mode !== filterPracticeMode
-      )
+      if (filterPracticeMode && a.practice_mode !== filterPracticeMode)
         return false;
       if (
         filterKeyword &&
@@ -370,8 +367,12 @@ export default function AssignmentManagementPage() {
           onChange={(e) => setFilterClassroom(e.target.value)}
           className="h-9 rounded-md border border-input bg-background px-3 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200"
         >
-          <option value="">{t("assignmentManagement.filters.allClassrooms")}</option>
-          <option value="none">{t("assignmentManagement.filters.noClassroom")}</option>
+          <option value="">
+            {t("assignmentManagement.filters.allClassrooms")}
+          </option>
+          <option value="none">
+            {t("assignmentManagement.filters.noClassroom")}
+          </option>
           {classroomOptions.map((c) => (
             <option key={c.id} value={c.id}>
               {c.name}
@@ -385,8 +386,12 @@ export default function AssignmentManagementPage() {
           className="h-9 rounded-md border border-input bg-background px-3 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200"
         >
           <option value="">{t("assignmentManagement.filters.allTypes")}</option>
-          <option value="regular">{t("assignmentManagement.filters.regularOnly")}</option>
-          <option value="instant">{t("assignmentManagement.filters.instantOnly")}</option>
+          <option value="regular">
+            {t("assignmentManagement.filters.regularOnly")}
+          </option>
+          <option value="instant">
+            {t("assignmentManagement.filters.instantOnly")}
+          </option>
         </select>
 
         <select
@@ -465,14 +470,30 @@ export default function AssignmentManagementPage() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>{t("assignmentManagement.columns.title")}</TableHead>
-                  <TableHead>{t("assignmentManagement.columns.classroom")}</TableHead>
-                  <TableHead>{t("assignmentManagement.columns.type")}</TableHead>
-                  <TableHead>{t("assignmentManagement.columns.mode")}</TableHead>
-                  <TableHead>{t("assignmentManagement.columns.students")}</TableHead>
-                  <TableHead>{t("assignmentManagement.columns.completion")}</TableHead>
-                  <TableHead>{t("assignmentManagement.columns.createdAt")}</TableHead>
-                  <TableHead>{t("assignmentManagement.columns.dueDate")}</TableHead>
+                  <TableHead>
+                    {t("assignmentManagement.columns.title")}
+                  </TableHead>
+                  <TableHead>
+                    {t("assignmentManagement.columns.classroom")}
+                  </TableHead>
+                  <TableHead>
+                    {t("assignmentManagement.columns.type")}
+                  </TableHead>
+                  <TableHead>
+                    {t("assignmentManagement.columns.mode")}
+                  </TableHead>
+                  <TableHead>
+                    {t("assignmentManagement.columns.students")}
+                  </TableHead>
+                  <TableHead>
+                    {t("assignmentManagement.columns.completion")}
+                  </TableHead>
+                  <TableHead>
+                    {t("assignmentManagement.columns.createdAt")}
+                  </TableHead>
+                  <TableHead>
+                    {t("assignmentManagement.columns.dueDate")}
+                  </TableHead>
                   <TableHead className="w-[50px]"></TableHead>
                 </TableRow>
               </TableHeader>
@@ -709,7 +730,6 @@ export default function AssignmentManagementPage() {
           </div>
         </>
       )}
-
     </div>
   );
 }

--- a/frontend/src/pages/teacher/AssignmentManagementPage.tsx
+++ b/frontend/src/pages/teacher/AssignmentManagementPage.tsx
@@ -267,6 +267,7 @@ export default function AssignmentManagementPage() {
 
   const getPracticeModeLabel = (mode?: string) => {
     switch (mode) {
+      // "reading" mode = read aloud (speaking); reuses SPEAKING i18n key for app-wide consistency
       case "reading":
         return t("classroomDetail.contentTypes.SPEAKING");
       case "rearrangement":


### PR DESCRIPTION
## Summary
- 新增跨班級「作業管理」頁面（`/teacher/assignments`），支援篩選班級、類型、練習模式、關鍵字、日期範圍
- 即刻練習改為學生角度作答（作答者為老師，記錄於 `teacher_id`），所有紀錄永久保存
- 取消 lazy cleanup，preview endpoints 在即刻練習模式下同步儲存進度
- `StudentAssignment.student_id` 改為 nullable，新增 `teacher_id` 欄位
- API 新增 `is_instant_practice` 篩選參數（None=全部, True=僅即刻練習, False=排除即刻練習）
- 左側選單新增「作業管理」入口

## Changed Files
### Backend
- `backend/models/assignment.py` — student_id/classroom_id/title nullable, 新增 teacher_id
- `backend/routers/teachers/instant_practice.py` — 移除 lazy cleanup, 建立 StudentAssignment 記錄
- `backend/routers/teachers/assignment_ops.py` — preview endpoints 儲存即刻練習進度
- `backend/routers/assignments/crud.py` — is_instant_practice 篩選參數, classroom_name 回傳
- `backend/alembic/versions/20260327_1000_instant_practice_student_assignment.py` — idempotent migration

### Frontend
- `frontend/src/pages/teacher/AssignmentManagementPage.tsx` — 新頁面（桌面表格+手機卡片）
- `frontend/src/config/sidebarConfig.tsx` — 左側選單新增作業管理
- `frontend/src/App.tsx` — 路由設定
- `frontend/src/i18n/locales/{en,zh-TW}/translation.json` — i18n 翻譯

## Test plan
- [ ] 即刻練習建立後，確認 student_assignment 有 teacher_id、student_id 為 null
- [ ] 即刻練習作答流程正常儲存進度（word_selection / rearrangement）
- [ ] 作業管理頁面可正確顯示一般作業與即刻練習
- [ ] 篩選功能正常（班級、類型、練習模式、日期）
- [ ] 有 classroom_id 的即刻練習在班級作業 tab 也可見
- [ ] 無 classroom_id 的即刻練習只在作業管理頁面可見
- [ ] Migration 可重複執行不報錯

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)