### PR TITLE
fix: staging 503 — gemini-2.0-flash 不可用，改用 thinking disabled

### DIFF
--- a/backend/services/translation.py
+++ b/backend/services/translation.py
@@ -143,7 +143,8 @@ class TranslationService:
             if self.use_vertex_ai:
                 result = await self.vertex_ai.generate_text(
                     prompt=prompt,
-                    model_type="fast",
+                    model_type="flash",
+                    disable_thinking=True,
                     max_tokens=token_limit,
                     temperature=0.3,
                     system_instruction=system_instruction,
@@ -261,7 +262,8 @@ Required: Return format must be ["translation1", "translation2", ...]"""
             if self.use_vertex_ai:
                 translations = await self.vertex_ai.generate_json(
                     prompt=prompt,
-                    model_type="fast",
+                    model_type="flash",
+                    disable_thinking=True,
                     max_tokens=3500,
                     temperature=0.3,
                     system_instruction=system_instruction,
@@ -449,7 +451,8 @@ Only reply with JSON array, no other text."""
             if self.use_vertex_ai:
                 results = await self.vertex_ai.generate_json(
                     prompt=prompt,
-                    model_type="fast",
+                    model_type="flash",
+                    disable_thinking=True,
                     max_tokens=2000,
                     temperature=0.2,
                     system_instruction=system_instruction,

--- a/backend/services/vertex_ai.py
+++ b/backend/services/vertex_ai.py
@@ -21,7 +21,6 @@ from typing import Optional, Literal
 logger = logging.getLogger(__name__)
 
 # Model name constants
-FAST_MODEL = "gemini-2.0-flash"  # 快速模型，適合簡單翻譯等任務
 FLASH_MODEL = "gemini-2.5-flash"
 PRO_MODEL = "gemini-2.5-pro"
 
@@ -37,7 +36,6 @@ class VertexAIService:
         self.location = os.getenv("VERTEX_AI_LOCATION", "us-central1")
         self._initialized = False
         # Cached models without system_instruction (for reuse)
-        self._fast_model = None
         self._flash_model = None
         self._pro_model = None
 
@@ -59,15 +57,14 @@ class VertexAIService:
 
     def _get_model(
         self,
-        model_type: Literal["fast", "flash", "pro"] = "flash",
+        model_type: Literal["flash", "pro"] = "flash",
         system_instruction: Optional[str] = None,
     ):
         """
         取得 GenerativeModel 實例
 
         model_type:
-        - "fast": gemini-2.0-flash（快速，適合翻譯等簡單任務）
-        - "flash": gemini-2.5-flash（平衡，適合例句生成等需推理的任務）
+        - "flash": gemini-2.5-flash
         - "pro": gemini-2.5-pro（複雜分析）
 
         當有 system_instruction 時，建立新的 model 實例（Gemini 原生支援）。
@@ -76,22 +73,13 @@ class VertexAIService:
         self._ensure_initialized()
         from vertexai.generative_models import GenerativeModel
 
-        model_name_map = {
-            "fast": FAST_MODEL,
-            "flash": FLASH_MODEL,
-            "pro": PRO_MODEL,
-        }
-        model_name = model_name_map.get(model_type, FLASH_MODEL)
+        model_name = FLASH_MODEL if model_type == "flash" else PRO_MODEL
 
         if system_instruction:
             return GenerativeModel(model_name, system_instruction=system_instruction)
 
         # 無 system_instruction 時使用 cached model
-        if model_type == "fast":
-            if self._fast_model is None:
-                self._fast_model = GenerativeModel(model_name)
-            return self._fast_model
-        elif model_type == "flash":
+        if model_type == "flash":
             if self._flash_model is None:
                 self._flash_model = GenerativeModel(model_name)
             return self._flash_model
@@ -103,11 +91,12 @@ class VertexAIService:
     async def generate_text(
         self,
         prompt: str,
-        model_type: Literal["fast", "flash", "pro"] = "flash",
+        model_type: Literal["flash", "pro"] = "flash",
         max_tokens: int = 1000,
         temperature: float = 0.7,
         system_instruction: Optional[str] = None,
         timeout: Optional[int] = VERTEX_AI_TIMEOUT,
+        disable_thinking: bool = False,
     ) -> str:
         """
         統一的文字生成介面
@@ -118,6 +107,7 @@ class VertexAIService:
             max_tokens: 最大輸出 token 數
             temperature: 溫度參數 (0-1)
             system_instruction: 系統指令（使用 Gemini 原生 system_instruction）
+            disable_thinking: 關閉 thinking（加速簡單任務如翻譯）
 
         Returns:
             生成的文字
@@ -126,10 +116,13 @@ class VertexAIService:
 
         model = self._get_model(model_type, system_instruction)
 
-        config = GenerationConfig(
-            max_output_tokens=max_tokens,
-            temperature=temperature,
-        )
+        config_kwargs = {
+            "max_output_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        if disable_thinking:
+            config_kwargs["thinking_config"] = {"thinking_budget": 0}
+        config = GenerationConfig(**config_kwargs)
 
         try:
             logger.info(f"Vertex AI generate_text: calling model (type={model_type})")
@@ -155,11 +148,12 @@ class VertexAIService:
     async def generate_json(
         self,
         prompt: str,
-        model_type: Literal["fast", "flash", "pro"] = "flash",
+        model_type: Literal["flash", "pro"] = "flash",
         max_tokens: int = 1000,
         temperature: float = 0.3,
         system_instruction: Optional[str] = None,
         timeout: Optional[int] = VERTEX_AI_TIMEOUT,
+        disable_thinking: bool = False,
     ) -> dict:
         """
         生成 JSON 格式的回應
@@ -170,6 +164,7 @@ class VertexAIService:
             max_tokens: 最大輸出 token 數
             temperature: 溫度參數
             system_instruction: 系統指令（使用 Gemini 原生 system_instruction）
+            disable_thinking: 關閉 thinking（加速簡單任務如翻譯）
 
         Returns:
             解析後的 JSON dict
@@ -178,11 +173,14 @@ class VertexAIService:
 
         model = self._get_model(model_type, system_instruction)
 
-        config = GenerationConfig(
-            max_output_tokens=max_tokens,
-            temperature=temperature,
-            response_mime_type="application/json",  # 強制 JSON 輸出
-        )
+        config_kwargs = {
+            "max_output_tokens": max_tokens,
+            "temperature": temperature,
+            "response_mime_type": "application/json",
+        }
+        if disable_thinking:
+            config_kwargs["thinking_config"] = {"thinking_budget": 0}
+        config = GenerationConfig(**config_kwargs)
 
         try:
             logger.info(f"Vertex AI generate_json: calling model (type={model_type})")


### PR DESCRIPTION
## Summary

Staging 環境批次匯入單字時回傳 503，原因是 `gemini-2.0-flash` 在 GCP project `duotopia-472708` / `us-central1` 不可用 (404 NOT_FOUND)。

**修正方案**：移除 `FAST_MODEL` / `fast` model type，改為在 `generate_text` / `generate_json` 加上 `disable_thinking` 參數。翻譯呼叫使用 `gemini-2.5-flash` + `thinking_budget=0`，跳過 thinking phase 達到類似速度。

### Changes
- `vertex_ai.py`: 移除 `FAST_MODEL`，新增 `disable_thinking` 參數，使用 `thinkingConfig: {thinking_budget: 0}`
- `translation.py`: 翻譯呼叫改為 `model_type="flash", disable_thinking=True`

## Test plan

- [ ] Staging 批次匯入單字不再回傳 503
- [ ] 翻譯+詞性呼叫使用 gemini-2.5-flash（thinking disabled）
- [ ] 例句生成維持 gemini-2.5-flash（thinking enabled）
- [ ] 不影響其他 AI 功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)