### PR TITLE
fix: production frontend 使用正確的 PRODUCTION_BACKEND_URL

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -157,7 +157,9 @@ jobs:
       run: |
         # 優先使用 GitHub secrets（gcloud status.url 仍回傳已停用的舊格式 URL）
         # See: https://github.com/myduotopia/duotopia/issues/548
-        if [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+        if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+          BACKEND_URL="${{ secrets.PRODUCTION_BACKEND_URL }}"
+        elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
           BACKEND_URL="${{ secrets.DEVELOP_BACKEND_URL }}"
         else
           BACKEND_URL="${{ secrets.STAGING_BACKEND_URL }}"


### PR DESCRIPTION
## Summary
- Production frontend deploy 時，`Get backend URL` step 缺少 `main` branch 判斷，導致 `VITE_API_URL` 錯誤使用 `STAGING_BACKEND_URL`
- 加上 `main` → `PRODUCTION_BACKEND_URL` 的判斷，修正 production frontend 連到 staging backend 的問題
- 同步更新了 GitHub Secret `PRODUCTION_BACKEND_URL` 為正確的新格式 URL

## Test plan
- [ ] Merge 後觸發 production frontend deploy
- [ ] 確認 production frontend 的 API 請求導向 production backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)