### PR TITLE
fix: AI批改按鈕在機構教師有個人額度時仍未顯示

### DIFF
--- a/backend/services/quota_service.py
+++ b/backend/services/quota_service.py
@@ -189,6 +189,10 @@ class QuotaService:
         檢查教師是否有 AI 分析額度（舊版：基於教師身份判斷）。
         用於教師端 dashboard 等不需要作業 context 的場景。
 
+        規則：
+        - 任一 active 機構有剩餘點數 → True
+        - 所有機構都沒點數（或無機構）→ fallback 檢查個人配額
+
         注意：學生端應使用 check_ai_analysis_availability_by_assignment，
         根據作業所屬班級判斷。
         """
@@ -196,16 +200,16 @@ class QuotaService:
         if not teacher:
             return False
 
-        teacher_org = (
+        teacher_orgs = (
             db.query(TeacherOrganization)
             .filter(
                 TeacherOrganization.teacher_id == teacher_id,
                 TeacherOrganization.is_active.is_(True),
             )
-            .first()
+            .all()
         )
 
-        if teacher_org:
+        for teacher_org in teacher_orgs:
             org = (
                 db.query(Organization)
                 .filter(
@@ -214,9 +218,8 @@ class QuotaService:
                 )
                 .first()
             )
-            if org:
-                remaining = org.total_points - org.used_points
-                return remaining > 0
+            if org and (org.total_points - org.used_points) > 0:
+                return True
 
         return QuotaService._get_total_remaining(teacher, db) > 0
 

--- a/backend/tests/unit/test_quota_service.py
+++ b/backend/tests/unit/test_quota_service.py
@@ -225,6 +225,7 @@ class TestCheckAiAnalysisAvailability:
             elif model is TeacherOrganization:
                 q.filter.return_value.all.return_value = teacher_orgs
             elif model is Organization:
+
                 def org_filter(*args, **kwargs):
                     inner = MagicMock()
                     # Return org matching the id from the filter call
@@ -233,6 +234,7 @@ class TestCheckAiAnalysisAvailability:
                         return inner
                     inner.first.return_value = None
                     return inner
+
                 q.filter.side_effect = org_filter
             return q
 
@@ -261,9 +263,7 @@ class TestCheckAiAnalysisAvailability:
         org2 = self._make_org(total_points=0, used_points=0)
         db = self._setup_db(teacher, teacher_orgs, {"org-1": org1, "org-2": org2})
 
-        with patch.object(
-            QuotaService, "_get_total_remaining", return_value=960
-        ):
+        with patch.object(QuotaService, "_get_total_remaining", return_value=960):
             assert QuotaService.check_ai_analysis_availability(99, db) is True
 
     def test_org_no_points_and_no_personal_quota_returns_false(self):
@@ -274,9 +274,7 @@ class TestCheckAiAnalysisAvailability:
         org = self._make_org(total_points=0, used_points=0)
         db = self._setup_db(teacher, teacher_orgs, {"org-1": org})
 
-        with patch.object(
-            QuotaService, "_get_total_remaining", return_value=0
-        ):
+        with patch.object(QuotaService, "_get_total_remaining", return_value=0):
             assert QuotaService.check_ai_analysis_availability(99, db) is False
 
     def test_no_org_personal_quota_returns_true(self):
@@ -285,9 +283,7 @@ class TestCheckAiAnalysisAvailability:
         teacher.id = 99
         db = self._setup_db(teacher, [], {})
 
-        with patch.object(
-            QuotaService, "_get_total_remaining", return_value=500
-        ):
+        with patch.object(QuotaService, "_get_total_remaining", return_value=500):
             assert QuotaService.check_ai_analysis_availability(99, db) is True
 
     def test_no_org_no_personal_quota_returns_false(self):
@@ -296,9 +292,7 @@ class TestCheckAiAnalysisAvailability:
         teacher.id = 99
         db = self._setup_db(teacher, [], {})
 
-        with patch.object(
-            QuotaService, "_get_total_remaining", return_value=0
-        ):
+        with patch.object(QuotaService, "_get_total_remaining", return_value=0):
             assert QuotaService.check_ai_analysis_availability(99, db) is False
 
     def test_teacher_not_found_returns_false(self):

--- a/backend/tests/unit/test_quota_service.py
+++ b/backend/tests/unit/test_quota_service.py
@@ -2,8 +2,10 @@
 QuotaService 單元測試
 """
 import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
 from services.quota_service import QuotaService
 from models import Teacher
+from models.organization import Organization, TeacherOrganization
 from database import get_session_local
 from fastapi import HTTPException
 
@@ -194,6 +196,117 @@ class TestQuotaDeduction:
             assert period.quota_used == 70  # 50 + 20
 
         db.close()
+
+
+class TestCheckAiAnalysisAvailability:
+    """check_ai_analysis_availability 測試 — Issue #615"""
+
+    def _make_org(self, total_points: int, used_points: int, is_active: bool = True):
+        org = MagicMock(spec=Organization)
+        org.total_points = total_points
+        org.used_points = used_points
+        org.is_active = is_active
+        return org
+
+    def _make_teacher_org(self, org_id: str, is_active: bool = True):
+        to = MagicMock(spec=TeacherOrganization)
+        to.organization_id = org_id
+        to.is_active = is_active
+        return to
+
+    def _setup_db(self, teacher, teacher_orgs, orgs_by_id):
+        """Build a mock db session that handles the queries in check_ai_analysis_availability."""
+        db = MagicMock()
+
+        def query_side_effect(model):
+            q = MagicMock()
+            if model is Teacher:
+                q.filter.return_value.first.return_value = teacher
+            elif model is TeacherOrganization:
+                q.filter.return_value.all.return_value = teacher_orgs
+            elif model is Organization:
+                def org_filter(*args, **kwargs):
+                    inner = MagicMock()
+                    # Return org matching the id from the filter call
+                    for org_id, org in orgs_by_id.items():
+                        inner.first.return_value = org
+                        return inner
+                    inner.first.return_value = None
+                    return inner
+                q.filter.side_effect = org_filter
+            return q
+
+        db.query.side_effect = query_side_effect
+        return db
+
+    def test_org_has_points_returns_true(self):
+        """教師屬於有餘額的機構 → True"""
+        teacher = MagicMock(spec=Teacher)
+        teacher.id = 99
+        teacher_orgs = [self._make_teacher_org("org-1")]
+        org = self._make_org(total_points=100, used_points=50)
+        db = self._setup_db(teacher, teacher_orgs, {"org-1": org})
+
+        assert QuotaService.check_ai_analysis_availability(99, db) is True
+
+    def test_org_no_points_but_personal_quota_returns_true(self):
+        """Issue #615: 機構點數為 0，但個人配額有剩餘 → True"""
+        teacher = MagicMock(spec=Teacher)
+        teacher.id = 99
+        teacher_orgs = [
+            self._make_teacher_org("org-1"),
+            self._make_teacher_org("org-2"),
+        ]
+        org1 = self._make_org(total_points=0, used_points=0)
+        org2 = self._make_org(total_points=0, used_points=0)
+        db = self._setup_db(teacher, teacher_orgs, {"org-1": org1, "org-2": org2})
+
+        with patch.object(
+            QuotaService, "_get_total_remaining", return_value=960
+        ):
+            assert QuotaService.check_ai_analysis_availability(99, db) is True
+
+    def test_org_no_points_and_no_personal_quota_returns_false(self):
+        """機構點數為 0，個人配額也用完 → False"""
+        teacher = MagicMock(spec=Teacher)
+        teacher.id = 99
+        teacher_orgs = [self._make_teacher_org("org-1")]
+        org = self._make_org(total_points=0, used_points=0)
+        db = self._setup_db(teacher, teacher_orgs, {"org-1": org})
+
+        with patch.object(
+            QuotaService, "_get_total_remaining", return_value=0
+        ):
+            assert QuotaService.check_ai_analysis_availability(99, db) is False
+
+    def test_no_org_personal_quota_returns_true(self):
+        """無機構，個人有額度 → True"""
+        teacher = MagicMock(spec=Teacher)
+        teacher.id = 99
+        db = self._setup_db(teacher, [], {})
+
+        with patch.object(
+            QuotaService, "_get_total_remaining", return_value=500
+        ):
+            assert QuotaService.check_ai_analysis_availability(99, db) is True
+
+    def test_no_org_no_personal_quota_returns_false(self):
+        """無機構，個人沒額度 → False"""
+        teacher = MagicMock(spec=Teacher)
+        teacher.id = 99
+        db = self._setup_db(teacher, [], {})
+
+        with patch.object(
+            QuotaService, "_get_total_remaining", return_value=0
+        ):
+            assert QuotaService.check_ai_analysis_availability(99, db) is False
+
+    def test_teacher_not_found_returns_false(self):
+        """教師不存在 → False"""
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        assert QuotaService.check_ai_analysis_availability(999, db) is False
 
 
 class TestQuotaInfo:

--- a/backend/tests/unit/test_quota_service.py
+++ b/backend/tests/unit/test_quota_service.py
@@ -215,8 +215,13 @@ class TestCheckAiAnalysisAvailability:
         return to
 
     def _setup_db(self, teacher, teacher_orgs, orgs_by_id):
-        """Build a mock db session that handles the queries in check_ai_analysis_availability."""
+        """Build a mock db session that handles the queries in check_ai_analysis_availability.
+
+        Organization lookups are dispatched by call order matching the teacher_orgs list,
+        so orgs_by_id[teacher_org.organization_id] returns the correct org for each iteration.
+        """
         db = MagicMock()
+        org_call_index = {"i": 0}
 
         def query_side_effect(model):
             q = MagicMock()
@@ -228,11 +233,13 @@ class TestCheckAiAnalysisAvailability:
 
                 def org_filter(*args, **kwargs):
                     inner = MagicMock()
-                    # Return org matching the id from the filter call
-                    for org_id, org in orgs_by_id.items():
-                        inner.first.return_value = org
-                        return inner
-                    inner.first.return_value = None
+                    idx = org_call_index["i"]
+                    org_call_index["i"] += 1
+                    if idx < len(teacher_orgs):
+                        oid = teacher_orgs[idx].organization_id
+                        inner.first.return_value = orgs_by_id.get(oid)
+                    else:
+                        inner.first.return_value = None
                     return inner
 
                 q.filter.side_effect = org_filter
@@ -294,6 +301,53 @@ class TestCheckAiAnalysisAvailability:
 
         with patch.object(QuotaService, "_get_total_remaining", return_value=0):
             assert QuotaService.check_ai_analysis_availability(99, db) is False
+
+    def test_inactive_org_skipped_fallback_to_personal(self):
+        """機構 is_active=False（被 filter 排除）→ fallback 到個人配額"""
+        teacher = MagicMock(spec=Teacher)
+        teacher.id = 99
+        teacher_orgs = [self._make_teacher_org("org-1")]
+        # org not in orgs_by_id → filter returns None (simulates inactive org)
+        db = self._setup_db(teacher, teacher_orgs, {})
+
+        with patch.object(QuotaService, "_get_total_remaining", return_value=500):
+            assert QuotaService.check_ai_analysis_availability(99, db) is True
+
+    def test_mixed_orgs_first_has_points_short_circuits(self):
+        """多機構：第一個有餘額 → 直接 return True，不查第二個"""
+        teacher = MagicMock(spec=Teacher)
+        teacher.id = 99
+        teacher_orgs = [
+            self._make_teacher_org("org-rich"),
+            self._make_teacher_org("org-empty"),
+        ]
+        org_rich = self._make_org(total_points=100, used_points=10)
+        org_empty = self._make_org(total_points=0, used_points=0)
+        db = self._setup_db(
+            teacher,
+            teacher_orgs,
+            {"org-rich": org_rich, "org-empty": org_empty},
+        )
+
+        assert QuotaService.check_ai_analysis_availability(99, db) is True
+
+    def test_mixed_orgs_second_has_points(self):
+        """多機構：第一個沒餘額，第二個有 → True"""
+        teacher = MagicMock(spec=Teacher)
+        teacher.id = 99
+        teacher_orgs = [
+            self._make_teacher_org("org-empty"),
+            self._make_teacher_org("org-rich"),
+        ]
+        org_empty = self._make_org(total_points=0, used_points=0)
+        org_rich = self._make_org(total_points=200, used_points=50)
+        db = self._setup_db(
+            teacher,
+            teacher_orgs,
+            {"org-empty": org_empty, "org-rich": org_rich},
+        )
+
+        assert QuotaService.check_ai_analysis_availability(99, db) is True
 
     def test_teacher_not_found_returns_false(self):
         """教師不存在 → False"""


### PR DESCRIPTION
## Summary

- **Bug**: `check_ai_analysis_availability` 用 `.first()` 只查第一個 active 機構，機構點數為 0 就直接 return False，跳過個人配額檢查
- **Fix**: 改為遍歷所有 active 機構，任一有餘額即 return True；全部沒有才 fallthrough 到個人額度（subscription + credit packages）
- 新增 6 個 unit tests 覆蓋所有分支情境

Fixes #615

## Test plan

- [x] 教師有 active 機構且機構有餘額 → True
- [x] 教師有 active 機構但機構無餘額，個人有額度 → True（修復的 case）
- [x] 教師有 active 機構但機構無餘額，個人也沒額度 → False
- [x] 教師無機構，個人有額度 → True
- [x] 教師無機構，個人沒額度 → False
- [x] 教師不存在 → False

🤖 Generated with [Claude Code](https://claude.com/claude-code)