### PR TITLE
fix: widen email_verification_token from VARCHAR(100) to TEXT

### DIFF
--- a/backend/alembic/versions/20260403_1000_widen_email_verification_token_to_text.py
+++ b/backend/alembic/versions/20260403_1000_widen_email_verification_token_to_text.py
@@ -16,7 +16,8 @@ depends_on = None
 
 def upgrade() -> None:
     # Idempotent: ALTER TYPE to TEXT is safe even if already TEXT
-    op.execute("""
+    op.execute(
+        """
         DO $$ BEGIN
             IF EXISTS (
                 SELECT 1 FROM information_schema.columns
@@ -28,9 +29,11 @@ def upgrade() -> None:
                     ALTER COLUMN email_verification_token TYPE TEXT;
             END IF;
         END $$;
-    """)
+    """
+    )
 
-    op.execute("""
+    op.execute(
+        """
         DO $$ BEGIN
             IF EXISTS (
                 SELECT 1 FROM information_schema.columns
@@ -42,7 +45,8 @@ def upgrade() -> None:
                     ALTER COLUMN email_verification_token TYPE TEXT;
             END IF;
         END $$;
-    """)
+    """
+    )
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/20260403_1000_widen_email_verification_token_to_text.py
+++ b/backend/alembic/versions/20260403_1000_widen_email_verification_token_to_text.py
@@ -1,0 +1,49 @@
+"""Widen email_verification_token from VARCHAR(100) to TEXT
+
+Revision ID: 20260403_1000
+Revises: 20260327_1100
+Create Date: 2026-04-03
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260403_1000"
+down_revision = "20260327_1100"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Idempotent: ALTER TYPE to TEXT is safe even if already TEXT
+    op.execute("""
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'teachers'
+                  AND column_name = 'email_verification_token'
+                  AND data_type = 'character varying'
+            ) THEN
+                ALTER TABLE teachers
+                    ALTER COLUMN email_verification_token TYPE TEXT;
+            END IF;
+        END $$;
+    """)
+
+    op.execute("""
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'students'
+                  AND column_name = 'email_verification_token'
+                  AND data_type = 'character varying'
+            ) THEN
+                ALTER TABLE students
+                    ALTER COLUMN email_verification_token TYPE TEXT;
+            END IF;
+        END $$;
+    """)
+
+
+def downgrade() -> None:
+    pass

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     String,
+    Text,
     DateTime,
     Boolean,
     Date,
@@ -100,7 +101,7 @@ class Teacher(Base):
     # Email 驗證字段
     email_verified = Column(Boolean, default=False)
     email_verified_at = Column(DateTime(timezone=True))
-    email_verification_token = Column(String(100))
+    email_verification_token = Column(Text)
     email_verification_sent_at = Column(DateTime(timezone=True))
 
     # 密碼重設字段
@@ -323,7 +324,7 @@ class Student(Base):
     password_changed = Column(Boolean, default=False)
     email_verified = Column(Boolean, default=False)
     email_verified_at = Column(DateTime(timezone=True))
-    email_verification_token = Column(String(100))
+    email_verification_token = Column(Text)
     email_verification_sent_at = Column(DateTime(timezone=True))
 
     # 密碼重設字段


### PR DESCRIPTION
## Summary

預防性修復：Claude Code Review 在 PR #561 發現 `email_verification_token` 欄位為 VARCHAR(100)，但 1Campus SSO 帳號綁定（#552）使用的 HMAC-signed token 長度約 145-185 字元，會導致存儲失敗。

- `Teacher.email_verification_token`: String(100) → Text
- `Student.email_verification_token`: String(100) → Text
- 新增 idempotent migration，安全地將兩個表的欄位從 VARCHAR 改為 TEXT

## Test plan

- [ ] Migration 在 develop/staging/production 可安全重複執行（idempotent）
- [ ] 現有 email 驗證流程不受影響（`secrets.token_urlsafe(32)` ≈ 43 chars，TEXT 相容）
- [ ] 為 #552 (1Campus SSO 手動綁定) 的 merge token 預留空間

🤖 Generated with [Claude Code](https://claude.com/claude-code)