### PR TITLE
Release: [Feature]: 我的教材/資源教材包/組織教材 條列式改為資料夾式 (Fixes #574)

### DIFF
--- a/backend/routers/teachers/program_ops.py
+++ b/backend/routers/teachers/program_ops.py
@@ -142,6 +142,7 @@ async def get_teacher_programs(
                                             "translation": item.translation,
                                             "audio_url": item.audio_url,
                                             "order_index": item.order_index,
+                                            "image_url": item.image_url,
                                         }
                                     )
 

--- a/frontend/src/components/TeacherLayout.tsx
+++ b/frontend/src/components/TeacherLayout.tsx
@@ -223,7 +223,7 @@ function TeacherLayoutInner({
           )}
 
           {/* Navigation */}
-          <nav className="flex-1 p-4 overflow-y-auto">
+          <nav className={`flex-1 overflow-y-auto ${sidebarCollapsed ? "p-2" : "p-4"}`}>
             <ul className="space-y-1">
               {filteredGroups.map((group) => (
                 <SidebarGroup

--- a/frontend/src/components/TeacherLayout.tsx
+++ b/frontend/src/components/TeacherLayout.tsx
@@ -223,7 +223,9 @@ function TeacherLayoutInner({
           )}
 
           {/* Navigation */}
-          <nav className={`flex-1 overflow-y-auto ${sidebarCollapsed ? "p-2" : "p-4"}`}>
+          <nav
+            className={`flex-1 overflow-y-auto ${sidebarCollapsed ? "p-2" : "p-4"}`}
+          >
             <ul className="space-y-1">
               {filteredGroups.map((group) => (
                 <SidebarGroup

--- a/frontend/src/components/shared/MaterialsToolbar.tsx
+++ b/frontend/src/components/shared/MaterialsToolbar.tsx
@@ -35,13 +35,13 @@ export default function MaterialsToolbar({
   const { t } = useTranslation();
 
   return (
-    <div className="flex flex-col md:flex-row md:items-center gap-3">
+    <div className="flex flex-col lg:flex-row lg:items-center gap-3">
       <h2 className="text-[22px] font-bold text-gray-900 whitespace-nowrap">
         {title}
       </h2>
 
       {/* Spacer (desktop only) */}
-      <div className="hidden md:block flex-1" />
+      <div className="hidden lg:block flex-1" />
 
       {/* Add + Search + View toggle */}
       <div className="flex items-center gap-3">

--- a/frontend/src/components/shared/MaterialsToolbar.tsx
+++ b/frontend/src/components/shared/MaterialsToolbar.tsx
@@ -63,7 +63,13 @@ export default function MaterialsToolbar({
             className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
           />
           <Input
-            placeholder={searchPlaceholder ?? t("teacherTemplatePrograms.toolbar.searchPlaceholder", "搜尋教材...")}
+            placeholder={
+              searchPlaceholder ??
+              t(
+                "teacherTemplatePrograms.toolbar.searchPlaceholder",
+                "搜尋教材...",
+              )
+            }
             value={searchQuery}
             onChange={(e) => onSearchChange(e.target.value)}
             className="pl-8 h-9 text-[13px] border-gray-200 rounded-lg"

--- a/frontend/src/components/shared/MaterialsToolbar.tsx
+++ b/frontend/src/components/shared/MaterialsToolbar.tsx
@@ -1,0 +1,99 @@
+/**
+ * MaterialsToolbar - 教材頁面共用工具列
+ *
+ * 包含：標題、新增按鈕（可選）、搜尋框、條列式/資料夾式 view toggle
+ * 用於：我的教材、機構教材、組織管理教材
+ */
+
+import { useTranslation } from "react-i18next";
+import { Input } from "@/components/ui/input";
+import { Search, FolderPlus, List, LayoutGrid } from "lucide-react";
+
+export type ViewMode = "tree" | "folder";
+
+export interface MaterialsToolbarProps {
+  title: string;
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  searchPlaceholder?: string;
+  viewMode: ViewMode;
+  onViewModeChange: (mode: ViewMode) => void;
+  onAdd?: () => void;
+  addButtonText?: string;
+}
+
+export default function MaterialsToolbar({
+  title,
+  searchQuery,
+  onSearchChange,
+  searchPlaceholder,
+  viewMode,
+  onViewModeChange,
+  onAdd,
+  addButtonText,
+}: MaterialsToolbarProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-col md:flex-row md:items-center gap-3">
+      <h2 className="text-[22px] font-bold text-gray-900 whitespace-nowrap">
+        {title}
+      </h2>
+
+      {/* Spacer (desktop only) */}
+      <div className="hidden md:block flex-1" />
+
+      {/* Add + Search + View toggle */}
+      <div className="flex items-center gap-3">
+        {onAdd && (
+          <button
+            onClick={onAdd}
+            className="flex items-center gap-1.5 sm:px-3.5 sm:py-2 sm:bg-white sm:border sm:border-gray-200 sm:rounded-lg text-gray-700 text-[13px] font-medium sm:hover:bg-gray-50 transition-colors shrink-0"
+          >
+            <FolderPlus size={20} className="sm:hidden" />
+            <FolderPlus size={16} className="hidden sm:block" />
+            {addButtonText && (
+              <span className="hidden sm:inline">{addButtonText}</span>
+            )}
+          </button>
+        )}
+        <div className="relative flex-1 md:w-60 md:flex-none">
+          <Search
+            size={16}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+          />
+          <Input
+            placeholder={searchPlaceholder ?? t("teacherTemplatePrograms.toolbar.searchPlaceholder", "搜尋教材...")}
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            className="pl-8 h-9 text-[13px] border-gray-200 rounded-lg"
+          />
+        </div>
+        <div className="flex border border-gray-200 rounded-lg overflow-hidden shrink-0">
+          <button
+            onClick={() => onViewModeChange("tree")}
+            className={`p-2 transition-colors ${
+              viewMode === "tree"
+                ? "bg-blue-600 text-white"
+                : "bg-white text-gray-500 hover:bg-gray-100"
+            }`}
+            title={t("teacherTemplatePrograms.toolbar.treeView", "條列式")}
+          >
+            <List size={16} />
+          </button>
+          <button
+            onClick={() => onViewModeChange("folder")}
+            className={`p-2 transition-colors ${
+              viewMode === "folder"
+                ? "bg-blue-600 text-white"
+                : "bg-white text-gray-500 hover:bg-gray-100"
+            }`}
+            title={t("teacherTemplatePrograms.toolbar.folderView", "資料夾式")}
+          >
+            <LayoutGrid size={16} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shared/ProgramFolderView.tsx
+++ b/frontend/src/components/shared/ProgramFolderView.tsx
@@ -36,7 +36,8 @@ const LEVEL_COVERS: Record<string, string> = {
   C2: "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/C2.png",
 };
 
-const DEFAULT_COVER = "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/A1.png";
+const DEFAULT_COVER =
+  "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/A1.png";
 
 function getCoverImage(level?: string): string {
   if (!level) return DEFAULT_COVER;
@@ -44,18 +45,16 @@ function getCoverImage(level?: string): string {
 }
 
 /* ── Content type badge config ── */
-const TYPE_BADGE: Record<
-  string,
-  { label: string; bg: string; text: string }
-> = {
-  example_sentences: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
-  EXAMPLE_SENTENCES: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
-  reading_assessment: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
-  vocabulary_set: { label: "單字集", bg: "#FFFBEB", text: "#D97706" },
-  VOCABULARY_SET: { label: "單字集", bg: "#FFFBEB", text: "#D97706" },
-  sentence_making: { label: "造句", bg: "#F5F3FF", text: "#7C3AED" },
-  SENTENCE_MAKING: { label: "造句", bg: "#F5F3FF", text: "#7C3AED" },
-};
+const TYPE_BADGE: Record<string, { label: string; bg: string; text: string }> =
+  {
+    example_sentences: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
+    EXAMPLE_SENTENCES: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
+    reading_assessment: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
+    vocabulary_set: { label: "單字集", bg: "#FFFBEB", text: "#D97706" },
+    VOCABULARY_SET: { label: "單字集", bg: "#FFFBEB", text: "#D97706" },
+    sentence_making: { label: "造句", bg: "#F5F3FF", text: "#7C3AED" },
+    SENTENCE_MAKING: { label: "造句", bg: "#F5F3FF", text: "#7C3AED" },
+  };
 
 /* ── Dropdown Menu ── */
 interface MenuAction {
@@ -141,9 +140,7 @@ function ProgramCard({
     <div
       className="relative rounded-2xl bg-white cursor-pointer transition-all hover:shadow-md"
       style={{
-        border: isSelected
-          ? "3px solid #4CAF50"
-          : "1px solid #E5E7EB",
+        border: isSelected ? "3px solid #4CAF50" : "1px solid #E5E7EB",
       }}
       onClick={onClick}
     >
@@ -229,16 +226,15 @@ function LessonCard({
     <div
       className="relative rounded-2xl bg-white cursor-pointer transition-all hover:shadow-md"
       style={{
-        border: isSelected
-          ? "3px solid #7C3AED"
-          : "1px solid #E5E7EB",
+        border: isSelected ? "3px solid #7C3AED" : "1px solid #E5E7EB",
       }}
       onClick={onClick}
     >
       {/* Description preview */}
       <div className="h-[100px] px-3.5 py-3 overflow-hidden rounded-t-2xl bg-[#EEEAF5]">
         <p className="text-xs text-gray-500 leading-relaxed line-clamp-4 whitespace-pre-line">
-          {lesson.description || t("programFolderView.noDescription", "尚無描述")}
+          {lesson.description ||
+            t("programFolderView.noDescription", "尚無描述")}
         </p>
       </div>
 
@@ -360,7 +356,9 @@ function ContentCard({
                     {item.translation && (
                       <>
                         <span className="mx-1 text-gray-300">·</span>
-                        <span className="text-gray-400">{item.translation}</span>
+                        <span className="text-gray-400">
+                          {item.translation}
+                        </span>
                       </>
                     )}
                   </div>
@@ -450,7 +448,6 @@ function ContentCard({
           />
         )}
       </div>
-
     </div>
   );
 }
@@ -519,8 +516,8 @@ function ExpandArea({
 
   // Contents to display: selected lesson's contents, or program-level contents
   const displayContents = selectedLesson
-    ? selectedLesson.contents ?? []
-    : program.contents ?? [];
+    ? (selectedLesson.contents ?? [])
+    : (program.contents ?? []);
   const contentsSectionTitle = selectedLesson
     ? `${t("programFolderView.contentsSection", "內容")}: ${selectedLesson.name}`
     : t("programFolderView.contentsSection", "內容");
@@ -545,7 +542,11 @@ function ExpandArea({
                 key={lesson.id}
                 lesson={lesson}
                 isSelected={lesson.id === selectedLessonId}
-                onClick={() => setSelectedLessonId(lesson.id === selectedLessonId ? null : lesson.id)}
+                onClick={() =>
+                  setSelectedLessonId(
+                    lesson.id === selectedLessonId ? null : lesson.id,
+                  )
+                }
                 onEdit={() => onEditLesson(program.id, lesson.id)}
                 onDelete={() => onDeleteLesson(program.id, lesson.id)}
               />
@@ -575,9 +576,7 @@ function ExpandArea({
         iconColor="#059669"
         // TODO: 當沒有選中 lesson 時，新增內容的 lessonId 傳 0，
         // 後端工程師需決定 program-level content 的建立方式與儲存邏輯
-        onAdd={() =>
-          onCreateContent(program.id, selectedLesson?.id ?? 0)
-        }
+        onAdd={() => onCreateContent(program.id, selectedLesson?.id ?? 0)}
         addLabel={t("programFolderView.addContent", "新增內容")}
       />
 
@@ -716,9 +715,7 @@ export default function ProgramFolderView({
       ))}
 
       {programs.length === 0 && (
-        <div className="text-center py-12 text-gray-400">
-          尚無教材
-        </div>
+        <div className="text-center py-12 text-gray-400">尚無教材</div>
       )}
     </div>
   );

--- a/frontend/src/components/shared/ProgramFolderView.tsx
+++ b/frontend/src/components/shared/ProgramFolderView.tsx
@@ -20,6 +20,7 @@ import {
   Pencil,
   Trash2,
   Copy,
+  ArrowRightLeft,
   Play,
   Plus,
 } from "lucide-react";
@@ -27,15 +28,15 @@ import type { Program, Lesson, Content } from "@/types";
 
 /* ── Cover image mapping by level ── */
 const LEVEL_COVERS: Record<string, string> = {
-  A1: "/images/course-covers/A1.png",
-  A2: "/images/course-covers/A2.png",
-  B1: "/images/course-covers/B1.png",
-  B2: "/images/course-covers/B2.png",
-  C1: "/images/course-covers/C1.png",
-  C2: "/images/course-covers/C2.png",
+  A1: "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/A1.png",
+  A2: "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/A2.png",
+  B1: "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/B1.png",
+  B2: "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/B2.png",
+  C1: "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/C1.png",
+  C2: "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/C2.png",
 };
 
-const DEFAULT_COVER = "/images/course-covers/A1.png";
+const DEFAULT_COVER = "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/A1.png";
 
 function getCoverImage(level?: string): string {
   if (!level) return DEFAULT_COVER;
@@ -62,6 +63,7 @@ interface MenuAction {
   icon: React.ReactNode;
   onClick: () => void;
   danger?: boolean;
+  disabled?: boolean;
 }
 
 function DropdownMenu({
@@ -89,13 +91,20 @@ function DropdownMenu({
       {actions.map((a, i) => (
         <button
           key={i}
+          disabled={a.disabled}
           onClick={(e) => {
             e.stopPropagation();
-            a.onClick();
-            onClose();
+            if (!a.disabled) {
+              a.onClick();
+              onClose();
+            }
           }}
-          className={`flex items-center gap-1.5 w-full px-2.5 py-1.5 rounded-md text-xs hover:bg-gray-50 transition-colors ${
-            a.danger ? "text-red-500" : "text-gray-700"
+          className={`flex items-center gap-1.5 w-full px-2.5 py-1.5 rounded-md text-xs transition-colors ${
+            a.disabled
+              ? "text-gray-300 cursor-not-allowed"
+              : a.danger
+                ? "text-red-500 hover:bg-gray-50"
+                : "text-gray-700 hover:bg-gray-50"
           }`}
         >
           {a.icon}
@@ -280,14 +289,12 @@ function LessonCard({
 function ContentCard({
   content,
   onClick,
-  onEdit,
   onDelete,
   onCopy,
   onInstantPractice,
 }: {
   content: Content;
   onClick: () => void;
-  onEdit?: () => void;
   onDelete?: () => void;
   onCopy?: () => void;
   onInstantPractice?: () => void;
@@ -306,23 +313,53 @@ function ContentCard({
       className="relative rounded-xl bg-white border border-gray-200 transition-all hover:shadow-md group"
       onClick={onClick}
     >
-      {/* Text preview */}
-      <div className="h-[160px] p-6 overflow-hidden rounded-t-xl relative">
+      {/* Preview: image + text or text only */}
+      <div className="h-[160px] p-6 overflow-hidden rounded-t-xl relative select-none">
         {items.length > 0 ? (
-          <div className="space-y-1.5 text-[13px] w-full">
-            {items.slice(0, 5).map((item, i) => (
-              <p
-                key={i}
-                className={`break-words ${i >= 3 ? "text-gray-400" : i >= 2 ? "text-gray-500" : "text-gray-700"}`}
-              >
-                {item.text}
-                {item.translation && (
-                  <span className="ml-2 text-gray-400">
-                    {item.translation}
-                  </span>
-                )}
-              </p>
-            ))}
+          <div className="flex gap-3 h-full">
+            {/* First item image (if exists) */}
+            {items[0].image_url && (
+              <img
+                src={items[0].image_url}
+                alt={items[0].text}
+                className="w-20 h-20 object-cover rounded-lg shrink-0 opacity-60"
+                draggable={false}
+              />
+            )}
+            {items[0].image_url ? (
+              // 有圖：text 和 translation 上下排列，truncate 節省空間
+              <div className="space-y-0.5 text-[12px] flex-1 min-w-0">
+                {items.slice(0, 4).map((item, i) => (
+                  <div
+                    key={i}
+                    className={`truncate leading-tight ${i >= 3 ? "text-gray-400" : i >= 2 ? "text-gray-500" : "text-gray-700"}`}
+                  >
+                    {item.text}
+                    {item.translation && (
+                      <span className="text-gray-400"> {item.translation}</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              // 無圖：text · translation 同一行，break-words
+              <div className="space-y-1 text-[13px] flex-1 min-w-0">
+                {items.slice(0, 5).map((item, i) => (
+                  <div
+                    key={i}
+                    className={`break-words leading-tight ${i >= 3 ? "text-gray-400" : i >= 2 ? "text-gray-500" : "text-gray-700"}`}
+                  >
+                    <span>{item.text}</span>
+                    {item.translation && (
+                      <>
+                        <span className="mx-1 text-gray-300">·</span>
+                        <span className="text-gray-400">{item.translation}</span>
+                      </>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         ) : (
           <div className="text-gray-300">
@@ -381,15 +418,6 @@ function ContentCard({
             <DropdownMenu
               onClose={() => setShowMenu(false)}
               actions={[
-                ...(onEdit
-                  ? [
-                      {
-                        label: t("common.edit", "編輯"),
-                        icon: <Pencil size={13} />,
-                        onClick: onEdit,
-                      },
-                    ]
-                  : []),
                 ...(onCopy
                   ? [
                       {
@@ -399,6 +427,14 @@ function ContentCard({
                       },
                     ]
                   : []),
+                {
+                  label: t("common.move", "移動"),
+                  icon: <ArrowRightLeft size={13} />,
+                  onClick: () => {
+                    // TODO: 等工程師實作移動功能
+                  },
+                  disabled: true,
+                },
                 ...(onDelete
                   ? [
                       {
@@ -425,11 +461,13 @@ function SectionHeader({
   title,
   iconColor,
   onAdd,
+  addLabel,
 }: {
   icon: React.ReactNode;
   title: string;
   iconColor?: string;
   onAdd?: () => void;
+  addLabel?: string;
 }) {
   const { t } = useTranslation();
   return (
@@ -443,7 +481,7 @@ function SectionHeader({
           className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 transition-colors"
         >
           <Plus size={14} />
-          {t("common.add", "新增")}
+          {addLabel ?? t("common.add", "新增")}
         </button>
       )}
     </div>
@@ -498,9 +536,10 @@ function ExpandArea({
             icon={<Folder size={14} />}
             title={t("programFolderView.lessonsSection", "單元")}
             onAdd={() => onCreateLesson(program.id)}
+            addLabel={t("programFolderView.addLesson", "新增單元")}
           />
 
-          <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-5">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-5">
             {lessons.map((lesson) => (
               <LessonCard
                 key={lesson.id}
@@ -520,6 +559,7 @@ function ExpandArea({
           icon={<Folder size={14} />}
           title={t("programFolderView.lessonsSection", "單元")}
           onAdd={() => onCreateLesson(program.id)}
+          addLabel={t("programFolderView.addLesson", "新增單元")}
         />
       )}
 
@@ -533,15 +573,15 @@ function ExpandArea({
         onAdd={() =>
           onCreateContent(program.id, selectedLesson?.id ?? 0)
         }
+        addLabel={t("programFolderView.addContent", "新增內容")}
       />
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-5">
         {displayContents.map((content) => (
           <ContentCard
             key={content.id}
             content={content}
-            onClick={() => {/* 點擊卡片不開啟編輯器，透過三點選單操作 */}}
-            onEdit={() => onContentClick(content, contentsLessonId)}
+            onClick={() => onContentClick(content, contentsLessonId)}
             onDelete={() =>
               onDeleteContent(contentsLessonId, content.id, content.title)
             }

--- a/frontend/src/components/shared/ProgramFolderView.tsx
+++ b/frontend/src/components/shared/ProgramFolderView.tsx
@@ -1,0 +1,672 @@
+/**
+ * ProgramFolderView - 資料夾式手風琴教材顯示
+ *
+ * 設計稿: docs/design/teacher-template-programs.pen
+ * Issue: #574
+ *
+ * 結構：
+ * - Program 卡片 grid（封面圖 + 名稱 + 統計 + ellipsis menu）
+ * - 選中 program 展開區（lessons grid + contents grid）
+ * - Lesson 卡片（描述預覽 + 名稱 + 統計 + ellipsis menu）
+ * - Content 卡片（文字預覽 + type badge + title + play 按鈕）
+ */
+
+import { useState, useRef, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Folder,
+  FileText,
+  Ellipsis,
+  Pencil,
+  Trash2,
+  Copy,
+  Play,
+  Plus,
+} from "lucide-react";
+import type { Program, Lesson, Content } from "@/types";
+
+/* ── Cover image mapping by level ── */
+const LEVEL_COVERS: Record<string, string> = {
+  A1: "/images/course-covers/A1.png",
+  A2: "/images/course-covers/A2.png",
+  B1: "/images/course-covers/B1.png",
+  B2: "/images/course-covers/B2.png",
+  C1: "/images/course-covers/C1.png",
+  C2: "/images/course-covers/C2.png",
+};
+
+const DEFAULT_COVER = "/images/course-covers/A1.png";
+
+function getCoverImage(level?: string): string {
+  if (!level) return DEFAULT_COVER;
+  return LEVEL_COVERS[level.toUpperCase()] ?? DEFAULT_COVER;
+}
+
+/* ── Content type badge config ── */
+const TYPE_BADGE: Record<
+  string,
+  { label: string; bg: string; text: string }
+> = {
+  example_sentences: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
+  EXAMPLE_SENTENCES: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
+  reading_assessment: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
+  vocabulary_set: { label: "單字集", bg: "#FFFBEB", text: "#D97706" },
+  VOCABULARY_SET: { label: "單字集", bg: "#FFFBEB", text: "#D97706" },
+  sentence_making: { label: "造句", bg: "#F5F3FF", text: "#7C3AED" },
+  SENTENCE_MAKING: { label: "造句", bg: "#F5F3FF", text: "#7C3AED" },
+};
+
+/* ── Dropdown Menu ── */
+interface MenuAction {
+  label: string;
+  icon: React.ReactNode;
+  onClick: () => void;
+  danger?: boolean;
+}
+
+function DropdownMenu({
+  actions,
+  onClose,
+}: {
+  actions: MenuAction[];
+  onClose: () => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      className="absolute right-0 top-full mt-1 z-20 w-[100px] bg-white rounded-2xl shadow-lg border border-gray-100 py-[3px]"
+    >
+      {actions.map((a, i) => (
+        <button
+          key={i}
+          onClick={(e) => {
+            e.stopPropagation();
+            a.onClick();
+            onClose();
+          }}
+          className={`flex items-center gap-1.5 w-full px-2.5 py-1.5 rounded-md text-xs hover:bg-gray-50 transition-colors ${
+            a.danger ? "text-red-500" : "text-gray-700"
+          }`}
+        >
+          {a.icon}
+          {a.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/* ── Program Card ── */
+function ProgramCard({
+  program,
+  isSelected,
+  onClick,
+  onEdit,
+  onDelete,
+}: {
+  program: Program;
+  isSelected: boolean;
+  onClick: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const { t } = useTranslation();
+  const [showMenu, setShowMenu] = useState(false);
+  const lessons = program.lessons ?? [];
+  const contentCount = lessons.reduce(
+    (sum, l) => sum + (l.contents?.length ?? 0),
+    0,
+  );
+
+  return (
+    <div
+      className="relative rounded-2xl bg-white cursor-pointer transition-all hover:shadow-md"
+      style={{
+        border: isSelected
+          ? "2px solid #4CAF50"
+          : "1px solid #E5E7EB",
+      }}
+      onClick={onClick}
+    >
+      {/* Cover image + hover description overlay */}
+      <div className="h-[100px] w-full overflow-hidden rounded-t-2xl relative group/cover">
+        <img
+          src={getCoverImage(program.level)}
+          alt={program.name}
+          className="w-full h-full object-cover"
+        />
+        {program.description && (
+          <div className="absolute inset-0 bg-black/60 opacity-0 group-hover/cover:opacity-100 transition-opacity p-3 flex items-center">
+            <p className="text-white text-xs leading-relaxed line-clamp-4 whitespace-pre-line">
+              {program.description}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Info */}
+      <div className="relative px-4 py-3.5 h-[90px] flex flex-col gap-2">
+        <h3 className="text-[15px] font-semibold text-gray-800 line-clamp-2 leading-tight">
+          {program.name}
+        </h3>
+        <p className="text-xs text-gray-500">
+          {lessons.length} {t("programFolderView.units", "個單元")} ·{" "}
+          {contentCount} {t("programFolderView.contents", "內容")}
+        </p>
+
+        {/* Ellipsis menu trigger */}
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            setShowMenu(!showMenu);
+          }}
+          className="absolute right-3 bottom-3 p-1 opacity-70 hover:opacity-100 transition-opacity"
+        >
+          <Ellipsis size={18} className="text-gray-500" />
+        </button>
+
+        {showMenu && (
+          <DropdownMenu
+            onClose={() => setShowMenu(false)}
+            actions={[
+              {
+                label: t("common.edit", "編輯"),
+                icon: <Pencil size={13} />,
+                onClick: onEdit,
+              },
+              {
+                label: t("common.delete", "刪除"),
+                icon: <Trash2 size={13} />,
+                onClick: onDelete,
+                danger: true,
+              },
+            ]}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Lesson Card ── */
+function LessonCard({
+  lesson,
+  index,
+  isSelected,
+  onClick,
+  onEdit,
+  onDelete,
+}: {
+  lesson: Lesson;
+  index: number;
+  isSelected: boolean;
+  onClick: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const { t } = useTranslation();
+  const [showMenu, setShowMenu] = useState(false);
+  const contents = lesson.contents ?? [];
+
+  return (
+    <div
+      className="relative rounded-2xl bg-white cursor-pointer transition-all hover:shadow-md"
+      style={{
+        border: isSelected
+          ? "2px solid #7C3AED"
+          : "1px solid #E5E7EB",
+      }}
+      onClick={onClick}
+    >
+      {/* Description preview */}
+      <div className="h-[100px] px-3.5 py-3 overflow-hidden rounded-t-2xl bg-[#EEEAF5]">
+        <p className="text-xs text-gray-500 leading-relaxed line-clamp-4 whitespace-pre-line">
+          {lesson.description || t("programFolderView.noDescription", "尚無描述")}
+        </p>
+      </div>
+
+      {/* Info */}
+      <div className="relative px-4 py-3.5 h-[90px] flex flex-col gap-2">
+        <h3 className="text-[15px] font-semibold text-[#1E3A5F] line-clamp-2 leading-tight">
+          {lesson.name}
+        </h3>
+        <p className="text-xs text-gray-500">
+          {contents.length} {t("programFolderView.contents", "內容")}
+        </p>
+
+        {/* Ellipsis menu trigger */}
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            setShowMenu(!showMenu);
+          }}
+          className="absolute right-3 bottom-3 p-1 opacity-70 hover:opacity-100 transition-opacity"
+        >
+          <Ellipsis size={18} className="text-gray-500" />
+        </button>
+
+        {showMenu && (
+          <DropdownMenu
+            onClose={() => setShowMenu(false)}
+            actions={[
+              {
+                label: t("common.edit", "編輯"),
+                icon: <Pencil size={13} />,
+                onClick: onEdit,
+              },
+              {
+                label: t("common.delete", "刪除"),
+                icon: <Trash2 size={13} />,
+                onClick: onDelete,
+                danger: true,
+              },
+            ]}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Content Card ── */
+function ContentCard({
+  content,
+  onClick,
+  onEdit,
+  onDelete,
+  onCopy,
+  onInstantPractice,
+}: {
+  content: Content;
+  onClick: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+  onCopy?: () => void;
+  onInstantPractice?: () => void;
+}) {
+  const { t } = useTranslation();
+  const [showMenu, setShowMenu] = useState(false);
+  const items = content.items ?? [];
+  const badge = TYPE_BADGE[content.type ?? ""] ?? {
+    label: content.type ?? "其他",
+    bg: "#F3F4F6",
+    text: "#6B7280",
+  };
+
+  return (
+    <div
+      className="relative rounded-xl bg-white border border-gray-200 transition-all hover:shadow-md group"
+      onClick={onClick}
+    >
+      {/* Text preview */}
+      <div className="h-[160px] p-6 overflow-hidden rounded-t-xl relative">
+        {items.length > 0 ? (
+          <div className="space-y-1.5 text-[13px] w-full">
+            {items.slice(0, 5).map((item, i) => (
+              <p
+                key={i}
+                className={`break-words ${i >= 3 ? "text-gray-400" : i >= 2 ? "text-gray-500" : "text-gray-700"}`}
+              >
+                {item.text}
+                {item.translation && (
+                  <span className="ml-2 text-gray-400">
+                    {item.translation}
+                  </span>
+                )}
+              </p>
+            ))}
+          </div>
+        ) : (
+          <div className="text-gray-300">
+            <FileText size={32} />
+          </div>
+        )}
+        {items.length > 3 && (
+          <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent" />
+        )}
+
+        {/* Play button — centered in preview area */}
+        {onInstantPractice && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onInstantPractice();
+            }}
+            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-14 h-14 bg-amber-500/60 hover:bg-amber-500/85 rounded-full flex items-center justify-center shadow-lg transition-colors"
+          >
+            <Play size={24} className="text-white ml-0.5" />
+          </button>
+        )}
+      </div>
+
+      {/* Info */}
+      <div className="px-3.5 py-2.5 space-y-1.5">
+        {/* Type badge + count */}
+        <div className="flex items-center gap-2">
+          <span
+            className="text-[10px] font-medium px-2 py-0.5 rounded"
+            style={{ backgroundColor: badge.bg, color: badge.text }}
+          >
+            {badge.label}
+          </span>
+          <span className="text-[11px] text-gray-400">
+            {content.items_count ?? items.length}{" "}
+            {t("programFolderView.questions", "題")}
+          </span>
+        </div>
+
+        {/* Title + ellipsis */}
+        <div className="relative flex items-center gap-1">
+          <h3 className="text-sm font-semibold text-gray-800 truncate flex-1">
+            {content.title}
+          </h3>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              setShowMenu(!showMenu);
+            }}
+            className="text-gray-400 hover:text-gray-600 shrink-0"
+          >
+            <span className="text-sm font-bold">⋯</span>
+          </button>
+          {showMenu && (
+            <DropdownMenu
+              onClose={() => setShowMenu(false)}
+              actions={[
+                ...(onEdit
+                  ? [
+                      {
+                        label: t("common.edit", "編輯"),
+                        icon: <Pencil size={13} />,
+                        onClick: onEdit,
+                      },
+                    ]
+                  : []),
+                ...(onCopy
+                  ? [
+                      {
+                        label: t("common.copy", "複製"),
+                        icon: <Copy size={13} />,
+                        onClick: onCopy,
+                      },
+                    ]
+                  : []),
+                ...(onDelete
+                  ? [
+                      {
+                        label: t("common.delete", "刪除"),
+                        icon: <Trash2 size={13} />,
+                        onClick: onDelete,
+                        danger: true,
+                      },
+                    ]
+                  : []),
+              ]}
+            />
+          )}
+        </div>
+      </div>
+
+    </div>
+  );
+}
+
+/* ── Section Header ── */
+function SectionHeader({
+  icon,
+  title,
+  iconColor,
+  onAdd,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  iconColor?: string;
+  onAdd?: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex items-center gap-2">
+      <span style={{ color: iconColor ?? "#6B7280" }}>{icon}</span>
+      <span className="text-[13px] font-semibold text-gray-700">{title}</span>
+      <div className="flex-1 h-px bg-gray-200" />
+      {onAdd && (
+        <button
+          onClick={onAdd}
+          className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 transition-colors"
+        >
+          <Plus size={14} />
+          {t("common.add", "新增")}
+        </button>
+      )}
+    </div>
+  );
+}
+
+/* ── Expand Area (Lessons + Contents for selected program) ── */
+function ExpandArea({
+  program,
+  onEditLesson,
+  onDeleteLesson,
+  onCreateLesson,
+  onContentClick,
+  onDeleteContent,
+  onCopyContent,
+  onInstantPractice,
+  onCreateContent,
+}: {
+  program: Program;
+  onEditLesson: (programId: number, lessonId: number) => void;
+  onDeleteLesson: (programId: number, lessonId: number) => void;
+  onCreateLesson: (programId: number) => void;
+  onContentClick: (content: Content, lessonId: number) => void;
+  onDeleteContent: (lessonId: number, contentId: number, title: string) => void;
+  onCopyContent: (contentId: number, title: string) => void;
+  onInstantPractice: (content: Content) => void;
+  onCreateContent: (programId: number, lessonId: number) => void;
+}) {
+  const { t } = useTranslation();
+  const lessons = program.lessons ?? [];
+  const [selectedLessonId, setSelectedLessonId] = useState<number | null>(
+    lessons.length > 0 ? lessons[0].id : null,
+  );
+  const selectedLesson = lessons.find((l) => l.id === selectedLessonId);
+
+  // Contents to display: selected lesson's contents, or program-level contents
+  const displayContents = selectedLesson
+    ? selectedLesson.contents ?? []
+    : program.contents ?? [];
+  const contentsSectionTitle = selectedLesson
+    ? `${t("programFolderView.contentsSection", "內容")} — ${selectedLesson.name}`
+    : t("programFolderView.contentsSection", "內容");
+  // lessonId for callbacks: use selected lesson, or 0 for program-level
+  const contentsLessonId = selectedLesson?.id ?? 0;
+
+  return (
+    <div className="bg-white rounded-2xl p-5 space-y-4">
+      {/* Lessons section */}
+      {lessons.length > 0 && (
+        <>
+          <SectionHeader
+            icon={<Folder size={14} />}
+            title={t("programFolderView.lessonsSection", "單元")}
+            onAdd={() => onCreateLesson(program.id)}
+          />
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5">
+            {lessons.map((lesson, i) => (
+              <LessonCard
+                key={lesson.id}
+                lesson={lesson}
+                index={i}
+                isSelected={lesson.id === selectedLessonId}
+                onClick={() => setSelectedLessonId(lesson.id === selectedLessonId ? null : lesson.id)}
+                onEdit={() => onEditLesson(program.id, lesson.id)}
+                onDelete={() => onDeleteLesson(program.id, lesson.id)}
+              />
+            ))}
+          </div>
+        </>
+      )}
+
+      {lessons.length === 0 && (
+        <SectionHeader
+          icon={<Folder size={14} />}
+          title={t("programFolderView.lessonsSection", "單元")}
+          onAdd={() => onCreateLesson(program.id)}
+        />
+      )}
+
+      {/* Contents section — always visible */}
+      <SectionHeader
+        icon={<FileText size={14} />}
+        title={contentsSectionTitle}
+        iconColor="#059669"
+        // TODO: 當沒有選中 lesson 時，新增內容的 lessonId 傳 0，
+        // 後端工程師需決定 program-level content 的建立方式與儲存邏輯
+        onAdd={() =>
+          onCreateContent(program.id, selectedLesson?.id ?? 0)
+        }
+      />
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+        {displayContents.map((content) => (
+          <ContentCard
+            key={content.id}
+            content={content}
+            onClick={() => {/* 點擊卡片不開啟編輯器，透過三點選單操作 */}}
+            onEdit={() => onContentClick(content, contentsLessonId)}
+            onDelete={() =>
+              onDeleteContent(contentsLessonId, content.id, content.title)
+            }
+            onCopy={() => onCopyContent(content.id, content.title)}
+            onInstantPractice={() => onInstantPractice(content)}
+          />
+        ))}
+        {displayContents.length === 0 && (
+          <p className="text-sm text-gray-400 col-span-full text-center py-8">
+            {selectedLesson
+              ? t("programFolderView.noContents", "此單元尚無內容")
+              : t("programFolderView.noProgramContents", "此教材尚無內容")}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Main: ProgramFolderView ── */
+export interface ProgramFolderViewProps {
+  programs: Program[];
+  onEditProgram: (programId: number) => void;
+  onDeleteProgram: (programId: number) => void;
+  onEditLesson: (programId: number, lessonId: number) => void;
+  onDeleteLesson: (programId: number, lessonId: number) => void;
+  onCreateLesson: (programId: number) => void;
+  onContentClick: (content: Content, lessonId: number) => void;
+  onDeleteContent: (lessonId: number, contentId: number, title: string) => void;
+  onCopyContent: (contentId: number, title: string) => void;
+  onInstantPractice: (content: Content) => void;
+  onCreateContent: (programId: number, lessonId: number) => void;
+}
+
+export default function ProgramFolderView({
+  programs,
+  onEditProgram,
+  onDeleteProgram,
+  onEditLesson,
+  onDeleteLesson,
+  onCreateLesson,
+  onContentClick,
+  onDeleteContent,
+  onCopyContent,
+  onInstantPractice,
+  onCreateContent,
+}: ProgramFolderViewProps) {
+  const [selectedProgramId, setSelectedProgramId] = useState<number | null>(
+    null,
+  );
+  const selectedProgram = programs.find((p) => p.id === selectedProgramId);
+
+  // Find which row the selected program is in (4-column grid)
+  const selectedIndex = programs.findIndex((p) => p.id === selectedProgramId);
+
+  // Group programs into rows of 4
+  const rows: Program[][] = [];
+  for (let i = 0; i < programs.length; i += 4) {
+    rows.push(programs.slice(i, i + 4));
+  }
+  const selectedRowIndex =
+    selectedIndex >= 0 ? Math.floor(selectedIndex / 4) : -1;
+
+  // Calculate arrow position (which column in the row)
+  const selectedColIndex = selectedIndex >= 0 ? selectedIndex % 4 : -1;
+
+  return (
+    <div className="space-y-4">
+      {rows.map((row, rowIndex) => (
+        <div key={rowIndex}>
+          {/* Program cards row */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5">
+            {row.map((program) => (
+              <ProgramCard
+                key={program.id}
+                program={program}
+                isSelected={program.id === selectedProgramId}
+                onClick={() =>
+                  setSelectedProgramId(
+                    program.id === selectedProgramId ? null : program.id,
+                  )
+                }
+                onEdit={() => onEditProgram(program.id)}
+                onDelete={() => onDeleteProgram(program.id)}
+              />
+            ))}
+          </div>
+
+          {/* Expand area below the row containing the selected program */}
+          {selectedRowIndex === rowIndex && selectedProgram && (
+            <div className="relative mt-4">
+              {/* Arrow pointing to selected card */}
+              <div
+                className="absolute -top-2 z-10 hidden lg:block"
+                style={{
+                  left: `calc(${selectedColIndex * 25}% + ${selectedColIndex * 5}px + 12.5% - 12px)`,
+                }}
+              >
+                <div className="w-0 h-0 border-l-[12px] border-r-[12px] border-b-[12px] border-l-transparent border-r-transparent border-b-white" />
+              </div>
+
+              <ExpandArea
+                program={selectedProgram}
+                onEditLesson={onEditLesson}
+                onDeleteLesson={onDeleteLesson}
+                onCreateLesson={onCreateLesson}
+                onContentClick={onContentClick}
+                onDeleteContent={onDeleteContent}
+                onCopyContent={onCopyContent}
+                onInstantPractice={onInstantPractice}
+                onCreateContent={onCreateContent}
+              />
+            </div>
+          )}
+        </div>
+      ))}
+
+      {programs.length === 0 && (
+        <div className="text-center py-12 text-gray-400">
+          尚無教材
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/shared/ProgramFolderView.tsx
+++ b/frontend/src/components/shared/ProgramFolderView.tsx
@@ -142,7 +142,7 @@ function ProgramCard({
       className="relative rounded-2xl bg-white cursor-pointer transition-all hover:shadow-md"
       style={{
         border: isSelected
-          ? "2px solid #4CAF50"
+          ? "3px solid #4CAF50"
           : "1px solid #E5E7EB",
       }}
       onClick={onClick}
@@ -165,7 +165,7 @@ function ProgramCard({
 
       {/* Info */}
       <div className="relative px-4 pt-2.5 pb-3.5 h-[90px] flex flex-col gap-2">
-        <h3 className="text-[18px] font-semibold text-gray-800 line-clamp-2 leading-tight">
+        <h3 className="text-[17px] font-semibold text-gray-800 line-clamp-2 leading-tight">
           {program.name}
         </h3>
         <p className="text-xs text-gray-500">
@@ -230,7 +230,7 @@ function LessonCard({
       className="relative rounded-2xl bg-white cursor-pointer transition-all hover:shadow-md"
       style={{
         border: isSelected
-          ? "2px solid #7C3AED"
+          ? "3px solid #7C3AED"
           : "1px solid #E5E7EB",
       }}
       onClick={onClick}
@@ -244,7 +244,7 @@ function LessonCard({
 
       {/* Info */}
       <div className="relative px-4 pt-2.5 pb-3.5 h-[90px] flex flex-col gap-2">
-        <h3 className="text-[18px] font-semibold text-[#1E3A5F] line-clamp-2 leading-tight">
+        <h3 className="text-[17px] font-semibold text-[#1E3A5F] line-clamp-2 leading-tight">
           {lesson.name}
         </h3>
         <p className="text-xs text-gray-500">
@@ -394,7 +394,7 @@ function ContentCard({
       {/* Info */}
       <div className="relative px-3.5 pt-2.5 pb-2 space-y-1.5">
         {/* Title */}
-        <h3 className="text-[18px] font-semibold text-gray-800 truncate pr-6">
+        <h3 className="text-[17px] font-semibold text-gray-800 truncate pr-6">
           {content.title}
         </h3>
 
@@ -473,12 +473,12 @@ function SectionHeader({
   return (
     <div className="flex items-center gap-2">
       <span style={{ color: iconColor ?? "#6B7280" }}>{icon}</span>
-      <span className="text-[13px] font-semibold text-gray-700">{title}</span>
+      <span className="text-[15px] font-semibold text-gray-700">{title}</span>
       <div className="flex-1 h-px bg-gray-200" />
       {onAdd && (
         <button
           onClick={onAdd}
-          className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 transition-colors"
+          className="flex items-center gap-1 text-[14px] text-blue-600 hover:text-blue-700 border border-blue-200 rounded-lg px-2.5 py-1 hover:bg-blue-50 transition-colors"
         >
           <Plus size={14} />
           {addLabel ?? t("common.add", "新增")}
@@ -522,7 +522,7 @@ function ExpandArea({
     ? selectedLesson.contents ?? []
     : program.contents ?? [];
   const contentsSectionTitle = selectedLesson
-    ? `${t("programFolderView.contentsSection", "內容")} — ${selectedLesson.name}`
+    ? `${t("programFolderView.contentsSection", "內容")}: ${selectedLesson.name}`
     : t("programFolderView.contentsSection", "內容");
   // lessonId for callbacks: use selected lesson, or 0 for program-level
   const contentsLessonId = selectedLesson?.id ?? 0;
@@ -533,8 +533,8 @@ function ExpandArea({
       {lessons.length > 0 && (
         <>
           <SectionHeader
-            icon={<Folder size={14} />}
-            title={t("programFolderView.lessonsSection", "單元")}
+            icon={<Folder size={15} />}
+            title={`${t("programFolderView.lessonsSection", "單元")}: ${program.name}`}
             onAdd={() => onCreateLesson(program.id)}
             addLabel={t("programFolderView.addLesson", "新增單元")}
           />
@@ -555,17 +555,22 @@ function ExpandArea({
       )}
 
       {lessons.length === 0 && (
-        <SectionHeader
-          icon={<Folder size={14} />}
-          title={t("programFolderView.lessonsSection", "單元")}
-          onAdd={() => onCreateLesson(program.id)}
-          addLabel={t("programFolderView.addLesson", "新增單元")}
-        />
+        <>
+          <SectionHeader
+            icon={<Folder size={15} />}
+            title={`${t("programFolderView.lessonsSection", "單元")}: ${program.name}`}
+            onAdd={() => onCreateLesson(program.id)}
+            addLabel={t("programFolderView.addLesson", "新增單元")}
+          />
+          <p className="text-sm text-gray-400 text-center py-4">
+            {t("programFolderView.noLessons", "尚無單元")}
+          </p>
+        </>
       )}
 
       {/* Contents section — always visible */}
       <SectionHeader
-        icon={<FileText size={14} />}
+        icon={<FileText size={15} />}
         title={contentsSectionTitle}
         iconColor="#059669"
         // TODO: 當沒有選中 lesson 時，新增內容的 lessonId 傳 0，
@@ -686,7 +691,14 @@ export default function ProgramFolderView({
 
           {/* Expand area below the visual row containing the selected program */}
           {selectedRowIndex === rowIndex && selectedProgram && (
-            <div className="mt-4">
+            <div className="relative mt-4 animate-fade-up">
+              {/* Triangle pointer to selected program card */}
+              <div
+                className="absolute -top-3 w-0 h-0 border-l-[30px] border-l-transparent border-r-[30px] border-r-transparent border-b-[12px] border-b-white z-10"
+                style={{
+                  left: `calc((100% / ${columns}) * (${selectedIndex % columns} + 0.5) - 30px)`,
+                }}
+              />
               <ExpandArea
                 program={selectedProgram}
                 onEditLesson={onEditLesson}

--- a/frontend/src/components/shared/ProgramFolderView.tsx
+++ b/frontend/src/components/shared/ProgramFolderView.tsx
@@ -504,7 +504,7 @@ function ExpandArea({
   onContentClick: (content: Content, lessonId: number) => void;
   onDeleteContent: (lessonId: number, contentId: number, title: string) => void;
   onCopyContent: (contentId: number, title: string) => void;
-  onInstantPractice: (content: Content) => void;
+  onInstantPractice?: (content: Content) => void;
   onCreateContent: (programId: number, lessonId: number) => void;
 }) {
   const { t } = useTranslation();
@@ -590,7 +590,9 @@ function ExpandArea({
               onDeleteContent(contentsLessonId, content.id, content.title)
             }
             onCopy={() => onCopyContent(content.id, content.title)}
-            onInstantPractice={() => onInstantPractice(content)}
+            onInstantPractice={
+              onInstantPractice ? () => onInstantPractice(content) : undefined
+            }
           />
         ))}
         {displayContents.length === 0 && (
@@ -616,7 +618,7 @@ export interface ProgramFolderViewProps {
   onContentClick: (content: Content, lessonId: number) => void;
   onDeleteContent: (lessonId: number, contentId: number, title: string) => void;
   onCopyContent: (contentId: number, title: string) => void;
-  onInstantPractice: (content: Content) => void;
+  onInstantPractice?: (content: Content) => void;
   onCreateContent: (programId: number, lessonId: number) => void;
 }
 
@@ -633,6 +635,7 @@ export default function ProgramFolderView({
   onInstantPractice,
   onCreateContent,
 }: ProgramFolderViewProps) {
+  const { t } = useTranslation();
   const [selectedProgramId, setSelectedProgramId] = useState<number | null>(
     null,
   );
@@ -715,7 +718,9 @@ export default function ProgramFolderView({
       ))}
 
       {programs.length === 0 && (
-        <div className="text-center py-12 text-gray-400">尚無教材</div>
+        <div className="text-center py-12 text-gray-400">
+          {t("programFolderView.noPrograms", "尚無教材")}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/shared/ProgramFolderView.tsx
+++ b/frontend/src/components/shared/ProgramFolderView.tsx
@@ -11,7 +11,7 @@
  * - Content 卡片（文字預覽 + type badge + title + play 按鈕）
  */
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Folder,
@@ -201,14 +201,12 @@ function ProgramCard({
 /* ── Lesson Card ── */
 function LessonCard({
   lesson,
-  index,
   isSelected,
   onClick,
   onEdit,
   onDelete,
 }: {
   lesson: Lesson;
-  index: number;
   isSelected: boolean;
   onClick: () => void;
   onEdit: () => void;
@@ -502,12 +500,11 @@ function ExpandArea({
             onAdd={() => onCreateLesson(program.id)}
           />
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5">
-            {lessons.map((lesson, i) => (
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-5">
+            {lessons.map((lesson) => (
               <LessonCard
                 key={lesson.id}
                 lesson={lesson}
-                index={i}
                 isSelected={lesson.id === selectedLessonId}
                 onClick={() => setSelectedLessonId(lesson.id === selectedLessonId ? null : lesson.id)}
                 onEdit={() => onEditLesson(program.id, lesson.id)}
@@ -597,26 +594,40 @@ export default function ProgramFolderView({
   );
   const selectedProgram = programs.find((p) => p.id === selectedProgramId);
 
-  // Find which row the selected program is in (4-column grid)
-  const selectedIndex = programs.findIndex((p) => p.id === selectedProgramId);
+  // Detect actual number of grid columns based on container width
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [columns, setColumns] = useState(4);
 
-  // Group programs into rows of 4
+  const updateColumns = useCallback(() => {
+    const w = containerRef.current?.offsetWidth ?? 1024;
+    // Match auto-fill with minmax(240px, 1fr): calculate how many 240px cards fit
+    const gap = 20; // gap-5 = 20px
+    const cols = Math.max(1, Math.floor((w + gap) / (240 + gap)));
+    setColumns(cols);
+  }, []);
+
+  useEffect(() => {
+    updateColumns();
+    const observer = new ResizeObserver(updateColumns);
+    if (containerRef.current) observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [updateColumns]);
+
+  // Group programs into rows based on actual column count
   const rows: Program[][] = [];
-  for (let i = 0; i < programs.length; i += 4) {
-    rows.push(programs.slice(i, i + 4));
+  for (let i = 0; i < programs.length; i += columns) {
+    rows.push(programs.slice(i, i + columns));
   }
-  const selectedRowIndex =
-    selectedIndex >= 0 ? Math.floor(selectedIndex / 4) : -1;
 
-  // Calculate arrow position (which column in the row)
-  const selectedColIndex = selectedIndex >= 0 ? selectedIndex % 4 : -1;
+  const selectedIndex = programs.findIndex((p) => p.id === selectedProgramId);
+  const selectedRowIndex =
+    selectedIndex >= 0 ? Math.floor(selectedIndex / columns) : -1;
 
   return (
-    <div className="space-y-4">
+    <div ref={containerRef} className="space-y-5">
       {rows.map((row, rowIndex) => (
         <div key={rowIndex}>
-          {/* Program cards row */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-5">
             {row.map((program) => (
               <ProgramCard
                 key={program.id}
@@ -633,19 +644,9 @@ export default function ProgramFolderView({
             ))}
           </div>
 
-          {/* Expand area below the row containing the selected program */}
+          {/* Expand area below the visual row containing the selected program */}
           {selectedRowIndex === rowIndex && selectedProgram && (
-            <div className="relative mt-4">
-              {/* Arrow pointing to selected card */}
-              <div
-                className="absolute -top-2 z-10 hidden lg:block"
-                style={{
-                  left: `calc(${selectedColIndex * 25}% + ${selectedColIndex * 5}px + 12.5% - 12px)`,
-                }}
-              >
-                <div className="w-0 h-0 border-l-[12px] border-r-[12px] border-b-[12px] border-l-transparent border-r-transparent border-b-white" />
-              </div>
-
+            <div className="mt-4">
               <ExpandArea
                 program={selectedProgram}
                 onEditLesson={onEditLesson}

--- a/frontend/src/components/shared/ProgramFolderView.tsx
+++ b/frontend/src/components/shared/ProgramFolderView.tsx
@@ -152,7 +152,7 @@ function ProgramCard({
         <img
           src={getCoverImage(program.level)}
           alt={program.name}
-          className="w-full h-full object-cover"
+          className="w-full h-full object-cover object-bottom"
         />
         {program.description && (
           <div className="absolute inset-0 bg-black/60 opacity-0 group-hover/cover:opacity-100 transition-opacity p-3 flex items-center">
@@ -164,8 +164,8 @@ function ProgramCard({
       </div>
 
       {/* Info */}
-      <div className="relative px-4 py-3.5 h-[90px] flex flex-col gap-2">
-        <h3 className="text-[15px] font-semibold text-gray-800 line-clamp-2 leading-tight">
+      <div className="relative px-4 pt-2.5 pb-3.5 h-[90px] flex flex-col gap-2">
+        <h3 className="text-[18px] font-semibold text-gray-800 line-clamp-2 leading-tight">
           {program.name}
         </h3>
         <p className="text-xs text-gray-500">
@@ -243,8 +243,8 @@ function LessonCard({
       </div>
 
       {/* Info */}
-      <div className="relative px-4 py-3.5 h-[90px] flex flex-col gap-2">
-        <h3 className="text-[15px] font-semibold text-[#1E3A5F] line-clamp-2 leading-tight">
+      <div className="relative px-4 pt-2.5 pb-3.5 h-[90px] flex flex-col gap-2">
+        <h3 className="text-[18px] font-semibold text-[#1E3A5F] line-clamp-2 leading-tight">
           {lesson.name}
         </h3>
         <p className="text-xs text-gray-500">
@@ -314,7 +314,14 @@ function ContentCard({
       onClick={onClick}
     >
       {/* Preview: image + text or text only */}
-      <div className="h-[160px] p-6 overflow-hidden rounded-t-xl relative select-none">
+      <div className="h-[160px] pt-10 px-6 pb-6 overflow-hidden rounded-t-xl relative select-none">
+        {/* Type badge */}
+        <span
+          className="absolute top-2 left-2 z-10 text-[12px] font-medium px-2.5 py-1 rounded"
+          style={{ backgroundColor: badge.bg, color: badge.text }}
+        >
+          {badge.label}
+        </span>
         {items.length > 0 ? (
           <div className="flex gap-3 h-full">
             {/* First item image (if exists) */}
@@ -385,70 +392,63 @@ function ContentCard({
       </div>
 
       {/* Info */}
-      <div className="px-3.5 py-2.5 space-y-1.5">
-        {/* Type badge + count */}
-        <div className="flex items-center gap-2">
-          <span
-            className="text-[10px] font-medium px-2 py-0.5 rounded"
-            style={{ backgroundColor: badge.bg, color: badge.text }}
-          >
-            {badge.label}
-          </span>
-          <span className="text-[11px] text-gray-400">
-            {content.items_count ?? items.length}{" "}
-            {t("programFolderView.questions", "題")}
-          </span>
-        </div>
+      <div className="relative px-3.5 pt-2.5 pb-2 space-y-1.5">
+        {/* Title */}
+        <h3 className="text-[18px] font-semibold text-gray-800 truncate pr-6">
+          {content.title}
+        </h3>
 
-        {/* Title + ellipsis */}
-        <div className="relative flex items-center gap-1">
-          <h3 className="text-sm font-semibold text-gray-800 truncate flex-1">
-            {content.title}
-          </h3>
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              setShowMenu(!showMenu);
-            }}
-            className="text-gray-400 hover:text-gray-600 shrink-0"
-          >
-            <span className="text-sm font-bold">⋯</span>
-          </button>
-          {showMenu && (
-            <DropdownMenu
-              onClose={() => setShowMenu(false)}
-              actions={[
-                ...(onCopy
-                  ? [
-                      {
-                        label: t("common.copy", "複製"),
-                        icon: <Copy size={13} />,
-                        onClick: onCopy,
-                      },
-                    ]
-                  : []),
-                {
-                  label: t("common.move", "移動"),
-                  icon: <ArrowRightLeft size={13} />,
-                  onClick: () => {
-                    // TODO: 等工程師實作移動功能
-                  },
-                  disabled: true,
+        {/* Count */}
+        <span className="text-[11px] text-gray-400">
+          {content.items_count ?? items.length}{" "}
+          {t("programFolderView.questions", "題")}
+        </span>
+
+        {/* Ellipsis menu trigger */}
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            setShowMenu(!showMenu);
+          }}
+          className="absolute right-3 bottom-3 p-1 opacity-70 hover:opacity-100 transition-opacity"
+        >
+          <Ellipsis size={18} className="text-gray-500" />
+        </button>
+
+        {showMenu && (
+          <DropdownMenu
+            onClose={() => setShowMenu(false)}
+            actions={[
+              ...(onCopy
+                ? [
+                    {
+                      label: t("common.copy", "複製"),
+                      icon: <Copy size={13} />,
+                      onClick: onCopy,
+                    },
+                  ]
+                : []),
+              {
+                label: t("common.move", "移動"),
+                icon: <ArrowRightLeft size={13} />,
+                onClick: () => {
+                  // TODO: 等工程師實作移動功能
                 },
-                ...(onDelete
-                  ? [
-                      {
-                        label: t("common.delete", "刪除"),
-                        icon: <Trash2 size={13} />,
-                        onClick: onDelete,
-                        danger: true,
-                      },
-                    ]
-                  : []),
-              ]}
-            />
-          )}
-        </div>
+                disabled: true,
+              },
+              ...(onDelete
+                ? [
+                    {
+                      label: t("common.delete", "刪除"),
+                      icon: <Trash2 size={13} />,
+                      onClick: onDelete,
+                      danger: true,
+                    },
+                  ]
+                : []),
+            ]}
+          />
+        )}
       </div>
 
     </div>

--- a/frontend/src/components/shared/RecursiveTreeAccordion.tsx
+++ b/frontend/src/components/shared/RecursiveTreeAccordion.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
+  ArrowRightLeft,
   Copy,
   Edit,
   Trash2,
@@ -342,7 +343,7 @@ function RecursiveTreeNode({
                               title={disableActions ? disableReason : ""}
                             >
                               <Edit className="h-4 w-4 mr-2" />
-                              編輯
+                              {t("common.edit")}
                             </DropdownMenuItem>
                           )}
                           {config.canDelete && onDelete && (
@@ -357,7 +358,7 @@ function RecursiveTreeNode({
                               title={disableActions ? disableReason : ""}
                             >
                               <Trash2 className="h-4 w-4 mr-2" />
-                              刪除
+                              {t("common.delete")}
                             </DropdownMenuItem>
                           )}
                         </DropdownMenuContent>
@@ -564,31 +565,14 @@ function RecursiveTreeNode({
                 </span>
               ))}
 
-              {/* Copy button - hover on desktop, always visible on mobile (icon only) */}
-              {onCopy && (
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onCopy(data, level, parentId);
-                  }}
-                  className="opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity h-7 w-7 sm:h-auto sm:w-auto sm:px-2.5 sm:py-1 inline-flex items-center justify-center sm:gap-1.5 rounded-md bg-blue-50 hover:bg-blue-100 dark:bg-blue-950/30 dark:hover:bg-blue-900/40 text-blue-600 dark:text-blue-400 border border-blue-200 dark:border-blue-800"
-                  title={t("contentCopy.button")}
-                >
-                  <Copy className="h-3.5 w-3.5 sm:h-3.5 sm:w-3.5" />
-                  <span className="hidden sm:inline text-xs font-medium">
-                    {t("contentCopy.button")}
-                  </span>
-                </button>
-              )}
-
-              {/* Instant practice button - hover on desktop, always visible on mobile (icon only) */}
+              {/* Instant practice button - always visible */}
               {onInstantPractice && (
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
                     onInstantPractice(data, level, parentId);
                   }}
-                  className="opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity h-7 w-7 sm:h-auto sm:w-auto sm:px-2.5 sm:py-1 inline-flex items-center justify-center sm:gap-1.5 rounded-md bg-amber-50 hover:bg-amber-100 dark:bg-amber-950/30 dark:hover:bg-amber-900/40 text-amber-600 dark:text-amber-400 border border-amber-200 dark:border-amber-800"
+                  className="h-7 w-7 sm:h-auto sm:w-auto sm:px-2.5 sm:py-1 inline-flex items-center justify-center sm:gap-1.5 rounded-md bg-amber-50 hover:bg-amber-100 dark:bg-amber-950/30 dark:hover:bg-amber-900/40 text-amber-600 dark:text-amber-400 border border-amber-200 dark:border-amber-800"
                   title={t("instantPractice.title")}
                 >
                   <Zap className="h-3.5 w-3.5 sm:h-3.5 sm:w-3.5 fill-current" />
@@ -598,8 +582,8 @@ function RecursiveTreeNode({
                 </button>
               )}
 
-              {/* More menu (⋯) with delete */}
-              {config.canDelete && onDelete && (
+              {/* More menu (⋯) with copy, move, delete */}
+              {(config.canDelete || onCopy) && (
                 <DropdownMenu>
                   <DropdownMenuTrigger
                     onClick={(e) => e.stopPropagation()}
@@ -611,16 +595,37 @@ function RecursiveTreeNode({
                     align="end"
                     className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700"
                   >
+                    {onCopy && (
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onCopy(data, level, parentId);
+                        }}
+                        className="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700"
+                      >
+                        <Copy className="h-4 w-4 mr-2" />
+                        {t("contentCopy.button")}
+                      </DropdownMenuItem>
+                    )}
                     <DropdownMenuItem
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onDelete(data, level, parentId);
-                      }}
-                      className="cursor-pointer text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30 focus:text-red-600"
+                      disabled
+                      className="cursor-not-allowed text-gray-300"
                     >
-                      <Trash2 className="h-4 w-4 mr-2" />
-                      刪除
+                      <ArrowRightLeft className="h-4 w-4 mr-2" />
+                      {t("common.move", "移動")}
                     </DropdownMenuItem>
+                    {config.canDelete && onDelete && (
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDelete(data, level, parentId);
+                        }}
+                        className="cursor-pointer text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30 focus:text-red-600"
+                      >
+                        <Trash2 className="h-4 w-4 mr-2" />
+                        {t("common.delete")}
+                      </DropdownMenuItem>
+                    )}
                   </DropdownMenuContent>
                 </DropdownMenu>
               )}

--- a/frontend/src/components/shared/ResourceFolderView.tsx
+++ b/frontend/src/components/shared/ResourceFolderView.tsx
@@ -185,22 +185,38 @@ function ContentPreviewCard({
                 draggable={false}
               />
             )}
-            <div className="space-y-1 text-[13px] flex-1 min-w-0">
-              {items.slice(0, items[0].image_url ? 4 : 5).map((item, i) => (
-                <div
-                  key={i}
-                  className={`break-words leading-tight ${i >= 3 ? "text-gray-400" : i >= 2 ? "text-gray-500" : "text-gray-700"}`}
-                >
-                  <span>{item.text}</span>
-                  {item.translation && (
-                    <>
-                      <span className="mx-1 text-gray-300">·</span>
-                      <span className="text-gray-400">{item.translation}</span>
-                    </>
-                  )}
-                </div>
-              ))}
-            </div>
+            {items[0].image_url ? (
+              <div className="space-y-0.5 text-[12px] flex-1 min-w-0">
+                {items.slice(0, 4).map((item, i) => (
+                  <div
+                    key={item.id ?? i}
+                    className={`truncate leading-tight ${i >= 3 ? "text-gray-400" : i >= 2 ? "text-gray-500" : "text-gray-700"}`}
+                  >
+                    {item.text}
+                    {item.translation && (
+                      <span className="text-gray-400"> {item.translation}</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="space-y-1 text-[13px] flex-1 min-w-0">
+                {items.slice(0, 5).map((item, i) => (
+                  <div
+                    key={item.id ?? i}
+                    className={`break-words leading-tight ${i >= 3 ? "text-gray-400" : i >= 2 ? "text-gray-500" : "text-gray-700"}`}
+                  >
+                    <span>{item.text}</span>
+                    {item.translation && (
+                      <>
+                        <span className="mx-1 text-gray-300">·</span>
+                        <span className="text-gray-400">{item.translation}</span>
+                      </>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         ) : (
           <div className="flex items-center justify-center h-full text-gray-300">
@@ -401,6 +417,7 @@ export default function ResourceFolderView({
   selectedId,
   pageSize = 12,
 }: ResourceFolderViewProps) {
+  const { t } = useTranslation();
   const [page, setPage] = useState(0);
 
   // Reset page when materials change
@@ -445,7 +462,7 @@ export default function ResourceFolderView({
   return (
     <div ref={containerRef} className="space-y-5">
       {rows.map((row, rowIndex) => (
-        <div key={rowIndex}>
+        <div key={row[0]?.id ?? rowIndex}>
           <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-5">
             {row.map((material) => (
               <ResourceProgramCard
@@ -478,7 +495,7 @@ export default function ResourceFolderView({
       ))}
 
       {materials.length === 0 && (
-        <div className="text-center py-12 text-gray-400">尚無公版教材</div>
+        <div className="text-center py-12 text-gray-400">{t("resourceFolderView.empty", "尚無公版教材")}</div>
       )}
 
       <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />

--- a/frontend/src/components/shared/ResourceFolderView.tsx
+++ b/frontend/src/components/shared/ResourceFolderView.tsx
@@ -97,10 +97,8 @@ function ResourceProgramCard({
           {material.name}
         </h3>
         <p className="text-xs text-gray-500">
-          {material.lesson_count}{" "}
-          {t("programFolderView.units", "個單元")} ·{" "}
-          {material.content_count}{" "}
-          {t("programFolderView.contents", "內容")}
+          {material.lesson_count} {t("programFolderView.units", "個單元")} ·{" "}
+          {material.content_count} {t("programFolderView.contents", "內容")}
         </p>
 
         {/* Copy button */}
@@ -236,7 +234,9 @@ function ExpandArea({
 }: {
   detail: ResourceMaterialDetail | null;
   loadingDetail: boolean;
-  onContentClick?: (content: ResourceMaterialDetail["lessons"][0]["contents"][0]) => void;
+  onContentClick?: (
+    content: ResourceMaterialDetail["lessons"][0]["contents"][0],
+  ) => void;
 }) {
   const { t } = useTranslation();
   const [selectedLessonId, setSelectedLessonId] = useState<number | null>(null);
@@ -292,7 +292,8 @@ function ExpandArea({
               >
                 <div className="h-[100px] px-3.5 py-3 overflow-hidden rounded-t-2xl bg-[#EEEAF5]">
                   <p className="text-xs text-gray-500 leading-relaxed line-clamp-4 whitespace-pre-line">
-                    {lesson.description || t("programFolderView.noDescription", "尚無描述")}
+                    {lesson.description ||
+                      t("programFolderView.noDescription", "尚無描述")}
                   </p>
                 </div>
                 <div className="px-4 pt-2.5 pb-3.5 h-[90px] flex flex-col gap-2">
@@ -376,7 +377,8 @@ function Pagination({
 }
 
 /* ── Main: ResourceFolderView ── */
-export type ResourceContentItem = ResourceMaterialDetail["lessons"][0]["contents"][0];
+export type ResourceContentItem =
+  ResourceMaterialDetail["lessons"][0]["contents"][0];
 
 export interface ResourceFolderViewProps {
   materials: ResourceMaterial[];
@@ -476,9 +478,7 @@ export default function ResourceFolderView({
       ))}
 
       {materials.length === 0 && (
-        <div className="text-center py-12 text-gray-400">
-          尚無公版教材
-        </div>
+        <div className="text-center py-12 text-gray-400">尚無公版教材</div>
       )}
 
       <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />

--- a/frontend/src/components/shared/ResourceFolderView.tsx
+++ b/frontend/src/components/shared/ResourceFolderView.tsx
@@ -71,7 +71,7 @@ function ResourceProgramCard({
     <div
       className="relative rounded-2xl bg-white cursor-pointer transition-all hover:shadow-md"
       style={{
-        border: isSelected ? "2px solid #4CAF50" : "1px solid #E5E7EB",
+        border: isSelected ? "3px solid #4CAF50" : "1px solid #E5E7EB",
       }}
       onClick={onClick}
     >
@@ -80,7 +80,7 @@ function ResourceProgramCard({
         <img
           src={getCoverImage(material.level)}
           alt={material.name}
-          className="w-full h-full object-cover"
+          className="w-full h-full object-cover object-bottom"
         />
         {material.description && (
           <div className="absolute inset-0 bg-black/60 opacity-0 group-hover/cover:opacity-100 transition-opacity p-3 flex items-center">
@@ -92,8 +92,8 @@ function ResourceProgramCard({
       </div>
 
       {/* Info */}
-      <div className="relative px-4 py-3.5 h-[90px] flex flex-col gap-2">
-        <h3 className="text-[15px] font-semibold text-gray-800 line-clamp-2 leading-tight">
+      <div className="relative px-4 pt-2.5 pb-3.5 h-[90px] flex flex-col gap-2">
+        <h3 className="text-[17px] font-semibold text-gray-800 line-clamp-2 leading-tight">
           {material.name}
         </h3>
         <p className="text-xs text-gray-500">
@@ -141,7 +141,7 @@ function SectionHeader({
   return (
     <div className="flex items-center gap-2">
       <span style={{ color: iconColor ?? "#6B7280" }}>{icon}</span>
-      <span className="text-[13px] font-semibold text-gray-700">{title}</span>
+      <span className="text-[15px] font-semibold text-gray-700">{title}</span>
       <div className="flex-1 h-px bg-gray-200" />
     </div>
   );
@@ -169,14 +169,21 @@ function ContentPreviewCard({
       onClick={onClick}
     >
       {/* Preview: image + text or text only */}
-      <div className="h-[160px] p-6 overflow-hidden rounded-t-xl relative">
+      <div className="h-[160px] pt-10 px-6 pb-6 overflow-hidden rounded-t-xl relative select-none">
+        {/* Type badge */}
+        <span
+          className="absolute top-2 left-2 z-10 text-[12px] font-medium px-2.5 py-1 rounded"
+          style={{ backgroundColor: badge.bg, color: badge.text }}
+        >
+          {badge.label}
+        </span>
         {items.length > 0 ? (
           <div className="flex gap-3 h-full">
             {items[0].image_url && (
               <img
                 src={items[0].image_url}
                 alt={items[0].text}
-                className="w-20 h-20 object-cover rounded-lg shrink-0"
+                className="w-20 h-20 object-cover rounded-lg shrink-0 opacity-60"
                 draggable={false}
               />
             )}
@@ -208,22 +215,14 @@ function ContentPreviewCard({
       </div>
 
       {/* Info */}
-      <div className="px-3.5 py-2.5 space-y-1.5">
-        <div className="flex items-center gap-2">
-          <span
-            className="text-[10px] font-medium px-2 py-0.5 rounded"
-            style={{ backgroundColor: badge.bg, color: badge.text }}
-          >
-            {badge.label}
-          </span>
-          <span className="text-[11px] text-gray-400">
-            {content.item_count ?? items.length}{" "}
-            {t("programFolderView.questions", "題")}
-          </span>
-        </div>
-        <h3 className="text-sm font-semibold text-gray-800 truncate">
+      <div className="px-3.5 pt-2.5 pb-2 space-y-1.5">
+        <h3 className="text-[17px] font-semibold text-gray-800 truncate">
           {content.title}
         </h3>
+        <span className="text-[11px] text-gray-400">
+          {content.item_count ?? items.length}{" "}
+          {t("programFolderView.questions", "題")}
+        </span>
       </div>
     </div>
   );
@@ -271,8 +270,8 @@ function ExpandArea({
       {lessons.length > 0 && (
         <>
           <SectionHeader
-            icon={<Folder size={14} />}
-            title={t("programFolderView.lessonsSection", "單元")}
+            icon={<Folder size={15} />}
+            title={`${t("programFolderView.lessonsSection", "單元")}: ${detail.name}`}
           />
           <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-5">
             {lessons.map((lesson) => (
@@ -282,7 +281,7 @@ function ExpandArea({
                 style={{
                   border:
                     lesson.id === selectedLessonId
-                      ? "2px solid #7C3AED"
+                      ? "3px solid #7C3AED"
                       : "1px solid #E5E7EB",
                 }}
                 onClick={() =>
@@ -296,8 +295,8 @@ function ExpandArea({
                     {lesson.description || t("programFolderView.noDescription", "尚無描述")}
                   </p>
                 </div>
-                <div className="px-4 py-3.5 h-[90px] flex flex-col gap-2">
-                  <h3 className="text-[15px] font-semibold text-[#1E3A5F] line-clamp-2 leading-tight">
+                <div className="px-4 pt-2.5 pb-3.5 h-[90px] flex flex-col gap-2">
+                  <h3 className="text-[17px] font-semibold text-[#1E3A5F] line-clamp-2 leading-tight">
                     {lesson.name}
                   </h3>
                   <p className="text-xs text-gray-500">
@@ -313,10 +312,10 @@ function ExpandArea({
 
       {/* Contents section */}
       <SectionHeader
-        icon={<FileText size={14} />}
+        icon={<FileText size={15} />}
         title={
           selectedLesson
-            ? `${t("programFolderView.contentsSection", "內容")} — ${selectedLesson.name}`
+            ? `${t("programFolderView.contentsSection", "內容")}: ${selectedLesson.name}`
             : t("programFolderView.contentsSection", "內容")
         }
         iconColor="#059669"
@@ -458,7 +457,14 @@ export default function ResourceFolderView({
           </div>
 
           {selectedRowIndex === rowIndex && (
-            <div className="mt-4">
+            <div className="relative mt-4 animate-fade-up">
+              {/* Triangle pointer to selected program card */}
+              <div
+                className="absolute -top-3 w-0 h-0 border-l-[30px] border-l-transparent border-r-[30px] border-r-transparent border-b-[12px] border-b-white z-10"
+                style={{
+                  left: `calc((100% / ${columns}) * (${selectedIndex % columns} + 0.5) - 30px)`,
+                }}
+              />
               <ExpandArea
                 detail={selectedDetail}
                 loadingDetail={loadingDetail}

--- a/frontend/src/components/shared/ResourceFolderView.tsx
+++ b/frontend/src/components/shared/ResourceFolderView.tsx
@@ -210,7 +210,9 @@ function ContentPreviewCard({
                     {item.translation && (
                       <>
                         <span className="mx-1 text-gray-300">·</span>
-                        <span className="text-gray-400">{item.translation}</span>
+                        <span className="text-gray-400">
+                          {item.translation}
+                        </span>
                       </>
                     )}
                   </div>
@@ -495,7 +497,9 @@ export default function ResourceFolderView({
       ))}
 
       {materials.length === 0 && (
-        <div className="text-center py-12 text-gray-400">{t("resourceFolderView.empty", "尚無公版教材")}</div>
+        <div className="text-center py-12 text-gray-400">
+          {t("resourceFolderView.empty", "尚無公版教材")}
+        </div>
       )}
 
       <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />

--- a/frontend/src/components/shared/ResourceFolderView.tsx
+++ b/frontend/src/components/shared/ResourceFolderView.tsx
@@ -1,0 +1,481 @@
+/**
+ * ResourceFolderView - 公版教材資料夾式顯示（唯讀 + 複製）
+ *
+ * 與 ProgramFolderView 類似的卡片樣式，但：
+ * - 唯讀：無編輯/刪除/排序
+ * - 無即時練習
+ * - 課程卡上有複製按鈕
+ * - 點擊卡片 fetch detail 後展開顯示 lessons/contents
+ * - 分頁（預設 12 個/頁）
+ */
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Copy,
+  Folder,
+  FileText,
+  ChevronLeft,
+  ChevronRight,
+  Loader2,
+} from "lucide-react";
+import type {
+  ResourceMaterial,
+  ResourceMaterialDetail,
+} from "@/hooks/useResourceMaterialsAPI";
+
+/* ── Cover image mapping by level ── */
+const LEVEL_COVERS: Record<string, string> = {
+  A1: "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/A1.png",
+  A2: "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/A2.png",
+  B1: "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/B1.png",
+  B2: "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/B2.png",
+  C1: "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/C1.png",
+  C2: "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/C2.png",
+};
+const DEFAULT_COVER =
+  "https://storage.googleapis.com/duotopia-social-media-videos/website/level-images/A1.png";
+
+function getCoverImage(level?: string | null): string {
+  if (!level) return DEFAULT_COVER;
+  return LEVEL_COVERS[level.toUpperCase()] ?? DEFAULT_COVER;
+}
+
+/* ── Content type badge config ── */
+const TYPE_BADGE: Record<string, { label: string; bg: string; text: string }> =
+  {
+    example_sentences: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
+    EXAMPLE_SENTENCES: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
+    reading_assessment: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
+    vocabulary_set: { label: "單字集", bg: "#FFFBEB", text: "#D97706" },
+    VOCABULARY_SET: { label: "單字集", bg: "#FFFBEB", text: "#D97706" },
+    sentence_making: { label: "造句", bg: "#F5F3FF", text: "#7C3AED" },
+    SENTENCE_MAKING: { label: "造句", bg: "#F5F3FF", text: "#7C3AED" },
+  };
+
+/* ── Resource Program Card ── */
+function ResourceProgramCard({
+  material,
+  isSelected,
+  onClick,
+  onCopy,
+}: {
+  material: ResourceMaterial;
+  isSelected: boolean;
+  onClick: () => void;
+  onCopy: () => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className="relative rounded-2xl bg-white cursor-pointer transition-all hover:shadow-md"
+      style={{
+        border: isSelected ? "2px solid #4CAF50" : "1px solid #E5E7EB",
+      }}
+      onClick={onClick}
+    >
+      {/* Cover image + hover description */}
+      <div className="h-[100px] w-full overflow-hidden rounded-t-2xl relative group/cover">
+        <img
+          src={getCoverImage(material.level)}
+          alt={material.name}
+          className="w-full h-full object-cover"
+        />
+        {material.description && (
+          <div className="absolute inset-0 bg-black/60 opacity-0 group-hover/cover:opacity-100 transition-opacity p-3 flex items-center">
+            <p className="text-white text-xs leading-relaxed line-clamp-4 whitespace-pre-line">
+              {material.description}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Info */}
+      <div className="relative px-4 py-3.5 h-[90px] flex flex-col gap-2">
+        <h3 className="text-[15px] font-semibold text-gray-800 line-clamp-2 leading-tight">
+          {material.name}
+        </h3>
+        <p className="text-xs text-gray-500">
+          {material.lesson_count}{" "}
+          {t("programFolderView.units", "個單元")} ·{" "}
+          {material.content_count}{" "}
+          {t("programFolderView.contents", "內容")}
+        </p>
+
+        {/* Copy button */}
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onCopy();
+          }}
+          disabled={material.copied_today}
+          className={`absolute right-3 bottom-3 p-1.5 rounded-lg transition-colors ${
+            material.copied_today
+              ? "text-gray-300 cursor-not-allowed"
+              : "text-gray-500 hover:text-blue-600 hover:bg-blue-50"
+          }`}
+          title={
+            material.copied_today
+              ? t("resourceMaterials.card.copiedToday", "今日已複製")
+              : t("resourceMaterials.card.copyToMy", "複製到我的教材")
+          }
+        >
+          <Copy size={18} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ── Section Header ── */
+function SectionHeader({
+  icon,
+  title,
+  iconColor,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  iconColor?: string;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span style={{ color: iconColor ?? "#6B7280" }}>{icon}</span>
+      <span className="text-[13px] font-semibold text-gray-700">{title}</span>
+      <div className="flex-1 h-px bg-gray-200" />
+    </div>
+  );
+}
+
+/* ── Content Preview Card (read-only) ── */
+function ContentPreviewCard({
+  content,
+  onClick,
+}: {
+  content: ResourceMaterialDetail["lessons"][0]["contents"][0];
+  onClick?: () => void;
+}) {
+  const { t } = useTranslation();
+  const items = content.items ?? [];
+  const badge = TYPE_BADGE[content.type ?? ""] ?? {
+    label: content.type ?? "其他",
+    bg: "#F3F4F6",
+    text: "#6B7280",
+  };
+
+  return (
+    <div
+      className="rounded-xl bg-white border border-gray-200 transition-all hover:shadow-md cursor-pointer"
+      onClick={onClick}
+    >
+      {/* Preview: image + text or text only */}
+      <div className="h-[160px] p-6 overflow-hidden rounded-t-xl relative">
+        {items.length > 0 ? (
+          <div className="flex gap-3 h-full">
+            {items[0].image_url && (
+              <img
+                src={items[0].image_url}
+                alt={items[0].text}
+                className="w-20 h-20 object-cover rounded-lg shrink-0"
+                draggable={false}
+              />
+            )}
+            <div className="space-y-1 text-[13px] flex-1 min-w-0">
+              {items.slice(0, items[0].image_url ? 4 : 5).map((item, i) => (
+                <div
+                  key={i}
+                  className={`break-words leading-tight ${i >= 3 ? "text-gray-400" : i >= 2 ? "text-gray-500" : "text-gray-700"}`}
+                >
+                  <span>{item.text}</span>
+                  {item.translation && (
+                    <>
+                      <span className="mx-1 text-gray-300">·</span>
+                      <span className="text-gray-400">{item.translation}</span>
+                    </>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center justify-center h-full text-gray-300">
+            <FileText size={32} />
+          </div>
+        )}
+        {items.length > 3 && (
+          <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent" />
+        )}
+      </div>
+
+      {/* Info */}
+      <div className="px-3.5 py-2.5 space-y-1.5">
+        <div className="flex items-center gap-2">
+          <span
+            className="text-[10px] font-medium px-2 py-0.5 rounded"
+            style={{ backgroundColor: badge.bg, color: badge.text }}
+          >
+            {badge.label}
+          </span>
+          <span className="text-[11px] text-gray-400">
+            {content.item_count ?? items.length}{" "}
+            {t("programFolderView.questions", "題")}
+          </span>
+        </div>
+        <h3 className="text-sm font-semibold text-gray-800 truncate">
+          {content.title}
+        </h3>
+      </div>
+    </div>
+  );
+}
+
+/* ── Expand Area ── */
+function ExpandArea({
+  detail,
+  loadingDetail,
+  onContentClick,
+}: {
+  detail: ResourceMaterialDetail | null;
+  loadingDetail: boolean;
+  onContentClick?: (content: ResourceMaterialDetail["lessons"][0]["contents"][0]) => void;
+}) {
+  const { t } = useTranslation();
+  const [selectedLessonId, setSelectedLessonId] = useState<number | null>(null);
+
+  // Reset selection when detail changes
+  useEffect(() => {
+    if (detail && detail.lessons.length > 0) {
+      setSelectedLessonId(detail.lessons[0].id);
+    } else {
+      setSelectedLessonId(null);
+    }
+  }, [detail]);
+
+  if (loadingDetail) {
+    return (
+      <div className="bg-white rounded-2xl p-8 flex items-center justify-center">
+        <Loader2 size={24} className="animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  if (!detail) return null;
+
+  const lessons = detail.lessons;
+  const selectedLesson = lessons.find((l) => l.id === selectedLessonId);
+  const displayContents = selectedLesson?.contents ?? [];
+
+  return (
+    <div className="bg-white rounded-2xl p-5 space-y-4">
+      {/* Lessons section */}
+      {lessons.length > 0 && (
+        <>
+          <SectionHeader
+            icon={<Folder size={14} />}
+            title={t("programFolderView.lessonsSection", "單元")}
+          />
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-5">
+            {lessons.map((lesson) => (
+              <div
+                key={lesson.id}
+                className="rounded-2xl bg-white cursor-pointer transition-all hover:shadow-md"
+                style={{
+                  border:
+                    lesson.id === selectedLessonId
+                      ? "2px solid #7C3AED"
+                      : "1px solid #E5E7EB",
+                }}
+                onClick={() =>
+                  setSelectedLessonId(
+                    lesson.id === selectedLessonId ? null : lesson.id,
+                  )
+                }
+              >
+                <div className="h-[100px] px-3.5 py-3 overflow-hidden rounded-t-2xl bg-[#EEEAF5]">
+                  <p className="text-xs text-gray-500 leading-relaxed line-clamp-4 whitespace-pre-line">
+                    {lesson.description || t("programFolderView.noDescription", "尚無描述")}
+                  </p>
+                </div>
+                <div className="px-4 py-3.5 h-[90px] flex flex-col gap-2">
+                  <h3 className="text-[15px] font-semibold text-[#1E3A5F] line-clamp-2 leading-tight">
+                    {lesson.name}
+                  </h3>
+                  <p className="text-xs text-gray-500">
+                    {lesson.content_count}{" "}
+                    {t("programFolderView.contents", "內容")}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Contents section */}
+      <SectionHeader
+        icon={<FileText size={14} />}
+        title={
+          selectedLesson
+            ? `${t("programFolderView.contentsSection", "內容")} — ${selectedLesson.name}`
+            : t("programFolderView.contentsSection", "內容")
+        }
+        iconColor="#059669"
+      />
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-5">
+        {displayContents.map((content) => (
+          <ContentPreviewCard
+            key={content.id}
+            content={content}
+            onClick={onContentClick ? () => onContentClick(content) : undefined}
+          />
+        ))}
+        {displayContents.length === 0 && (
+          <p className="text-sm text-gray-400 col-span-full text-center py-8">
+            {selectedLesson
+              ? t("programFolderView.noContents", "此單元尚無內容")
+              : t("programFolderView.noProgramContents", "此教材尚無內容")}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Pagination ── */
+function Pagination({
+  page,
+  totalPages,
+  onPageChange,
+}: {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex items-center justify-center gap-2 pt-4">
+      <button
+        onClick={() => onPageChange(page - 1)}
+        disabled={page === 0}
+        className="p-2 rounded-lg border border-gray-200 disabled:opacity-30 hover:bg-gray-50 transition-colors"
+      >
+        <ChevronLeft size={16} />
+      </button>
+      <span className="text-sm text-gray-600 px-3">
+        {page + 1} / {totalPages}
+      </span>
+      <button
+        onClick={() => onPageChange(page + 1)}
+        disabled={page >= totalPages - 1}
+        className="p-2 rounded-lg border border-gray-200 disabled:opacity-30 hover:bg-gray-50 transition-colors"
+      >
+        <ChevronRight size={16} />
+      </button>
+    </div>
+  );
+}
+
+/* ── Main: ResourceFolderView ── */
+export type ResourceContentItem = ResourceMaterialDetail["lessons"][0]["contents"][0];
+
+export interface ResourceFolderViewProps {
+  materials: ResourceMaterial[];
+  onSelect: (material: ResourceMaterial) => void;
+  onCopy: (material: ResourceMaterial) => void;
+  onContentClick?: (content: ResourceContentItem) => void;
+  selectedDetail: ResourceMaterialDetail | null;
+  loadingDetail: boolean;
+  selectedId: number | null;
+  pageSize?: number;
+}
+
+export default function ResourceFolderView({
+  materials,
+  onSelect,
+  onCopy,
+  onContentClick,
+  selectedDetail,
+  loadingDetail,
+  selectedId,
+  pageSize = 12,
+}: ResourceFolderViewProps) {
+  const [page, setPage] = useState(0);
+
+  // Reset page when materials change
+  useEffect(() => {
+    setPage(0);
+  }, [materials.length]);
+
+  const totalPages = Math.ceil(materials.length / pageSize);
+  const pagedMaterials = materials.slice(
+    page * pageSize,
+    (page + 1) * pageSize,
+  );
+
+  // Responsive row grouping (same as ProgramFolderView)
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [columns, setColumns] = useState(4);
+
+  const updateColumns = useCallback(() => {
+    const w = containerRef.current?.offsetWidth ?? 1024;
+    const gap = 20;
+    const cols = Math.max(1, Math.floor((w + gap) / (240 + gap)));
+    setColumns(cols);
+  }, []);
+
+  useEffect(() => {
+    updateColumns();
+    const observer = new ResizeObserver(updateColumns);
+    if (containerRef.current) observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [updateColumns]);
+
+  // Group into rows
+  const rows: ResourceMaterial[][] = [];
+  for (let i = 0; i < pagedMaterials.length; i += columns) {
+    rows.push(pagedMaterials.slice(i, i + columns));
+  }
+
+  const selectedIndex = pagedMaterials.findIndex((m) => m.id === selectedId);
+  const selectedRowIndex =
+    selectedIndex >= 0 ? Math.floor(selectedIndex / columns) : -1;
+
+  return (
+    <div ref={containerRef} className="space-y-5">
+      {rows.map((row, rowIndex) => (
+        <div key={rowIndex}>
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-5">
+            {row.map((material) => (
+              <ResourceProgramCard
+                key={material.id}
+                material={material}
+                isSelected={material.id === selectedId}
+                onClick={() => onSelect(material)}
+                onCopy={() => onCopy(material)}
+              />
+            ))}
+          </div>
+
+          {selectedRowIndex === rowIndex && (
+            <div className="mt-4">
+              <ExpandArea
+                detail={selectedDetail}
+                loadingDetail={loadingDetail}
+                onContentClick={onContentClick}
+              />
+            </div>
+          )}
+        </div>
+      ))}
+
+      {materials.length === 0 && (
+        <div className="text-center py-12 text-gray-400">
+          尚無公版教材
+        </div>
+      )}
+
+      <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+    </div>
+  );
+}

--- a/frontend/src/components/sidebar/SidebarItem.tsx
+++ b/frontend/src/components/sidebar/SidebarItem.tsx
@@ -36,9 +36,9 @@ export const SidebarItem = ({
     <Link to={item.path} className="block" onClick={onNavigate}>
       <Button
         variant={isActive ? "default" : "ghost"}
-        className={`w-full justify-start h-10 min-h-10 ${isCollapsed ? "px-3" : "px-4"}`}
+        className={`w-full h-10 min-h-10 ${isCollapsed ? "justify-center px-0" : "justify-start px-4"}`}
       >
-        <Icon className="h-4 w-4" />
+        <Icon className="h-4 w-4 flex-shrink-0" />
         {!isCollapsed && (
           <>
             <span className="ml-2 text-sm flex-1 text-left">{item.label}</span>

--- a/frontend/src/hooks/useResourceMaterialsAPI.ts
+++ b/frontend/src/hooks/useResourceMaterialsAPI.ts
@@ -44,6 +44,7 @@ export interface ResourceMaterialDetail {
         order_index: number;
         text: string;
         translation: string | null;
+        image_url?: string | null;
       }[];
     }[];
   }[];

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -3227,6 +3227,11 @@
     "dialogs": {
       "addReadingTitle": "Add Paragraph Set",
       "editContentTitle": "Edit Content"
+    },
+    "toolbar": {
+      "searchPlaceholder": "Search my materials...",
+      "treeView": "List View",
+      "folderView": "Folder View"
     }
   },
   "teacherSubscription": {

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -24,6 +24,7 @@
     "upload": "Upload",
     "preview": "Preview",
     "copy": "Copy",
+    "move": "Move",
     "paste": "Paste",
     "cut": "Cut",
     "yes": "Yes",
@@ -3203,6 +3204,19 @@
       "noStudents": "No students yet"
     }
   },
+  "programFolderView": {
+    "units": "units",
+    "contents": "contents",
+    "questions": "items",
+    "noDescription": "No description",
+    "lessonsSection": "Lessons",
+    "contentsSection": "Contents",
+    "addLesson": "Add Lesson",
+    "addContent": "Add Content",
+    "noContents": "No contents in this lesson",
+    "noProgramContents": "No contents in this program",
+    "noLessons": "No lessons in this program"
+  },
   "teacherTemplatePrograms": {
     "title": "My Teaching Materials",
     "buttons": {
@@ -4701,6 +4715,7 @@
     "title": "Resource Materials",
     "subtitle": "Browse and copy public teaching resources to your material library",
     "subtitleOrg": "Browse and copy teaching resources to your organization's material library",
+    "searchPlaceholder": "Search resource materials...",
     "browseAndCopy": "Browse & Copy Materials",
     "loading": "Loading...",
     "empty": {

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -3232,6 +3232,11 @@
     "dialogs": {
       "addReadingTitle": "新增段落集",
       "editContentTitle": "編輯內容"
+    },
+    "toolbar": {
+      "searchPlaceholder": "搜尋我的教材...",
+      "treeView": "條列式",
+      "folderView": "資料夾式"
     }
   },
   "teacherSubscription": {

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -24,6 +24,7 @@
     "upload": "上傳",
     "preview": "預覽",
     "copy": "複製",
+    "move": "移動",
     "paste": "貼上",
     "cut": "剪下",
     "yes": "是",
@@ -3208,6 +3209,19 @@
       "noStudents": "尚未建立學生"
     }
   },
+  "programFolderView": {
+    "units": "個單元",
+    "contents": "內容",
+    "questions": "題",
+    "noDescription": "尚無描述",
+    "lessonsSection": "單元",
+    "contentsSection": "內容",
+    "addLesson": "新增單元",
+    "addContent": "新增內容",
+    "noContents": "此單元尚無內容",
+    "noProgramContents": "此教材尚無內容",
+    "noLessons": "此教材尚無單元"
+  },
   "teacherTemplatePrograms": {
     "title": "我的教材",
     "buttons": {
@@ -4720,6 +4734,7 @@
     "title": "資源教材包",
     "subtitle": "瀏覽並複製公開的教材資源到你的教材庫",
     "subtitleOrg": "瀏覽並複製教材資源到組織教材庫",
+    "searchPlaceholder": "搜尋公版教材...",
     "browseAndCopy": "瀏覽與複製教材",
     "loading": "載入中...",
     "empty": {

--- a/frontend/src/pages/teacher/OrgMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/OrgMaterialsPage.tsx
@@ -544,101 +544,107 @@ export default function OrgMaterialsPage() {
           />
 
           {viewMode === "tree" ? (
-          <RecursiveTreeAccordion
-            data={filteredPrograms}
-            config={programTreeConfig}
-            showCreateButton={false}
-            disableActions={!canManage}
-            disableReason="僅機構管理員可編輯機構教材"
-            onEdit={(item, level, parentId) => {
-              if (level === 0) handleEditProgram(item.id);
-              else if (level === 1)
-                handleEditLesson(parentId as number, item.id);
-            }}
-            onDelete={(item, level, parentId) => {
-              if (level === 0) handleDeleteProgram(item.id);
-              else if (level === 1)
-                handleDeleteLesson(parentId as number, item.id);
-              else if (level === 2)
-                handleDeleteContent(parentId as number, item.id, item.title);
-            }}
-            onClick={(item, level, parentId) => {
-              if (level === 2) {
+            <RecursiveTreeAccordion
+              data={filteredPrograms}
+              config={programTreeConfig}
+              showCreateButton={false}
+              disableActions={!canManage}
+              disableReason="僅機構管理員可編輯機構教材"
+              onEdit={(item, level, parentId) => {
+                if (level === 0) handleEditProgram(item.id);
+                else if (level === 1)
+                  handleEditLesson(parentId as number, item.id);
+              }}
+              onDelete={(item, level, parentId) => {
+                if (level === 0) handleDeleteProgram(item.id);
+                else if (level === 1)
+                  handleDeleteLesson(parentId as number, item.id);
+                else if (level === 2)
+                  handleDeleteContent(parentId as number, item.id, item.title);
+              }}
+              onClick={(item, level, parentId) => {
+                if (level === 2) {
+                  const program = programs.find((p) =>
+                    p.lessons?.some((l) => l.id === parentId),
+                  );
+                  const lesson = program?.lessons?.find(
+                    (l) => l.id === parentId,
+                  );
+                  handleContentClick({
+                    ...item,
+                    lesson_id: parentId as number,
+                    lessonName: lesson?.name,
+                    programName: program?.name,
+                  });
+                }
+              }}
+              onCreate={(level, parentId) => {
+                if (level === 1) {
+                  handleCreateLesson(parentId as number);
+                } else if (level === 2) {
+                  const program = programs.find((p) =>
+                    p.lessons?.some((l) => l.id === parentId),
+                  );
+                  if (program) {
+                    handleCreateContent(program.id, parentId as number);
+                  }
+                }
+              }}
+              onReorder={(fromIndex, toIndex, level, parentId) => {
+                if (level === 0) handleReorderPrograms(fromIndex, toIndex);
+                else if (level === 1)
+                  handleReorderLessons(parentId as number, fromIndex, toIndex);
+                else if (level === 2)
+                  handleReorderContents(parentId as number, fromIndex, toIndex);
+              }}
+              onCopy={(item, level) => {
+                if (level === 2) {
+                  setCopyContentInfo({
+                    id: item.id as number,
+                    title: (item.title || item.name) as string,
+                  });
+                  setShowCopyDialog(true);
+                }
+              }}
+            />
+          ) : (
+            <ProgramFolderView
+              programs={filteredPrograms}
+              onEditProgram={canManage ? handleEditProgram : () => {}}
+              onDeleteProgram={canManage ? handleDeleteProgram : () => {}}
+              onEditLesson={(programId, lessonId) =>
+                canManage && handleEditLesson(programId, lessonId)
+              }
+              onDeleteLesson={(programId, lessonId) =>
+                canManage && handleDeleteLesson(programId, lessonId)
+              }
+              onCreateLesson={(programId) =>
+                canManage && handleCreateLesson(programId)
+              }
+              onContentClick={(content, lessonId) => {
                 const program = programs.find((p) =>
-                  p.lessons?.some((l) => l.id === parentId),
+                  p.lessons?.some((l) => l.id === lessonId),
                 );
-                const lesson = program?.lessons?.find((l) => l.id === parentId);
+                const lesson = program?.lessons?.find((l) => l.id === lessonId);
                 handleContentClick({
-                  ...item,
-                  lesson_id: parentId as number,
+                  ...content,
+                  lesson_id: lessonId,
                   lessonName: lesson?.name,
                   programName: program?.name,
                 });
+              }}
+              onDeleteContent={(lessonId, contentId, title) =>
+                canManage && handleDeleteContent(lessonId, contentId, title)
               }
-            }}
-            onCreate={(level, parentId) => {
-              if (level === 1) {
-                handleCreateLesson(parentId as number);
-              } else if (level === 2) {
-                const program = programs.find((p) =>
-                  p.lessons?.some((l) => l.id === parentId),
-                );
-                if (program) {
-                  handleCreateContent(program.id, parentId as number);
-                }
-              }
-            }}
-            onReorder={(fromIndex, toIndex, level, parentId) => {
-              if (level === 0) handleReorderPrograms(fromIndex, toIndex);
-              else if (level === 1)
-                handleReorderLessons(parentId as number, fromIndex, toIndex);
-              else if (level === 2)
-                handleReorderContents(parentId as number, fromIndex, toIndex);
-            }}
-            onCopy={(item, level) => {
-              if (level === 2) {
-                setCopyContentInfo({
-                  id: item.id as number,
-                  title: (item.title || item.name) as string,
-                });
+              onCopyContent={(contentId, title) => {
+                setCopyContentInfo({ id: contentId, title });
                 setShowCopyDialog(true);
+              }}
+              onInstantPractice={() => {}}
+              onCreateContent={(programId, lessonId) =>
+                canManage && handleCreateContent(programId, lessonId)
               }
-            }}
-          />
-          ) : (
-          <ProgramFolderView
-            programs={filteredPrograms}
-            onEditProgram={canManage ? handleEditProgram : () => {}}
-            onDeleteProgram={canManage ? handleDeleteProgram : () => {}}
-            onEditLesson={(programId, lessonId) => canManage && handleEditLesson(programId, lessonId)}
-            onDeleteLesson={(programId, lessonId) => canManage && handleDeleteLesson(programId, lessonId)}
-            onCreateLesson={(programId) => canManage && handleCreateLesson(programId)}
-            onContentClick={(content, lessonId) => {
-              const program = programs.find((p) =>
-                p.lessons?.some((l) => l.id === lessonId),
-              );
-              const lesson = program?.lessons?.find(
-                (l) => l.id === lessonId,
-              );
-              handleContentClick({
-                ...content,
-                lesson_id: lessonId,
-                lessonName: lesson?.name,
-                programName: program?.name,
-              });
-            }}
-            onDeleteContent={(lessonId, contentId, title) =>
-              canManage && handleDeleteContent(lessonId, contentId, title)
-            }
-            onCopyContent={(contentId, title) => {
-              setCopyContentInfo({ id: contentId, title });
-              setShowCopyDialog(true);
-            }}
-            onInstantPractice={() => {}}
-            onCreateContent={(programId, lessonId) =>
-              canManage && handleCreateContent(programId, lessonId)
-            }
-          />
+            />
           )}
         </div>
 

--- a/frontend/src/pages/teacher/OrgMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/OrgMaterialsPage.tsx
@@ -1,7 +1,10 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { RecursiveTreeAccordion } from "@/components/shared/RecursiveTreeAccordion";
 import { programTreeConfig } from "@/components/shared/programTreeConfig";
+import MaterialsToolbar from "@/components/shared/MaterialsToolbar";
+import type { ViewMode } from "@/components/shared/MaterialsToolbar";
+import ProgramFolderView from "@/components/shared/ProgramFolderView";
 import { ProgramDialog } from "@/components/ProgramDialog";
 import { LessonDialog } from "@/components/LessonDialog";
 import ContentTypeDialog from "@/components/ContentTypeDialog";
@@ -34,6 +37,9 @@ export default function OrgMaterialsPage() {
   const [programs, setPrograms] = useState<Program[]>([]);
   const [loading, setLoading] = useState(true);
   const [isReordering, setIsReordering] = useState(false);
+
+  const [viewMode, setViewMode] = useState<ViewMode>("folder");
+  const [searchQuery, setSearchQuery] = useState("");
 
   // Program dialog states
   const [programDialogType, setProgramDialogType] = useState<
@@ -454,6 +460,20 @@ export default function OrgMaterialsPage() {
     }
   };
 
+  const filteredPrograms = useMemo(() => {
+    if (!searchQuery.trim()) return programs;
+    const q = searchQuery.toLowerCase();
+    return programs.filter(
+      (p) =>
+        p.name.toLowerCase().includes(q) ||
+        p.lessons?.some(
+          (l) =>
+            l.name.toLowerCase().includes(q) ||
+            l.contents?.some((c) => c.title?.toLowerCase().includes(q)),
+        ),
+    );
+  }, [programs, searchQuery]);
+
   if (loading) {
     return (
       <>
@@ -491,9 +511,12 @@ export default function OrgMaterialsPage() {
 
   return (
     <>
-      <div className="relative h-full bg-gray-50">
+      <div
+        className="relative h-full overflow-y-auto"
+        style={{ scrollbarGutter: "stable" }}
+      >
         <div
-          className={`p-6 space-y-4 transition-all duration-300 ${
+          className={`p-5 space-y-4 transition-all duration-300 ${
             showReadingEditor && editorContentId !== null
               ? "pr-[calc(50%+2rem)]"
               : ""
@@ -501,7 +524,7 @@ export default function OrgMaterialsPage() {
         >
           {/* Workspace indicator */}
           {workspaceInfo && (
-            <div className="bg-blue-50 border border-blue-200 rounded-lg px-4 py-2 mb-4">
+            <div className="bg-blue-50 border border-blue-200 rounded-lg px-4 py-2">
               <p className="text-sm text-blue-700">
                 <span className="font-medium">目前工作區：</span>{" "}
                 {workspaceInfo}
@@ -509,13 +532,22 @@ export default function OrgMaterialsPage() {
             </div>
           )}
 
-          <RecursiveTreeAccordion
-            data={programs}
-            config={programTreeConfig}
+          <MaterialsToolbar
             title="機構教材"
-            showCreateButton={canManage}
-            createButtonText={t("teacherTemplatePrograms.buttons.addProgram")}
-            onCreateClick={handleCreateProgram}
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            searchPlaceholder="搜尋機構教材..."
+            viewMode={viewMode}
+            onViewModeChange={setViewMode}
+            onAdd={canManage ? handleCreateProgram : undefined}
+            addButtonText={t("teacherTemplatePrograms.buttons.addProgram")}
+          />
+
+          {viewMode === "tree" ? (
+          <RecursiveTreeAccordion
+            data={filteredPrograms}
+            config={programTreeConfig}
+            showCreateButton={false}
             disableActions={!canManage}
             disableReason="僅機構管理員可編輯機構教材"
             onEdit={(item, level, parentId) => {
@@ -546,10 +578,8 @@ export default function OrgMaterialsPage() {
             }}
             onCreate={(level, parentId) => {
               if (level === 1) {
-                // Creating lesson inside program
                 handleCreateLesson(parentId as number);
               } else if (level === 2) {
-                // Creating content inside lesson - need to find program
                 const program = programs.find((p) =>
                   p.lessons?.some((l) => l.id === parentId),
                 );
@@ -575,6 +605,41 @@ export default function OrgMaterialsPage() {
               }
             }}
           />
+          ) : (
+          <ProgramFolderView
+            programs={filteredPrograms}
+            onEditProgram={canManage ? handleEditProgram : () => {}}
+            onDeleteProgram={canManage ? handleDeleteProgram : () => {}}
+            onEditLesson={(programId, lessonId) => canManage && handleEditLesson(programId, lessonId)}
+            onDeleteLesson={(programId, lessonId) => canManage && handleDeleteLesson(programId, lessonId)}
+            onCreateLesson={(programId) => canManage && handleCreateLesson(programId)}
+            onContentClick={(content, lessonId) => {
+              const program = programs.find((p) =>
+                p.lessons?.some((l) => l.id === lessonId),
+              );
+              const lesson = program?.lessons?.find(
+                (l) => l.id === lessonId,
+              );
+              handleContentClick({
+                ...content,
+                lesson_id: lessonId,
+                lessonName: lesson?.name,
+                programName: program?.name,
+              });
+            }}
+            onDeleteContent={(lessonId, contentId, title) =>
+              canManage && handleDeleteContent(lessonId, contentId, title)
+            }
+            onCopyContent={(contentId, title) => {
+              setCopyContentInfo({ id: contentId, title });
+              setShowCopyDialog(true);
+            }}
+            onInstantPractice={() => {}}
+            onCreateContent={(programId, lessonId) =>
+              canManage && handleCreateContent(programId, lessonId)
+            }
+          />
+          )}
         </div>
 
         {/* Reading Assessment Modal (新增模式) */}

--- a/frontend/src/pages/teacher/OrgMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/OrgMaterialsPage.tsx
@@ -640,7 +640,6 @@ export default function OrgMaterialsPage() {
                 setCopyContentInfo({ id: contentId, title });
                 setShowCopyDialog(true);
               }}
-              onInstantPractice={() => {}}
               onCreateContent={(programId, lessonId) =>
                 canManage && handleCreateContent(programId, lessonId)
               }

--- a/frontend/src/pages/teacher/ResourceMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/ResourceMaterialsPage.tsx
@@ -607,7 +607,6 @@ function ResourceMaterialsInner() {
             className="fixed inset-0 bg-black/20 z-40"
             onClick={() => setViewerContent(null)}
           />
-          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
           <div
             className="fixed top-0 right-0 h-screen w-full max-w-lg bg-white shadow-2xl border-l border-gray-200 z-50 flex flex-col animate-in slide-in-from-right duration-300 select-none"
             onContextMenu={(e) => e.preventDefault()}

--- a/frontend/src/pages/teacher/ResourceMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/ResourceMaterialsPage.tsx
@@ -206,9 +206,12 @@ function ResourceMaterialsInner() {
     setSelectedId(material.id);
     setSelectedDetail(null);
     setLoadingDetail(true);
-    const detail = await getMaterialDetail(material.id);
-    if (detail) setSelectedDetail(detail);
-    setLoadingDetail(false);
+    try {
+      const detail = await getMaterialDetail(material.id);
+      if (detail) setSelectedDetail(detail);
+    } finally {
+      setLoadingDetail(false);
+    }
   };
 
   // List view: click card → fetch detail → show detail page

--- a/frontend/src/pages/teacher/ResourceMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/ResourceMaterialsPage.tsx
@@ -1,10 +1,14 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
   useResourceMaterialsAPI,
   ResourceMaterial,
   ResourceMaterialDetail,
 } from "@/hooks/useResourceMaterialsAPI";
+import ResourceFolderView from "@/components/shared/ResourceFolderView";
+import type { ResourceContentItem } from "@/components/shared/ResourceFolderView";
+import MaterialsToolbar from "@/components/shared/MaterialsToolbar";
+import type { ViewMode } from "@/components/shared/MaterialsToolbar";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -39,6 +43,7 @@ import {
   ListOrdered,
   Clock,
   ChevronDown,
+  X,
 } from "lucide-react";
 import { getContentTypeIcon } from "@/lib/contentTypeIcon";
 import { toast } from "sonner";
@@ -47,7 +52,7 @@ export default function ResourceMaterialsPage() {
   return <ResourceMaterialsInner />;
 }
 
-/** Expandable content card showing items inside */
+/** Expandable content card showing items inside (used in list/detail view) */
 function ContentItemAccordion({
   content,
 }: {
@@ -99,7 +104,6 @@ function ContentItemAccordion({
       {expanded && content.items && content.items.length > 0 && (
         <div className="px-3 pb-3">
           <div className="rounded-md border border-gray-200 bg-white overflow-hidden">
-            {/* Header */}
             <div className="flex items-center gap-x-2 border-b border-gray-100 bg-gray-50/80 px-3 py-1.5">
               <span className="w-8 text-xs font-medium text-gray-500 flex-shrink-0">
                 #
@@ -112,7 +116,6 @@ function ContentItemAccordion({
                 {t("resourceMaterials.detail.tableHeader.translation")}
               </span>
             </div>
-            {/* Items */}
             {content.items.map((item, idx) => (
               <div
                 key={item.id}
@@ -150,9 +153,25 @@ function ResourceMaterialsInner() {
     useResourceMaterialsAPI();
 
   const [materials, setMaterials] = useState<ResourceMaterial[]>([]);
+  const [viewMode, setViewMode] = useState<ViewMode>("folder");
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // Folder view states
+  const [selectedId, setSelectedId] = useState<number | null>(null);
   const [selectedDetail, setSelectedDetail] =
     useState<ResourceMaterialDetail | null>(null);
+  const [loadingDetail, setLoadingDetail] = useState(false);
+
+  // List view states
   const [showDetail, setShowDetail] = useState(false);
+  const [listDetail, setListDetail] = useState<ResourceMaterialDetail | null>(
+    null,
+  );
+
+  // Content viewer sheet
+  const [viewerContent, setViewerContent] = useState<ResourceContentItem | null>(null);
+
+  // Copy dialog states
   const [copyDialogOpen, setCopyDialogOpen] = useState(false);
   const [copyTarget, setCopyTarget] = useState<ResourceMaterial | null>(null);
   const [copying, setCopying] = useState(false);
@@ -166,10 +185,36 @@ function ResourceMaterialsInner() {
     fetchMaterials();
   }, [fetchMaterials]);
 
-  const handleViewDetail = async (material: ResourceMaterial) => {
+  const filteredMaterials = useMemo(() => {
+    if (!searchQuery.trim()) return materials;
+    const q = searchQuery.toLowerCase();
+    return materials.filter(
+      (m) =>
+        m.name.toLowerCase().includes(q) ||
+        m.description?.toLowerCase().includes(q),
+    );
+  }, [materials, searchQuery]);
+
+  // Folder view: select card → fetch detail
+  const handleFolderSelect = async (material: ResourceMaterial) => {
+    if (material.id === selectedId) {
+      setSelectedId(null);
+      setSelectedDetail(null);
+      return;
+    }
+    setSelectedId(material.id);
+    setSelectedDetail(null);
+    setLoadingDetail(true);
+    const detail = await getMaterialDetail(material.id);
+    if (detail) setSelectedDetail(detail);
+    setLoadingDetail(false);
+  };
+
+  // List view: click card → fetch detail → show detail page
+  const handleListViewDetail = async (material: ResourceMaterial) => {
     const detail = await getMaterialDetail(material.id);
     if (detail) {
-      setSelectedDetail(detail);
+      setListDetail(detail);
       setShowDetail(true);
     }
   };
@@ -187,7 +232,6 @@ function ResourceMaterialsInner() {
       toast.success(
         t("resourceMaterials.toast.copySuccess", { name: copyTarget.name }),
       );
-      // Optimistic update: increment local copy count
       setMaterials((prev) =>
         prev.map((m) => {
           if (m.id === copyTarget.id) {
@@ -223,7 +267,7 @@ function ResourceMaterialsInner() {
     return level ? (colors[level] ?? "bg-gray-100 text-gray-700") : "";
   };
 
-  // Copy dialog — rendered in both detail and list views
+  // Copy dialog (shared between views)
   const copyDialog = (
     <Dialog open={copyDialogOpen} onOpenChange={setCopyDialogOpen}>
       <DialogContent>
@@ -290,23 +334,22 @@ function ResourceMaterialsInner() {
     </Dialog>
   );
 
-  if (showDetail && selectedDetail) {
+  // List view: detail page
+  if (viewMode === "tree" && showDetail && listDetail) {
     return (
-      <div className="p-6 space-y-4 bg-gray-50 min-h-full">
-        {/* Back button */}
+      <div className="p-6 space-y-4 min-h-full">
         <Button
           variant="ghost"
           size="sm"
           onClick={() => {
             setShowDetail(false);
-            setSelectedDetail(null);
+            setListDetail(null);
           }}
         >
           <ArrowLeft className="w-4 h-4 mr-1" />
           {t("resourceMaterials.detail.backToList")}
         </Button>
 
-        {/* Program-level card (mimics RecursiveTreeAccordion program row) */}
         <div className="border-l-4 border-l-blue-500 bg-white shadow-sm rounded-[0.15rem]">
           <div className="px-4 py-3">
             <div className="flex items-center justify-between">
@@ -316,38 +359,37 @@ function ResourceMaterialsInner() {
                 </div>
                 <div className="flex-1 min-w-0">
                   <h4 className="font-semibold text-base">
-                    {selectedDetail.name}
+                    {listDetail.name}
                   </h4>
-                  {selectedDetail.description && (
+                  {listDetail.description && (
                     <p className="text-sm text-gray-500 truncate">
-                      {selectedDetail.description}
+                      {listDetail.description}
                     </p>
                   )}
                 </div>
               </div>
               <div className="flex items-center gap-3 flex-shrink-0">
-                {selectedDetail.level && (
+                {listDetail.level && (
                   <span
-                    className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getLevelBadgeColor(selectedDetail.level)}`}
+                    className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getLevelBadgeColor(listDetail.level)}`}
                   >
-                    {selectedDetail.level}
+                    {listDetail.level}
                   </span>
                 )}
-                {selectedDetail.estimated_hours && (
+                {listDetail.estimated_hours && (
                   <div className="flex items-center text-sm text-gray-500">
                     <Clock className="h-4 w-4 mr-1" />
                     <span>
-                      {selectedDetail.estimated_hours}{" "}
+                      {listDetail.estimated_hours}{" "}
                       {t("resourceMaterials.detail.hours")}
                     </span>
                   </div>
                 )}
               </div>
             </div>
-            {/* Tags */}
-            {selectedDetail.tags && selectedDetail.tags.length > 0 && (
+            {listDetail.tags && listDetail.tags.length > 0 && (
               <div className="flex flex-wrap gap-1.5 mt-2 pl-12">
-                {selectedDetail.tags.map((tag, index) => (
+                {listDetail.tags.map((tag, index) => (
                   <span
                     key={index}
                     className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-blue-50 text-blue-700 border border-blue-200"
@@ -359,10 +401,9 @@ function ResourceMaterialsInner() {
             )}
           </div>
 
-          {/* Lessons inside program */}
           <div className="px-3 pb-3 space-y-0">
             <Accordion type="multiple">
-              {selectedDetail.lessons.map((lesson) => (
+              {listDetail.lessons.map((lesson) => (
                 <div
                   key={lesson.id}
                   className="border-l-4 border-l-emerald-500 bg-gray-50/80 shadow-sm rounded-[0.15rem] mb-3"
@@ -417,7 +458,7 @@ function ResourceMaterialsInner() {
                 </div>
               ))}
             </Accordion>
-            {selectedDetail.lessons.length === 0 && (
+            {listDetail.lessons.length === 0 && (
               <p className="text-sm text-gray-500 py-4 text-center">
                 {t("resourceMaterials.detail.noUnits")}
               </p>
@@ -425,17 +466,14 @@ function ResourceMaterialsInner() {
           </div>
         </div>
 
-        {/* Copy button at bottom */}
         <div className="flex justify-center pt-2">
           <Button
             size="lg"
             onClick={() => {
               const material = materials.find(
-                (m) => m.id === selectedDetail.id,
+                (m) => m.id === listDetail.id,
               );
-              if (material) {
-                handleCopyClick(material);
-              }
+              if (material) handleCopyClick(material);
             }}
             className="px-8"
           >
@@ -449,99 +487,202 @@ function ResourceMaterialsInner() {
   }
 
   return (
-    <div className="p-6 space-y-6">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <Package className="w-6 h-6 text-orange-500" />
-        <div>
-          <h1 className="text-2xl font-bold">{t("resourceMaterials.title")}</h1>
-          <p className="text-muted-foreground text-sm">
-            {t("resourceMaterials.subtitle")}
-          </p>
-        </div>
-      </div>
+    <div
+      className="relative h-full overflow-y-auto"
+      style={{ scrollbarGutter: "stable" }}
+    >
+      <div className="p-5 space-y-4">
+        <MaterialsToolbar
+          title={t("resourceMaterials.title")}
+          searchQuery={searchQuery}
+          onSearchChange={setSearchQuery}
+          searchPlaceholder={t("resourceMaterials.searchPlaceholder", "搜尋公版教材...")}
+          viewMode={viewMode}
+          onViewModeChange={setViewMode}
+        />
 
-      {/* Loading */}
-      {loading && materials.length === 0 && (
-        <div className="flex items-center justify-center py-12">
-          <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
-          <span className="ml-2 text-muted-foreground">
-            {t("resourceMaterials.loading")}
-          </span>
-        </div>
-      )}
+        {/* Loading */}
+        {loading && materials.length === 0 && (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="w-6 h-6 animate-spin text-gray-400" />
+            <span className="ml-2 text-gray-400">
+              {t("resourceMaterials.loading")}
+            </span>
+          </div>
+        )}
 
-      {/* Empty State */}
-      {!loading && materials.length === 0 && (
-        <div className="text-center py-12">
-          <Package className="w-12 h-12 mx-auto text-muted-foreground/50 mb-4" />
-          <h3 className="text-lg font-medium text-muted-foreground">
-            {t("resourceMaterials.empty.title")}
-          </h3>
-          <p className="text-sm text-muted-foreground mt-1">
-            {t("resourceMaterials.empty.subtitle")}
-          </p>
-        </div>
-      )}
+        {/* Empty State */}
+        {!loading && materials.length === 0 && (
+          <div className="text-center py-12">
+            <Package className="w-12 h-12 mx-auto text-gray-300 mb-4" />
+            <h3 className="text-lg font-medium text-gray-400">
+              {t("resourceMaterials.empty.title")}
+            </h3>
+            <p className="text-sm text-gray-400 mt-1">
+              {t("resourceMaterials.empty.subtitle")}
+            </p>
+          </div>
+        )}
 
-      {/* Materials Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {materials.map((material) => (
-          <Card
-            key={material.id}
-            className="hover:shadow-md transition-shadow cursor-pointer"
-            onClick={() => handleViewDetail(material)}
-          >
-            <CardHeader className="pb-3">
-              <div className="flex items-start justify-between">
-                <CardTitle className="text-base line-clamp-2">
-                  {material.name}
-                </CardTitle>
-                {material.level && (
-                  <Badge
-                    className={getLevelBadgeColor(material.level)}
-                    variant="secondary"
-                  >
-                    {material.level}
-                  </Badge>
-                )}
-              </div>
-              {material.description && (
-                <CardDescription className="line-clamp-2">
-                  {material.description}
-                </CardDescription>
-              )}
-            </CardHeader>
-            <CardContent>
-              <div className="flex items-center gap-4 text-sm text-muted-foreground mb-3">
-                <span className="flex items-center gap-1">
-                  <Layers className="w-3.5 h-3.5" />
-                  {material.lesson_count} {t("resourceMaterials.card.units")}
-                </span>
-                <span className="flex items-center gap-1">
-                  <FileText className="w-3.5 h-3.5" />
-                  {material.content_count}{" "}
-                  {t("resourceMaterials.card.contents")}
-                </span>
-              </div>
-              <Button
-                size="sm"
-                className="w-full"
-                variant={material.copied_today ? "secondary" : "default"}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleCopyClick(material);
-                }}
+        {/* Folder View */}
+        {viewMode === "folder" && materials.length > 0 && (
+          <ResourceFolderView
+            materials={filteredMaterials}
+            onSelect={handleFolderSelect}
+            onCopy={handleCopyClick}
+            onContentClick={setViewerContent}
+            selectedDetail={selectedDetail}
+            loadingDetail={loadingDetail}
+            selectedId={selectedId}
+          />
+        )}
+
+        {/* List View (original card grid) */}
+        {viewMode === "tree" && materials.length > 0 && (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {filteredMaterials.map((material) => (
+              <Card
+                key={material.id}
+                className="hover:shadow-md transition-shadow cursor-pointer"
+                onClick={() => handleListViewDetail(material)}
               >
-                <Copy className="w-4 h-4 mr-1" />
-                {t("resourceMaterials.card.copyToMy")}
-              </Button>
-            </CardContent>
-          </Card>
-        ))}
+                <CardHeader className="pb-3">
+                  <div className="flex items-start justify-between">
+                    <CardTitle className="text-base line-clamp-2">
+                      {material.name}
+                    </CardTitle>
+                    {material.level && (
+                      <Badge
+                        className={getLevelBadgeColor(material.level)}
+                        variant="secondary"
+                      >
+                        {material.level}
+                      </Badge>
+                    )}
+                  </div>
+                  {material.description && (
+                    <CardDescription className="line-clamp-2">
+                      {material.description}
+                    </CardDescription>
+                  )}
+                </CardHeader>
+                <CardContent>
+                  <div className="flex items-center gap-4 text-sm text-muted-foreground mb-3">
+                    <span className="flex items-center gap-1">
+                      <Layers className="w-3.5 h-3.5" />
+                      {material.lesson_count}{" "}
+                      {t("resourceMaterials.card.units")}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <FileText className="w-3.5 h-3.5" />
+                      {material.content_count}{" "}
+                      {t("resourceMaterials.card.contents")}
+                    </span>
+                  </div>
+                  <Button
+                    size="sm"
+                    className="w-full"
+                    variant={material.copied_today ? "secondary" : "default"}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleCopyClick(material);
+                    }}
+                  >
+                    <Copy className="w-4 h-4 mr-1" />
+                    {t("resourceMaterials.card.copyToMy")}
+                  </Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
       </div>
 
       {copyDialog}
+
+      {/* Read-only content viewer sheet */}
+      {viewerContent && (
+        <>
+          <div
+            className="fixed inset-0 bg-black/20 z-40"
+            onClick={() => setViewerContent(null)}
+          />
+          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+          <div
+            className="fixed top-0 right-0 h-screen w-full max-w-lg bg-white shadow-2xl border-l border-gray-200 z-50 flex flex-col animate-in slide-in-from-right duration-300 select-none"
+            onContextMenu={(e) => e.preventDefault()}
+          >
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+              <h2 className="text-lg font-semibold text-gray-900 truncate">
+                {viewerContent.title}
+              </h2>
+              <button
+                onClick={() => setViewerContent(null)}
+                className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+              >
+                <X className="w-5 h-5 text-gray-500" />
+              </button>
+            </div>
+            <div className="flex-1 overflow-auto p-6">
+              {/* Type badge + count */}
+              <div className="flex items-center gap-2 mb-4">
+                {viewerContent.type && (
+                  <span className="text-xs font-medium px-2 py-0.5 rounded bg-gray-100 text-gray-600">
+                    {viewerContent.type}
+                  </span>
+                )}
+                <span className="text-sm text-gray-400">
+                  {viewerContent.item_count} {t("programFolderView.questions", "題")}
+                </span>
+              </div>
+              {/* Items list */}
+              <div className="rounded-lg border border-gray-200 overflow-hidden">
+                <div className="flex items-center gap-2 bg-gray-50 px-4 py-2 border-b border-gray-200">
+                  <span className="w-8 text-xs font-medium text-gray-500">#</span>
+                  <span className="flex-1 text-xs font-medium text-gray-500">
+                    {t("resourceMaterials.detail.tableHeader.content", "內容")}
+                  </span>
+                  <span className="flex-1 text-xs font-medium text-gray-500">
+                    {t("resourceMaterials.detail.tableHeader.translation", "翻譯")}
+                  </span>
+                </div>
+                {viewerContent.items.map((item, idx) => (
+                  <div
+                    key={item.id}
+                    className="px-4 py-2.5 border-b border-gray-50 last:border-0"
+                  >
+                    <div className="flex items-baseline gap-2">
+                      <span className="w-8 text-xs text-gray-400 shrink-0">
+                        {idx + 1}
+                      </span>
+                      <span className="flex-1 text-sm text-gray-900 break-words">
+                        {item.text}
+                      </span>
+                      <span className="flex-1 text-sm text-gray-500 break-words">
+                        {item.translation || "—"}
+                      </span>
+                    </div>
+                    {/* TODO: 當 item 有 image_url 欄位時，在此顯示圖片
+                    {item.image_url && (
+                      <img
+                        src={item.image_url}
+                        alt={item.text}
+                        className="mt-2 ml-8 max-w-[200px] rounded-lg border border-gray-200"
+                        draggable={false}
+                      />
+                    )} */}
+                  </div>
+                ))}
+                {viewerContent.items.length === 0 && (
+                  <p className="text-sm text-gray-400 text-center py-6">
+                    {t("resourceMaterials.detail.noItems", "尚無內容項目")}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/teacher/ResourceMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/ResourceMaterialsPage.tsx
@@ -169,7 +169,8 @@ function ResourceMaterialsInner() {
   );
 
   // Content viewer sheet
-  const [viewerContent, setViewerContent] = useState<ResourceContentItem | null>(null);
+  const [viewerContent, setViewerContent] =
+    useState<ResourceContentItem | null>(null);
 
   // Copy dialog states
   const [copyDialogOpen, setCopyDialogOpen] = useState(false);
@@ -358,9 +359,7 @@ function ResourceMaterialsInner() {
                   <BookOpen className="h-5 w-5 text-blue-600" />
                 </div>
                 <div className="flex-1 min-w-0">
-                  <h4 className="font-semibold text-base">
-                    {listDetail.name}
-                  </h4>
+                  <h4 className="font-semibold text-base">{listDetail.name}</h4>
                   {listDetail.description && (
                     <p className="text-sm text-gray-500 truncate">
                       {listDetail.description}
@@ -470,9 +469,7 @@ function ResourceMaterialsInner() {
           <Button
             size="lg"
             onClick={() => {
-              const material = materials.find(
-                (m) => m.id === listDetail.id,
-              );
+              const material = materials.find((m) => m.id === listDetail.id);
               if (material) handleCopyClick(material);
             }}
             className="px-8"
@@ -496,7 +493,10 @@ function ResourceMaterialsInner() {
           title={t("resourceMaterials.title")}
           searchQuery={searchQuery}
           onSearchChange={setSearchQuery}
-          searchPlaceholder={t("resourceMaterials.searchPlaceholder", "搜尋公版教材...")}
+          searchPlaceholder={t(
+            "resourceMaterials.searchPlaceholder",
+            "搜尋公版教材...",
+          )}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
         />
@@ -632,18 +632,24 @@ function ResourceMaterialsInner() {
                   </span>
                 )}
                 <span className="text-sm text-gray-400">
-                  {viewerContent.item_count} {t("programFolderView.questions", "題")}
+                  {viewerContent.item_count}{" "}
+                  {t("programFolderView.questions", "題")}
                 </span>
               </div>
               {/* Items list */}
               <div className="rounded-lg border border-gray-200 overflow-hidden">
                 <div className="flex items-center gap-2 bg-gray-50 px-4 py-2 border-b border-gray-200">
-                  <span className="w-8 text-xs font-medium text-gray-500">#</span>
+                  <span className="w-8 text-xs font-medium text-gray-500">
+                    #
+                  </span>
                   <span className="flex-1 text-xs font-medium text-gray-500">
                     {t("resourceMaterials.detail.tableHeader.content", "內容")}
                   </span>
                   <span className="flex-1 text-xs font-medium text-gray-500">
-                    {t("resourceMaterials.detail.tableHeader.translation", "翻譯")}
+                    {t(
+                      "resourceMaterials.detail.tableHeader.translation",
+                      "翻譯",
+                    )}
                   </span>
                 </div>
                 {viewerContent.items.map((item, idx) => (

--- a/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
+++ b/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
@@ -574,7 +574,10 @@ function TeacherTemplateProgramsInner() {
           title={t("teacherTemplatePrograms.title")}
           searchQuery={searchQuery}
           onSearchChange={setSearchQuery}
-          searchPlaceholder={t("teacherTemplatePrograms.toolbar.searchPlaceholder", "搜尋我的教材...")}
+          searchPlaceholder={t(
+            "teacherTemplatePrograms.toolbar.searchPlaceholder",
+            "搜尋我的教材...",
+          )}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
           onAdd={handleCreateProgram}
@@ -583,77 +586,78 @@ function TeacherTemplateProgramsInner() {
 
         {/* ── Content area ── */}
         {viewMode === "tree" ? (
-        <RecursiveTreeAccordion
-          data={filteredPrograms}
-          config={treeConfig}
-          showCreateButton={false}
-          onCreateClick={handleCreateProgram}
-          onEdit={(item, level, parentId) => {
-            if (level === 0) handleEditProgram(item.id);
-            else if (level === 1) handleEditLesson(parentId as number, item.id);
-          }}
-          onDelete={(item, level, parentId) => {
-            if (level === 0) handleDeleteProgram(item.id);
-            else if (level === 1)
-              handleDeleteLesson(parentId as number, item.id);
-            else if (level === 2)
-              handleDeleteContent(parentId as number, item.id, item.title);
-          }}
-          onClick={(item, level, parentId) => {
-            if (level === 2) {
-              const program = programs.find((p) =>
-                p.lessons?.some((l) => l.id === parentId),
-              );
-              const lesson = program?.lessons?.find((l) => l.id === parentId);
-              handleContentClick({
-                ...item,
-                lesson_id: parentId as number,
-                lessonName: lesson?.name,
-                programName: program?.name,
-              });
-            }
-          }}
-          onCreate={(level, parentId) => {
-            if (level === 1) {
-              // Creating lesson inside program
-              handleCreateLesson(parentId as number);
-            } else if (level === 2) {
-              // Creating content inside lesson - need to find program
-              const program = programs.find((p) =>
-                p.lessons?.some((l) => l.id === parentId),
-              );
-              if (program) {
-                handleCreateContent(program.id, parentId as number);
+          <RecursiveTreeAccordion
+            data={filteredPrograms}
+            config={treeConfig}
+            showCreateButton={false}
+            onCreateClick={handleCreateProgram}
+            onEdit={(item, level, parentId) => {
+              if (level === 0) handleEditProgram(item.id);
+              else if (level === 1)
+                handleEditLesson(parentId as number, item.id);
+            }}
+            onDelete={(item, level, parentId) => {
+              if (level === 0) handleDeleteProgram(item.id);
+              else if (level === 1)
+                handleDeleteLesson(parentId as number, item.id);
+              else if (level === 2)
+                handleDeleteContent(parentId as number, item.id, item.title);
+            }}
+            onClick={(item, level, parentId) => {
+              if (level === 2) {
+                const program = programs.find((p) =>
+                  p.lessons?.some((l) => l.id === parentId),
+                );
+                const lesson = program?.lessons?.find((l) => l.id === parentId);
+                handleContentClick({
+                  ...item,
+                  lesson_id: parentId as number,
+                  lessonName: lesson?.name,
+                  programName: program?.name,
+                });
               }
-            }
-          }}
-          onReorder={(fromIndex, toIndex, level, parentId) => {
-            if (level === 0) handleReorderPrograms(fromIndex, toIndex);
-            else if (level === 1)
-              handleReorderLessons(parentId as number, fromIndex, toIndex);
-            else if (level === 2)
-              handleReorderContents(parentId as number, fromIndex, toIndex);
-          }}
-          onInstantPractice={(item, level) => {
-            if (level === 2) {
-              setInstantPracticeContent({
-                id: item.id as number,
-                title: (item.title || item.name) as string,
-                type: item.type as string | undefined,
-              });
-              setShowInstantPractice(true);
-            }
-          }}
-          onCopy={(item, level) => {
-            if (level === 2) {
-              setCopyContentInfo({
-                id: item.id as number,
-                title: (item.title || item.name) as string,
-              });
-              setShowCopyDialog(true);
-            }
-          }}
-        />
+            }}
+            onCreate={(level, parentId) => {
+              if (level === 1) {
+                // Creating lesson inside program
+                handleCreateLesson(parentId as number);
+              } else if (level === 2) {
+                // Creating content inside lesson - need to find program
+                const program = programs.find((p) =>
+                  p.lessons?.some((l) => l.id === parentId),
+                );
+                if (program) {
+                  handleCreateContent(program.id, parentId as number);
+                }
+              }
+            }}
+            onReorder={(fromIndex, toIndex, level, parentId) => {
+              if (level === 0) handleReorderPrograms(fromIndex, toIndex);
+              else if (level === 1)
+                handleReorderLessons(parentId as number, fromIndex, toIndex);
+              else if (level === 2)
+                handleReorderContents(parentId as number, fromIndex, toIndex);
+            }}
+            onInstantPractice={(item, level) => {
+              if (level === 2) {
+                setInstantPracticeContent({
+                  id: item.id as number,
+                  title: (item.title || item.name) as string,
+                  type: item.type as string | undefined,
+                });
+                setShowInstantPractice(true);
+              }
+            }}
+            onCopy={(item, level) => {
+              if (level === 2) {
+                setCopyContentInfo({
+                  id: item.id as number,
+                  title: (item.title || item.name) as string,
+                });
+                setShowCopyDialog(true);
+              }
+            }}
+          />
         ) : (
           <ProgramFolderView
             programs={filteredPrograms}
@@ -666,9 +670,7 @@ function TeacherTemplateProgramsInner() {
               const program = programs.find((p) =>
                 p.lessons?.some((l) => l.id === lessonId),
               );
-              const lesson = program?.lessons?.find(
-                (l) => l.id === lessonId,
-              );
+              const lesson = program?.lessons?.find((l) => l.id === lessonId);
               handleContentClick({
                 ...content,
                 lesson_id: lessonId,

--- a/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
+++ b/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
@@ -21,14 +21,9 @@ import { ProgramVisibilitySelector } from "@/components/ProgramVisibilitySelecto
 import { RefSaveButton } from "@/components/shared/RefSaveButton";
 import ProgramFolderView from "@/components/shared/ProgramFolderView";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import {
-  X,
-  Search,
-  FolderPlus,
-  List,
-  LayoutGrid,
-} from "lucide-react";
+import { X } from "lucide-react";
+import MaterialsToolbar from "@/components/shared/MaterialsToolbar";
+import type { ViewMode } from "@/components/shared/MaterialsToolbar";
 import { apiClient } from "@/lib/api";
 import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
 import { useResourceMaterialsAPI } from "@/hooks/useResourceMaterialsAPI";
@@ -62,7 +57,7 @@ function TeacherTemplateProgramsInner() {
   const [isReordering, setIsReordering] = useState(false);
 
   // View mode: 'tree' (original accordion) or 'folder' (folder-style grid)
-  const [viewMode, setViewMode] = useState<"tree" | "folder">("folder");
+  const [viewMode, setViewMode] = useState<ViewMode>("folder");
   const [searchQuery, setSearchQuery] = useState("");
 
   // Instant practice states
@@ -575,66 +570,16 @@ function TeacherTemplateProgramsInner() {
             : ""
         }`}
       >
-        {/* ── Toolbar ── */}
-        {/* Desktop: single row / Mobile: two rows */}
-        <div className="flex flex-col md:flex-row md:items-center gap-3">
-          <h2 className="text-[22px] font-bold text-gray-900 whitespace-nowrap">
-            {t("teacherTemplatePrograms.title")}
-          </h2>
-
-          {/* Spacer (desktop only) */}
-          <div className="hidden md:block flex-1" />
-
-          {/* Add + Search + View toggle */}
-          <div className="flex items-center gap-3">
-            <button
-              onClick={handleCreateProgram}
-              className="flex items-center gap-1.5 sm:px-3.5 sm:py-2 sm:bg-white sm:border sm:border-gray-200 sm:rounded-lg text-gray-700 text-[13px] font-medium sm:hover:bg-gray-50 transition-colors shrink-0"
-            >
-              <FolderPlus size={20} className="sm:hidden" />
-              <FolderPlus size={16} className="hidden sm:block" />
-              <span className="hidden sm:inline">
-                {t("teacherTemplatePrograms.buttons.addProgram")}
-              </span>
-            </button>
-            <div className="relative flex-1 md:w-60 md:flex-none">
-              <Search
-                size={16}
-                className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
-              />
-              <Input
-                placeholder={t("teacherTemplatePrograms.toolbar.searchPlaceholder", "搜尋我的教材...")}
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-8 h-9 text-[13px] border-gray-200 rounded-lg"
-              />
-            </div>
-            <div className="flex border border-gray-200 rounded-lg overflow-hidden shrink-0">
-              <button
-                onClick={() => setViewMode("tree")}
-                className={`p-2 transition-colors ${
-                  viewMode === "tree"
-                    ? "bg-blue-600 text-white"
-                    : "bg-white text-gray-500 hover:bg-gray-100"
-                }`}
-                title={t("teacherTemplatePrograms.toolbar.treeView", "條列式")}
-              >
-                <List size={16} />
-              </button>
-              <button
-                onClick={() => setViewMode("folder")}
-                className={`p-2 transition-colors ${
-                  viewMode === "folder"
-                    ? "bg-blue-600 text-white"
-                    : "bg-white text-gray-500 hover:bg-gray-100"
-                }`}
-                title={t("teacherTemplatePrograms.toolbar.folderView", "資料夾式")}
-              >
-                <LayoutGrid size={16} />
-              </button>
-            </div>
-          </div>
-        </div>
+        <MaterialsToolbar
+          title={t("teacherTemplatePrograms.title")}
+          searchQuery={searchQuery}
+          onSearchChange={setSearchQuery}
+          searchPlaceholder={t("teacherTemplatePrograms.toolbar.searchPlaceholder", "搜尋我的教材...")}
+          viewMode={viewMode}
+          onViewModeChange={setViewMode}
+          onAdd={handleCreateProgram}
+          addButtonText={t("teacherTemplatePrograms.buttons.addProgram")}
+        />
 
         {/* ── Content area ── */}
         {viewMode === "tree" ? (

--- a/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
+++ b/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
@@ -19,8 +19,16 @@ import VocabularySetPanel, {
 import ContentCopyDialog from "@/components/ContentCopyDialog";
 import { ProgramVisibilitySelector } from "@/components/ProgramVisibilitySelector";
 import { RefSaveButton } from "@/components/shared/RefSaveButton";
+import ProgramFolderView from "@/components/shared/ProgramFolderView";
 import { Button } from "@/components/ui/button";
-import { X } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import {
+  X,
+  Search,
+  FolderPlus,
+  List,
+  LayoutGrid,
+} from "lucide-react";
 import { apiClient } from "@/lib/api";
 import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
 import { useResourceMaterialsAPI } from "@/hooks/useResourceMaterialsAPI";
@@ -52,6 +60,10 @@ function TeacherTemplateProgramsInner() {
   const [programs, setPrograms] = useState<Program[]>([]);
   const [loading, setLoading] = useState(true);
   const [isReordering, setIsReordering] = useState(false);
+
+  // View mode: 'tree' (original accordion) or 'folder' (folder-style grid)
+  const [viewMode, setViewMode] = useState<"tree" | "folder">("folder");
+  const [searchQuery, setSearchQuery] = useState("");
 
   // Instant practice states
   const [showInstantPractice, setShowInstantPractice] = useState(false);
@@ -525,6 +537,21 @@ function TeacherTemplateProgramsInner() {
     }
   };
 
+  // Filter programs by search query
+  const filteredPrograms = useMemo(() => {
+    if (!searchQuery.trim()) return programs;
+    const q = searchQuery.toLowerCase();
+    return programs.filter(
+      (p) =>
+        p.name.toLowerCase().includes(q) ||
+        p.lessons?.some(
+          (l) =>
+            l.name.toLowerCase().includes(q) ||
+            l.contents?.some((c) => c.title?.toLowerCase().includes(q)),
+        ),
+    );
+  }, [programs, searchQuery]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
@@ -537,20 +564,84 @@ function TeacherTemplateProgramsInner() {
   }
 
   return (
-    <div className="relative h-full bg-gray-50">
+    <div
+      className="relative h-full overflow-y-auto"
+      style={{ scrollbarGutter: "stable" }}
+    >
       <div
-        className={`p-6 space-y-4 transition-all duration-300 ${
+        className={`p-5 space-y-4 transition-all duration-300 ${
           showReadingEditor && editorContentId !== null
             ? "pr-[calc(50%+2rem)]"
             : ""
         }`}
       >
+        {/* ── Toolbar ── */}
+        {/* Desktop: single row / Mobile: two rows */}
+        <div className="flex flex-col md:flex-row md:items-center gap-3">
+          <h2 className="text-[22px] font-bold text-gray-900 whitespace-nowrap">
+            {t("teacherTemplatePrograms.title")}
+          </h2>
+
+          {/* Spacer (desktop only) */}
+          <div className="hidden md:block flex-1" />
+
+          {/* Add + Search + View toggle */}
+          <div className="flex items-center gap-3">
+            <button
+              onClick={handleCreateProgram}
+              className="flex items-center gap-1.5 sm:px-3.5 sm:py-2 sm:bg-white sm:border sm:border-gray-200 sm:rounded-lg text-gray-700 text-[13px] font-medium sm:hover:bg-gray-50 transition-colors shrink-0"
+            >
+              <FolderPlus size={20} className="sm:hidden" />
+              <FolderPlus size={16} className="hidden sm:block" />
+              <span className="hidden sm:inline">
+                {t("teacherTemplatePrograms.buttons.addProgram")}
+              </span>
+            </button>
+            <div className="relative flex-1 md:w-60 md:flex-none">
+              <Search
+                size={16}
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+              />
+              <Input
+                placeholder={t("teacherTemplatePrograms.toolbar.searchPlaceholder", "搜尋我的教材...")}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-8 h-9 text-[13px] border-gray-200 rounded-lg"
+              />
+            </div>
+            <div className="flex border border-gray-200 rounded-lg overflow-hidden shrink-0">
+              <button
+                onClick={() => setViewMode("tree")}
+                className={`p-2 transition-colors ${
+                  viewMode === "tree"
+                    ? "bg-blue-600 text-white"
+                    : "bg-white text-gray-500 hover:bg-gray-100"
+                }`}
+                title={t("teacherTemplatePrograms.toolbar.treeView", "條列式")}
+              >
+                <List size={16} />
+              </button>
+              <button
+                onClick={() => setViewMode("folder")}
+                className={`p-2 transition-colors ${
+                  viewMode === "folder"
+                    ? "bg-blue-600 text-white"
+                    : "bg-white text-gray-500 hover:bg-gray-100"
+                }`}
+                title={t("teacherTemplatePrograms.toolbar.folderView", "資料夾式")}
+              >
+                <LayoutGrid size={16} />
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Content area ── */}
+        {viewMode === "tree" ? (
         <RecursiveTreeAccordion
-          data={programs}
+          data={filteredPrograms}
           config={treeConfig}
-          title={t("teacherTemplatePrograms.title")}
-          showCreateButton
-          createButtonText={t("teacherTemplatePrograms.buttons.addProgram")}
+          showCreateButton={false}
           onCreateClick={handleCreateProgram}
           onEdit={(item, level, parentId) => {
             if (level === 0) handleEditProgram(item.id);
@@ -618,6 +709,44 @@ function TeacherTemplateProgramsInner() {
             }
           }}
         />
+        ) : (
+          <ProgramFolderView
+            programs={filteredPrograms}
+            onEditProgram={handleEditProgram}
+            onDeleteProgram={handleDeleteProgram}
+            onEditLesson={handleEditLesson}
+            onDeleteLesson={handleDeleteLesson}
+            onCreateLesson={handleCreateLesson}
+            onContentClick={(content, lessonId) => {
+              const program = programs.find((p) =>
+                p.lessons?.some((l) => l.id === lessonId),
+              );
+              const lesson = program?.lessons?.find(
+                (l) => l.id === lessonId,
+              );
+              handleContentClick({
+                ...content,
+                lesson_id: lessonId,
+                lessonName: lesson?.name,
+                programName: program?.name,
+              });
+            }}
+            onDeleteContent={handleDeleteContent}
+            onCopyContent={(contentId, title) => {
+              setCopyContentInfo({ id: contentId, title });
+              setShowCopyDialog(true);
+            }}
+            onInstantPractice={(content) => {
+              setInstantPracticeContent({
+                id: content.id,
+                title: content.title,
+                type: content.type,
+              });
+              setShowInstantPractice(true);
+            }}
+            onCreateContent={handleCreateContent}
+          />
+        )}
       </div>
 
       {/* Reading Assessment Modal (新增模式) */}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -59,6 +59,7 @@ export interface ContentItem {
   translation?: string;
   definition?: string;
   audio_url?: string;
+  image_url?: string;
   question?: string;
   answer?: string;
   options?: string[];

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -113,6 +113,7 @@ export interface Program {
   organization_id?: string; // UUID
   school_id?: string; // UUID
   lessons?: Lesson[];
+  contents?: Content[];
   classroom_name?: string;
   is_duplicate?: boolean;
   tags?: string[];


### PR DESCRIPTION
## Release PR

Fixes #574

### Summary
- 我的教材、資源教材包、組織教材頁面從條列式改為資料夾式顯示
- 新增 `ProgramFolderView` 元件與 `MaterialsToolbar` 元件
- 支援樹狀 (tree) 與資料夾 (folder) 兩種檢視模式切換
- 改善卡片佈局、動畫效果、搜尋功能

### Source
- **Issue**: #574 - [Feature]: 我的教材/資源教材包/組織教材 條列式改為資料夾式
- **Branch**: `claude/issue-574` (rebased onto latest staging)

### Test plan
- [ ] 我的教材頁面可切換 tree/folder 檢視模式
- [ ] 資源教材包頁面資料夾檢視正常
- [ ] 組織教材頁面資料夾檢視正常
- [ ] 卡片樣式、動畫、搜尋功能正常
- [ ] 行動裝置 RWD 正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)