### PR TITLE
fix: batch translate fallback 無限遞迴導致 504 timeout

### DIFF
--- a/backend/services/translation.py
+++ b/backend/services/translation.py
@@ -481,21 +481,40 @@ Only reply with JSON array, no other text."""
             # 確保返回數量正確
             if len(results) != len(texts):
                 logger.warning(
-                    "Expected %d results, got %d. Falling back.",
+                    "Expected %d results, got %d. Falling back to simple translate.",
                     len(texts),
                     len(results),
                 )
-                # Fallback: 逐個處理
-                tasks = [self.translate_with_pos(text, target_lang) for text in texts]
-                results = await asyncio.gather(*tasks)
+                # Fallback: 逐個用 translate_text（不遞迴回 batch）
+                fallback_results = []
+                for text in texts:
+                    try:
+                        trans = await self.translate_text(text, target_lang)
+                        fallback_results.append(
+                            {"translation": trans, "parts_of_speech": []}
+                        )
+                    except Exception:
+                        fallback_results.append(
+                            {"translation": text, "parts_of_speech": []}
+                        )
+                return fallback_results
 
             return results
         except Exception as e:
             logger.error("Batch translate with POS error: %s. Falling back.", e)
-            # Fallback: 逐個處理
-            tasks = [self.translate_with_pos(text, target_lang) for text in texts]
-            results = await asyncio.gather(*tasks)
-            return results
+            # Fallback: 逐個用 translate_text（不遞迴回 batch）
+            fallback_results = []
+            for text in texts:
+                try:
+                    trans = await self.translate_text(text, target_lang)
+                    fallback_results.append(
+                        {"translation": trans, "parts_of_speech": []}
+                    )
+                except Exception:
+                    fallback_results.append(
+                        {"translation": text, "parts_of_speech": []}
+                    )
+            return fallback_results
 
     # 每批最多處理的單字數量
     SENTENCE_CHUNK_SIZE = 5


### PR DESCRIPTION
## Summary

Staging 批次匯入單字 504 Gateway Timeout 的根本原因：**fallback 邏輯形成無限遞迴**。

### 問題

當 AI 把 phrase（如 "stringent regulations"）拆成 2 個結果，與期望的 1 不符時：

```
_batch_translate_with_pos_single (Expected 1, got 2)
  → translate_with_pos (fallback)
    → batch_translate_with_pos
      → _batch_translate_with_pos_single (Expected 1, got 2 again)
        → translate_with_pos → ... (無限循環直到 Cloud Run 504)
```

### 修正

Fallback 改用 `translate_text`（簡單翻譯），不再遞迴回 batch 版本。犧牲 POS 辨識但保證不會無限循環。

## Test plan

- [ ] 批次匯入包含 phrase（如 "stringent regulations"）不會 504
- [ ] 正常單字批次匯入仍走 batch 路徑（有 POS）
- [ ] Fallback 時仍能回傳翻譯結果（只是沒有 POS）

🤖 Generated with [Claude Code](https://claude.com/claude-code)