### PR TITLE
fix: 單字朗讀限時改為錄音完成後檢查長度 (Fixes #557)

### DIFF
--- a/backend/routers/students/assignments.py
+++ b/backend/routers/students/assignments.py
@@ -509,9 +509,7 @@ async def get_assignment_activities(
         "show_answer": show_answer,  # 例句重組：答題結束後是否顯示正確答案
         "score_category": score_category,  # 分數記錄分類
         "time_limit_per_question": (
-            parent_assignment.time_limit_per_question
-            if parent_assignment
-            else None
+            parent_assignment.time_limit_per_question if parent_assignment else None
         ),
         "total_activities": len(activities),
         "activities": activities,

--- a/backend/routers/students/assignments.py
+++ b/backend/routers/students/assignments.py
@@ -508,6 +508,11 @@ async def get_assignment_activities(
         "practice_mode": practice_mode,  # 前端用來判斷顯示哪個元件
         "show_answer": show_answer,  # 例句重組：答題結束後是否顯示正確答案
         "score_category": score_category,  # 分數記錄分類
+        "time_limit_per_question": (
+            parent_assignment.time_limit_per_question
+            if parent_assignment
+            else None
+        ),
         "total_activities": len(activities),
         "activities": activities,
         "can_use_ai_analysis": can_use_ai_analysis,  # 根據工作區判斷的 AI 分析額度

--- a/backend/services/preview_service.py
+++ b/backend/services/preview_service.py
@@ -182,6 +182,7 @@ def build_assignment_preview(assignment: Assignment, db: Session) -> dict:
         "practice_mode": assignment.practice_mode,
         "show_answer": assignment.show_answer or False,
         "score_category": assignment.score_category,
+        "time_limit_per_question": assignment.time_limit_per_question,
         "total_activities": len(activities),
         "activities": activities,
     }

--- a/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
+++ b/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
@@ -61,8 +61,6 @@ export default function ReadingAssessmentTemplate({
   // Recording start timestamp (for duration check against timeLimit)
   const recordingStartTimeRef = useRef<number>(0);
 
-
-
   /**
    * 背景上傳音檔和分析結果（不阻塞 UI）
    */

--- a/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
+++ b/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
@@ -387,7 +387,6 @@ export default function ReadingAssessmentTemplate({
           )}
         </div>
       </div>
-
     </>
   );
 }

--- a/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
+++ b/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
@@ -7,6 +7,8 @@ import AudioRecorder from "@/components/shared/AudioRecorder";
 import { useTranslation } from "react-i18next";
 import { useAzurePronunciation } from "@/hooks/useAzurePronunciation";
 import { useDemoAzurePronunciation } from "@/hooks/useDemoAzurePronunciation";
+import { useStudentAuthStore } from "@/stores/studentAuthStore";
+import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
 
 interface AssessmentResult {
   overallScore: number;
@@ -103,7 +105,7 @@ export default function ReadingAssessmentTemplate({
       fetch(`${apiUrl}/api/speech/upload-analysis`, {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${import.meta.env.VITE_STUDENT_TOKEN || ""}`,
+          Authorization: `Bearer ${useStudentAuthStore.getState().token || useTeacherAuthStore.getState().token || ""}`,
         },
         body: formData,
       })

--- a/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
+++ b/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
@@ -205,7 +205,7 @@ export default function ReadingAssessmentTemplate({
         {/* Right Side - Content Area */}
         <div className="flex-1 space-y-6">
           {/* Time Limit Display (static) */}
-          {!readOnly && timeLimit > 0 && (
+          {!readOnly && timeLimit > 0 && !audioUrl && (
             <div className="flex justify-end">
               <div className="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium bg-gray-100 text-gray-700">
                 <Clock className="h-4 w-4" />
@@ -242,13 +242,7 @@ export default function ReadingAssessmentTemplate({
           <AudioRecorder
             existingAudioUrl={audioUrl}
             onRecordingComplete={(blob, url) => {
-              setAudioUrl(url);
-              onRecordingComplete?.(blob, url);
-            }}
-            onRecordingStart={() => {
-              recordingStartTimeRef.current = Date.now();
-            }}
-            onRecordingStop={() => {
+              // Check recording duration against time limit
               if (timeLimit > 0 && recordingStartTimeRef.current > 0) {
                 const elapsedSeconds =
                   (Date.now() - recordingStartTimeRef.current) / 1000;
@@ -260,9 +254,15 @@ export default function ReadingAssessmentTemplate({
                     }) ||
                       `錄音時間 ${Math.round(elapsedSeconds)} 秒超過限制 ${timeLimit} 秒，請重新錄音`,
                   );
-                  setAudioUrl(undefined);
+                  URL.revokeObjectURL(url);
+                  return; // Don't set audioUrl — discard over-limit recording
                 }
               }
+              setAudioUrl(url);
+              onRecordingComplete?.(blob, url);
+            }}
+            onRecordingStart={() => {
+              recordingStartTimeRef.current = Date.now();
             }}
             readOnly={readOnly}
             variant="default"

--- a/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
+++ b/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
@@ -242,11 +242,12 @@ export default function ReadingAssessmentTemplate({
           <AudioRecorder
             existingAudioUrl={audioUrl}
             onRecordingComplete={(blob, url) => {
-              // Check recording duration against time limit
+              // Check recording duration against time limit (0.5s tolerance
+              // for auto-stop timer imprecision)
               if (timeLimit > 0 && recordingStartTimeRef.current > 0) {
                 const elapsedSeconds =
                   (Date.now() - recordingStartTimeRef.current) / 1000;
-                if (elapsedSeconds > timeLimit) {
+                if (elapsedSeconds > timeLimit + 0.5) {
                   toast.error(
                     t("wordReading.toast.recordingExceedsLimit", {
                       recorded: Math.round(elapsedSeconds),
@@ -265,6 +266,7 @@ export default function ReadingAssessmentTemplate({
               recordingStartTimeRef.current = Date.now();
             }}
             readOnly={readOnly}
+            autoStop={timeLimit > 0 ? timeLimit : undefined}
             variant="default"
             showProgress={true}
             showTimer={true}

--- a/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
+++ b/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
@@ -1,21 +1,12 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Brain, Star, Mic, Clock, RotateCcw, SkipForward } from "lucide-react";
+import { Brain, Star, Mic, Clock } from "lucide-react";
 import { toast } from "sonner";
 import AudioRecorder from "@/components/shared/AudioRecorder";
 import { useTranslation } from "react-i18next";
-import { cn } from "@/lib/utils";
 import { useAzurePronunciation } from "@/hooks/useAzurePronunciation";
 import { useDemoAzurePronunciation } from "@/hooks/useDemoAzurePronunciation";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 
 interface AssessmentResult {
   overallScore: number;
@@ -35,10 +26,7 @@ interface ReadingAssessmentProps {
   progressId?: number;
   readOnly?: boolean; // 唯讀模式
   isDemoMode?: boolean; // Demo mode - uses public demo API endpoints
-  timeLimit?: number; // 作答時間限制（秒）
-  onTimeout?: () => void; // 超時回調
-  onRetry?: () => void; // 重試回調
-  onSkip?: () => void; // 跳過回調
+  timeLimit?: number; // 錄音時間限制（秒），0 = 不限時
   canUseAiAnalysis?: boolean; // 教師/機構是否有 AI 分析額度
 }
 
@@ -51,10 +39,7 @@ export default function ReadingAssessmentTemplate({
   progressId: _progressId, // Legacy prop (not used with Azure direct calls)
   readOnly = false,
   isDemoMode = false,
-  timeLimit = 30, // 預設 30 秒
-  onTimeout,
-  onRetry,
-  onSkip,
+  timeLimit = 0, // 預設不限時
   canUseAiAnalysis = true,
 }: ReadingAssessmentProps) {
   const { t } = useTranslation();
@@ -73,83 +58,8 @@ export default function ReadingAssessmentTemplate({
   const demoHook = useDemoAzurePronunciation();
   const { analyzePronunciation } = isDemoMode ? demoHook : regularHook;
 
-  // 計時器狀態
-  const [timeRemaining, setTimeRemaining] = useState(timeLimit);
-  const [showTimeoutDialog, setShowTimeoutDialog] = useState(false);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
-
-  // 格式化時間
-  const formatTime = useCallback((seconds: number) => {
-    const mins = Math.floor(seconds / 60);
-    const secs = seconds % 60;
-    return `${mins}:${secs.toString().padStart(2, "0")}`;
-  }, []);
-
-  // 啟動計時器
-  const startTimer = useCallback(() => {
-    if (timerRef.current) {
-      clearInterval(timerRef.current);
-    }
-
-    timerRef.current = setInterval(() => {
-      setTimeRemaining((prev) => {
-        if (prev <= 1) {
-          // 時間到
-          if (timerRef.current) {
-            clearInterval(timerRef.current);
-          }
-          setShowTimeoutDialog(true);
-          onTimeout?.();
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-  }, [onTimeout]);
-
-  // 重置計時器
-  const resetTimer = useCallback(() => {
-    setTimeRemaining(timeLimit);
-    setShowTimeoutDialog(false);
-    startTimer();
-  }, [timeLimit, startTimer]);
-
-  // 初始化計時器
-  useEffect(() => {
-    if (!readOnly && !audioUrl && timeLimit > 0) {
-      startTimer();
-    }
-
-    return () => {
-      if (timerRef.current) {
-        clearInterval(timerRef.current);
-      }
-    };
-  }, [readOnly, timeLimit, startTimer]);
-
-  // 錄音完成時停止計時器
-  useEffect(() => {
-    if (audioUrl && timerRef.current) {
-      clearInterval(timerRef.current);
-    }
-  }, [audioUrl]);
-
-  // 處理重試
-  const handleRetry = () => {
-    setShowTimeoutDialog(false);
-    setAudioUrl(undefined);
-    setAssessmentResult(null);
-    resetTimer();
-    onRetry?.();
-  };
-
-  // 處理跳過
-  const handleSkip = () => {
-    setShowTimeoutDialog(false);
-    onSkip?.();
-  };
-
-  const isLowTime = timeRemaining <= 10 && timeRemaining > 0;
+  // Recording start timestamp (for duration check against timeLimit)
+  const recordingStartTimeRef = useRef<number>(0);
 
   // const handlePlayExample = () => {
   //   if (!exampleAudioRef.current) return;
@@ -294,19 +204,15 @@ export default function ReadingAssessmentTemplate({
 
         {/* Right Side - Content Area */}
         <div className="flex-1 space-y-6">
-          {/* Timer Display */}
-          {!readOnly && timeLimit > 0 && !audioUrl && (
+          {/* Time Limit Display (static) */}
+          {!readOnly && timeLimit > 0 && (
             <div className="flex justify-end">
-              <div
-                className={cn(
-                  "flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium",
-                  isLowTime
-                    ? "bg-red-100 text-red-700 animate-pulse"
-                    : "bg-gray-100 text-gray-700",
-                )}
-              >
+              <div className="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium bg-gray-100 text-gray-700">
                 <Clock className="h-4 w-4" />
-                <span>{formatTime(timeRemaining)}</span>
+                <span>
+                  {t("wordReading.timeLimit", { seconds: timeLimit }) ||
+                    `限時 ${timeLimit} 秒`}
+                </span>
               </div>
             </div>
           )}
@@ -339,8 +245,26 @@ export default function ReadingAssessmentTemplate({
               setAudioUrl(url);
               onRecordingComplete?.(blob, url);
             }}
+            onRecordingStart={() => {
+              recordingStartTimeRef.current = Date.now();
+            }}
+            onRecordingStop={() => {
+              if (timeLimit > 0 && recordingStartTimeRef.current > 0) {
+                const elapsedSeconds =
+                  (Date.now() - recordingStartTimeRef.current) / 1000;
+                if (elapsedSeconds > timeLimit) {
+                  toast.error(
+                    t("wordReading.toast.recordingExceedsLimit", {
+                      recorded: Math.round(elapsedSeconds),
+                      limit: timeLimit,
+                    }) ||
+                      `錄音時間 ${Math.round(elapsedSeconds)} 秒超過限制 ${timeLimit} 秒，請重新錄音`,
+                  );
+                  setAudioUrl(undefined);
+                }
+              }
+            }}
             readOnly={readOnly}
-            autoStop={timeLimit}
             variant="default"
             showProgress={true}
             showTimer={true}
@@ -464,36 +388,6 @@ export default function ReadingAssessmentTemplate({
         </div>
       </div>
 
-      {/* Timeout Dialog */}
-      <Dialog open={showTimeoutDialog} onOpenChange={setShowTimeoutDialog}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2 text-orange-600">
-              <Clock className="h-5 w-5" />
-              時間到了！
-            </DialogTitle>
-            <DialogDescription>
-              作答時間已結束。您可以選擇重新作答此題，或跳到下一題繼續。
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="flex gap-2 sm:gap-0">
-            <Button
-              variant="outline"
-              onClick={handleRetry}
-              className="flex items-center gap-2"
-            >
-              <RotateCcw className="h-4 w-4" />
-              重新作答
-            </Button>
-            {onSkip && (
-              <Button onClick={handleSkip} className="flex items-center gap-2">
-                <SkipForward className="h-4 w-4" />
-                跳到下一題
-              </Button>
-            )}
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </>
   );
 }

--- a/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
+++ b/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
@@ -61,16 +61,7 @@ export default function ReadingAssessmentTemplate({
   // Recording start timestamp (for duration check against timeLimit)
   const recordingStartTimeRef = useRef<number>(0);
 
-  // const handlePlayExample = () => {
-  //   if (!exampleAudioRef.current) return;
 
-  //   if (isPlayingExample) {
-  //     exampleAudioRef.current.pause();
-  //   } else {
-  //     exampleAudioRef.current.play();
-  //   }
-  //   setIsPlayingExample(!isPlayingExample);
-  // };
 
   /**
    * 背景上傳音檔和分析結果（不阻塞 UI）

--- a/frontend/src/components/activities/WordReadingActivity.tsx
+++ b/frontend/src/components/activities/WordReadingActivity.tsx
@@ -419,11 +419,6 @@ export default function WordReadingActivity({
     }
   }, [items, currentIndex, assignmentId, token, isPreviewMode, isDemoMode]);
 
-  // Handle skip
-  const handleSkip = () => {
-    handleNext();
-  };
-
   // Submit assignment
   const handleSubmit = async () => {
     if (isPreviewMode || isDemoMode) {
@@ -684,7 +679,6 @@ export default function WordReadingActivity({
         readOnly={readOnly}
         isDemoMode={isDemoMode}
         timeLimit={timeLimitPerQuestion}
-        onSkip={handleSkip}
         onAssessmentComplete={handleAssessmentComplete}
         onClearRecording={handleClearRecording}
         canUseAiAnalysis={canUseAiAnalysisProp ?? canUseAiAnalysisFromApi}

--- a/frontend/src/components/activities/WordReadingActivity.tsx
+++ b/frontend/src/components/activities/WordReadingActivity.tsx
@@ -176,7 +176,7 @@ export default function WordReadingActivity({
 
       return assessment;
     },
-    [analyzePronunciation, assignmentId, token],
+    [analyzePronunciation, token],
   );
 
   // Load vocabulary items from backend
@@ -327,11 +327,13 @@ export default function WordReadingActivity({
       phonemes?: Array<{ phoneme: string; accuracy_score: number }>;
     }>;
   }) => {
+    // 🔧 Review fix: 捕獲 index 避免 async assessment 完成時使用 stale closure
+    const capturedIndex = currentIndex;
     // Update local state（含音素詳細資料，切換題目時可還原）
     setItems((prev) => {
       const updated = [...prev];
-      updated[currentIndex] = {
-        ...updated[currentIndex],
+      updated[capturedIndex] = {
+        ...updated[capturedIndex],
         ai_assessment: {
           accuracy_score: result.accuracyScore,
           fluency_score: result.fluencyScore,

--- a/frontend/src/components/activities/WordReadingActivity.tsx
+++ b/frontend/src/components/activities/WordReadingActivity.tsx
@@ -69,6 +69,7 @@ interface WordReadingActivityProps {
   onComplete?: () => void;
   canUseAiAnalysis?: boolean; // 教師/機構是否有 AI 分析額度
   readOnly?: boolean; // 已提交/已完成/已訂正時禁止修改
+  timeLimitPerQuestion?: number; // 每題錄音限時（秒），由父元件傳入，覆蓋 API 值
 }
 
 export default function WordReadingActivity({
@@ -81,6 +82,7 @@ export default function WordReadingActivity({
   onComplete,
   readOnly = false,
   canUseAiAnalysis: canUseAiAnalysisProp,
+  timeLimitPerQuestion: timeLimitProp,
 }: WordReadingActivityProps) {
   const { t } = useTranslation();
   const { token: studentToken } = useStudentAuthStore();
@@ -93,7 +95,9 @@ export default function WordReadingActivity({
   const [currentIndex, setCurrentIndex] = useState(0);
   const [submitting, setSubmitting] = useState(false);
   const [uploading, setUploading] = useState(false);
-  const [timeLimitPerQuestion, setTimeLimitPerQuestion] = useState(0); // 0 = 不限時
+  const [timeLimitFromApi, setTimeLimitFromApi] = useState(0);
+  // 優先使用父元件傳入的 prop，與例句朗讀統一資料來源
+  const timeLimitPerQuestion = timeLimitProp ?? timeLimitFromApi;
   // 從 API 讀取的顯示設定（解決圖片不顯示的 bug）
   const [showImageFromApi, setShowImageFromApi] = useState(true);
   const [showTranslationFromApi, setShowTranslationFromApi] = useState(true);
@@ -200,7 +204,7 @@ export default function WordReadingActivity({
 
       const data = await response.json();
       setItems(data.items || []);
-      setTimeLimitPerQuestion(data.time_limit_per_question || 0);
+      setTimeLimitFromApi(data.time_limit_per_question || 0);
       // 讀取 API 返回的顯示設定
       setShowImageFromApi(data.show_image ?? true);
       setShowTranslationFromApi(data.show_translation ?? true);

--- a/frontend/src/components/activities/WordReadingTemplate.tsx
+++ b/frontend/src/components/activities/WordReadingTemplate.tsx
@@ -465,7 +465,8 @@ export default function WordReadingTemplate({
     } catch (error) {
       console.error("Error starting recording:", error);
       toast.error(
-        t("audioRecorder.toast.cannotStart") || "無法啟動錄音，請檢查麥克風權限",
+        t("audioRecorder.toast.cannotStart") ||
+          "無法啟動錄音，請檢查麥克風權限",
       );
     }
   };

--- a/frontend/src/components/activities/WordReadingTemplate.tsx
+++ b/frontend/src/components/activities/WordReadingTemplate.tsx
@@ -221,7 +221,6 @@ export default function WordReadingTemplate({
     return { overallScore, dimensions, details };
   }, [assessmentResult, phonemeResult, t]);
 
-
   // Reset state when item changes (only triggered by currentItem.id change)
   useEffect(() => {
     // Revoke previous blob URL to prevent memory leak
@@ -262,7 +261,6 @@ export default function WordReadingTemplate({
         });
       }
     }
-
   }, [currentItem.id]); // Only run when item changes, not when existingAudioUrl/timeLimit changes
 
   // Sync assessment from background analysis completing after navigation
@@ -326,7 +324,6 @@ export default function WordReadingTemplate({
       }
     };
   }, [currentItem.id, currentItem.audio_url, playbackRate]);
-
 
   // Play example audio
   const handlePlayExample = () => {
@@ -1132,7 +1129,6 @@ export default function WordReadingTemplate({
           </div>
         </div>
       </div>
-
 
       {/* 🎯 Issue #461: 分析完成星星鼓勵動畫 overlay */}
       <ScoreOverlay

--- a/frontend/src/components/activities/WordReadingTemplate.tsx
+++ b/frontend/src/components/activities/WordReadingTemplate.tsx
@@ -14,14 +14,12 @@
  * 已指派 -> 未開始 -> 已開始 -> 已提交 -> 待訂正 -> 已訂正 -> 已完成
  */
 
-import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
   Brain,
   Clock,
-  RotateCcw,
-  SkipForward,
   Volume2,
   Mic,
   Square,
@@ -44,14 +42,6 @@ import {
 import { useDemoAzurePronunciation } from "@/hooks/useDemoAzurePronunciation";
 import ScoreOverlay from "./shared/ScoreOverlay";
 import PronunciationScoreChart from "./shared/PronunciationScoreChart";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 
 interface AssessmentResult {
   overallScore: number;
@@ -122,9 +112,6 @@ interface WordReadingTemplateProps {
   isDemoMode?: boolean; // Demo mode - uses public demo API endpoints
 
   // Callbacks
-  onTimeout?: () => void;
-  onRetry?: () => void;
-  onSkip?: () => void;
   onAssessmentComplete?: (result: AssessmentResult) => void;
   onClearRecording?: () => void;
 
@@ -144,9 +131,6 @@ export default function WordReadingTemplate({
   readOnly = false,
   isDemoMode = false,
   timeLimit = 0, // Default unlimited
-  onTimeout,
-  onRetry,
-  onSkip,
   onAssessmentComplete,
   onClearRecording,
   canUseAiAnalysis = true,
@@ -193,10 +177,8 @@ export default function WordReadingTemplate({
   const demoHook = useDemoAzurePronunciation();
   const { analyzePronunciation } = isDemoMode ? demoHook : regularHook;
 
-  // Timer state
-  const [timeRemaining, setTimeRemaining] = useState(timeLimit);
-  const [showTimeoutDialog, setShowTimeoutDialog] = useState(false);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  // Recording start timestamp (for duration check against timeLimit)
+  const recordingStartTimeRef = useRef<number>(0);
 
   // Image error handling
   const [imageError, setImageError] = useState(false);
@@ -239,62 +221,6 @@ export default function WordReadingTemplate({
     return { overallScore, dimensions, details };
   }, [assessmentResult, phonemeResult, t]);
 
-  // Format time helper
-  const formatTime = useCallback((seconds: number) => {
-    const mins = Math.floor(seconds / 60);
-    const secs = seconds % 60;
-    return `${mins}:${secs.toString().padStart(2, "0")}`;
-  }, []);
-
-  // Start timer
-  const startTimer = useCallback(() => {
-    if (timerRef.current) {
-      clearInterval(timerRef.current);
-    }
-
-    timerRef.current = setInterval(() => {
-      setTimeRemaining((prev) => {
-        if (prev <= 1) {
-          if (timerRef.current) {
-            clearInterval(timerRef.current);
-          }
-          setShowTimeoutDialog(true);
-          onTimeout?.();
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-  }, [onTimeout]);
-
-  // Reset timer
-  const resetTimer = useCallback(() => {
-    setTimeRemaining(timeLimit);
-    setShowTimeoutDialog(false);
-    if (timeLimit > 0) {
-      startTimer();
-    }
-  }, [timeLimit, startTimer]);
-
-  // Initialize timer when component mounts or item changes
-  useEffect(() => {
-    if (!readOnly && !audioUrl && timeLimit > 0) {
-      startTimer();
-    }
-
-    return () => {
-      if (timerRef.current) {
-        clearInterval(timerRef.current);
-      }
-    };
-  }, [readOnly, timeLimit, startTimer, currentItem.id]);
-
-  // Stop timer when recording is complete
-  useEffect(() => {
-    if (audioUrl && timerRef.current) {
-      clearInterval(timerRef.current);
-    }
-  }, [audioUrl]);
 
   // Reset state when item changes (only triggered by currentItem.id change)
   useEffect(() => {
@@ -307,7 +233,6 @@ export default function WordReadingTemplate({
     setPhonemeResult(null);
     setScoreOverlayOpen(false);
     setScoreModalOpen(false);
-    setTimeRemaining(timeLimit);
     setImageError(false);
     setIsPlaying(false);
     setCurrentTime(0);
@@ -338,12 +263,6 @@ export default function WordReadingTemplate({
       }
     }
 
-    // Start timer for new item without existing audio.
-    // Must be done here because the timer init useEffect (line 280) reads
-    // stale audioUrl from closure when both effects fire in the same render.
-    if (!readOnly && !existingAudioUrl && timeLimit > 0) {
-      startTimer();
-    }
   }, [currentItem.id]); // Only run when item changes, not when existingAudioUrl/timeLimit changes
 
   // Sync assessment from background analysis completing after navigation
@@ -408,24 +327,6 @@ export default function WordReadingTemplate({
     };
   }, [currentItem.id, currentItem.audio_url, playbackRate]);
 
-  // Handle retry
-  const handleRetry = () => {
-    setShowTimeoutDialog(false);
-    setAudioUrl(undefined);
-    setAssessmentResult(null);
-    setScoreOverlayOpen(false);
-    setScoreModalOpen(false);
-    resetTimer();
-    onRetry?.();
-  };
-
-  // Handle skip
-  const handleSkip = () => {
-    setShowTimeoutDialog(false);
-    onSkip?.();
-  };
-
-  const isLowTime = timeRemaining <= 5 && timeRemaining > 0;
 
   // Play example audio
   const handlePlayExample = () => {
@@ -477,6 +378,22 @@ export default function WordReadingTemplate({
         const audioBlob = new Blob(audioChunksRef.current, {
           type: "audio/webm",
         });
+
+        // Check recording duration against time limit
+        const elapsedSeconds =
+          (Date.now() - recordingStartTimeRef.current) / 1000;
+        if (timeLimit > 0 && elapsedSeconds > timeLimit) {
+          toast.error(
+            t("wordReading.toast.recordingExceedsLimit", {
+              recorded: Math.round(elapsedSeconds),
+              limit: timeLimit,
+            }) ||
+              `錄音時間 ${Math.round(elapsedSeconds)} 秒超過限制 ${timeLimit} 秒，請重新錄音`,
+          );
+          stream.getTracks().forEach((track) => track.stop());
+          return;
+        }
+
         // Revoke previous blob URL to prevent memory leak
         if (audioUrl && audioUrl.startsWith("blob:")) {
           URL.revokeObjectURL(audioUrl);
@@ -492,6 +409,7 @@ export default function WordReadingTemplate({
       mediaRecorder.start();
       setIsRecording(true);
       setRecordingTime(0);
+      recordingStartTimeRef.current = Date.now();
 
       // Start recording timer
       recordingIntervalRef.current = setInterval(() => {
@@ -807,18 +725,14 @@ export default function WordReadingTemplate({
                   <option value={2.0}>2.0x</option>
                 </select>
 
-                {/* Timer Display */}
-                {!readOnly && timeLimit > 0 && !audioUrl && (
-                  <div
-                    className={cn(
-                      "flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium",
-                      isLowTime
-                        ? "bg-red-100 text-red-700 animate-pulse"
-                        : "bg-gray-100 text-gray-700",
-                    )}
-                  >
+                {/* Time Limit Display (static) */}
+                {!readOnly && timeLimit > 0 && (
+                  <div className="flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700">
                     <Clock className="h-3 w-3" />
-                    <span>{formatTime(timeRemaining)}</span>
+                    <span>
+                      {t("wordReading.timeLimit", { seconds: timeLimit }) ||
+                        `限時 ${timeLimit} 秒`}
+                    </span>
                   </div>
                 )}
               </div>
@@ -961,7 +875,7 @@ export default function WordReadingTemplate({
                     {/* 錄音中狀態 */}
                     <div className="w-2 h-2 bg-red-600 rounded-full animate-pulse" />
                     <span className="text-base font-medium text-red-600">
-                      {formatTime(recordingTime)}
+                      {`${Math.floor(recordingTime / 60)}:${(recordingTime % 60).toString().padStart(2, "0")}`}
                     </span>
                     <Button
                       size="sm"
@@ -1219,37 +1133,6 @@ export default function WordReadingTemplate({
         </div>
       </div>
 
-      {/* Timeout Dialog */}
-      <Dialog open={showTimeoutDialog} onOpenChange={setShowTimeoutDialog}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2 text-orange-600">
-              <Clock className="h-5 w-5" />
-              {t("wordReading.timeUp") || "時間到！"}
-            </DialogTitle>
-            <DialogDescription>
-              {t("wordReading.timeUpDescription") ||
-                "錄音時間已結束，您可以選擇重試或跳過此題。"}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="flex gap-2 sm:gap-0">
-            <Button
-              variant="outline"
-              onClick={handleRetry}
-              className="flex items-center gap-2"
-            >
-              <RotateCcw className="h-4 w-4" />
-              {t("wordReading.retry") || "重試"}
-            </Button>
-            {onSkip && (
-              <Button onClick={handleSkip} className="flex items-center gap-2">
-                <SkipForward className="h-4 w-4" />
-                {t("wordReading.skip") || "跳過"}
-              </Button>
-            )}
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
 
       {/* 🎯 Issue #461: 分析完成星星鼓勵動畫 overlay */}
       <ScoreOverlay

--- a/frontend/src/components/activities/WordReadingTemplate.tsx
+++ b/frontend/src/components/activities/WordReadingTemplate.tsx
@@ -269,11 +269,17 @@ export default function WordReadingTemplate({
     }
   }, [currentItem.id]); // Only run when item changes, not when existingAudioUrl/timeLimit changes
 
-  // Cleanup autoStopTimerRef on unmount
+  // Cleanup all recording resources on unmount
   useEffect(() => {
     return () => {
       if (autoStopTimerRef.current) {
         clearTimeout(autoStopTimerRef.current);
+      }
+      if (recordingIntervalRef.current) {
+        clearInterval(recordingIntervalRef.current);
+      }
+      if (mediaRecorderRef.current?.state === "recording") {
+        mediaRecorderRef.current.stop();
       }
     };
   }, []);
@@ -458,7 +464,9 @@ export default function WordReadingTemplate({
       }
     } catch (error) {
       console.error("Error starting recording:", error);
-      toast.error("無法啟動錄音，請檢查麥克風權限");
+      toast.error(
+        t("audioRecorder.toast.cannotStart") || "無法啟動錄音，請檢查麥克風權限",
+      );
     }
   };
 

--- a/frontend/src/components/activities/WordReadingTemplate.tsx
+++ b/frontend/src/components/activities/WordReadingTemplate.tsx
@@ -377,10 +377,12 @@ export default function WordReadingTemplate({
           type: "audio/webm",
         });
 
-        // Check recording duration against time limit
+        // Check recording duration against time limit (0.5s tolerance for
+        // auto-stop timer imprecision — auto-stopped recordings land at
+        // timeLimit + a few ms and should be accepted)
         const elapsedSeconds =
           (Date.now() - recordingStartTimeRef.current) / 1000;
-        if (timeLimit > 0 && elapsedSeconds > timeLimit) {
+        if (timeLimit > 0 && elapsedSeconds > timeLimit + 0.5) {
           toast.error(
             t("wordReading.toast.recordingExceedsLimit", {
               recorded: Math.round(elapsedSeconds),
@@ -389,6 +391,10 @@ export default function WordReadingTemplate({
               `錄音時間 ${Math.round(elapsedSeconds)} 秒超過限制 ${timeLimit} 秒，請重新錄音`,
           );
           stream.getTracks().forEach((track) => track.stop());
+          if (recordingIntervalRef.current) {
+            clearInterval(recordingIntervalRef.current);
+            recordingIntervalRef.current = null;
+          }
           return;
         }
 

--- a/frontend/src/components/activities/WordReadingTemplate.tsx
+++ b/frontend/src/components/activities/WordReadingTemplate.tsx
@@ -723,7 +723,7 @@ export default function WordReadingTemplate({
                 </select>
 
                 {/* Time Limit Display (static) */}
-                {!readOnly && timeLimit > 0 && (
+                {!readOnly && timeLimit > 0 && !audioUrl && (
                   <div className="flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700">
                     <Clock className="h-3 w-3" />
                     <span>

--- a/frontend/src/components/activities/WordReadingTemplate.tsx
+++ b/frontend/src/components/activities/WordReadingTemplate.tsx
@@ -179,6 +179,7 @@ export default function WordReadingTemplate({
 
   // Recording start timestamp (for duration check against timeLimit)
   const recordingStartTimeRef = useRef<number>(0);
+  const autoStopTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   // Image error handling
   const [imageError, setImageError] = useState(false);
@@ -412,6 +413,27 @@ export default function WordReadingTemplate({
       recordingIntervalRef.current = setInterval(() => {
         setRecordingTime((prev) => prev + 1);
       }, 1000);
+
+      // Auto-stop recording when time limit is reached
+      if (timeLimit > 0) {
+        if (autoStopTimerRef.current) {
+          clearTimeout(autoStopTimerRef.current);
+        }
+        autoStopTimerRef.current = setTimeout(() => {
+          if (
+            mediaRecorderRef.current &&
+            mediaRecorderRef.current.state === "recording"
+          ) {
+            mediaRecorderRef.current.stop();
+            setIsRecording(false);
+            if (recordingIntervalRef.current) {
+              clearInterval(recordingIntervalRef.current);
+              recordingIntervalRef.current = null;
+            }
+          }
+          autoStopTimerRef.current = null;
+        }, timeLimit * 1000);
+      }
     } catch (error) {
       console.error("Error starting recording:", error);
       toast.error("無法啟動錄音，請檢查麥克風權限");
@@ -427,6 +449,10 @@ export default function WordReadingTemplate({
       if (recordingIntervalRef.current) {
         clearInterval(recordingIntervalRef.current);
         recordingIntervalRef.current = null;
+      }
+      if (autoStopTimerRef.current) {
+        clearTimeout(autoStopTimerRef.current);
+        autoStopTimerRef.current = null;
       }
     }
   };

--- a/frontend/src/components/activities/WordReadingTemplate.tsx
+++ b/frontend/src/components/activities/WordReadingTemplate.tsx
@@ -224,6 +224,11 @@ export default function WordReadingTemplate({
 
   // Reset state when item changes (only triggered by currentItem.id change)
   useEffect(() => {
+    // Clear auto-stop timer from previous item's recording
+    if (autoStopTimerRef.current) {
+      clearTimeout(autoStopTimerRef.current);
+      autoStopTimerRef.current = null;
+    }
     // Revoke previous blob URL to prevent memory leak
     if (audioUrl && audioUrl.startsWith("blob:")) {
       URL.revokeObjectURL(audioUrl);
@@ -263,6 +268,15 @@ export default function WordReadingTemplate({
       }
     }
   }, [currentItem.id]); // Only run when item changes, not when existingAudioUrl/timeLimit changes
+
+  // Cleanup autoStopTimerRef on unmount
+  useEffect(() => {
+    return () => {
+      if (autoStopTimerRef.current) {
+        clearTimeout(autoStopTimerRef.current);
+      }
+    };
+  }, []);
 
   // Sync assessment from background analysis completing after navigation
   // The reset effect (above) only runs on currentItem.id change, so if
@@ -380,22 +394,24 @@ export default function WordReadingTemplate({
         // Check recording duration against time limit (0.5s tolerance for
         // auto-stop timer imprecision — auto-stopped recordings land at
         // timeLimit + a few ms and should be accepted)
-        const elapsedSeconds =
-          (Date.now() - recordingStartTimeRef.current) / 1000;
-        if (timeLimit > 0 && elapsedSeconds > timeLimit + 0.5) {
-          toast.error(
-            t("wordReading.toast.recordingExceedsLimit", {
-              recorded: Math.round(elapsedSeconds),
-              limit: timeLimit,
-            }) ||
-              `錄音時間 ${Math.round(elapsedSeconds)} 秒超過限制 ${timeLimit} 秒，請重新錄音`,
-          );
-          stream.getTracks().forEach((track) => track.stop());
-          if (recordingIntervalRef.current) {
-            clearInterval(recordingIntervalRef.current);
-            recordingIntervalRef.current = null;
+        if (timeLimit > 0 && recordingStartTimeRef.current > 0) {
+          const elapsedSeconds =
+            (Date.now() - recordingStartTimeRef.current) / 1000;
+          if (elapsedSeconds > timeLimit + 0.5) {
+            toast.error(
+              t("wordReading.toast.recordingExceedsLimit", {
+                recorded: Math.round(elapsedSeconds),
+                limit: timeLimit,
+              }) ||
+                `錄音時間 ${Math.round(elapsedSeconds)} 秒超過限制 ${timeLimit} 秒，請重新錄音`,
+            );
+            stream.getTracks().forEach((track) => track.stop());
+            if (recordingIntervalRef.current) {
+              clearInterval(recordingIntervalRef.current);
+              recordingIntervalRef.current = null;
+            }
+            return;
           }
-          return;
         }
 
         // Revoke previous blob URL to prevent memory leak

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -4540,8 +4540,10 @@
       "submitFailed": "Submit failed",
       "completed": "Assignment completed!",
       "missingData": "Please record first",
-      "recordingTooLong": "Recording too long, maximum 10 seconds"
-    }
+      "recordingTooLong": "Recording too long, maximum 10 seconds",
+      "recordingExceedsLimit": "Recording {{recorded}}s exceeds the {{limit}}s limit. Please re-record."
+    },
+    "timeLimit": "Time limit: {{seconds}}s"
   },
   "wordSelection": {
     "loading": "Loading vocabulary...",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -4559,8 +4559,10 @@
       "submitFailed": "提交失敗",
       "completed": "作業已完成！",
       "missingData": "請先錄音",
-      "recordingTooLong": "錄音時間過長，限制最長 10 秒"
-    }
+      "recordingTooLong": "錄音時間過長，限制最長 10 秒",
+      "recordingExceedsLimit": "錄音時間 {{recorded}} 秒超過限制 {{limit}} 秒，請重新錄音"
+    },
+    "timeLimit": "限時 {{seconds}} 秒"
   },
   "wordSelection": {
     "loading": "正在載入單字...",

--- a/frontend/src/pages/DemoAssignmentPage.tsx
+++ b/frontend/src/pages/DemoAssignmentPage.tsx
@@ -23,6 +23,7 @@ interface DemoActivityResponse {
   title: string;
   practice_mode?: string | null;
   show_answer?: boolean;
+  time_limit_per_question?: number;
   total_activities: number;
   activities: Activity[];
 }
@@ -128,6 +129,7 @@ export default function DemoAssignmentPage() {
         assignmentId={activityData.assignment_id}
         practiceMode={activityData.practice_mode || null}
         showAnswer={activityData.show_answer || false}
+        timeLimitPerQuestion={activityData.time_limit_per_question ?? 0}
         isDemoMode={true}
         isPreviewMode={true}
         onBack={handleBack}

--- a/frontend/src/pages/student/StudentActivityPage.tsx
+++ b/frontend/src/pages/student/StudentActivityPage.tsx
@@ -84,6 +84,7 @@ interface ActivityResponse {
   practice_mode?: string | null;
   score_category?: string | null;
   show_answer?: boolean; // 例句重組：答題結束後是否顯示正確答案
+  time_limit_per_question?: number;
   total_activities: number;
   activities: Activity[];
   can_use_ai_analysis?: boolean; // 教師/機構是否有 AI 分析額度
@@ -102,6 +103,7 @@ export default function StudentActivityPage() {
   const [practiceMode, setPracticeMode] = useState<string | null>(null);
   const [showAnswer, setShowAnswer] = useState<boolean>(false);
   const [canUseAiAnalysis, setCanUseAiAnalysis] = useState<boolean>(true);
+  const [timeLimitPerQuestion, setTimeLimitPerQuestion] = useState<number>(0);
   const [loading, setLoading] = useState(true);
   const [_isSubmitting, setIsSubmitting] = useState(false);
   const isSubmittingRef = useRef(false);
@@ -161,6 +163,7 @@ export default function StudentActivityPage() {
       setPracticeMode(data.practice_mode || null);
       setShowAnswer(data.show_answer || false);
       setCanUseAiAnalysis(data.can_use_ai_analysis ?? true);
+      setTimeLimitPerQuestion(data.time_limit_per_question ?? 0);
     } catch (error) {
       console.error("Failed to load activities:", error);
       toast.error(t("studentActivityPage.errors.loadFailed"));
@@ -296,6 +299,7 @@ export default function StudentActivityPage() {
       practiceMode={practiceMode}
       showAnswer={showAnswer}
       canUseAiAnalysis={canUseAiAnalysis}
+      timeLimitPerQuestion={timeLimitPerQuestion}
       onBack={() => navigate("/student/assignments")}
       onSubmit={handleSubmit}
     />

--- a/frontend/src/pages/student/StudentActivityPageContent.tsx
+++ b/frontend/src/pages/student/StudentActivityPageContent.tsx
@@ -2002,6 +2002,7 @@ export default function StudentActivityPageContent({
             authToken={authToken}
             canUseAiAnalysis={canUseAiAnalysis}
             readOnly={isReadOnly}
+            timeLimitPerQuestion={timeLimitPerQuestion}
             onComplete={async () => {
               if (onSubmit) {
                 try {

--- a/frontend/src/pages/student/StudentActivityPageContent.tsx
+++ b/frontend/src/pages/student/StudentActivityPageContent.tsx
@@ -695,8 +695,8 @@ export default function StudentActivityPageContent({
             recordingInterval.current = null;
           }
           setTimeout(() => {
-            if (mediaRecorder && mediaRecorder.state === "recording") {
-              mediaRecorder.stop();
+            if (recorder && recorder.state === "recording") {
+              recorder.stop();
               setMediaRecorder(null);
               setIsRecording(false);
               toast.info(t("studentActivityPage.warnings.recordingLimit"));

--- a/frontend/src/pages/student/StudentActivityPageContent.tsx
+++ b/frontend/src/pages/student/StudentActivityPageContent.tsx
@@ -159,6 +159,7 @@ interface StudentActivityPageContentProps {
   practiceMode?: string | null; // 例句重組/朗讀模式
   showAnswer?: boolean; // 例句重組：答題結束後是否顯示正確答案
   canUseAiAnalysis?: boolean; // 教師/機構是否有 AI 分析額度
+  timeLimitPerQuestion?: number; // 每題錄音時間限制（秒）
 }
 
 // =============================================================================
@@ -199,6 +200,7 @@ export default function StudentActivityPageContent({
   practiceMode = null,
   showAnswer = false,
   canUseAiAnalysis = true,
+  timeLimitPerQuestion = 0,
 }: StudentActivityPageContentProps) {
   const { t } = useTranslation();
 
@@ -1933,13 +1935,8 @@ export default function StudentActivityPageContent({
             progressId={activity.id}
             readOnly={isReadOnly}
             isDemoMode={isDemoMode}
-            timeLimit={activity.duration || 60}
+            timeLimit={timeLimitPerQuestion}
             canUseAiAnalysis={canUseAiAnalysis}
-            onSkip={
-              currentActivityIndex < activities.length - 1
-                ? () => handleActivitySelect(currentActivityIndex + 1)
-                : undefined
-            }
           />
         );
       }
@@ -2127,12 +2124,7 @@ export default function StudentActivityPageContent({
             progressId={activity.id}
             readOnly={isReadOnly}
             isDemoMode={isDemoMode}
-            timeLimit={activity.duration || 60}
-            onSkip={
-              currentActivityIndex < activities.length - 1
-                ? () => handleActivitySelect(currentActivityIndex + 1)
-                : undefined
-            }
+            timeLimit={timeLimitPerQuestion}
           />
         );
     }

--- a/frontend/src/pages/student/StudentActivityPageContent.tsx
+++ b/frontend/src/pages/student/StudentActivityPageContent.tsx
@@ -1789,7 +1789,7 @@ export default function StudentActivityPageContent({
           }
           onFileUpload={handleFileUpload}
           formatTime={formatTime}
-          timeLimit={activity.duration || 30}
+          timeLimit={timeLimitPerQuestion}
           progressIds={
             // 🔧 Issue #118 Fix: Always use activity.items as base, merge in updated progressIds
             // Previous bug: answer?.progressIds || ... would use incomplete array [101] after first upload

--- a/frontend/src/pages/teacher/TeacherAssignmentPreviewPage.tsx
+++ b/frontend/src/pages/teacher/TeacherAssignmentPreviewPage.tsx
@@ -26,6 +26,7 @@ interface ActivityResponse {
   practice_mode?: string | null;
   score_category?: string | null;
   show_answer?: boolean; // 例句重組：答題結束後是否顯示正確答案
+  time_limit_per_question?: number;
   total_activities: number;
   activities: Activity[];
 }
@@ -134,6 +135,7 @@ export default function TeacherAssignmentPreviewPage() {
         assignmentId={parseInt(assignmentId!)}
         practiceMode={activityData.practice_mode || null}
         showAnswer={activityData.show_answer || false}
+        timeLimitPerQuestion={activityData.time_limit_per_question ?? 0}
         isPreviewMode={true}
         authToken={token || undefined}
         onBack={goBack}


### PR DESCRIPTION
## Summary
- 移除單字朗讀的倒數計時器（題目載入即倒數），改為錄音完成後檢查實際錄音時長
- 題目區靜態顯示「限時 X 秒」badge
- 錄音時長超過限制時 toast 提示重錄，不儲存音檔

## Test plan
- [ ] Preview 頁面：載入題目時不再有倒數計時
- [ ] Preview 頁面：題目區顯示「限時 X 秒」
- [ ] Demo 頁面：錄音超過限時後停止，顯示 toast 提示重錄
- [ ] 無限時設定（timeLimit=0）行為不變
- [ ] 切換題目時狀態正確重置

🤖 Generated with [Claude Code](https://claude.com/claude-code)