### PR TITLE
feat: 批次 API 效能監控 — [PERF] structured logging

### DIFF
--- a/backend/routers/teachers/translation_ops.py
+++ b/backend/routers/teachers/translation_ops.py
@@ -2,6 +2,7 @@
 Translation Ops operations for teachers.
 """
 import logging
+import time
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session, selectinload, joinedload
@@ -69,13 +70,33 @@ async def batch_translate_with_pos(
     current_teacher: Teacher = Depends(get_current_teacher),
 ):
     """批次翻譯多個單字並辨識詞性"""
+    t0 = time.monotonic()
+    word_count = len(request.texts)
+    logger.info(
+        "[PERF] API translate-with-pos/batch START | words=%d | lang=%s",
+        word_count,
+        request.target_lang,
+    )
     try:
         results = await translation_service.batch_translate_with_pos(
             request.texts, request.target_lang
         )
+        elapsed = time.monotonic() - t0
+        logger.info(
+            "[PERF] API translate-with-pos/batch DONE | words=%d | %.2fs | avg=%.2fs/word",
+            word_count,
+            elapsed,
+            elapsed / word_count if word_count else 0,
+        )
         return {"originals": request.texts, "results": results}
     except Exception as e:
-        logger.error("Batch translate with POS error: %s", e)
+        elapsed = time.monotonic() - t0
+        logger.error(
+            "[PERF] API translate-with-pos/batch ERROR | words=%d | %.2fs | %s",
+            word_count,
+            elapsed,
+            e,
+        )
         raise HTTPException(status_code=500, detail="Translation service error")
 
 
@@ -102,6 +123,13 @@ async def generate_sentences(
     db: Session = Depends(get_db),
 ):
     """AI 生成例句"""
+    t0 = time.monotonic()
+    word_count = len(request.words)
+    logger.info(
+        "[PERF] API generate-sentences START | words=%d | level=%s",
+        word_count,
+        request.level,
+    )
     try:
         # 如果有 lesson_id，查詢 Lesson 與 Program 取得完整教學情境
         unit_context = None
@@ -141,7 +169,20 @@ async def generate_sentences(
             translate_to=request.translate_to,
             parts_of_speech=request.parts_of_speech,
         )
+        elapsed = time.monotonic() - t0
+        logger.info(
+            "[PERF] API generate-sentences DONE | words=%d | %.2fs | avg=%.2fs/word",
+            word_count,
+            elapsed,
+            elapsed / word_count if word_count else 0,
+        )
         return {"sentences": sentences}
     except Exception as e:
-        logger.error("Generate sentences error: %s", e)
+        elapsed = time.monotonic() - t0
+        logger.error(
+            "[PERF] API generate-sentences ERROR | words=%d | %.2fs | %s",
+            word_count,
+            elapsed,
+            e,
+        )
         raise HTTPException(status_code=500, detail="Generate sentences failed")

--- a/backend/routers/teachers/tts_ops.py
+++ b/backend/routers/teachers/tts_ops.py
@@ -2,6 +2,7 @@
 Tts Ops operations for teachers.
 """
 import logging
+import time
 
 from fastapi import APIRouter, Depends, HTTPException
 
@@ -19,12 +20,17 @@ async def generate_tts(
     request: TTSRequest, current_teacher: Teacher = Depends(get_current_teacher)
 ):
     """生成單一 TTS 音檔"""
+    t0 = time.monotonic()
+    logger.info(
+        "[PERF] API tts START | text_len=%d | voice=%s",
+        len(request.text),
+        request.voice,
+    )
     try:
         from services.tts import get_tts_service
 
         tts_service = get_tts_service()
 
-        # 直接使用 await，因為 FastAPI 已經在異步環境中
         audio_url = await tts_service.generate_tts(
             text=request.text,
             voice=request.voice,
@@ -32,9 +38,12 @@ async def generate_tts(
             volume=request.volume,
         )
 
+        elapsed = time.monotonic() - t0
+        logger.info("[PERF] API tts DONE | %.2fs", elapsed)
         return {"audio_url": audio_url}
     except Exception as e:
-        logger.error(f"TTS error: {e}")
+        elapsed = time.monotonic() - t0
+        logger.error("[PERF] API tts ERROR | %.2fs | %s", elapsed, e)
         raise HTTPException(status_code=500, detail="TTS generation failed")
 
 

--- a/backend/services/vertex_ai.py
+++ b/backend/services/vertex_ai.py
@@ -16,6 +16,7 @@ import json
 import re
 import logging
 import asyncio
+import time
 from typing import Optional, Literal
 
 logger = logging.getLogger(__name__)
@@ -138,7 +139,12 @@ class VertexAIService:
             self._set_thinking_budget(config, 0)
 
         try:
-            logger.info(f"Vertex AI generate_text: calling model (type={model_type})")
+            t0 = time.monotonic()
+            logger.info(
+                "[PERF] Vertex AI generate_text START | model=%s | region=%s",
+                model_type,
+                self.location,
+            )
             response = await asyncio.wait_for(
                 model.generate_content_async(
                     prompt,
@@ -146,16 +152,32 @@ class VertexAIService:
                 ),
                 timeout=timeout,
             )
-            logger.info("Vertex AI generate_text: response received")
+            elapsed = time.monotonic() - t0
+            logger.info(
+                "[PERF] Vertex AI generate_text DONE | model=%s | region=%s | %.2fs",
+                model_type,
+                self.location,
+                elapsed,
+            )
             return response.text
         except asyncio.TimeoutError:
+            elapsed = time.monotonic() - t0
             logger.error(
-                f"Vertex AI generate_text timed out after {timeout}s "
-                f"(model_type={model_type})"
+                "[PERF] Vertex AI generate_text TIMEOUT | model=%s | region=%s | %.2fs",
+                model_type,
+                self.location,
+                elapsed,
             )
             raise TimeoutError(f"Vertex AI call timed out after {timeout} seconds")
         except Exception as e:
-            logger.error(f"Vertex AI generation failed: {e}", exc_info=True)
+            elapsed = time.monotonic() - t0
+            logger.error(
+                "[PERF] Vertex AI generate_text ERROR | model=%s | region=%s | %.2fs | %s",
+                model_type,
+                self.location,
+                elapsed,
+                e,
+            )
             raise
 
     async def generate_json(
@@ -195,7 +217,12 @@ class VertexAIService:
             self._set_thinking_budget(config, 0)
 
         try:
-            logger.info(f"Vertex AI generate_json: calling model (type={model_type})")
+            t0 = time.monotonic()
+            logger.info(
+                "[PERF] Vertex AI generate_json START | model=%s | region=%s",
+                model_type,
+                self.location,
+            )
             response = await asyncio.wait_for(
                 model.generate_content_async(
                     prompt,
@@ -203,7 +230,13 @@ class VertexAIService:
                 ),
                 timeout=timeout,
             )
-            logger.info("Vertex AI generate_json: response received")
+            elapsed = time.monotonic() - t0
+            logger.info(
+                "[PERF] Vertex AI generate_json DONE | model=%s | region=%s | %.2fs",
+                model_type,
+                self.location,
+                elapsed,
+            )
 
             content = response.text.strip()
 
@@ -254,9 +287,12 @@ class VertexAIService:
                 else:
                     raise
         except asyncio.TimeoutError:
+            elapsed = time.monotonic() - t0
             logger.error(
-                f"Vertex AI generate_json timed out after {timeout}s "
-                f"(model_type={model_type})"
+                "[PERF] Vertex AI generate_json TIMEOUT | model=%s | region=%s | %.2fs",
+                model_type,
+                self.location,
+                elapsed,
             )
             raise TimeoutError(f"Vertex AI call timed out after {timeout} seconds")
         except json.JSONDecodeError as e:
@@ -264,7 +300,14 @@ class VertexAIService:
             logger.error(f"Raw response: {response.text if response else 'None'}")
             raise
         except Exception as e:
-            logger.error(f"Vertex AI JSON generation failed: {e}", exc_info=True)
+            elapsed = time.monotonic() - t0
+            logger.error(
+                "[PERF] Vertex AI generate_json ERROR | model=%s | region=%s | %.2fs | %s",
+                model_type,
+                self.location,
+                elapsed,
+                e,
+            )
             raise
 
     def generate_text_sync(


### PR DESCRIPTION
## Summary

在批次匯入相關的 3 個 API 和底層 AI 呼叫加入 `[PERF]` 結構化效能日誌，方便在 GCP Log Explorer 中分析瓶頸。

### Log 格式

```
[PERF] API translate-with-pos/batch START | words=9 | lang=zh-TW
[PERF] Vertex AI generate_json START | model=flash | region=us-central1
[PERF] Vertex AI generate_json DONE  | model=flash | region=us-central1 | 3.42s
[PERF] API translate-with-pos/batch DONE  | words=9 | 3.58s | avg=0.40s/word
```

### 監控點

| Layer | File | Metrics |
|-------|------|---------|
| API | `translation_ops.py` | 總 request 時間、每字平均時間 |
| API | `tts_ops.py` | 總 request 時間 |
| AI | `vertex_ai.py` | 每次 AI 呼叫時間、model type、region |

### 跨區域 Latency 分析

目前架構的區域配置：
- **Cloud Run** (Backend): `asia-east1` (台灣)
- **Vertex AI** (翻譯/例句): `us-central1` (美國中部)
- **Azure TTS**: `eastasia` (香港)

Cloud Run → Vertex AI 跨太平洋 round-trip 預估增加 150-300ms latency。
部署後可從 log 確認實際數字，評估是否需要遷移 Vertex AI region。

### GCP Log Explorer 查詢

```
resource.type="cloud_run_revision"
resource.labels.service_name="duotopia-staging-backend"
"[PERF]"
```

## Test plan

- [ ] 部署後批次匯入單字，在 Log Explorer 看到 [PERF] log
- [ ] 確認 API 總時間和 AI 呼叫時間數據合理
- [ ] 不影響 API 功能和回應格式

🤖 Generated with [Claude Code](https://claude.com/claude-code)