### PR TITLE
fix(#560): 單字集批次匯入 AI 呼叫超時優化 — 三管齊下

### DIFF
--- a/backend/services/translation.py
+++ b/backend/services/translation.py
@@ -143,7 +143,7 @@ class TranslationService:
             if self.use_vertex_ai:
                 result = await self.vertex_ai.generate_text(
                     prompt=prompt,
-                    model_type="flash",
+                    model_type="fast",
                     max_tokens=token_limit,
                     temperature=0.3,
                     system_instruction=system_instruction,
@@ -261,7 +261,7 @@ Required: Return format must be ["translation1", "translation2", ...]"""
             if self.use_vertex_ai:
                 translations = await self.vertex_ai.generate_json(
                     prompt=prompt,
-                    model_type="flash",
+                    model_type="fast",
                     max_tokens=3500,
                     temperature=0.3,
                     system_instruction=system_instruction,
@@ -449,7 +449,7 @@ Only reply with JSON array, no other text."""
             if self.use_vertex_ai:
                 results = await self.vertex_ai.generate_json(
                     prompt=prompt,
-                    model_type="flash",
+                    model_type="fast",
                     max_tokens=2000,
                     temperature=0.2,
                     system_instruction=system_instruction,

--- a/backend/services/vertex_ai.py
+++ b/backend/services/vertex_ai.py
@@ -15,13 +15,18 @@ import os
 import json
 import re
 import logging
+import asyncio
 from typing import Optional, Literal
 
 logger = logging.getLogger(__name__)
 
 # Model name constants
+FAST_MODEL = "gemini-2.0-flash"  # 快速模型，適合簡單翻譯等任務
 FLASH_MODEL = "gemini-2.5-flash"
 PRO_MODEL = "gemini-2.5-pro"
+
+# Default timeout for Vertex AI calls (seconds)
+VERTEX_AI_TIMEOUT = 60
 
 
 class VertexAIService:
@@ -32,6 +37,7 @@ class VertexAIService:
         self.location = os.getenv("VERTEX_AI_LOCATION", "us-central1")
         self._initialized = False
         # Cached models without system_instruction (for reuse)
+        self._fast_model = None
         self._flash_model = None
         self._pro_model = None
 
@@ -53,11 +59,16 @@ class VertexAIService:
 
     def _get_model(
         self,
-        model_type: Literal["flash", "pro"] = "flash",
+        model_type: Literal["fast", "flash", "pro"] = "flash",
         system_instruction: Optional[str] = None,
     ):
         """
         取得 GenerativeModel 實例
+
+        model_type:
+        - "fast": gemini-2.0-flash（快速，適合翻譯等簡單任務）
+        - "flash": gemini-2.5-flash（平衡，適合例句生成等需推理的任務）
+        - "pro": gemini-2.5-pro（複雜分析）
 
         當有 system_instruction 時，建立新的 model 實例（Gemini 原生支援）。
         無 system_instruction 時，使用 cached model 以提升效能。
@@ -65,14 +76,22 @@ class VertexAIService:
         self._ensure_initialized()
         from vertexai.generative_models import GenerativeModel
 
-        model_name = FLASH_MODEL if model_type == "flash" else PRO_MODEL
+        model_name_map = {
+            "fast": FAST_MODEL,
+            "flash": FLASH_MODEL,
+            "pro": PRO_MODEL,
+        }
+        model_name = model_name_map.get(model_type, FLASH_MODEL)
 
         if system_instruction:
-            # 每次建立新 model，因為 system_instruction 是 constructor 參數
             return GenerativeModel(model_name, system_instruction=system_instruction)
 
         # 無 system_instruction 時使用 cached model
-        if model_type == "flash":
+        if model_type == "fast":
+            if self._fast_model is None:
+                self._fast_model = GenerativeModel(model_name)
+            return self._fast_model
+        elif model_type == "flash":
             if self._flash_model is None:
                 self._flash_model = GenerativeModel(model_name)
             return self._flash_model
@@ -84,10 +103,11 @@ class VertexAIService:
     async def generate_text(
         self,
         prompt: str,
-        model_type: Literal["flash", "pro"] = "flash",
+        model_type: Literal["fast", "flash", "pro"] = "flash",
         max_tokens: int = 1000,
         temperature: float = 0.7,
         system_instruction: Optional[str] = None,
+        timeout: Optional[int] = VERTEX_AI_TIMEOUT,
     ) -> str:
         """
         統一的文字生成介面
@@ -113,12 +133,23 @@ class VertexAIService:
 
         try:
             logger.info(f"Vertex AI generate_text: calling model (type={model_type})")
-            response = await model.generate_content_async(
-                prompt,
-                generation_config=config,
+            response = await asyncio.wait_for(
+                model.generate_content_async(
+                    prompt,
+                    generation_config=config,
+                ),
+                timeout=timeout,
             )
             logger.info("Vertex AI generate_text: response received")
             return response.text
+        except asyncio.TimeoutError:
+            logger.error(
+                f"Vertex AI generate_text timed out after {timeout}s "
+                f"(model_type={model_type})"
+            )
+            raise TimeoutError(
+                f"Vertex AI call timed out after {timeout} seconds"
+            )
         except Exception as e:
             logger.error(f"Vertex AI generation failed: {e}", exc_info=True)
             raise
@@ -126,10 +157,11 @@ class VertexAIService:
     async def generate_json(
         self,
         prompt: str,
-        model_type: Literal["flash", "pro"] = "flash",
+        model_type: Literal["fast", "flash", "pro"] = "flash",
         max_tokens: int = 1000,
         temperature: float = 0.3,
         system_instruction: Optional[str] = None,
+        timeout: Optional[int] = VERTEX_AI_TIMEOUT,
     ) -> dict:
         """
         生成 JSON 格式的回應
@@ -156,9 +188,12 @@ class VertexAIService:
 
         try:
             logger.info(f"Vertex AI generate_json: calling model (type={model_type})")
-            response = await model.generate_content_async(
-                prompt,
-                generation_config=config,
+            response = await asyncio.wait_for(
+                model.generate_content_async(
+                    prompt,
+                    generation_config=config,
+                ),
+                timeout=timeout,
             )
             logger.info("Vertex AI generate_json: response received")
 
@@ -210,6 +245,14 @@ class VertexAIService:
                     return json.loads(json_content)
                 else:
                     raise
+        except asyncio.TimeoutError:
+            logger.error(
+                f"Vertex AI generate_json timed out after {timeout}s "
+                f"(model_type={model_type})"
+            )
+            raise TimeoutError(
+                f"Vertex AI call timed out after {timeout} seconds"
+            )
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse JSON from Vertex AI response: {e}")
             logger.error(f"Raw response: {response.text if response else 'None'}")

--- a/backend/services/vertex_ai.py
+++ b/backend/services/vertex_ai.py
@@ -147,9 +147,7 @@ class VertexAIService:
                 f"Vertex AI generate_text timed out after {timeout}s "
                 f"(model_type={model_type})"
             )
-            raise TimeoutError(
-                f"Vertex AI call timed out after {timeout} seconds"
-            )
+            raise TimeoutError(f"Vertex AI call timed out after {timeout} seconds")
         except Exception as e:
             logger.error(f"Vertex AI generation failed: {e}", exc_info=True)
             raise
@@ -250,9 +248,7 @@ class VertexAIService:
                 f"Vertex AI generate_json timed out after {timeout}s "
                 f"(model_type={model_type})"
             )
-            raise TimeoutError(
-                f"Vertex AI call timed out after {timeout} seconds"
-            )
+            raise TimeoutError(f"Vertex AI call timed out after {timeout} seconds")
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse JSON from Vertex AI response: {e}")
             logger.error(f"Raw response: {response.text if response else 'None'}")

--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -3373,163 +3373,116 @@ export default function VocabularySetPanel({
           totalSteps,
         });
 
-        for (let i = 0; i < itemsToProcess.length; i++) {
-          if (batchPauseRef.current) {
-            toast.info(
-              `${t("contentEditor.messages.batchPaused")} (${completedItems}/${totalItems})`,
-            );
-            break;
+        // --- Helper: retry with backoff ---
+        const withRetry = async <T,>(
+          fn: () => Promise<T>,
+          retries = 2,
+          delays = [1000, 3000],
+        ): Promise<T> => {
+          for (let attempt = 0; ; attempt++) {
+            try {
+              return await fn();
+            } catch (err) {
+              if (attempt >= retries) throw err;
+              await new Promise((r) => setTimeout(r, delays[attempt] || 3000));
+            }
           }
+        };
 
-          const idx = itemsToProcess[i];
+        // --- Classify items by what they need ---
+        const needsTranslation: number[] = [];
+        const needsTTS: number[] = [];
+        const needsExamples: number[] = [];
+
+        for (const idx of itemsToProcess) {
           const row = currentRows[idx];
-          const text = row.text;
-          const rowSteps = getStepsForRow(row);
-          if (rowSteps === 0) continue;
+          if (autoTranslate) {
+            const hasTranslation = (() => {
+              if (batchLang === "chinese") return !!row.definition;
+              if (batchLang === "english") return !!row.translation;
+              if (batchLang === "japanese") return !!row.japanese_translation;
+              if (batchLang === "korean") return !!row.korean_translation;
+              return !!row.definition;
+            })();
+            if (!hasTranslation) needsTranslation.push(idx);
+          }
+          if (autoTTS && !row.audioUrl && !row.audio_url) needsTTS.push(idx);
+          if (shouldGenerateExamples && !row.example_sentence?.trim())
+            needsExamples.push(idx);
+        }
+
+        // --- Phase 1: Translation (parallel batch) ---
+        if (needsTranslation.length > 0 && !batchPauseRef.current) {
+          const textsToTranslate = needsTranslation.map(
+            (idx) => currentRows[idx].text,
+          );
 
           try {
-            // 補齊翻譯（如果缺少）
-            if (autoTranslate) {
-              const hasTranslation = (() => {
-                if (batchLang === "chinese") return !!row.definition;
-                if (batchLang === "english") return !!row.translation;
-                if (batchLang === "japanese") return !!row.japanese_translation;
-                if (batchLang === "korean") return !!row.korean_translation;
-                return !!row.definition;
-              })();
-
-              if (!hasTranslation) {
-                if (batchLang === "chinese") {
-                  const posResponse = await apiClient.batchTranslateWithPos(
-                    [text],
-                    batchLangCode,
-                  );
-                  const results = posResponse.results || [];
-                  if (results[0]) {
-                    const parsed = extractFirstDefinition(
-                      results[0].translation || "",
-                    );
-                    currentRows[idx].definition = parsed.text;
-                    if (results[0].parts_of_speech?.length > 0) {
-                      currentRows[idx].partsOfSpeech = convertAbbreviatedPOS(
-                        results[0].parts_of_speech,
-                      );
-                    } else if (parsed.pos) {
-                      currentRows[idx].partsOfSpeech = convertAbbreviatedPOS([
-                        parsed.pos,
-                      ]);
-                    }
-                  }
-                } else if (batchLang !== "other") {
-                  const translateResponse = await apiClient.batchTranslate(
-                    [text],
-                    batchLangCode,
-                  );
-                  const translations =
-                    (translateResponse as { translations?: string[] })
-                      .translations || [];
-                  if (translations[0]) {
-                    const parsed = extractFirstDefinition(translations[0]);
-                    if (batchLang === "english")
-                      currentRows[idx].translation = parsed.text;
-                    else if (batchLang === "japanese")
-                      currentRows[idx].japanese_translation = parsed.text;
-                    else if (batchLang === "korean")
-                      currentRows[idx].korean_translation = parsed.text;
-                    if (parsed.pos)
-                      currentRows[idx].partsOfSpeech = convertAbbreviatedPOS([
-                        parsed.pos,
-                      ]);
-                  }
-                }
-                completedSteps++;
-                setBatchProgress({
-                  completedItems,
-                  totalItems,
-                  completedSteps,
-                  totalSteps,
-                });
-                setRows([...currentRows]);
-              }
-            }
-
-            // 補齊 TTS（如果缺少）— 每題重新解析 Random
-            if (autoTTS && !row.audioUrl && !row.audio_url) {
-              const { voice, rate } = getVoiceAndRate(
-                batchTTSAccent,
-                batchTTSGender,
-                batchTTSSpeed,
+            if (batchLang === "chinese") {
+              const posResponse = await withRetry(() =>
+                apiClient.batchTranslateWithPos(
+                  textsToTranslate,
+                  batchLangCode,
+                ),
               );
-              const ttsResult = await apiClient.generateTTS(
-                text,
-                voice,
-                rate,
-                "+0%",
-              );
-              if (
-                ttsResult &&
-                typeof ttsResult === "object" &&
-                "audio_url" in ttsResult
-              ) {
-                const audioUrl = (ttsResult as { audio_url: string }).audio_url;
-                const fullUrl = audioUrl?.startsWith("http")
-                  ? audioUrl
-                  : `${import.meta.env.VITE_API_URL}${audioUrl}`;
-                currentRows[idx].audioUrl = fullUrl;
-                currentRows[idx].audio_url = fullUrl;
-              }
-              completedSteps++;
-              setBatchProgress({
-                completedItems,
-                totalItems,
-                completedSteps,
-                totalSteps,
-              });
-              setRows([...currentRows]);
-            }
-
-            // 補齊例句（如果缺少）
-            if (shouldGenerateExamples && !row.example_sentence?.trim()) {
-              const response = await apiClient.generateSentences({
-                words: [text],
-                definitions: [currentRows[idx].definition || ""],
-                lesson_id: lessonId,
-                level: aiGenerateLevel,
-                prompt: aiGeneratePrompt || undefined,
-                translate_to: exampleTargetLang || undefined,
-                parts_of_speech: [currentRows[idx].partsOfSpeech || []],
-              });
-              const sentencesData =
+              const results = posResponse.results || [];
+              results.forEach(
                 (
-                  response as {
-                    sentences?: Array<{
-                      sentence?: string;
-                      translation?: string;
-                    }>;
+                  result: {
+                    translation?: string;
+                    parts_of_speech?: string[];
+                  },
+                  i: number,
+                ) => {
+                  if (!result) return;
+                  const idx = needsTranslation[i];
+                  const parsed = extractFirstDefinition(
+                    result.translation || "",
+                  );
+                  currentRows[idx].definition = parsed.text;
+                  if (
+                    result.parts_of_speech &&
+                    result.parts_of_speech.length > 0
+                  ) {
+                    currentRows[idx].partsOfSpeech = convertAbbreviatedPOS(
+                      result.parts_of_speech,
+                    );
+                  } else if (parsed.pos) {
+                    currentRows[idx].partsOfSpeech = convertAbbreviatedPOS([
+                      parsed.pos,
+                    ]);
                   }
-                ).sentences || [];
-              if (sentencesData[0]) {
-                currentRows[idx].example_sentence =
-                  sentencesData[0].sentence || "";
-                if (sentencesData[0].translation) {
-                  currentRows[idx].example_sentence_translation =
-                    sentencesData[0].translation;
-                }
-              }
-              completedSteps++;
-              setBatchProgress({
-                completedItems,
-                totalItems,
-                completedSteps,
-                totalSteps,
+                },
+              );
+            } else if (batchLang !== "other") {
+              const translateResponse = await withRetry(() =>
+                apiClient.batchTranslate(textsToTranslate, batchLangCode),
+              );
+              const translations =
+                (translateResponse as { translations?: string[] })
+                  .translations || [];
+              translations.forEach((trans: string, i: number) => {
+                if (!trans) return;
+                const idx = needsTranslation[i];
+                const parsed = extractFirstDefinition(trans);
+                if (batchLang === "english")
+                  currentRows[idx].translation = parsed.text;
+                else if (batchLang === "japanese")
+                  currentRows[idx].japanese_translation = parsed.text;
+                else if (batchLang === "korean")
+                  currentRows[idx].korean_translation = parsed.text;
+                if (parsed.pos)
+                  currentRows[idx].partsOfSpeech = convertAbbreviatedPOS([
+                    parsed.pos,
+                  ]);
               });
-              setRows([...currentRows]);
             }
           } catch (error) {
-            console.error(`Error backfilling word "${text}":`, error);
+            console.error("Batch translation failed:", error);
           }
 
-          completedItems++;
+          completedSteps += needsTranslation.length;
+          setRows([...currentRows]);
           setBatchProgress({
             completedItems,
             totalItems,
@@ -3537,6 +3490,117 @@ export default function VocabularySetPanel({
             totalSteps,
           });
         }
+
+        // --- Phase 2: TTS (parallel per-item) ---
+        if (needsTTS.length > 0 && !batchPauseRef.current) {
+          const ttsResults = await Promise.allSettled(
+            needsTTS.map((idx) => {
+              const text = currentRows[idx].text;
+              const { voice, rate } = getVoiceAndRate(
+                batchTTSAccent,
+                batchTTSGender,
+                batchTTSSpeed,
+              );
+              return withRetry(() =>
+                apiClient.generateTTS(text, voice, rate, "+0%"),
+              );
+            }),
+          );
+
+          ttsResults.forEach((result, i) => {
+            if (result.status === "fulfilled") {
+              const ttsResult = result.value;
+              if (
+                ttsResult &&
+                typeof ttsResult === "object" &&
+                "audio_url" in ttsResult
+              ) {
+                const audioUrl = (ttsResult as { audio_url: string })
+                  .audio_url;
+                const fullUrl = audioUrl?.startsWith("http")
+                  ? audioUrl
+                  : `${import.meta.env.VITE_API_URL}${audioUrl}`;
+                const idx = needsTTS[i];
+                currentRows[idx].audioUrl = fullUrl;
+                currentRows[idx].audio_url = fullUrl;
+              }
+            } else {
+              console.error(
+                `TTS failed for "${currentRows[needsTTS[i]].text}":`,
+                result.reason,
+              );
+            }
+          });
+
+          completedSteps += needsTTS.length;
+          setRows([...currentRows]);
+          setBatchProgress({
+            completedItems,
+            totalItems,
+            completedSteps,
+            totalSteps,
+          });
+        }
+
+        // --- Phase 3: Example sentences (parallel batch) ---
+        if (needsExamples.length > 0 && !batchPauseRef.current) {
+          const exWords = needsExamples.map((idx) => currentRows[idx].text);
+          const exDefs = needsExamples.map(
+            (idx) => currentRows[idx].definition || "",
+          );
+          const exPOS = needsExamples.map(
+            (idx) => currentRows[idx].partsOfSpeech || [],
+          );
+
+          try {
+            const response = await withRetry(() =>
+              apiClient.generateSentences({
+                words: exWords,
+                definitions: exDefs,
+                lesson_id: lessonId,
+                level: aiGenerateLevel,
+                prompt: aiGeneratePrompt || undefined,
+                translate_to: exampleTargetLang || undefined,
+                parts_of_speech: exPOS,
+              }),
+            );
+            const sentencesData =
+              (
+                response as {
+                  sentences?: Array<{
+                    sentence?: string;
+                    translation?: string;
+                  }>;
+                }
+              ).sentences || [];
+            sentencesData.forEach(
+              (
+                s: { sentence?: string; translation?: string },
+                i: number,
+              ) => {
+                if (!s) return;
+                const idx = needsExamples[i];
+                currentRows[idx].example_sentence = s.sentence || "";
+                if (s.translation) {
+                  currentRows[idx].example_sentence_translation = s.translation;
+                }
+              },
+            );
+          } catch (error) {
+            console.error("Batch example sentence generation failed:", error);
+          }
+
+          completedSteps += needsExamples.length;
+          setRows([...currentRows]);
+          setBatchProgress({
+            completedItems,
+            totalItems,
+            completedSteps,
+            totalSteps,
+          });
+        }
+
+        completedItems = totalItems;
 
         toast.success(
           t("vocabularySet.messages.itemsAdded", {

--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -3515,8 +3515,7 @@ export default function VocabularySetPanel({
                 typeof ttsResult === "object" &&
                 "audio_url" in ttsResult
               ) {
-                const audioUrl = (ttsResult as { audio_url: string })
-                  .audio_url;
+                const audioUrl = (ttsResult as { audio_url: string }).audio_url;
                 const fullUrl = audioUrl?.startsWith("http")
                   ? audioUrl
                   : `${import.meta.env.VITE_API_URL}${audioUrl}`;
@@ -3574,10 +3573,7 @@ export default function VocabularySetPanel({
                 }
               ).sentences || [];
             sentencesData.forEach(
-              (
-                s: { sentence?: string; translation?: string },
-                i: number,
-              ) => {
+              (s: { sentence?: string; translation?: string }, i: number) => {
                 if (!s) return;
                 const idx = needsExamples[i];
                 currentRows[idx].example_sentence = s.sentence || "";


### PR DESCRIPTION
## Summary

Fixes #560

單字集批次匯入時 Vertex AI 回應過慢導致 Cloud Run timeout (300s)，斷線後瀏覽器誤報 CORS 錯誤。三管齊下優化：

- **翻譯模型降級**：翻譯+詞性辨識改用 `gemini-2.0-flash`（速度快 3-10 倍），例句生成維持 `gemini-2.5-flash`
- **Vertex AI timeout 防護**：`generate_text` / `generate_json` 加上 `asyncio.wait_for(timeout=60)`，超時拋出明確 `TimeoutError`
- **前端批次並行化**：從 27 次逐一串行改為 3 階段並行（翻譯→TTS→例句），失敗自動 retry 2 次（間隔 1s, 3s）

預期效果：批次匯入 9 個單字從 15-30 分鐘 → 2 分鐘內完成。

## Test plan

- [ ] 批次匯入 9 個單字（最高難度）在 3 分鐘內完成
- [ ] 單一 Vertex AI 呼叫超過 60 秒會被 abort，不會無限等待
- [ ] 失敗的單字會自動 retry，不會靜默跳過
- [ ] 翻譯+詞性使用 gemini-2.0-flash，例句生成使用 gemini-2.5-flash
- [ ] 前端進度條正確反映並行處理的進度
- [ ] 不影響單一單字的即時翻譯功能
- [ ] TypeScript 編譯通過 ✅
- [ ] Frontend build 通過 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)