### PR TITLE
fix: staging 503 — 移除 disable_thinking (SDK 不支援)

### DIFF
--- a/backend/services/translation.py
+++ b/backend/services/translation.py
@@ -144,7 +144,6 @@ class TranslationService:
                 result = await self.vertex_ai.generate_text(
                     prompt=prompt,
                     model_type="flash",
-                    disable_thinking=True,
                     max_tokens=token_limit,
                     temperature=0.3,
                     system_instruction=system_instruction,
@@ -263,7 +262,6 @@ Required: Return format must be ["translation1", "translation2", ...]"""
                 translations = await self.vertex_ai.generate_json(
                     prompt=prompt,
                     model_type="flash",
-                    disable_thinking=True,
                     max_tokens=3500,
                     temperature=0.3,
                     system_instruction=system_instruction,
@@ -452,7 +450,6 @@ Only reply with JSON array, no other text."""
                 results = await self.vertex_ai.generate_json(
                     prompt=prompt,
                     model_type="flash",
-                    disable_thinking=True,
                     max_tokens=2000,
                     temperature=0.2,
                     system_instruction=system_instruction,

--- a/backend/services/vertex_ai.py
+++ b/backend/services/vertex_ai.py
@@ -96,7 +96,6 @@ class VertexAIService:
         temperature: float = 0.7,
         system_instruction: Optional[str] = None,
         timeout: Optional[int] = VERTEX_AI_TIMEOUT,
-        disable_thinking: bool = False,
     ) -> str:
         """
         統一的文字生成介面
@@ -107,7 +106,6 @@ class VertexAIService:
             max_tokens: 最大輸出 token 數
             temperature: 溫度參數 (0-1)
             system_instruction: 系統指令（使用 Gemini 原生 system_instruction）
-            disable_thinking: 關閉 thinking（加速簡單任務如翻譯）
 
         Returns:
             生成的文字
@@ -116,13 +114,10 @@ class VertexAIService:
 
         model = self._get_model(model_type, system_instruction)
 
-        config_kwargs = {
-            "max_output_tokens": max_tokens,
-            "temperature": temperature,
-        }
-        if disable_thinking:
-            config_kwargs["thinking_config"] = {"thinking_budget": 0}
-        config = GenerationConfig(**config_kwargs)
+        config = GenerationConfig(
+            max_output_tokens=max_tokens,
+            temperature=temperature,
+        )
 
         try:
             logger.info(f"Vertex AI generate_text: calling model (type={model_type})")
@@ -153,7 +148,6 @@ class VertexAIService:
         temperature: float = 0.3,
         system_instruction: Optional[str] = None,
         timeout: Optional[int] = VERTEX_AI_TIMEOUT,
-        disable_thinking: bool = False,
     ) -> dict:
         """
         生成 JSON 格式的回應
@@ -164,7 +158,6 @@ class VertexAIService:
             max_tokens: 最大輸出 token 數
             temperature: 溫度參數
             system_instruction: 系統指令（使用 Gemini 原生 system_instruction）
-            disable_thinking: 關閉 thinking（加速簡單任務如翻譯）
 
         Returns:
             解析後的 JSON dict
@@ -173,14 +166,11 @@ class VertexAIService:
 
         model = self._get_model(model_type, system_instruction)
 
-        config_kwargs = {
-            "max_output_tokens": max_tokens,
-            "temperature": temperature,
-            "response_mime_type": "application/json",
-        }
-        if disable_thinking:
-            config_kwargs["thinking_config"] = {"thinking_budget": 0}
-        config = GenerationConfig(**config_kwargs)
+        config = GenerationConfig(
+            max_output_tokens=max_tokens,
+            temperature=temperature,
+            response_mime_type="application/json",
+        )
 
         try:
             logger.info(f"Vertex AI generate_json: calling model (type={model_type})")


### PR DESCRIPTION
## Summary

Staging 批次匯入單字仍然 503，原因是 `google-cloud-aiplatform==1.75.0` 的 `GenerationConfig` 不支援 `thinking_config` 參數。

移除 `disable_thinking` 邏輯，翻譯直接使用 `gemini-2.5-flash`（標準模式）。

## Test plan

- [ ] Staging 批次匯入單字不再回傳 503
- [ ] 翻譯功能正常運作
- [ ] 不影響其他 AI 功能（例句、干擾選項等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)