### PR TITLE
feat(#552): 1Campus SSO 手動綁定 Duotopia 帳號 (Path B)

### DIFF
--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -18,11 +18,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from auth import create_access_token
+from auth import create_access_token, get_current_user
 from core.config import settings
 from core.limiter import limiter
 from database import get_db
-from models.user import Student, Teacher
+from models.user import Identity, Student, Teacher
 from models.organization import TeacherOrganization, TeacherSchool
 from routers.students.auth import (
     _get_aggregated_classrooms,
@@ -57,6 +57,10 @@ class OneCampusCallbackResponse(BaseModel):
 
 class MergeConfirmRequest(BaseModel):
     merge_token: str
+
+
+class BindAccountRequest(BaseModel):
+    email: str
 
 
 # --- Helpers ---
@@ -389,3 +393,123 @@ async def merge_confirm(
         student=_build_student_response(db, primary_student),
         action="merged",
     )
+
+
+@router.post("/bind-account")
+@limiter.limit("5/minute")
+async def bind_account(
+    request: Request,
+    body: BindAccountRequest,
+    db: Session = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    """Request to bind a 1Campus SSO account to a Duotopia email.
+
+    The caller must be logged in via 1Campus SSO (has an Identity with
+    one_campus_student_id or one_campus_account but no verified email).
+    Sends a verification email to the provided address.
+    After verification, the Identity merge happens in verify-email endpoint.
+    """
+    user_type = current_user.get("type")
+    user_id = int(current_user.get("sub"))
+
+    # Resolve the Identity for the current user
+    if user_type == "student":
+        user = db.query(Student).filter(Student.id == user_id).first()
+        if not user:
+            raise HTTPException(status_code=404, detail="Student not found")
+        identity = (
+            db.query(Identity).filter(Identity.id == user.identity_id).first()
+            if user.identity_id
+            else None
+        )
+    elif user_type == "teacher":
+        user = db.query(Teacher).filter(Teacher.id == user_id).first()
+        if not user:
+            raise HTTPException(status_code=404, detail="Teacher not found")
+        identity = (
+            db.query(Identity).filter(Identity.id == user.identity_id).first()
+            if user.identity_id
+            else None
+        )
+    else:
+        raise HTTPException(status_code=400, detail="Unsupported user type")
+
+    if not identity:
+        raise HTTPException(
+            status_code=400,
+            detail="No identity found. Please log in via 1Campus SSO first.",
+        )
+
+    # Must be a 1Campus SSO account
+    if not identity.one_campus_account:
+        raise HTTPException(
+            status_code=400,
+            detail="This account is not linked to 1Campus SSO.",
+        )
+
+    # Must not already have a verified email
+    if identity.email_verified and identity.email:
+        raise HTTPException(
+            status_code=400,
+            detail="This account already has a verified email.",
+        )
+
+    target_email = body.email.strip().lower()
+
+    if user_type == "student":
+        from services.email_service import email_service
+        from services.identity_service import identity_service
+
+        # Set the email on the student record for verification flow
+        user.email = target_email
+        user.email_verified = False
+        user.email_verified_at = None
+
+        # Ensure Identity has the email (unverified) for later merge
+        if not identity.email or identity.email != target_email:
+            identity.email = target_email
+            identity.email_verified = False
+
+        # Send verification email (reuse existing flow)
+        success = email_service.send_verification_email(db, user, target_email)
+        if not success:
+            raise HTTPException(
+                status_code=500, detail="Failed to send verification email"
+            )
+
+        return {
+            "message": "Verification email sent. Please check your inbox.",
+            "email": target_email,
+            "action": "verification_sent",
+        }
+
+    else:
+        # Teacher flow — same logic
+        from services.email_service import email_service
+
+        # For teachers we need a Student-like token flow.
+        # Teachers don't have email_verification_token on their model,
+        # so we create a bind token instead.
+        bind_token = _create_merge_token(
+            existing_identity_id=identity.id,
+            one_campus_student_id=identity.one_campus_account,
+            one_campus_account=target_email,
+        )
+
+        # Update teacher email (unverified)
+        user.email = target_email
+        if not identity.email or identity.email != target_email:
+            identity.email = target_email
+            identity.email_verified = False
+        db.commit()
+
+        # For teachers, we'll use the merge-confirm flow with a special token
+        # that encodes the bind intent. The frontend will redirect to
+        # a verification page.
+        return {
+            "message": "Verification email sent. Please check your inbox.",
+            "email": target_email,
+            "bind_token": bind_token,
+            "action": "verification_sent",
+        }

--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
 from auth import create_access_token, get_current_user
@@ -61,7 +61,7 @@ class MergeConfirmRequest(BaseModel):
 
 
 class BindAccountRequest(BaseModel):
-    email: str
+    email: EmailStr
 
 
 # --- Helpers ---
@@ -441,8 +441,18 @@ async def verify_teacher_bind(
         db, sso_identity, target_email, user_type="teacher"
     )
 
-    # Update teacher email to the verified target email
-    teacher.email = target_email
+    # Update teacher email — check uniqueness first to avoid constraint violation
+    existing_teacher_with_email = (
+        db.query(Teacher)
+        .filter(
+            Teacher.email == target_email,
+            Teacher.id != teacher.id,
+            Teacher.is_active.is_(True),
+        )
+        .first()
+    )
+    if not existing_teacher_with_email:
+        teacher.email = target_email
     teacher.email_verified = True
     teacher.email_verified_at = datetime.now(timezone.utc)
     teacher.email_verification_token = None
@@ -533,9 +543,11 @@ async def bind_account(
 
     if user_type == "student":
         from services.email_service import email_service
-        from services.identity_service import identity_service
 
-        # Set the email on the student record for verification flow
+        # Set unverified email on student for the existing verification flow.
+        # send_verification_email() stores the token and commits internally.
+        # The email is marked unverified — actual bind/merge happens in
+        # verify-email endpoint after the user clicks the link.
         user.email = target_email
         user.email_verified = False
         user.email_verified_at = None
@@ -544,8 +556,9 @@ async def bind_account(
         if not identity.email or identity.email != target_email:
             identity.email = target_email
             identity.email_verified = False
+        db.flush()
 
-        # Send verification email (reuse existing flow)
+        # Send verification email (commits internally)
         success = email_service.send_verification_email(db, user, target_email)
         if not success:
             raise HTTPException(
@@ -565,7 +578,10 @@ async def bind_account(
         # and send the actual email.
         from services.email_service import email_service
 
-        # Create bind token encoding: identity_id + target_email
+        # Create bind token. Field mapping note: we reuse _create_merge_token
+        # with swapped semantics — "one_campus_student_id" carries the 1Campus
+        # account, and "one_campus_account" carries the target Duotopia email.
+        # verify_teacher_bind reads token_data["one_campus_account"] as target.
         bind_token = _create_merge_token(
             existing_identity_id=identity.id,
             one_campus_student_id=identity.one_campus_account or "",

--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -432,9 +432,7 @@ async def verify_teacher_bind(
         .first()
     )
     if not teacher:
-        raise HTTPException(
-            status_code=400, detail="Invalid or expired bind token"
-        )
+        raise HTTPException(status_code=400, detail="Invalid or expired bind token")
 
     # Perform the bind
     from services.identity_service import identity_service

--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -6,6 +6,7 @@ Provides:
 """
 
 import base64
+import binascii
 import hashlib
 import hmac
 import json
@@ -104,7 +105,7 @@ def _verify_merge_token(token: str) -> dict:
 
     try:
         payload_dict = json.loads(base64.urlsafe_b64decode(payload_b64))
-    except (json.JSONDecodeError, UnicodeDecodeError, KeyError) as e:
+    except (json.JSONDecodeError, UnicodeDecodeError, KeyError, binascii.Error) as e:
         raise ValueError(f"Invalid merge token payload: {e}")
 
     if payload_dict.get("exp", 0) < int(time.time()):
@@ -395,6 +396,81 @@ async def merge_confirm(
     )
 
 
+@router.get("/verify-teacher-bind")
+@limiter.limit("10/minute")
+async def verify_teacher_bind(
+    request: Request,
+    token: str = Query(..., description="Bind verification token"),
+    db: Session = Depends(get_db),
+):
+    """Verify teacher bind token and perform Identity merge.
+
+    Called when the teacher clicks the verification link in the bind email.
+    The token encodes: identity_id, one_campus_account, target_email.
+    """
+    try:
+        token_data = _verify_merge_token(token)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    identity_id = token_data["existing_identity_id"]
+    target_email = token_data["one_campus_account"]  # target email stored here
+
+    # Find the Identity
+    sso_identity = db.get(Identity, identity_id)
+    if not sso_identity or not sso_identity.is_active:
+        raise HTTPException(status_code=404, detail="Identity not found")
+
+    # Find the teacher with this bind token
+    teacher = (
+        db.query(Teacher)
+        .filter(
+            Teacher.identity_id == identity_id,
+            Teacher.email_verification_token == token,
+            Teacher.is_active.is_(True),
+        )
+        .first()
+    )
+    if not teacher:
+        raise HTTPException(
+            status_code=400, detail="Invalid or expired bind token"
+        )
+
+    # Perform the bind
+    from services.identity_service import identity_service
+
+    surviving_identity = identity_service.bind_1campus_identity_to_email(
+        db, sso_identity, target_email, user_type="teacher"
+    )
+
+    # Update teacher email to the verified target email
+    teacher.email = target_email
+    teacher.email_verified = True
+    teacher.email_verified_at = datetime.now(timezone.utc)
+    teacher.email_verification_token = None
+
+    # Update Identity email verification
+    surviving_identity.email = target_email
+    surviving_identity.email_verified = True
+    surviving_identity.email_verified_at = datetime.now(timezone.utc)
+
+    db.commit()
+
+    logger.info(
+        "Teacher bind verified: teacher_id=%s, email=%s, identity_id=%s",
+        teacher.id,
+        target_email,
+        surviving_identity.id,
+    )
+
+    return {
+        "message": "帳號綁定成功",
+        "teacher_name": teacher.name,
+        "email": target_email,
+        "verified": True,
+    }
+
+
 @router.post("/bind-account")
 @limiter.limit("5/minute")
 async def bind_account(
@@ -485,31 +561,36 @@ async def bind_account(
         }
 
     else:
-        # Teacher flow — same logic
+        # Teacher flow — Do NOT overwrite teacher.email or identity.email
+        # before verification. Use a signed bind token that encodes the
+        # target email, store it as the teacher's verification token,
+        # and send the actual email.
         from services.email_service import email_service
 
-        # For teachers we need a Student-like token flow.
-        # Teachers don't have email_verification_token on their model,
-        # so we create a bind token instead.
+        # Create bind token encoding: identity_id + target_email
         bind_token = _create_merge_token(
             existing_identity_id=identity.id,
-            one_campus_student_id=identity.one_campus_account,
+            one_campus_student_id=identity.one_campus_account or "",
             one_campus_account=target_email,
         )
 
-        # Update teacher email (unverified)
-        user.email = target_email
-        if not identity.email or identity.email != target_email:
-            identity.email = target_email
-            identity.email_verified = False
+        # Store bind token on teacher and send verification email
+        user.email_verification_token = bind_token
+        user.email_verification_sent_at = datetime.now(timezone.utc)
         db.commit()
 
-        # For teachers, we'll use the merge-confirm flow with a special token
-        # that encodes the bind intent. The frontend will redirect to
-        # a verification page.
+        success = email_service.send_teacher_bind_email(
+            target_email=target_email,
+            teacher_name=user.name,
+            bind_token=bind_token,
+        )
+        if not success:
+            raise HTTPException(
+                status_code=500, detail="Failed to send verification email"
+            )
+
         return {
             "message": "Verification email sent. Please check your inbox.",
             "email": target_email,
-            "bind_token": bind_token,
             "action": "verification_sent",
         }

--- a/backend/routers/students/email_verification.py
+++ b/backend/routers/students/email_verification.py
@@ -205,6 +205,19 @@ async def verify_email(token: str, db: Session = Depends(get_db)):
     # 更新 Identity 驗證狀態 + 密碼遷移
     identity = identity_service.on_email_verified(db, student)
 
+    # Path B: If this Identity is a 1Campus SSO account, perform bind/merge
+    bound_identity = None
+    if identity and identity.one_campus_account:
+        from models.user import Identity as IdentityModel
+
+        bound_identity = identity_service.bind_1campus_identity_to_email(
+            db, identity, student.email, user_type="student"
+        )
+        # If merge happened, update student's identity_id to the surviving one
+        if bound_identity and bound_identity.id != identity.id:
+            db.refresh(student)
+            identity = bound_identity
+
     # 將 identity_id 同步到所有同 email 的 sibling students
     if student.identity_id and student.email:
         siblings = (
@@ -224,6 +237,7 @@ async def verify_email(token: str, db: Session = Depends(get_db)):
 
     linked_count = 0
     if identity:
+        db.refresh(identity)
         linked_count = len(
             [s for s in identity.linked_students if s.id != student.id and s.is_active]
         )
@@ -235,6 +249,7 @@ async def verify_email(token: str, db: Session = Depends(get_db)):
         "verified": True,
         "identity_consolidated": identity is not None,
         "linked_accounts_count": linked_count,
+        "one_campus_bound": bound_identity is not None,
     }
 
 

--- a/backend/routers/students/email_verification.py
+++ b/backend/routers/students/email_verification.py
@@ -207,9 +207,7 @@ async def verify_email(token: str, db: Session = Depends(get_db)):
 
     # Path B: If this Identity is a 1Campus SSO account, perform bind/merge
     bound_identity = None
-    if identity and identity.one_campus_account:
-        from models.user import Identity as IdentityModel
-
+    if identity and identity.one_campus_account and identity.email_verified:
         bound_identity = identity_service.bind_1campus_identity_to_email(
             db, identity, student.email, user_type="student"
         )

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -415,6 +415,74 @@ class EmailService:
             logger.error(f"發送教師驗證 email 失敗: {str(e)}")
             return False
 
+    def send_teacher_bind_email(
+        self,
+        target_email: str,
+        teacher_name: str,
+        bind_token: str,
+    ) -> bool:
+        """Send a bind verification email to a teacher's target Duotopia email.
+
+        Unlike send_teacher_verification_email, this does NOT modify the
+        teacher record — the bind_token is already stored by the caller.
+        """
+        try:
+            verification_url = (
+                f"{self.frontend_url}/1campus-verify-bind?token={bind_token}"
+            )
+
+            subject = f"【Duotopia】帳號綁定驗證 - {teacher_name}"
+            html_content = f"""
+            <html><head><meta charset="UTF-8">
+            <style>
+                body {{ font-family: Arial, sans-serif; line-height: 1.6; color: #333; }}
+                .container {{ max-width: 600px; margin: 0 auto; padding: 20px; }}
+                .header {{ background: #2563eb; color: white; padding: 20px;
+                    text-align: center; border-radius: 8px 8px 0 0; }}
+                .content {{ background: #f8fafc; padding: 30px; border-radius: 0 0 8px 8px; }}
+                .button {{ display: inline-block; background: #2563eb; color: white;
+                    padding: 12px 24px; text-decoration: none; border-radius: 6px; }}
+            </style></head><body>
+            <div class="container">
+                <div class="header"><h1>Duotopia 帳號綁定</h1></div>
+                <div class="content">
+                    <h2>親愛的 {teacher_name} 老師：</h2>
+                    <p>您正在將學校帳號（1Campus）與此 Duotopia 帳號綁定。</p>
+                    <p>請點擊下方按鈕完成驗證：</p>
+                    <p style="text-align: center; margin: 30px 0;">
+                        <a href="{verification_url}" class="button">確認綁定</a>
+                    </p>
+                    <p><small>此連結將在 10 分鐘後失效。如果您沒有申請此綁定，請忽略此信件。</small></p>
+                </div>
+            </div></body></html>
+            """
+
+            if not self.smtp_user or not self.smtp_password:
+                logger.info(f"開發模式：教師綁定驗證連結 - {verification_url}")
+                print(f"\n📧 教師綁定驗證 Email（開發模式）")
+                print(f"   收件人: {target_email}")
+                print(f"   教師: {teacher_name}")
+                print(f"   驗證連結: {verification_url}\n")
+                return True
+
+            msg = MIMEMultipart("alternative")
+            msg["Subject"] = subject
+            msg["From"] = f"{self.from_name} <{self.from_email}>"
+            msg["To"] = target_email
+            msg.attach(MIMEText(html_content, "html", "utf-8"))
+
+            with smtplib.SMTP(self.smtp_host, self.smtp_port) as server:
+                server.starttls()
+                server.login(self.smtp_user, self.smtp_password)
+                server.send_message(msg)
+
+            logger.info(f"教師綁定驗證 email 已發送到 {target_email}")
+            return True
+
+        except Exception as e:
+            logger.error(f"發送教師綁定驗證 email 失敗: {str(e)}")
+            return False
+
     def verify_teacher_email_token(self, db: Session, token: str) -> Optional[Teacher]:
         """驗證教師 email token 並啟動訂閱
 

--- a/backend/services/identity_service.py
+++ b/backend/services/identity_service.py
@@ -296,6 +296,141 @@ class IdentityService:
         # 都有自定義密碼 or 都是預設密碼 -> 保持 Identity 的
         return
 
+    def bind_1campus_identity_to_email(
+        self,
+        db: Session,
+        sso_identity: Identity,
+        target_email: str,
+        user_type: str = "student",
+    ) -> Identity:
+        """Bind an SSO-only 1Campus Identity to an existing email-based Identity.
+
+        Called after email verification succeeds for a 1Campus user who
+        manually entered their Duotopia email.
+
+        Two scenarios:
+        1. target_email has an existing active Identity → migrate 1Campus fields
+           to that Identity, move linked users, deactivate the SSO Identity.
+        2. target_email has no Identity → set the email on the SSO Identity directly.
+
+        Returns the surviving Identity.
+        """
+        # Look for an existing Identity with the target email
+        email_identity = (
+            db.query(Identity)
+            .filter(
+                Identity.email == target_email,
+                Identity.is_active.is_(True),
+                Identity.id != sso_identity.id,
+            )
+            .first()
+        )
+
+        if email_identity:
+            # Scenario 1: Merge SSO fields into the email Identity
+            email_identity.one_campus_student_id = sso_identity.one_campus_student_id
+            email_identity.one_campus_account = sso_identity.one_campus_account
+            if sso_identity.national_id_hash:
+                email_identity.national_id_hash = sso_identity.national_id_hash
+
+            # Smart password merge
+            self._smart_password_merge_identity(sso_identity, email_identity)
+
+            # Migrate linked users from SSO Identity to email Identity
+            if user_type == "student":
+                students = (
+                    db.query(Student)
+                    .filter(
+                        Student.identity_id == sso_identity.id,
+                        Student.is_active.is_(True),
+                    )
+                    .all()
+                )
+                for s in students:
+                    s.identity_id = email_identity.id
+                    # Don't override existing primary
+                    has_primary = (
+                        db.query(Student)
+                        .filter(
+                            Student.identity_id == email_identity.id,
+                            Student.is_primary_account.is_(True),
+                            Student.is_active.is_(True),
+                            Student.id != s.id,
+                        )
+                        .first()
+                    )
+                    if has_primary:
+                        s.is_primary_account = False
+            else:
+                teachers = (
+                    db.query(Teacher)
+                    .filter(
+                        Teacher.identity_id == sso_identity.id,
+                        Teacher.is_active.is_(True),
+                    )
+                    .all()
+                )
+                for t in teachers:
+                    t.identity_id = email_identity.id
+                    # Only update email if it won't violate uniqueness
+                    existing_teacher_with_email = (
+                        db.query(Teacher)
+                        .filter(
+                            Teacher.email == target_email,
+                            Teacher.id != t.id,
+                            Teacher.is_active.is_(True),
+                        )
+                        .first()
+                    )
+                    if not existing_teacher_with_email:
+                        t.email = target_email
+
+            # Deactivate the SSO-only Identity
+            sso_identity.is_active = False
+            db.flush()
+
+            logger.info(
+                "1Campus bind: merged sso_identity=%s into email_identity=%s "
+                "(email=%s, type=%s)",
+                sso_identity.id,
+                email_identity.id,
+                target_email,
+                user_type,
+            )
+            return email_identity
+
+        else:
+            # Scenario 2: No existing email Identity → set email on SSO Identity
+            sso_identity.email = target_email
+            db.flush()
+
+            logger.info(
+                "1Campus bind: set email=%s on sso_identity=%s (type=%s)",
+                target_email,
+                sso_identity.id,
+                user_type,
+            )
+            return sso_identity
+
+    def _smart_password_merge_identity(
+        self, source: Identity, target: Identity
+    ) -> None:
+        """Merge password from source Identity into target Identity.
+
+        Same strategy as _smart_password_merge but between two Identities.
+        """
+        if target.password_changed:
+            return
+        if source.password_changed and not target.password_changed:
+            target.password_hash = source.password_hash
+            target.password_changed = True
+            target.last_password_change = datetime.now(timezone.utc)
+            logger.info(
+                "Adopted sso identity %s password for target identity %s",
+                source.id,
+                target.id,
+            )
+
     def get_linked_students(self, db: Session, identity_id: int) -> list[Student]:
         """取得 Identity 下所有關聯的 Student 帳號"""
         return (

--- a/backend/services/one_campus_account_service.py
+++ b/backend/services/one_campus_account_service.py
@@ -340,7 +340,37 @@ class OneCampusAccountService:
                     return email_identity, teacher, "existing"
 
         # Step 3: Create new Identity + Teacher
+        # Use the real 1Campus account email instead of a placeholder,
+        # but only if no other Identity/Teacher already uses this email.
+        identity_email_taken = (
+            db.query(Identity)
+            .filter(
+                Identity.email == one_campus_account,
+                Identity.is_active.is_(True),
+            )
+            .first()
+        ) is not None
+
+        teacher_email_taken = (
+            db.query(Teacher)
+            .filter(
+                Teacher.email == one_campus_account,
+                Teacher.is_active.is_(True),
+            )
+            .first()
+        ) is not None
+
+        use_real_email = not identity_email_taken and not teacher_email_taken
+
+        # Fallback to placeholder if email is already taken
+        if not use_real_email:
+            safe_account = one_campus_account.replace("@", "_at_")
+            teacher_email = f"1campus_{safe_account}@sso.duotopia.com"
+        else:
+            teacher_email = one_campus_account
+
         identity = Identity(
+            email=one_campus_account if not identity_email_taken else None,
             one_campus_account=one_campus_account,
             national_id_hash=national_id_hash,
             email_verified=False,
@@ -349,15 +379,9 @@ class OneCampusAccountService:
         db.add(identity)
         db.flush()
 
-        # Generate a placeholder email for Teacher (required NOT NULL)
-        # one_campus_account may contain '@' (e.g. user@1campus.net),
-        # so replace it to form a valid email address.
-        safe_account = one_campus_account.replace("@", "_at_")
-        placeholder_email = f"1campus_{safe_account}@sso.duotopia.com"
-
         teacher = Teacher(
             name=teacher_name,
-            email=placeholder_email,
+            email=teacher_email,
             password_hash=None,
             has_password=False,
             identity_id=identity.id,

--- a/backend/tests/unit/test_one_campus_manual_bind.py
+++ b/backend/tests/unit/test_one_campus_manual_bind.py
@@ -1,0 +1,337 @@
+"""
+Tests for 1Campus SSO manual account binding (Path B).
+
+Covers:
+- Teacher creation with real email (not placeholder)
+- bind_1campus_identity_to_email: merge into existing email Identity
+- bind_1campus_identity_to_email: set email on SSO-only Identity
+- Password merge between Identities
+- Student/Teacher binding with deactivation of old Identity
+"""
+
+import pytest
+from models.user import Identity, Student, Teacher
+from services.identity_service import identity_service
+from services.one_campus_account_service import OneCampusAccountService
+from auth import get_password_hash
+
+
+# ---------------------------------------------------------------------------
+# Part 0: Teacher creation uses real email
+# ---------------------------------------------------------------------------
+
+
+class TestTeacherCreationRealEmail:
+    """find_or_create_teacher Step 3 should use real 1Campus account as email."""
+
+    def test_teacher_created_with_real_email(self, shared_test_session):
+        """New teacher should have the real 1Campus email, not a placeholder."""
+        db = shared_test_session
+
+        identity, teacher, action = OneCampusAccountService.find_or_create_teacher(
+            db,
+            one_campus_account="dev.teacher01@1campus.net",
+            teacher_name="Teacher One",
+        )
+
+        assert action == "created"
+        assert teacher.email == "dev.teacher01@1campus.net"
+        assert identity.email == "dev.teacher01@1campus.net"
+        assert identity.one_campus_account == "dev.teacher01@1campus.net"
+        # Should NOT be a placeholder
+        assert "sso.duotopia.com" not in teacher.email
+
+    def test_teacher_identity_has_real_email(self, shared_test_session):
+        """The Identity created for teacher should also have the real email."""
+        db = shared_test_session
+
+        identity, teacher, action = OneCampusAccountService.find_or_create_teacher(
+            db,
+            one_campus_account="real.teacher@school.edu.tw",
+            teacher_name="Real Teacher",
+            national_id_hash="c" * 64,
+        )
+
+        assert action == "created"
+        assert identity.email == "real.teacher@school.edu.tw"
+        assert identity.national_id_hash == "c" * 64
+
+
+# ---------------------------------------------------------------------------
+# Part 1: bind_1campus_identity_to_email — Student
+# ---------------------------------------------------------------------------
+
+
+class TestBindStudentToEmail:
+    """Test binding a 1Campus SSO student Identity to an email-based Identity."""
+
+    def test_bind_merge_into_existing_email_identity(self, shared_test_session):
+        """SSO Identity should merge into existing email Identity, deactivating SSO Identity."""
+        db = shared_test_session
+
+        # Existing Duotopia Identity with verified email
+        email_identity = Identity(
+            email="existing@duotopia.com",
+            email_verified=True,
+            password_hash=get_password_hash("existing_pass"),
+            password_changed=True,
+            is_active=True,
+        )
+        db.add(email_identity)
+        db.flush()
+
+        email_student = Student(
+            name="Existing Student",
+            email="existing@duotopia.com",
+            password_hash=get_password_hash("existing_pass"),
+            identity_id=email_identity.id,
+            is_primary_account=True,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(email_student)
+        db.flush()
+
+        # SSO-only Identity (no email)
+        sso_identity = Identity(
+            one_campus_student_id="SC_BIND_01",
+            one_campus_account="sso_student@1campus.net",
+            national_id_hash="d" * 64,
+            email_verified=False,
+            is_active=True,
+        )
+        db.add(sso_identity)
+        db.flush()
+
+        sso_student = Student(
+            name="SSO Student",
+            identity_id=sso_identity.id,
+            is_primary_account=True,
+            is_active=True,
+        )
+        db.add(sso_student)
+        db.commit()
+
+        # Perform bind
+        result = identity_service.bind_1campus_identity_to_email(
+            db, sso_identity, "existing@duotopia.com", user_type="student"
+        )
+        db.commit()
+
+        # Should merge into the email Identity
+        assert result.id == email_identity.id
+        assert result.one_campus_student_id == "SC_BIND_01"
+        assert result.one_campus_account == "sso_student@1campus.net"
+        assert result.national_id_hash == "d" * 64
+
+        # SSO Identity should be deactivated
+        db.refresh(sso_identity)
+        assert sso_identity.is_active is False
+
+        # SSO student should now be linked to email Identity
+        db.refresh(sso_student)
+        assert sso_student.identity_id == email_identity.id
+
+    def test_bind_set_email_on_sso_identity(self, shared_test_session):
+        """If no existing email Identity, set email directly on SSO Identity."""
+        db = shared_test_session
+
+        sso_identity = Identity(
+            one_campus_student_id="SC_BIND_02",
+            one_campus_account="solo@1campus.net",
+            email_verified=False,
+            is_active=True,
+        )
+        db.add(sso_identity)
+        db.flush()
+
+        sso_student = Student(
+            name="Solo SSO Student",
+            identity_id=sso_identity.id,
+            is_primary_account=True,
+            is_active=True,
+        )
+        db.add(sso_student)
+        db.commit()
+
+        # Bind to a new email (no existing Identity with this email)
+        result = identity_service.bind_1campus_identity_to_email(
+            db, sso_identity, "newemail@duotopia.com", user_type="student"
+        )
+        db.commit()
+
+        # Should set email on the SSO Identity itself
+        assert result.id == sso_identity.id
+        assert result.email == "newemail@duotopia.com"
+        assert result.one_campus_student_id == "SC_BIND_02"
+        assert sso_identity.is_active is True
+
+    def test_bind_password_merge_sso_has_custom(self, shared_test_session):
+        """If SSO Identity has custom password and email Identity doesn't, adopt SSO's."""
+        db = shared_test_session
+
+        email_identity = Identity(
+            email="nopass@duotopia.com",
+            email_verified=True,
+            password_hash=get_password_hash("default"),
+            password_changed=False,
+            is_active=True,
+        )
+        db.add(email_identity)
+        db.flush()
+
+        email_student = Student(
+            name="NoPass Student",
+            email="nopass@duotopia.com",
+            identity_id=email_identity.id,
+            is_primary_account=True,
+            is_active=True,
+        )
+        db.add(email_student)
+
+        sso_identity = Identity(
+            one_campus_student_id="SC_BIND_03",
+            one_campus_account="custompass@1campus.net",
+            password_hash=get_password_hash("custom_pass"),
+            password_changed=True,
+            email_verified=False,
+            is_active=True,
+        )
+        db.add(sso_identity)
+        db.flush()
+
+        sso_student = Student(
+            name="CustomPass SSO",
+            identity_id=sso_identity.id,
+            is_primary_account=True,
+            is_active=True,
+        )
+        db.add(sso_student)
+        db.commit()
+
+        result = identity_service.bind_1campus_identity_to_email(
+            db, sso_identity, "nopass@duotopia.com", user_type="student"
+        )
+        db.commit()
+
+        # Email Identity should now have the custom password
+        db.refresh(email_identity)
+        assert email_identity.password_changed is True
+
+    def test_bind_primary_account_not_overridden(self, shared_test_session):
+        """When merging, existing primary student should keep primary status."""
+        db = shared_test_session
+
+        email_identity = Identity(
+            email="primary@duotopia.com",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(email_identity)
+        db.flush()
+
+        primary_student = Student(
+            name="Primary",
+            email="primary@duotopia.com",
+            identity_id=email_identity.id,
+            is_primary_account=True,
+            is_active=True,
+        )
+        db.add(primary_student)
+
+        sso_identity = Identity(
+            one_campus_student_id="SC_BIND_04",
+            one_campus_account="incoming@1campus.net",
+            email_verified=False,
+            is_active=True,
+        )
+        db.add(sso_identity)
+        db.flush()
+
+        incoming_student = Student(
+            name="Incoming",
+            identity_id=sso_identity.id,
+            is_primary_account=True,
+            is_active=True,
+        )
+        db.add(incoming_student)
+        db.commit()
+
+        identity_service.bind_1campus_identity_to_email(
+            db, sso_identity, "primary@duotopia.com", user_type="student"
+        )
+        db.commit()
+
+        db.refresh(primary_student)
+        db.refresh(incoming_student)
+        assert primary_student.is_primary_account is True
+        assert incoming_student.is_primary_account is False
+
+
+# ---------------------------------------------------------------------------
+# Part 2: bind_1campus_identity_to_email — Teacher
+# ---------------------------------------------------------------------------
+
+
+class TestBindTeacherToEmail:
+    """Test binding a 1Campus SSO teacher Identity to an email-based Identity."""
+
+    def test_bind_teacher_merge_into_existing(self, shared_test_session):
+        """Teacher SSO Identity should merge into existing email Identity."""
+        db = shared_test_session
+
+        email_identity = Identity(
+            email="existingteacher@duotopia.com",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(email_identity)
+        db.flush()
+
+        email_teacher = Teacher(
+            name="Existing Teacher",
+            email="existingteacher@duotopia.com",
+            password_hash=get_password_hash("pass"),
+            identity_id=email_identity.id,
+            is_active=True,
+        )
+        db.add(email_teacher)
+
+        sso_identity = Identity(
+            one_campus_account="sso.teacher@1campus.net",
+            national_id_hash="e" * 64,
+            email="sso.teacher@1campus.net",
+            email_verified=False,
+            is_active=True,
+        )
+        db.add(sso_identity)
+        db.flush()
+
+        sso_teacher = Teacher(
+            name="SSO Teacher",
+            email="sso.teacher@1campus.net",
+            password_hash=None,
+            identity_id=sso_identity.id,
+            is_active=True,
+        )
+        db.add(sso_teacher)
+        db.commit()
+
+        result = identity_service.bind_1campus_identity_to_email(
+            db, sso_identity, "existingteacher@duotopia.com", user_type="teacher"
+        )
+        db.commit()
+
+        assert result.id == email_identity.id
+        assert result.one_campus_account == "sso.teacher@1campus.net"
+        assert result.national_id_hash == "e" * 64
+
+        # SSO teacher should be moved to email Identity
+        # Email stays as original because existing teacher already has target email
+        db.refresh(sso_teacher)
+        assert sso_teacher.identity_id == email_identity.id
+        assert sso_teacher.email == "sso.teacher@1campus.net"
+
+        # SSO Identity deactivated
+        db.refresh(sso_identity)
+        assert sso_identity.is_active is False

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1398,6 +1398,16 @@
       "newAccount": "School account",
       "confirm": "Merge Accounts",
       "skip": "Skip for now"
+    },
+    "bind": {
+      "title": "Bind Duotopia Account",
+      "description": "If you already have a Duotopia account, enter your email to link it with your school account.",
+      "emailPlaceholder": "your-email@example.com",
+      "sendVerification": "Send Verification Email",
+      "skip": "Skip for now",
+      "sentTitle": "Verification Email Sent",
+      "sentDescription": "We've sent a verification email to {{email}}. Please check your inbox and click the verification link.",
+      "continue": "Continue to Dashboard"
     }
   },
   "teacherRegister": {

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -1377,7 +1377,7 @@
       "skip": "先跳過",
       "sentTitle": "驗證信已發送",
       "sentDescription": "我們已發送驗證信到 {{email}}，請查看信箱並點擊驗證連結。",
-      "continue": "前往首頁"
+      "continue": "前往儀表板"
     }
   },
   "studentDashboard": {

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -1368,6 +1368,16 @@
       "newAccount": "學校帳號",
       "confirm": "合併帳號",
       "skip": "先跳過"
+    },
+    "bind": {
+      "title": "綁定 Duotopia 帳號",
+      "description": "如果你已經有 Duotopia 帳號，輸入 Email 即可將學校帳號與 Duotopia 帳號綁定。",
+      "emailPlaceholder": "your-email@example.com",
+      "sendVerification": "發送驗證信",
+      "skip": "先跳過",
+      "sentTitle": "驗證信已發送",
+      "sentDescription": "我們已發送驗證信到 {{email}}，請查看信箱並點擊驗證連結。",
+      "continue": "前往首頁"
     }
   },
   "studentDashboard": {

--- a/frontend/src/pages/OneCampusCallback.tsx
+++ b/frontend/src/pages/OneCampusCallback.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useState } from "react";
 import { useSearchParams, useNavigate, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Loader2, AlertCircle, Home, MergeIcon, Link2, Mail } from "lucide-react";
+import {
+  Loader2,
+  AlertCircle,
+  Home,
+  MergeIcon,
+  Link2,
+  Mail,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -206,7 +213,10 @@ export default function OneCampusCallback() {
         const resp = err.response as { data: { detail?: string } };
         setErrorMessage(
           resp.data.detail ||
-            t("oneCampus.errors.generic", "Operation failed. Please try again."),
+            t(
+              "oneCampus.errors.generic",
+              "Operation failed. Please try again.",
+            ),
         );
       } else {
         setErrorMessage(
@@ -306,7 +316,11 @@ export default function OneCampusCallback() {
               {t("oneCampus.bind.sendVerification", "Send Verification Email")}
             </Button>
 
-            <Button variant="outline" onClick={handleBindSkip} className="w-full">
+            <Button
+              variant="outline"
+              onClick={handleBindSkip}
+              className="w-full"
+            >
               {t("oneCampus.bind.skip", "Skip for now")}
             </Button>
           </CardContent>

--- a/frontend/src/pages/OneCampusCallback.tsx
+++ b/frontend/src/pages/OneCampusCallback.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { useSearchParams, useNavigate, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Loader2, AlertCircle, Home, MergeIcon } from "lucide-react";
+import { Loader2, AlertCircle, Home, MergeIcon, Link2, Mail } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Card,
   CardContent,
@@ -21,9 +22,9 @@ export default function OneCampusCallback() {
   const { login: studentLogin } = useStudentAuthStore();
   const { login: teacherLogin } = useTeacherAuthStore();
 
-  const [status, setStatus] = useState<"loading" | "error" | "merge_prompt">(
-    "loading",
-  );
+  const [status, setStatus] = useState<
+    "loading" | "error" | "merge_prompt" | "bind_prompt" | "bind_sent"
+  >("loading");
   const [errorMessage, setErrorMessage] = useState("");
   const [mergeInfo, setMergeInfo] = useState<{
     merge_token: string;
@@ -33,6 +34,11 @@ export default function OneCampusCallback() {
     message: string;
   } | null>(null);
   const [merging, setMerging] = useState(false);
+  const [bindEmail, setBindEmail] = useState("");
+  const [bindLoading, setBindLoading] = useState(false);
+  const [bindRoleType, setBindRoleType] = useState<"student" | "teacher">(
+    "student",
+  );
 
   useEffect(() => {
     const code = searchParams.get("code");
@@ -80,6 +86,11 @@ export default function OneCampusCallback() {
             is_demo: data.user.is_demo,
             is_admin: data.user.is_admin,
           });
+          if (data.action === "created") {
+            setBindRoleType("teacher");
+            setStatus("bind_prompt");
+            return;
+          }
           navigate("/teacher/dashboard", { replace: true });
         } else if (data.student) {
           studentLogin(data.access_token, {
@@ -98,6 +109,11 @@ export default function OneCampusCallback() {
             classrooms: data.student.classrooms,
             classrooms_count: data.student.classrooms_count,
           });
+          if (data.action === "created") {
+            setBindRoleType("student");
+            setStatus("bind_prompt");
+            return;
+          }
           navigate("/student/dashboard", { replace: true });
         }
       }
@@ -170,6 +186,45 @@ export default function OneCampusCallback() {
     navigate("/student/login", { replace: true });
   }
 
+  async function handleBindSubmit() {
+    if (!bindEmail.trim()) return;
+    setBindLoading(true);
+    try {
+      await api.post("/api/auth/1campus/bind-account", {
+        email: bindEmail.trim(),
+      });
+      setStatus("bind_sent");
+    } catch (err: unknown) {
+      if (
+        err &&
+        typeof err === "object" &&
+        "response" in err &&
+        err.response &&
+        typeof err.response === "object" &&
+        "data" in err.response
+      ) {
+        const resp = err.response as { data: { detail?: string } };
+        setErrorMessage(
+          resp.data.detail ||
+            t("oneCampus.errors.generic", "Operation failed. Please try again."),
+        );
+      } else {
+        setErrorMessage(
+          t("oneCampus.errors.generic", "Operation failed. Please try again."),
+        );
+      }
+      setStatus("error");
+    } finally {
+      setBindLoading(false);
+    }
+  }
+
+  function handleBindSkip() {
+    const dashboardPath =
+      bindRoleType === "teacher" ? "/teacher/dashboard" : "/student/dashboard";
+    navigate(dashboardPath, { replace: true });
+  }
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center p-4">
       <Link
@@ -203,6 +258,79 @@ export default function OneCampusCallback() {
               className="w-full"
             >
               {t("oneCampus.errors.backToLogin", "Back to Login")}
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {status === "bind_prompt" && (
+        <Card className="max-w-md w-full">
+          <CardHeader className="text-center">
+            <Link2 className="h-12 w-12 text-blue-500 mx-auto mb-2" />
+            <CardTitle>
+              {t("oneCampus.bind.title", "Bind Duotopia Account")}
+            </CardTitle>
+            <CardDescription>
+              {t(
+                "oneCampus.bind.description",
+                "If you already have a Duotopia account, enter your email to link it with your school account.",
+              )}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Input
+                type="email"
+                placeholder={t(
+                  "oneCampus.bind.emailPlaceholder",
+                  "your-email@example.com",
+                )}
+                value={bindEmail}
+                onChange={(e) => setBindEmail(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleBindSubmit();
+                }}
+              />
+            </div>
+
+            <Button
+              onClick={handleBindSubmit}
+              disabled={bindLoading || !bindEmail.trim()}
+              className="w-full"
+            >
+              {bindLoading ? (
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+              ) : (
+                <Mail className="h-4 w-4 mr-2" />
+              )}
+              {t("oneCampus.bind.sendVerification", "Send Verification Email")}
+            </Button>
+
+            <Button variant="outline" onClick={handleBindSkip} className="w-full">
+              {t("oneCampus.bind.skip", "Skip for now")}
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {status === "bind_sent" && (
+        <Card className="max-w-md w-full">
+          <CardHeader className="text-center">
+            <Mail className="h-12 w-12 text-green-500 mx-auto mb-2" />
+            <CardTitle>
+              {t("oneCampus.bind.sentTitle", "Verification Email Sent")}
+            </CardTitle>
+            <CardDescription>
+              {t(
+                "oneCampus.bind.sentDescription",
+                "We've sent a verification email to {{email}}. Please check your inbox and click the verification link.",
+                { email: bindEmail },
+              )}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-center">
+            <Button onClick={handleBindSkip} className="w-full">
+              {t("oneCampus.bind.continue", "Continue to Dashboard")}
             </Button>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- **修正 Teacher 建立**：`find_or_create_teacher` Step 3 改用真實 1Campus email 取代 placeholder（`sso.duotopia.com`），讓下次登入能正確比對
- **新增手動綁定 API**：`POST /api/auth/1campus/bind-account` — SSO 登入後輸入 Duotopia email，發送驗證信
- **Email 驗證後自動合併**：`verify-email` 偵測 1Campus Identity，驗證成功後將 SSO 欄位搬到 email Identity，停用舊 Identity
- **前端綁定 UI**：SSO 首次登入（`action=created`）顯示「綁定 Duotopia 帳號」畫面，可輸入 email 或跳過

### 技術細節
- `IdentityService.bind_1campus_identity_to_email()` 處理兩種情境：
  1. 目標 email 已有 Identity → 搬移 1Campus 欄位 + 停用舊 Identity
  2. 目標 email 無 Identity → 直接設定在 SSO Identity 上
- 密碼合併使用 `_smart_password_merge_identity()`
- Teacher email 唯一性保護（避免 UNIQUE constraint 衝突）

## Test plan
- [x] Teacher 建立使用真實 email（不含 `sso.duotopia.com`）
- [x] Student bind: SSO Identity 合併到既有 email Identity，舊 Identity 停用
- [x] Student bind: 無既有 Identity 時直接設定 email
- [x] 密碼合併：SSO 有自訂密碼時正確遷移
- [x] Primary account 不被覆蓋
- [x] Teacher bind: 合併到既有 email Identity
- [x] 15/15 unit tests passing（7 new + 8 existing Path A）
- [x] TypeScript 編譯通過
- [ ] E2E: SSO 登入 → bind prompt → 輸入 email → 收驗證信 → 驗證 → 合併成功

Fixes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)