### PR TITLE
feat: 暫時隱藏作業管理選單及 1Campus 登入按鈕

### DIFF
--- a/frontend/src/config/featureFlags.ts
+++ b/frontend/src/config/featureFlags.ts
@@ -1,0 +1,10 @@
+/**
+ * Feature flags for temporarily enabling/disabling features.
+ * Set to `true` to re-enable when ready.
+ */
+export const FEATURE_FLAGS = {
+  /** 左側選單「作業管理」 */
+  ASSIGNMENTS: false,
+  /** 1Campus SSO 登入按鈕 */
+  ONE_CAMPUS_LOGIN: false,
+} as const;

--- a/frontend/src/config/sidebarConfig.tsx
+++ b/frontend/src/config/sidebarConfig.tsx
@@ -12,6 +12,7 @@ import {
   ClipboardList,
 } from "lucide-react";
 import { SidebarGroup } from "@/types/sidebar";
+import { FEATURE_FLAGS } from "@/config/featureFlags";
 
 export const getSidebarGroups = (
   t: (key: string) => string,
@@ -49,12 +50,16 @@ export const getSidebarGroups = (
         icon: GraduationCap,
         path: "/teacher/classrooms",
       },
-      {
-        id: "assignments",
-        label: t("assignmentManagement.title"),
-        icon: ClipboardList,
-        path: "/teacher/assignments",
-      },
+      ...(FEATURE_FLAGS.ASSIGNMENTS
+        ? [
+            {
+              id: "assignments" as const,
+              label: t("assignmentManagement.title"),
+              icon: ClipboardList,
+              path: "/teacher/assignments",
+            },
+          ]
+        : []),
       {
         id: "students",
         label: t("teacherLayout.nav.allStudents"),

--- a/frontend/src/pages/StudentLogin.tsx
+++ b/frontend/src/pages/StudentLogin.tsx
@@ -9,6 +9,7 @@ import { authService } from "@/services/authService";
 import { teacherService } from "@/services/teacherService";
 import { useTranslation } from "react-i18next";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { FEATURE_FLAGS } from "@/config/featureFlags";
 
 interface TeacherHistory {
   email: string;
@@ -477,19 +478,21 @@ export default function StudentLogin() {
 
               {/* 1Campus SSO + Email login links */}
               <div className="mt-6 pt-6 border-t space-y-3">
-                <Button
-                  variant="outline"
-                  className="w-full py-4 bg-gradient-to-r from-green-50 to-emerald-50 hover:from-green-100 hover:to-emerald-100 border-green-200 text-green-700 font-medium"
-                  onClick={() => {
-                    window.location.href = "https://1campus.net";
-                  }}
-                >
-                  🏫{" "}
-                  {t(
-                    "studentLogin.oneCampus.button",
-                    "Log in with School Account (1Campus)",
-                  )}
-                </Button>
+                {FEATURE_FLAGS.ONE_CAMPUS_LOGIN && (
+                  <Button
+                    variant="outline"
+                    className="w-full py-4 bg-gradient-to-r from-green-50 to-emerald-50 hover:from-green-100 hover:to-emerald-100 border-green-200 text-green-700 font-medium"
+                    onClick={() => {
+                      window.location.href = "https://1campus.net";
+                    }}
+                  >
+                    🏫{" "}
+                    {t(
+                      "studentLogin.oneCampus.button",
+                      "Log in with School Account (1Campus)",
+                    )}
+                  </Button>
+                )}
 
                 <div className="text-center">
                   <Button

--- a/frontend/src/pages/TeacherLogin.tsx
+++ b/frontend/src/pages/TeacherLogin.tsx
@@ -18,6 +18,7 @@ import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
 import { useTranslation } from "react-i18next";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { getTeacherDashboardRoute } from "@/utils/authNavigation";
+import { FEATURE_FLAGS } from "@/config/featureFlags";
 
 export default function TeacherLogin() {
   const navigate = useNavigate();
@@ -237,31 +238,35 @@ export default function TeacherLogin() {
             </form>
 
             {/* 1Campus SSO Login */}
-            <div className="relative my-6">
-              <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-gray-200" />
-              </div>
-              <div className="relative flex justify-center text-sm">
-                <span className="px-2 bg-white text-gray-500">
-                  {t("teacherLogin.oneCampus.separator", "or")}
-                </span>
-              </div>
-            </div>
+            {FEATURE_FLAGS.ONE_CAMPUS_LOGIN && (
+              <>
+                <div className="relative my-6">
+                  <div className="absolute inset-0 flex items-center">
+                    <div className="w-full border-t border-gray-200" />
+                  </div>
+                  <div className="relative flex justify-center text-sm">
+                    <span className="px-2 bg-white text-gray-500">
+                      {t("teacherLogin.oneCampus.separator", "or")}
+                    </span>
+                  </div>
+                </div>
 
-            <Button
-              type="button"
-              variant="outline"
-              className="w-full py-4 bg-gradient-to-r from-green-50 to-emerald-50 hover:from-green-100 hover:to-emerald-100 border-green-200 text-green-700 font-medium"
-              onClick={() => {
-                window.location.href = "https://1campus.net";
-              }}
-            >
-              🏫{" "}
-              {t(
-                "teacherLogin.oneCampus.button",
-                "Log in with School Account (1Campus)",
-              )}
-            </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full py-4 bg-gradient-to-r from-green-50 to-emerald-50 hover:from-green-100 hover:to-emerald-100 border-green-200 text-green-700 font-medium"
+                  onClick={() => {
+                    window.location.href = "https://1campus.net";
+                  }}
+                >
+                  🏫{" "}
+                  {t(
+                    "teacherLogin.oneCampus.button",
+                    "Log in with School Account (1Campus)",
+                  )}
+                </Button>
+              </>
+            )}
 
             {/* Quick Login Buttons - 只在非 production 或有 ?is_demo=true 時顯示 */}
             {showDemoBlocks && (


### PR DESCRIPTION
## Summary
- 新增 `featureFlags.ts` 集中管理 feature flags
- 隱藏左側選單「作業管理」項目
- 隱藏老師/學生登入頁的 1Campus SSO 登入按鈕
- 下一版將 flag 改為 `true` 即可恢復

Fixes #583

## Test plan
- [ ] 確認左側選單不顯示「作業管理」
- [ ] 確認老師登入頁不顯示 1Campus 按鈕
- [ ] 確認學生登入頁不顯示 1Campus 按鈕
- [ ] 確認其他選單項目與登入功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)