### PR TITLE
fix(#551): 1Campus SSO 帳號自動合併 Duotopia Email 帳號

### DIFF
--- a/backend/routers/students/auth.py
+++ b/backend/routers/students/auth.py
@@ -68,21 +68,38 @@ def _get_classrooms_for_student(db: Session, student_id: int) -> list:
 
 
 def _get_aggregated_classrooms(db: Session, student: Student) -> list:
-    """取得學生的所有班級（含跨帳號已驗證 email 的 sibling students）"""
+    """取得學生的所有班級（含跨帳號 identity_id 或已驗證 email 的 sibling students）"""
     classrooms_list = _get_classrooms_for_student(db, student.id)
+    seen_student_ids = {student.id}
 
-    if student.email_verified and student.email:
-        sibling_students = (
+    # Path 1: identity_id — 同一 Identity 下所有 students 的班級
+    if student.identity_id:
+        identity_siblings = (
             db.query(Student)
             .filter(
-                Student.email == student.email,
-                Student.email_verified.is_(True),
+                Student.identity_id == student.identity_id,
                 Student.id != student.id,
                 Student.is_active.is_(True),
             )
             .all()
         )
-        for sibling in sibling_students:
+        for sibling in identity_siblings:
+            seen_student_ids.add(sibling.id)
+            classrooms_list.extend(_get_classrooms_for_student(db, sibling.id))
+
+    # Path 2: email — 已驗證 email 相同的 students（排除已透過 identity 聚合的）
+    if student.email_verified and student.email:
+        email_siblings = (
+            db.query(Student)
+            .filter(
+                Student.email == student.email,
+                Student.email_verified.is_(True),
+                Student.id.notin_(seen_student_ids),
+                Student.is_active.is_(True),
+            )
+            .all()
+        )
+        for sibling in email_siblings:
             classrooms_list.extend(_get_classrooms_for_student(db, sibling.id))
 
     return classrooms_list

--- a/backend/services/one_campus_account_service.py
+++ b/backend/services/one_campus_account_service.py
@@ -117,6 +117,44 @@ class OneCampusAccountService:
                 )
                 return existing_identity, student, "merge_prompt"
 
+        # Step 2.5: Check if 1Campus account matches an existing verified email
+        if one_campus_account:
+            email_identity = (
+                db.query(Identity)
+                .filter(
+                    Identity.email == one_campus_account,
+                    Identity.email_verified.is_(True),
+                    Identity.is_active.is_(True),
+                )
+                .first()
+            )
+            if email_identity:
+                # Merge 1Campus fields into existing email-verified Identity
+                email_identity.one_campus_student_id = one_campus_student_id
+                email_identity.one_campus_account = one_campus_account
+                if national_id_hash:
+                    email_identity.national_id_hash = national_id_hash
+                db.commit()
+
+                student = (
+                    db.query(Student)
+                    .filter(
+                        Student.identity_id == email_identity.id,
+                        Student.is_active.is_(True),
+                    )
+                    .order_by(Student.is_primary_account.desc().nulls_last())
+                    .first()
+                )
+                if student:
+                    logger.info(
+                        "1Campus SSO: auto-merged student by email match, "
+                        "student_id=%s, identity_id=%s, email=%s",
+                        student.id,
+                        email_identity.id,
+                        one_campus_account,
+                    )
+                    return email_identity, student, "existing"
+
         # Step 3: Create new Identity + Student
         identity = Identity(
             one_campus_student_id=one_campus_student_id,
@@ -266,6 +304,41 @@ class OneCampusAccountService:
                         existing_identity.id,
                     )
                     return existing_identity, teacher, "existing"
+
+        # Step 2.5: Check if 1Campus account matches an existing verified email
+        if one_campus_account:
+            email_identity = (
+                db.query(Identity)
+                .filter(
+                    Identity.email == one_campus_account,
+                    Identity.email_verified.is_(True),
+                    Identity.is_active.is_(True),
+                )
+                .first()
+            )
+            if email_identity:
+                teacher = (
+                    db.query(Teacher)
+                    .filter(
+                        Teacher.identity_id == email_identity.id,
+                        Teacher.is_active.is_(True),
+                    )
+                    .first()
+                )
+                if teacher:
+                    # Merge 1Campus fields into existing email-verified Identity
+                    email_identity.one_campus_account = one_campus_account
+                    if national_id_hash:
+                        email_identity.national_id_hash = national_id_hash
+                    db.commit()
+                    logger.info(
+                        "1Campus SSO: auto-merged teacher by email match, "
+                        "teacher_id=%s, identity_id=%s, email=%s",
+                        teacher.id,
+                        email_identity.id,
+                        one_campus_account,
+                    )
+                    return email_identity, teacher, "existing"
 
         # Step 3: Create new Identity + Teacher
         identity = Identity(

--- a/backend/services/one_campus_account_service.py
+++ b/backend/services/one_campus_account_service.py
@@ -129,13 +129,6 @@ class OneCampusAccountService:
                 .first()
             )
             if email_identity:
-                # Merge 1Campus fields into existing email-verified Identity
-                email_identity.one_campus_student_id = one_campus_student_id
-                email_identity.one_campus_account = one_campus_account
-                if national_id_hash:
-                    email_identity.national_id_hash = national_id_hash
-                db.commit()
-
                 student = (
                     db.query(Student)
                     .filter(
@@ -146,6 +139,12 @@ class OneCampusAccountService:
                     .first()
                 )
                 if student:
+                    # Only write 1Campus fields after confirming student exists
+                    email_identity.one_campus_student_id = one_campus_student_id
+                    email_identity.one_campus_account = one_campus_account
+                    if national_id_hash:
+                        email_identity.national_id_hash = national_id_hash
+                    db.commit()
                     logger.info(
                         "1Campus SSO: auto-merged student by email match, "
                         "student_id=%s, identity_id=%s, email=%s",
@@ -326,7 +325,7 @@ class OneCampusAccountService:
                     .first()
                 )
                 if teacher:
-                    # Merge 1Campus fields into existing email-verified Identity
+                    # Only write 1Campus fields after confirming teacher exists
                     email_identity.one_campus_account = one_campus_account
                     if national_id_hash:
                         email_identity.national_id_hash = national_id_hash

--- a/backend/tests/unit/test_one_campus_account_merge.py
+++ b/backend/tests/unit/test_one_campus_account_merge.py
@@ -1,0 +1,352 @@
+"""
+Tests for 1Campus SSO account merge with existing Duotopia email accounts.
+
+Covers:
+- Path A: Auto-merge when 1Campus account matches verified Duotopia email
+- Aggregated classrooms via identity_id path
+"""
+
+import pytest
+from models.user import Identity, Student, Teacher
+from services.one_campus_account_service import OneCampusAccountService
+from auth import get_password_hash
+
+
+# ---------------------------------------------------------------------------
+# Student: auto-merge by email (Step 2.5)
+# ---------------------------------------------------------------------------
+
+
+class TestStudentEmailAutoMerge:
+    """find_or_create_student should merge when 1Campus account == existing verified email."""
+
+    def test_auto_merge_when_email_matches(self, shared_test_session):
+        """1Campus account matches an existing verified email → merge into that Identity."""
+        db = shared_test_session
+
+        # Pre-existing Duotopia Identity with verified email
+        existing_identity = Identity(
+            email="student@school.edu.tw",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(existing_identity)
+        db.flush()
+
+        existing_student = Student(
+            name="Existing Student",
+            email="student@school.edu.tw",
+            password_hash=get_password_hash("pass123"),
+            identity_id=existing_identity.id,
+            is_primary_account=True,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(existing_student)
+        db.commit()
+
+        # 1Campus SSO login with same email as account
+        identity, student, action = OneCampusAccountService.find_or_create_student(
+            db,
+            one_campus_student_id="SC001",
+            one_campus_account="student@school.edu.tw",
+            student_name="SSO Student",
+            national_id_hash="abc123def456" * 4 + "abcd" * 4,  # 64 chars
+        )
+
+        assert action == "existing"
+        assert identity.id == existing_identity.id
+        assert student.id == existing_student.id
+        # 1Campus fields written to existing Identity
+        assert identity.one_campus_student_id == "SC001"
+        assert identity.one_campus_account == "student@school.edu.tw"
+
+    def test_no_merge_when_email_not_verified(self, shared_test_session):
+        """Unverified email should NOT trigger auto-merge → create new."""
+        db = shared_test_session
+
+        unverified_identity = Identity(
+            email="unverified@school.edu.tw",
+            email_verified=False,
+            is_active=True,
+        )
+        db.add(unverified_identity)
+        db.flush()
+
+        Student(
+            name="Unverified Student",
+            email="unverified@school.edu.tw",
+            identity_id=unverified_identity.id,
+            is_primary_account=True,
+            is_active=True,
+        )
+        db.commit()
+
+        identity, student, action = OneCampusAccountService.find_or_create_student(
+            db,
+            one_campus_student_id="SC002",
+            one_campus_account="unverified@school.edu.tw",
+            student_name="SSO Student 2",
+        )
+
+        assert action == "created"
+        assert identity.id != unverified_identity.id
+
+    def test_no_merge_when_email_differs(self, shared_test_session):
+        """Different email → no merge, create new Identity."""
+        db = shared_test_session
+
+        existing_identity = Identity(
+            email="other@school.edu.tw",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(existing_identity)
+        db.commit()
+
+        identity, student, action = OneCampusAccountService.find_or_create_student(
+            db,
+            one_campus_student_id="SC003",
+            one_campus_account="different@1campus.net",
+            student_name="SSO Student 3",
+        )
+
+        assert action == "created"
+        assert identity.id != existing_identity.id
+
+    def test_national_id_merge_prompt_takes_priority(self, shared_test_session):
+        """national_id_hash match (Step 2) should take priority over email match (Step 2.5)."""
+        db = shared_test_session
+
+        # Identity with national_id_hash AND email
+        existing_identity = Identity(
+            email="priority@school.edu.tw",
+            email_verified=True,
+            one_campus_student_id="SC_OLD",
+            national_id_hash="a" * 64,
+            is_active=True,
+        )
+        db.add(existing_identity)
+        db.flush()
+
+        existing_student = Student(
+            name="Priority Student",
+            identity_id=existing_identity.id,
+            is_primary_account=True,
+            is_active=True,
+        )
+        db.add(existing_student)
+        db.commit()
+
+        # New SSO login with same national_id_hash but different 1campus_student_id
+        identity, student, action = OneCampusAccountService.find_or_create_student(
+            db,
+            one_campus_student_id="SC_NEW",
+            one_campus_account="priority@school.edu.tw",
+            student_name="New SSO",
+            national_id_hash="a" * 64,
+        )
+
+        # Should hit Step 2 (merge_prompt) before Step 2.5
+        assert action == "merge_prompt"
+
+
+# ---------------------------------------------------------------------------
+# Teacher: auto-merge by email (Step 2.5)
+# ---------------------------------------------------------------------------
+
+
+class TestTeacherEmailAutoMerge:
+    """find_or_create_teacher should merge when 1Campus account == existing verified email."""
+
+    def test_auto_merge_teacher_by_email(self, shared_test_session):
+        """Teacher 1Campus account matches verified email → merge."""
+        db = shared_test_session
+
+        existing_identity = Identity(
+            email="teacher@school.edu.tw",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(existing_identity)
+        db.flush()
+
+        existing_teacher = Teacher(
+            name="Existing Teacher",
+            email="teacher@school.edu.tw",
+            password_hash=get_password_hash("pass123"),
+            identity_id=existing_identity.id,
+            is_active=True,
+        )
+        db.add(existing_teacher)
+        db.commit()
+
+        identity, teacher, action = OneCampusAccountService.find_or_create_teacher(
+            db,
+            one_campus_account="teacher@school.edu.tw",
+            teacher_name="SSO Teacher",
+            national_id_hash="b" * 64,
+        )
+
+        assert action == "existing"
+        assert identity.id == existing_identity.id
+        assert teacher.id == existing_teacher.id
+        assert identity.one_campus_account == "teacher@school.edu.tw"
+        assert identity.national_id_hash == "b" * 64
+
+    def test_no_merge_teacher_unverified(self, shared_test_session):
+        """Unverified teacher email → create new."""
+        db = shared_test_session
+
+        unverified = Identity(
+            email="unteacher@school.edu.tw",
+            email_verified=False,
+            is_active=True,
+        )
+        db.add(unverified)
+        db.flush()
+
+        Teacher(
+            name="Unverified Teacher",
+            email="unteacher@school.edu.tw",
+            identity_id=unverified.id,
+            is_active=True,
+        )
+        db.commit()
+
+        identity, teacher, action = OneCampusAccountService.find_or_create_teacher(
+            db,
+            one_campus_account="unteacher@school.edu.tw",
+            teacher_name="SSO Teacher 2",
+        )
+
+        assert action == "created"
+        assert identity.id != unverified.id
+
+
+# ---------------------------------------------------------------------------
+# Aggregated classrooms via identity_id
+# ---------------------------------------------------------------------------
+
+
+class TestAggregatedClassroomsIdentityPath:
+    """_get_aggregated_classrooms should aggregate by identity_id."""
+
+    def test_identity_siblings_aggregated(self, shared_test_session):
+        """Students under the same Identity should have their classrooms aggregated."""
+        from routers.students.auth import _get_aggregated_classrooms
+        from models import Classroom, ClassroomStudent, Teacher as TeacherModel
+
+        db = shared_test_session
+
+        # Create a teacher for classrooms
+        teacher = TeacherModel(
+            name="CR Teacher",
+            email="crteacher@test.com",
+            password_hash="x",
+            is_active=True,
+        )
+        db.add(teacher)
+        db.flush()
+
+        # Shared Identity (no email, SSO-only — like 1Campus)
+        shared_identity = Identity(
+            email_verified=False,
+            is_active=True,
+        )
+        db.add(shared_identity)
+        db.flush()
+
+        # Student A in Classroom 1
+        student_a = Student(
+            name="Student A",
+            identity_id=shared_identity.id,
+            is_primary_account=True,
+            is_active=True,
+        )
+        db.add(student_a)
+        db.flush()
+
+        cr1 = Classroom(name="Classroom 1", teacher_id=teacher.id)
+        db.add(cr1)
+        db.flush()
+        db.add(ClassroomStudent(classroom_id=cr1.id, student_id=student_a.id, is_active=True))
+
+        # Student B (sibling) in Classroom 2
+        student_b = Student(
+            name="Student B",
+            identity_id=shared_identity.id,
+            is_active=True,
+        )
+        db.add(student_b)
+        db.flush()
+
+        cr2 = Classroom(name="Classroom 2", teacher_id=teacher.id)
+        db.add(cr2)
+        db.flush()
+        db.add(ClassroomStudent(classroom_id=cr2.id, student_id=student_b.id, is_active=True))
+
+        db.commit()
+
+        # Aggregate from Student A should include both classrooms
+        result = _get_aggregated_classrooms(db, student_a)
+        classroom_names = {r["name"] for r in result}
+        assert "Classroom 1" in classroom_names
+        assert "Classroom 2" in classroom_names
+
+    def test_no_duplicate_when_identity_and_email_overlap(self, shared_test_session):
+        """If sibling is found by both identity_id and email, classrooms should not duplicate."""
+        from routers.students.auth import _get_aggregated_classrooms
+        from models import Classroom, ClassroomStudent, Teacher as TeacherModel
+
+        db = shared_test_session
+
+        teacher = TeacherModel(
+            name="Dup Teacher",
+            email="dupteacher@test.com",
+            password_hash="x",
+            is_active=True,
+        )
+        db.add(teacher)
+        db.flush()
+
+        shared_identity = Identity(
+            email="shared@test.com",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(shared_identity)
+        db.flush()
+
+        student_a = Student(
+            name="Dup A",
+            email="shared@test.com",
+            email_verified=True,
+            identity_id=shared_identity.id,
+            is_primary_account=True,
+            is_active=True,
+        )
+        db.add(student_a)
+        db.flush()
+
+        student_b = Student(
+            name="Dup B",
+            email="shared@test.com",
+            email_verified=True,
+            identity_id=shared_identity.id,
+            is_active=True,
+        )
+        db.add(student_b)
+        db.flush()
+
+        cr = Classroom(name="Shared CR", teacher_id=teacher.id)
+        db.add(cr)
+        db.flush()
+        db.add(ClassroomStudent(classroom_id=cr.id, student_id=student_b.id, is_active=True))
+        db.commit()
+
+        result = _get_aggregated_classrooms(db, student_a)
+        # Student B's classroom should appear exactly once (via identity path),
+        # not duplicated via email path
+        cr_names = [r["name"] for r in result]
+        assert cr_names.count("Shared CR") == 1

--- a/backend/tests/unit/test_one_campus_account_merge.py
+++ b/backend/tests/unit/test_one_campus_account_merge.py
@@ -270,7 +270,11 @@ class TestAggregatedClassroomsIdentityPath:
         cr1 = Classroom(name="Classroom 1", teacher_id=teacher.id)
         db.add(cr1)
         db.flush()
-        db.add(ClassroomStudent(classroom_id=cr1.id, student_id=student_a.id, is_active=True))
+        db.add(
+            ClassroomStudent(
+                classroom_id=cr1.id, student_id=student_a.id, is_active=True
+            )
+        )
 
         # Student B (sibling) in Classroom 2
         student_b = Student(
@@ -284,7 +288,11 @@ class TestAggregatedClassroomsIdentityPath:
         cr2 = Classroom(name="Classroom 2", teacher_id=teacher.id)
         db.add(cr2)
         db.flush()
-        db.add(ClassroomStudent(classroom_id=cr2.id, student_id=student_b.id, is_active=True))
+        db.add(
+            ClassroomStudent(
+                classroom_id=cr2.id, student_id=student_b.id, is_active=True
+            )
+        )
 
         db.commit()
 
@@ -342,7 +350,11 @@ class TestAggregatedClassroomsIdentityPath:
         cr = Classroom(name="Shared CR", teacher_id=teacher.id)
         db.add(cr)
         db.flush()
-        db.add(ClassroomStudent(classroom_id=cr.id, student_id=student_b.id, is_active=True))
+        db.add(
+            ClassroomStudent(
+                classroom_id=cr.id, student_id=student_b.id, is_active=True
+            )
+        )
         db.commit()
 
         result = _get_aggregated_classrooms(db, student_a)

--- a/backend/tests/unit/test_one_campus_account_merge.py
+++ b/backend/tests/unit/test_one_campus_account_merge.py
@@ -73,13 +73,14 @@ class TestStudentEmailAutoMerge:
         db.add(unverified_identity)
         db.flush()
 
-        Student(
+        unverified_student = Student(
             name="Unverified Student",
             email="unverified@school.edu.tw",
             identity_id=unverified_identity.id,
             is_primary_account=True,
             is_active=True,
         )
+        db.add(unverified_student)
         db.commit()
 
         identity, student, action = OneCampusAccountService.find_or_create_student(
@@ -206,12 +207,13 @@ class TestTeacherEmailAutoMerge:
         db.add(unverified)
         db.flush()
 
-        Teacher(
+        unverified_teacher = Teacher(
             name="Unverified Teacher",
             email="unteacher@school.edu.tw",
             identity_id=unverified.id,
             is_active=True,
         )
+        db.add(unverified_teacher)
         db.commit()
 
         identity, teacher, action = OneCampusAccountService.find_or_create_teacher(


### PR DESCRIPTION
## Summary
- 1Campus SSO 登入時，若 `one_campus_account` 與 Duotopia 已驗證 email 相同，自動合併到既有 Identity（不再建立重複帳號）
- `_get_aggregated_classrooms` 新增 `identity_id` 聚合路徑，SSO-only 帳號也能看到同 Identity 下的所有班級
- 新增 8 個 unit tests 覆蓋合併、不合併、優先級、去重等場景

## Changes
- `backend/services/one_campus_account_service.py` — `find_or_create_student` / `find_or_create_teacher` 加入 Step 2.5 email match
- `backend/routers/students/auth.py` — `_get_aggregated_classrooms` 加入 identity_id path
- `backend/tests/unit/test_one_campus_account_merge.py` — 8 tests

## Test plan
- [x] 學生：1Campus account == Duotopia email → 自動合併 ✅
- [x] 學生：email 未驗證 → 不合併，建新帳號 ✅
- [x] 學生：email 不同 → 不合併，建新帳號 ✅
- [x] 學生：national_id_hash match 優先於 email match ✅
- [x] 老師：email match → 自動合併 ✅
- [x] 老師：email 未驗證 → 不合併 ✅
- [x] identity_id 聚合班級 ✅
- [x] identity + email 不重複聚合 ✅

Fixes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)