### PR TITLE
fix: AssignmentManagementPage analysis, dropdown bg, remove row click

### DIFF
--- a/frontend/src/pages/teacher/AssignmentManagementPage.tsx
+++ b/frontend/src/pages/teacher/AssignmentManagementPage.tsx
@@ -597,9 +597,7 @@ export default function AssignmentManagementPage() {
                               }}
                             >
                               <BarChart3 className="h-4 w-4 mr-2" />
-                              {t(
-                                "classroomDetail.buttons.analysisReport",
-                              )}
+                              {t("classroomDetail.buttons.analysisReport")}
                             </DropdownMenuItem>
                           )}
                           {showArchived ? (
@@ -700,9 +698,7 @@ export default function AssignmentManagementPage() {
                           }}
                         >
                           <BarChart3 className="h-4 w-4 mr-2" />
-                          {t(
-                            "classroomDetail.buttons.analysisReport",
-                          )}
+                          {t("classroomDetail.buttons.analysisReport")}
                         </DropdownMenuItem>
                       )}
                       {showArchived ? (

--- a/frontend/src/pages/teacher/AssignmentManagementPage.tsx
+++ b/frontend/src/pages/teacher/AssignmentManagementPage.tsx
@@ -37,9 +37,11 @@ import {
   RefreshCw,
   X,
   Loader2,
+  BarChart3,
 } from "lucide-react";
 import { apiClient } from "@/lib/api";
 import { toast } from "sonner";
+import { AssignmentAnalysisDialog } from "@/components/AssignmentAnalysisDialog";
 
 interface Assignment {
   id: number;
@@ -81,6 +83,9 @@ export default function AssignmentManagementPage() {
 
   // View toggle
   const [showArchived, setShowArchived] = useState(false);
+
+  // Analysis dialog
+  const [analysisTarget, setAnalysisTarget] = useState<Assignment | null>(null);
 
   // Filters
   const [filterClassroom, setFilterClassroom] = useState<string>("");
@@ -502,8 +507,7 @@ export default function AssignmentManagementPage() {
                 {filteredAssignments.map((assignment) => (
                   <TableRow
                     key={assignment.id}
-                    className="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50"
-                    onClick={() => handleViewDetails(assignment)}
+                    className="hover:bg-gray-50 dark:hover:bg-gray-800/50"
                   >
                     <TableCell className="font-medium max-w-[200px] truncate">
                       {assignment.title}
@@ -572,7 +576,10 @@ export default function AssignmentManagementPage() {
                             <MoreHorizontal className="h-4 w-4" />
                           </Button>
                         </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
+                        <DropdownMenuContent
+                          align="end"
+                          className="bg-white dark:bg-gray-800 border dark:border-gray-700"
+                        >
                           <DropdownMenuItem
                             onClick={(e) => {
                               e.stopPropagation();
@@ -582,6 +589,19 @@ export default function AssignmentManagementPage() {
                             <Eye className="h-4 w-4 mr-2" />
                             {t("assignmentManagement.actions.view")}
                           </DropdownMenuItem>
+                          {showArchived && (
+                            <DropdownMenuItem
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setAnalysisTarget(assignment);
+                              }}
+                            >
+                              <BarChart3 className="h-4 w-4 mr-2" />
+                              {t(
+                                "classroomDetail.buttons.analysisReport",
+                              )}
+                            </DropdownMenuItem>
+                          )}
                           {showArchived ? (
                             <DropdownMenuItem
                               onClick={(e) => {
@@ -627,8 +647,7 @@ export default function AssignmentManagementPage() {
             {filteredAssignments.map((assignment) => (
               <div
                 key={assignment.id}
-                className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg p-4 space-y-2 cursor-pointer"
-                onClick={() => handleViewDetails(assignment)}
+                className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg p-4 space-y-2"
               >
                 <div className="flex items-start justify-between gap-2">
                   <div className="flex-1 min-w-0">
@@ -660,7 +679,10 @@ export default function AssignmentManagementPage() {
                         <MoreHorizontal className="h-4 w-4" />
                       </Button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
+                    <DropdownMenuContent
+                      align="end"
+                      className="bg-white dark:bg-gray-800 border dark:border-gray-700"
+                    >
                       <DropdownMenuItem
                         onClick={(e) => {
                           e.stopPropagation();
@@ -670,6 +692,19 @@ export default function AssignmentManagementPage() {
                         <Eye className="h-4 w-4 mr-2" />
                         {t("assignmentManagement.actions.view")}
                       </DropdownMenuItem>
+                      {showArchived && (
+                        <DropdownMenuItem
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setAnalysisTarget(assignment);
+                          }}
+                        >
+                          <BarChart3 className="h-4 w-4 mr-2" />
+                          {t(
+                            "classroomDetail.buttons.analysisReport",
+                          )}
+                        </DropdownMenuItem>
+                      )}
                       {showArchived ? (
                         <DropdownMenuItem
                           onClick={(e) => {
@@ -730,6 +765,17 @@ export default function AssignmentManagementPage() {
             ))}
           </div>
         </>
+      )}
+
+      {analysisTarget && (
+        <AssignmentAnalysisDialog
+          open={!!analysisTarget}
+          onOpenChange={(open) => {
+            if (!open) setAnalysisTarget(null);
+          }}
+          assignmentId={analysisTarget.id}
+          assignmentTitle={analysisTarget.title}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- 作業管理頁面封存區的 dropdown menu 加入「作業分析」按鈕
- 修正 DropdownMenuContent 背景透明導致點擊穿透到預覽的問題
- 移除點擊 row 直接進入預覽的行為（改用 menu 裡的「查看」）

## Changes
- `AssignmentManagementPage.tsx`
  - Import `BarChart3` + `AssignmentAnalysisDialog`
  - Add `analysisTarget` state for dialog control
  - Desktop table: remove `cursor-pointer` and `onClick` from `TableRow`
  - Mobile card: remove `cursor-pointer` and `onClick` from card div
  - Both dropdown menus: add `bg-white dark:bg-gray-800 border` to `DropdownMenuContent`
  - Both dropdown menus: add analysis report menu item (only in archived view)
  - Add `AssignmentAnalysisDialog` at bottom of page

## Note
CORS error on staging `generate-analysis` endpoint is likely a backend 500 (not a CORS config issue — staging allows all origins). Need to check Cloud Run logs for the actual error.

## Test plan
- [ ] 作業管理頁面 → 封存區 → dropdown 看到「作業分析」按鈕
- [ ] 進行中作業的 dropdown 不會出現「作業分析」
- [ ] dropdown 展開時有白色背景，不會穿透
- [ ] 點擊 row 不再自動跳轉到預覽
- [ ] 行動版同樣行為正確

🤖 Generated with [Claude Code](https://claude.com/claude-code)