### PR TITLE
fix: 修復作業副本編輯儲存失敗 (#578)

### DIFF
--- a/backend/alembic/versions/20260415_1000_add_cascade_delete_practice_answers_fk.py
+++ b/backend/alembic/versions/20260415_1000_add_cascade_delete_practice_answers_fk.py
@@ -48,4 +48,27 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    pass
+    # Restore original FK without CASCADE
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'practice_answers_content_item_id_fkey'
+            ) THEN
+                ALTER TABLE practice_answers
+                    DROP CONSTRAINT practice_answers_content_item_id_fkey;
+            END IF;
+
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'practice_answers_content_item_id_fkey'
+            ) THEN
+                ALTER TABLE practice_answers
+                    ADD CONSTRAINT practice_answers_content_item_id_fkey
+                    FOREIGN KEY (content_item_id)
+                    REFERENCES content_items(id);
+            END IF;
+        END $$;
+    """
+    )

--- a/backend/alembic/versions/20260415_1000_add_cascade_delete_practice_answers_fk.py
+++ b/backend/alembic/versions/20260415_1000_add_cascade_delete_practice_answers_fk.py
@@ -1,0 +1,51 @@
+"""Add ON DELETE CASCADE to practice_answers.content_item_id FK
+
+Fixes issue #578: editing a content copy fails when practice_answers
+reference the content_items being replaced.
+
+Revision ID: 20260415_1000
+Revises: 20260403_1000
+Create Date: 2026-04-15
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260415_1000"
+down_revision = "20260403_1000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Idempotent: drop old FK if exists, then add with CASCADE
+    op.execute(
+        """
+        DO $$ BEGIN
+            -- Drop existing FK constraint (name may vary)
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'practice_answers_content_item_id_fkey'
+            ) THEN
+                ALTER TABLE practice_answers
+                    DROP CONSTRAINT practice_answers_content_item_id_fkey;
+            END IF;
+
+            -- Re-add with ON DELETE CASCADE
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'practice_answers_content_item_id_fkey'
+            ) THEN
+                ALTER TABLE practice_answers
+                    ADD CONSTRAINT practice_answers_content_item_id_fkey
+                    FOREIGN KEY (content_item_id)
+                    REFERENCES content_items(id)
+                    ON DELETE CASCADE;
+            END IF;
+        END $$;
+    """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/models/progress.py
+++ b/backend/models/progress.py
@@ -279,7 +279,11 @@ class PracticeAnswer(Base):
     practice_session_id = Column(
         Integer, ForeignKey("practice_sessions.id", ondelete="CASCADE"), nullable=False
     )
-    content_item_id = Column(Integer, ForeignKey("content_items.id"), nullable=False)
+    content_item_id = Column(
+        Integer,
+        ForeignKey("content_items.id", ondelete="CASCADE"),
+        nullable=False,
+    )
 
     # 答題結果
     is_correct = Column(Boolean, nullable=False)

--- a/backend/routers/teachers/content_ops.py
+++ b/backend/routers/teachers/content_ops.py
@@ -426,6 +426,7 @@ async def update_content(
         # 先刪除參照 content_items 的 practice_answers（老師修改內容後舊答題紀錄失效）
         existing_item_ids = [item.id for item in existing_items]
         if existing_item_ids:
+            # Lazy import to avoid circular dependency (progress → program → content)
             from models.progress import PracticeAnswer
 
             db.query(PracticeAnswer).filter(

--- a/backend/routers/teachers/content_ops.py
+++ b/backend/routers/teachers/content_ops.py
@@ -435,11 +435,15 @@ async def update_content(
             ).delete(synchronize_session=False)
 
         # 使用參數化查詢刪除所有現有的 ContentItem，確保唯一約束不衝突
-        db.execute(
-            text("DELETE FROM content_items WHERE content_id = :content_id"),
-            {"content_id": content.id},
-        )
-        db.flush()
+        try:
+            db.execute(
+                text("DELETE FROM content_items WHERE content_id = :content_id"),
+                {"content_id": content.id},
+            )
+            db.flush()
+        except IntegrityError:
+            db.rollback()
+            raise HTTPException(status_code=409, detail="無法刪除內容項目，因為存在相關引用")
 
         # 創建新的 ContentItem
         for idx, item_data in enumerate(update_data.items):

--- a/backend/routers/teachers/content_ops.py
+++ b/backend/routers/teachers/content_ops.py
@@ -424,6 +424,7 @@ async def update_content(
                     audio_manager.delete_old_audio(existing_item.audio_url)
 
         # 先刪除參照 content_items 的 practice_answers（老師修改內容後舊答題紀錄失效）
+        # 顯式刪除：防止 ON DELETE CASCADE migration (20260415_1000) 尚未執行的環境
         existing_item_ids = [item.id for item in existing_items]
         if existing_item_ids:
             # Lazy import to avoid circular dependency (progress → program → content)

--- a/backend/routers/teachers/content_ops.py
+++ b/backend/routers/teachers/content_ops.py
@@ -423,20 +423,21 @@ async def update_content(
                 if existing_item.audio_url not in new_audio_urls:
                     audio_manager.delete_old_audio(existing_item.audio_url)
 
+        # 先刪除參照 content_items 的 practice_answers（老師修改內容後舊答題紀錄失效）
+        existing_item_ids = [item.id for item in existing_items]
+        if existing_item_ids:
+            from models.progress import PracticeAnswer
+
+            db.query(PracticeAnswer).filter(
+                PracticeAnswer.content_item_id.in_(existing_item_ids)
+            ).delete(synchronize_session=False)
+
         # 使用參數化查詢刪除所有現有的 ContentItem，確保唯一約束不衝突
-        try:
-            db.execute(
-                text("DELETE FROM content_items WHERE content_id = :content_id"),
-                {"content_id": content.id},
-            )
-            # 確保刪除操作執行完成
-            db.flush()
-        except IntegrityError as e:
-            db.rollback()
-            raise HTTPException(
-                status_code=409,
-                detail="無法刪除內容項目，因為存在相關引用",
-            )
+        db.execute(
+            text("DELETE FROM content_items WHERE content_id = :content_id"),
+            {"content_id": content.id},
+        )
+        db.flush()
 
         # 創建新的 ContentItem
         for idx, item_data in enumerate(update_data.items):

--- a/backend/tests/unit/test_content_update_with_practice_answers.py
+++ b/backend/tests/unit/test_content_update_with_practice_answers.py
@@ -229,9 +229,9 @@ class TestUpdateContentWithPracticeAnswers:
             },
         )
 
-        assert response.status_code == 200, (
-            f"Expected 200, got {response.status_code}: {response.json()}"
-        )
+        assert (
+            response.status_code == 200
+        ), f"Expected 200, got {response.status_code}: {response.json()}"
         data = response.json()
         assert data["title"] == "Word Selection Updated"
         assert len(data["items"]) == 3

--- a/backend/tests/unit/test_content_update_with_practice_answers.py
+++ b/backend/tests/unit/test_content_update_with_practice_answers.py
@@ -1,0 +1,268 @@
+"""
+Test: Updating content with existing practice_answers should succeed.
+
+Regression test for Issue #578:
+When a teacher edits a content copy that students have already practiced on,
+the save failed with 409 because practice_answers had a FK to content_items
+without ON DELETE CASCADE.
+
+The fix: content_ops.update_content now explicitly deletes practice_answers
+before deleting content_items.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from main import app
+from database import get_db
+from models import (
+    Base,
+    Teacher,
+    Student,
+    Classroom,
+    ClassroomStudent,
+    Program,
+    Lesson,
+    Content,
+    ContentItem,
+    ContentType,
+    Assignment,
+    AssignmentContent,
+    StudentAssignment,
+)
+from models.progress import PracticeSession, PracticeAnswer
+from auth import get_password_hash
+
+# ---------- SQLite test DB ----------
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test_content_update_practice.db"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+client = TestClient(app)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+
+# ---------- Fixtures ----------
+@pytest.fixture(scope="module", autouse=True)
+def setup_database():
+    Base.metadata.create_all(bind=engine)
+
+    db = TestingSessionLocal()
+
+    teacher = Teacher(
+        email="practice-test@teacher.com",
+        name="Practice Test Teacher",
+        password_hash=get_password_hash("test123"),
+        email_verified=True,
+    )
+    db.add(teacher)
+    db.flush()
+
+    classroom = Classroom(
+        name="Practice Test Classroom", teacher_id=teacher.id, grade="Grade 1"
+    )
+    db.add(classroom)
+    db.flush()
+
+    student = Student(
+        name="Test Student",
+        student_number="S001",
+    )
+    db.add(student)
+    db.flush()
+
+    cs = ClassroomStudent(
+        classroom_id=classroom.id,
+        student_id=student.id,
+    )
+    db.add(cs)
+
+    program = Program(
+        name="Practice Test Program",
+        description="Test",
+        teacher_id=teacher.id,
+        classroom_id=classroom.id,
+    )
+    db.add(program)
+    db.flush()
+
+    lesson = Lesson(
+        name="Practice Test Lesson",
+        program_id=program.id,
+        order_index=1,
+    )
+    db.add(lesson)
+    db.flush()
+
+    # Create a vocabulary_set content with items
+    content = Content(
+        title="Word Selection Test",
+        type=ContentType.VOCABULARY_SET,
+        lesson_id=lesson.id,
+        order_index=1,
+        level="A1",
+    )
+    db.add(content)
+    db.flush()
+
+    item1 = ContentItem(
+        content_id=content.id, order_index=0, text="apple", translation="蘋果"
+    )
+    item2 = ContentItem(
+        content_id=content.id, order_index=1, text="banana", translation="香蕉"
+    )
+    db.add_all([item1, item2])
+    db.flush()
+
+    # Create assignment referencing this content
+    assignment = Assignment(
+        title="Test Assignment",
+        classroom_id=classroom.id,
+        teacher_id=teacher.id,
+    )
+    db.add(assignment)
+    db.flush()
+
+    ac = AssignmentContent(
+        assignment_id=assignment.id,
+        content_id=content.id,
+    )
+    db.add(ac)
+    db.flush()
+
+    sa = StudentAssignment(
+        assignment_id=assignment.id,
+        student_id=student.id,
+    )
+    db.add(sa)
+    db.flush()
+
+    # Simulate student practice: create session + answers
+    session = PracticeSession(
+        student_id=student.id,
+        student_assignment_id=sa.id,
+        practice_mode="word_selection",
+        words_practiced=2,
+        correct_count=1,
+    )
+    db.add(session)
+    db.flush()
+
+    ans1 = PracticeAnswer(
+        practice_session_id=session.id,
+        content_item_id=item1.id,
+        is_correct=True,
+    )
+    ans2 = PracticeAnswer(
+        practice_session_id=session.id,
+        content_item_id=item2.id,
+        is_correct=False,
+    )
+    db.add_all([ans1, ans2])
+
+    db.commit()
+    db.close()
+
+    yield
+
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def auth_token():
+    response = client.post(
+        "/api/auth/teacher/login",
+        json={"email": "practice-test@teacher.com", "password": "test123"},
+    )
+    assert response.status_code == 200
+    return response.json()["access_token"]
+
+
+# ---------- Tests ----------
+class TestUpdateContentWithPracticeAnswers:
+    """Issue #578: 作業副本編輯後儲存失敗"""
+
+    def test_update_content_items_with_existing_practice_answers(self, auth_token):
+        """Updating content items should succeed even when practice_answers exist.
+
+        Before the fix, this returned 409 because DELETE FROM content_items
+        violated the FK constraint from practice_answers.
+        """
+        db = TestingSessionLocal()
+        content = db.query(Content).filter(Content.title == "Word Selection Test").one()
+        content_id = content.id
+
+        # Verify practice_answers exist before update
+        item_ids = [item.id for item in content.content_items]
+        pa_count = (
+            db.query(PracticeAnswer)
+            .filter(PracticeAnswer.content_item_id.in_(item_ids))
+            .count()
+        )
+        assert pa_count == 2, "Expected 2 practice_answers before update"
+        db.close()
+
+        # Update content items (this triggers delete-and-recreate)
+        response = client.put(
+            f"/api/teachers/contents/{content_id}",
+            headers={"Authorization": f"Bearer {auth_token}"},
+            json={
+                "title": "Word Selection Updated",
+                "items": [
+                    {"text": "cherry", "translation": "櫻桃"},
+                    {"text": "grape", "translation": "葡萄"},
+                    {"text": "mango", "translation": "芒果"},
+                ],
+            },
+        )
+
+        assert response.status_code == 200, (
+            f"Expected 200, got {response.status_code}: {response.json()}"
+        )
+        data = response.json()
+        assert data["title"] == "Word Selection Updated"
+        assert len(data["items"]) == 3
+
+        # Verify old practice_answers were cleaned up
+        db = TestingSessionLocal()
+        remaining_pa = (
+            db.query(PracticeAnswer)
+            .filter(PracticeAnswer.content_item_id.in_(item_ids))
+            .count()
+        )
+        assert remaining_pa == 0, "Old practice_answers should be deleted"
+        db.close()
+
+    def test_update_content_title_only_preserves_practice_answers(self, auth_token):
+        """Updating only the title (no items change) should not delete practice data."""
+        db = TestingSessionLocal()
+        content = (
+            db.query(Content).filter(Content.title == "Word Selection Updated").one()
+        )
+        content_id = content.id
+        db.close()
+
+        response = client.put(
+            f"/api/teachers/contents/{content_id}",
+            headers={"Authorization": f"Bearer {auth_token}"},
+            json={"title": "Title Only Change"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["title"] == "Title Only Change"
+        # Items should remain unchanged
+        assert len(data["items"]) == 3

--- a/backend/tests/unit/test_content_update_with_practice_answers.py
+++ b/backend/tests/unit/test_content_update_with_practice_answers.py
@@ -14,6 +14,7 @@ pre-deletion logic but does NOT test the Alembic migration or the
 ON DELETE CASCADE FK behavior (which require PostgreSQL).
 """
 
+import os
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -183,6 +184,9 @@ def setup_database():
     yield
 
     Base.metadata.drop_all(bind=engine)
+    engine.dispose()
+    if os.path.exists("./test_content_update_practice.db"):
+        os.remove("./test_content_update_practice.db")
 
 
 @pytest.fixture

--- a/backend/tests/unit/test_content_update_with_practice_answers.py
+++ b/backend/tests/unit/test_content_update_with_practice_answers.py
@@ -191,19 +191,32 @@ def auth_token():
     return response.json()["access_token"]
 
 
+@pytest.fixture
+def content_id():
+    """Get the test content ID by querying the DB directly (order-independent)."""
+    db = TestingSessionLocal()
+    content = (
+        db.query(Content).filter(Content.type == ContentType.VOCABULARY_SET).first()
+    )
+    cid = content.id
+    db.close()
+    return cid
+
+
 # ---------- Tests ----------
 class TestUpdateContentWithPracticeAnswers:
     """Issue #578: 作業副本編輯後儲存失敗"""
 
-    def test_update_content_items_with_existing_practice_answers(self, auth_token):
+    def test_update_content_items_with_existing_practice_answers(
+        self, auth_token, content_id
+    ):
         """Updating content items should succeed even when practice_answers exist.
 
         Before the fix, this returned 409 because DELETE FROM content_items
         violated the FK constraint from practice_answers.
         """
         db = TestingSessionLocal()
-        content = db.query(Content).filter(Content.title == "Word Selection Test").one()
-        content_id = content.id
+        content = db.query(Content).filter(Content.id == content_id).one()
 
         # Verify practice_answers exist before update
         item_ids = [item.id for item in content.content_items]
@@ -246,13 +259,13 @@ class TestUpdateContentWithPracticeAnswers:
         assert remaining_pa == 0, "Old practice_answers should be deleted"
         db.close()
 
-    def test_update_content_title_only_preserves_practice_answers(self, auth_token):
-        """Updating only the title (no items change) should not delete practice data."""
+    def test_update_title_only_does_not_replace_items(self, auth_token, content_id):
+        """Updating only the title (no items in payload) should not replace items."""
+        # Get current item count before title-only update
         db = TestingSessionLocal()
-        content = (
-            db.query(Content).filter(Content.title == "Word Selection Updated").one()
+        items_before = (
+            db.query(ContentItem).filter(ContentItem.content_id == content_id).count()
         )
-        content_id = content.id
         db.close()
 
         response = client.put(
@@ -264,5 +277,4 @@ class TestUpdateContentWithPracticeAnswers:
         assert response.status_code == 200
         data = response.json()
         assert data["title"] == "Title Only Change"
-        # Items should remain unchanged
-        assert len(data["items"]) == 3
+        assert len(data["items"]) == items_before

--- a/backend/tests/unit/test_content_update_with_practice_answers.py
+++ b/backend/tests/unit/test_content_update_with_practice_answers.py
@@ -8,6 +8,10 @@ without ON DELETE CASCADE.
 
 The fix: content_ops.update_content now explicitly deletes practice_answers
 before deleting content_items.
+
+Note: Uses SQLite for testing. This validates the application-level
+pre-deletion logic but does NOT test the Alembic migration or the
+ON DELETE CASCADE FK behavior (which require PostgreSQL).
 """
 
 import pytest

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -1140,12 +1140,13 @@ export function AssignmentDetailSheet({
       {/* Content Edit - Right-side sheet with sidebar offset */}
       {editingContentId && contentDetails[editingContentId] && (
         <>
+          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
           <div
-            className="fixed inset-0 z-[60] bg-black/50"
+            className="fixed inset-0 z-[60] bg-black/50 pointer-events-auto"
             onClick={() => setEditingContentId(null)}
           />
           <div
-            className="fixed top-0 right-0 h-full z-[61] bg-white shadow-xl border-l flex flex-col"
+            className="fixed top-0 right-0 h-full z-[61] bg-white shadow-xl border-l flex flex-col pointer-events-auto"
             style={{ left: `${sidebarWidth}px` }}
           >
             {/* Header */}

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
-import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import {
   Sheet,
@@ -1145,25 +1144,11 @@ export function AssignmentDetailSheet({
               </Button>
             )}
           </div>
-        </SheetContent>
-      </Sheet>
 
-      {/* Content Edit - Portaled to document.body to escape Radix Sheet's focus trap */}
-      {editingContentId &&
-        contentDetails[editingContentId] &&
-        createPortal(
-          <>
-            <div
-              className="fixed inset-0 z-[60] bg-black/30"
-              role="button"
-              tabIndex={0}
-              aria-label={t("common.close", "關閉")}
-              onClick={() => setEditingContentId(null)}
-              onKeyDown={(e) => {
-                if (e.key === "Escape") setEditingContentId(null);
-              }}
-            />
-            {(() => {
+          {/* Content Edit Overlay — inside SheetContent to stay within Radix focus trap */}
+          {editingContentId &&
+            contentDetails[editingContentId] &&
+            (() => {
               const editingDetail = contentDetails[editingContentId];
               const isVocabSet = ["VOCABULARY_SET", "SENTENCE_MAKING"].includes(
                 editingDetail?.type?.toUpperCase() ?? "",
@@ -1185,86 +1170,97 @@ export function AssignmentDetailSheet({
                 <div
                   ref={contentEditPanelRef}
                   tabIndex={-1}
-                  className="fixed top-0 right-0 h-full z-[61] bg-white shadow-xl border-l flex flex-col pointer-events-auto outline-none"
-                  style={{ left: `${sidebarWidth}px` }}
+                  className="fixed inset-0 z-[60] flex outline-none"
                 >
-                  {/* Header */}
-                  <div className="flex items-center justify-between px-6 py-4 border-b bg-gray-50">
-                    <div>
-                      <h2 className="text-lg font-semibold text-gray-900">
-                        {t("assignmentDetail.labels.editContent") ||
-                          "編輯作業內容"}
-                      </h2>
-                      <p className="text-sm text-amber-600 mt-1">
-                        ⚠️{" "}
-                        {t(
-                          "assignmentDetail.sheet.editContentWarning",
-                          "注意：此為作業副本。刪除已有學生進度的題目將被阻止。",
-                        )}
-                      </p>
+                  {/* Backdrop — click to cancel */}
+                  <div
+                    className="absolute inset-0 bg-black/30"
+                    onClick={() => setEditingContentId(null)}
+                  />
+                  {/* Panel */}
+                  <div
+                    className="absolute top-0 right-0 h-full bg-white shadow-xl border-l flex flex-col"
+                    style={{ left: `${sidebarWidth}px` }}
+                  >
+                    {/* Header */}
+                    <div className="flex items-center justify-between px-6 py-4 border-b bg-gray-50">
+                      <div>
+                        <h2 className="text-lg font-semibold text-gray-900">
+                          {t("assignmentDetail.labels.editContent") ||
+                            "編輯作業內容"}
+                        </h2>
+                        <p className="text-sm text-amber-600 mt-1">
+                          ⚠️{" "}
+                          {t(
+                            "assignmentDetail.sheet.editContentWarning",
+                            "注意：此為作業副本。刪除已有學生進度的題目將被阻止。",
+                          )}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setEditingContentId(null)}
+                        >
+                          {t("common.cancel", "取消")}
+                        </Button>
+                        <RefSaveButton
+                          panelRef={
+                            isVocabSet ? vocabPanelRef : readingPanelRef
+                          }
+                        />
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            setEditingContentId(null);
+                            onOpenChange(false);
+                          }}
+                          className="hover:bg-gray-200"
+                        >
+                          <X className="h-5 w-5" />
+                        </Button>
+                      </div>
                     </div>
-                    <div className="flex items-center gap-2">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setEditingContentId(null)}
-                      >
-                        {t("common.cancel", "取消")}
-                      </Button>
-                      <RefSaveButton
-                        panelRef={isVocabSet ? vocabPanelRef : readingPanelRef}
-                      />
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => {
-                          setEditingContentId(null);
-                          onOpenChange(false);
-                        }}
-                        className="hover:bg-gray-200"
-                      >
-                        <X className="h-5 w-5" />
-                      </Button>
+                    {/* Content */}
+                    <div className="flex-1 overflow-y-auto p-6">
+                      {isVocabSet ? (
+                        <VocabularySetPanel
+                          ref={vocabPanelRef}
+                          content={{
+                            id: editingContentId,
+                            title: editingDetail.title || "",
+                          }}
+                          editingContent={editingDetail as never}
+                          onUpdateContent={async () => {}}
+                          onSave={handleEditSave}
+                          lessonId={0}
+                          isCreating={false}
+                          isAssignmentCopy={true}
+                        />
+                      ) : (
+                        <ReadingAssessmentPanel
+                          ref={readingPanelRef}
+                          content={{
+                            id: editingContentId,
+                            title: editingDetail.title || "",
+                          }}
+                          editingContent={editingDetail as never}
+                          onUpdateContent={async () => {}}
+                          onSave={handleEditSave}
+                          lessonId={0}
+                          isCreating={false}
+                          isAssignmentCopy={true}
+                        />
+                      )}
                     </div>
-                  </div>
-                  {/* Content */}
-                  <div className="flex-1 overflow-y-auto p-6">
-                    {isVocabSet ? (
-                      <VocabularySetPanel
-                        ref={vocabPanelRef}
-                        content={{
-                          id: editingContentId,
-                          title: editingDetail.title || "",
-                        }}
-                        editingContent={editingDetail as never}
-                        onUpdateContent={async () => {}}
-                        onSave={handleEditSave}
-                        lessonId={0}
-                        isCreating={false}
-                        isAssignmentCopy={true}
-                      />
-                    ) : (
-                      <ReadingAssessmentPanel
-                        ref={readingPanelRef}
-                        content={{
-                          id: editingContentId,
-                          title: editingDetail.title || "",
-                        }}
-                        editingContent={editingDetail as never}
-                        onUpdateContent={async () => {}}
-                        onSave={handleEditSave}
-                        lessonId={0}
-                        isCreating={false}
-                        isAssignmentCopy={true}
-                      />
-                    )}
                   </div>
                 </div>
               );
             })()}
-          </>,
-          document.body,
-        )}
+        </SheetContent>
+      </Sheet>
     </>
   );
 }

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -37,6 +37,7 @@ import { Assignment } from "@/types";
 import StudentStatusPanel, {
   StudentProgress,
 } from "@/components/StudentStatusPanel";
+import { useSidebar } from "@/contexts/SidebarContext";
 
 interface AssignmentContent {
   id: number;
@@ -93,6 +94,7 @@ export function AssignmentDetailSheet({
   onAssignmentUpdated,
 }: AssignmentDetailSheetProps) {
   const { t } = useTranslation();
+  const { sidebarWidth } = useSidebar();
   const [isEditing, setIsEditing] = useState(false);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -449,7 +451,7 @@ export function AssignmentDetailSheet({
                   className="gap-1.5 mr-6"
                 >
                   <Pencil className="h-3.5 w-3.5" />
-                  {t("assignmentDetail.sheet.editButton", "編輯")}
+                  {t("assignmentDetail.sheet.viewDetailsButton", "查看詳情")}
                 </Button>
               )}
             </div>
@@ -1135,16 +1137,17 @@ export function AssignmentDetailSheet({
         </SheetContent>
       </Sheet>
 
-      {/* Content Edit - Full-width right-side sheet */}
+      {/* Content Edit - Right-side sheet with sidebar offset */}
       {editingContentId && contentDetails[editingContentId] && (
-        <div className="fixed inset-0 z-[60] flex">
-          {/* Backdrop */}
+        <>
           <div
-            className="flex-shrink-0 bg-black/50"
+            className="fixed inset-0 z-[60] bg-black/50"
             onClick={() => setEditingContentId(null)}
           />
-          {/* Panel */}
-          <div className="flex-1 bg-white flex flex-col min-w-0">
+          <div
+            className="fixed top-0 right-0 h-full z-[61] bg-white shadow-xl border-l flex flex-col"
+            style={{ left: `${sidebarWidth}px` }}
+          >
             {/* Header */}
             <div className="flex items-center justify-between px-6 py-4 border-b bg-gray-50">
               <div>
@@ -1240,7 +1243,7 @@ export function AssignmentDetailSheet({
               })()}
             </div>
           </div>
-        </div>
+        </>
       )}
     </>
   );

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -443,6 +443,12 @@ export function AssignmentDetailSheet({
         <SheetContent
           side="right"
           className="w-full sm:max-w-lg md:max-w-xl lg:max-w-2xl p-0 flex flex-col"
+          onEscapeKeyDown={(e) => {
+            if (editingContentId) {
+              e.preventDefault();
+              setEditingContentId(null);
+            }
+          }}
         >
           {/* Header */}
           <SheetHeader className="px-6 pt-6 pb-4 border-b dark:border-gray-700">
@@ -1179,13 +1185,13 @@ export function AssignmentDetailSheet({
                   />
                   {/* Panel */}
                   <div
-                    className="absolute top-0 right-0 h-full bg-white shadow-xl border-l flex flex-col"
+                    className="absolute top-0 right-0 h-full bg-white dark:bg-gray-950 shadow-xl border-l flex flex-col"
                     style={{ left: `${sidebarWidth}px` }}
                   >
                     {/* Header */}
-                    <div className="flex items-center justify-between px-6 py-4 border-b bg-gray-50">
+                    <div className="flex items-center justify-between px-6 py-4 border-b bg-gray-50 dark:bg-gray-800">
                       <div>
-                        <h2 className="text-lg font-semibold text-gray-900">
+                        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
                           {t("assignmentDetail.labels.editContent") ||
                             "編輯作業內容"}
                         </h2>

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import {
   Sheet,
@@ -119,22 +120,13 @@ export function AssignmentDetailSheet({
   const vocabPanelRef = useRef<VocabularySetPanelHandle>(null);
   const loadingRef = useRef<Set<number>>(new Set());
 
-  // When content edit overlay is open: disable Sheet's focus trap + auto-focus panel
+  // Auto-focus content edit panel so scroll works immediately
   const contentEditPanelRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (editingContentId) {
-      // Disable Radix Sheet's pointer-events lock and focus trap
-      const style = document.createElement("style");
-      style.setAttribute("data-content-edit-override", "true");
-      style.textContent =
-        "body { pointer-events: auto !important; } [data-radix-focus-guard] { display: none !important; }";
-      document.head.appendChild(style);
       requestAnimationFrame(() => {
         contentEditPanelRef.current?.focus();
       });
-      return () => {
-        style.remove();
-      };
     }
   }, [editingContentId]);
 
@@ -1156,120 +1148,123 @@ export function AssignmentDetailSheet({
         </SheetContent>
       </Sheet>
 
-      {/* Content Edit - Right-side sheet with sidebar offset */}
-      {editingContentId && contentDetails[editingContentId] && (
-        <>
-          <div
-            className="fixed inset-0 z-[60] bg-black/50 pointer-events-auto"
-            role="button"
-            tabIndex={0}
-            aria-label={t("common.close", "關閉")}
-            onClick={() => setEditingContentId(null)}
-            onKeyDown={(e) => {
-              if (e.key === "Escape") setEditingContentId(null);
-            }}
-          />
-          {(() => {
-            const editingDetail = contentDetails[editingContentId];
-            const isVocabSet = ["VOCABULARY_SET", "SENTENCE_MAKING"].includes(
-              editingDetail?.type?.toUpperCase() ?? "",
-            );
-            const handleEditSave = async () => {
-              const savedContentId = editingContentId;
-              setEditingContentId(null);
-              if (savedContentId) {
-                setContentDetails((prev) => {
-                  const updated = { ...prev };
-                  delete updated[savedContentId];
-                  return updated;
-                });
-                await loadContentDetail(savedContentId, true);
-              }
-            };
+      {/* Content Edit - Portaled to document.body to escape Radix Sheet's focus trap */}
+      {editingContentId &&
+        contentDetails[editingContentId] &&
+        createPortal(
+          <>
+            <div
+              className="fixed inset-0 z-[60] bg-black/30"
+              role="button"
+              tabIndex={0}
+              aria-label={t("common.close", "關閉")}
+              onClick={() => setEditingContentId(null)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") setEditingContentId(null);
+              }}
+            />
+            {(() => {
+              const editingDetail = contentDetails[editingContentId];
+              const isVocabSet = ["VOCABULARY_SET", "SENTENCE_MAKING"].includes(
+                editingDetail?.type?.toUpperCase() ?? "",
+              );
+              const handleEditSave = async () => {
+                const savedContentId = editingContentId;
+                setEditingContentId(null);
+                if (savedContentId) {
+                  setContentDetails((prev) => {
+                    const updated = { ...prev };
+                    delete updated[savedContentId];
+                    return updated;
+                  });
+                  await loadContentDetail(savedContentId, true);
+                }
+              };
 
-            return (
-              <div
-                ref={contentEditPanelRef}
-                tabIndex={-1}
-                className="fixed top-0 right-0 h-full z-[61] bg-white shadow-xl border-l flex flex-col pointer-events-auto outline-none"
-                style={{ left: `${sidebarWidth}px` }}
-              >
-                {/* Header */}
-                <div className="flex items-center justify-between px-6 py-4 border-b bg-gray-50">
-                  <div>
-                    <h2 className="text-lg font-semibold text-gray-900">
-                      {t("assignmentDetail.labels.editContent") ||
-                        "編輯作業內容"}
-                    </h2>
-                    <p className="text-sm text-amber-600 mt-1">
-                      ⚠️{" "}
-                      {t(
-                        "assignmentDetail.sheet.editContentWarning",
-                        "注意：此為作業副本。刪除已有學生進度的題目將被阻止。",
-                      )}
-                    </p>
+              return (
+                <div
+                  ref={contentEditPanelRef}
+                  tabIndex={-1}
+                  className="fixed top-0 right-0 h-full z-[61] bg-white shadow-xl border-l flex flex-col pointer-events-auto outline-none"
+                  style={{ left: `${sidebarWidth}px` }}
+                >
+                  {/* Header */}
+                  <div className="flex items-center justify-between px-6 py-4 border-b bg-gray-50">
+                    <div>
+                      <h2 className="text-lg font-semibold text-gray-900">
+                        {t("assignmentDetail.labels.editContent") ||
+                          "編輯作業內容"}
+                      </h2>
+                      <p className="text-sm text-amber-600 mt-1">
+                        ⚠️{" "}
+                        {t(
+                          "assignmentDetail.sheet.editContentWarning",
+                          "注意：此為作業副本。刪除已有學生進度的題目將被阻止。",
+                        )}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setEditingContentId(null)}
+                      >
+                        {t("common.cancel", "取消")}
+                      </Button>
+                      <RefSaveButton
+                        panelRef={isVocabSet ? vocabPanelRef : readingPanelRef}
+                      />
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setEditingContentId(null);
+                          onOpenChange(false);
+                        }}
+                        className="hover:bg-gray-200"
+                      >
+                        <X className="h-5 w-5" />
+                      </Button>
+                    </div>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setEditingContentId(null)}
-                    >
-                      {t("common.cancel", "取消")}
-                    </Button>
-                    <RefSaveButton
-                      panelRef={isVocabSet ? vocabPanelRef : readingPanelRef}
-                    />
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => {
-                        setEditingContentId(null);
-                        onOpenChange(false);
-                      }}
-                      className="hover:bg-gray-200"
-                    >
-                      <X className="h-5 w-5" />
-                    </Button>
+                  {/* Content */}
+                  <div className="flex-1 overflow-y-auto p-6">
+                    {isVocabSet ? (
+                      <VocabularySetPanel
+                        ref={vocabPanelRef}
+                        content={{
+                          id: editingContentId,
+                          title: editingDetail.title || "",
+                        }}
+                        editingContent={editingDetail as never}
+                        onUpdateContent={async () => {}}
+                        onSave={handleEditSave}
+                        lessonId={0}
+                        isCreating={false}
+                        isAssignmentCopy={true}
+                      />
+                    ) : (
+                      <ReadingAssessmentPanel
+                        ref={readingPanelRef}
+                        content={{
+                          id: editingContentId,
+                          title: editingDetail.title || "",
+                        }}
+                        editingContent={editingDetail as never}
+                        onUpdateContent={async () => {}}
+                        onSave={handleEditSave}
+                        lessonId={0}
+                        isCreating={false}
+                        isAssignmentCopy={true}
+                      />
+                    )}
                   </div>
                 </div>
-                {/* Content */}
-                <div className="flex-1 overflow-y-auto p-6">
-                  {isVocabSet ? (
-                    <VocabularySetPanel
-                      ref={vocabPanelRef}
-                      content={{
-                        id: editingContentId,
-                        title: editingDetail.title || "",
-                      }}
-                      editingContent={editingDetail as never}
-                      onUpdateContent={async () => {}}
-                      onSave={handleEditSave}
-                      lessonId={0}
-                      isCreating={false}
-                      isAssignmentCopy={true}
-                    />
-                  ) : (
-                    <ReadingAssessmentPanel
-                      ref={readingPanelRef}
-                      content={{
-                        id: editingContentId,
-                        title: editingDetail.title || "",
-                      }}
-                      editingContent={editingDetail as never}
-                      onUpdateContent={async () => {}}
-                      onSave={handleEditSave}
-                      lessonId={0}
-                      isCreating={false}
-                      isAssignmentCopy={true}
-                    />
-                  )}
-                </div>
-              </div>
-            );
-          })()}
-        </>
-      )}
+              );
+            })()}
+          </>,
+          document.body,
+        )}
     </>
   );
 }

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -7,19 +7,17 @@ import {
   SheetTitle,
   SheetDescription,
 } from "@/components/ui/sheet";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
-import ReadingAssessmentPanel from "@/components/ReadingAssessmentPanel";
-import VocabularySetPanel from "@/components/VocabularySetPanel";
+import ReadingAssessmentPanel, {
+  type ReadingAssessmentPanelHandle,
+} from "@/components/ReadingAssessmentPanel";
+import VocabularySetPanel, {
+  type VocabularySetPanelHandle,
+} from "@/components/VocabularySetPanel";
+import { RefSaveButton } from "@/components/shared/RefSaveButton";
 import { apiClient } from "@/lib/api";
 import { toast } from "sonner";
 import { Label } from "@/components/ui/label";
@@ -115,6 +113,8 @@ export function AssignmentDetailSheet({
     Record<number, ContentDetail>
   >({});
   const [editingContentId, setEditingContentId] = useState<number | null>(null);
+  const readingPanelRef = useRef<ReadingAssessmentPanelHandle>(null);
+  const vocabPanelRef = useRef<VocabularySetPanelHandle>(null);
   const loadingRef = useRef<Set<number>>(new Set());
 
   // Detail data from API (includes advanced settings)
@@ -1135,28 +1135,55 @@ export function AssignmentDetailSheet({
         </SheetContent>
       </Sheet>
 
-      {/* Content Edit Dialog */}
+      {/* Content Edit - Full-width right-side sheet */}
       {editingContentId && contentDetails[editingContentId] && (
-        <Dialog
-          open={editingContentId !== null}
-          onOpenChange={(dialogOpen) =>
-            !dialogOpen && setEditingContentId(null)
-          }
-        >
-          <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
-            <DialogHeader>
-              <DialogTitle>
-                {t("assignmentDetail.labels.editContent") || "編輯作業內容"}
-              </DialogTitle>
-              <p className="text-sm text-amber-600 mt-2">
-                ⚠️{" "}
-                {t(
-                  "assignmentDetail.sheet.editContentWarning",
-                  "注意：此為作業副本。刪除已有學生進度的題目將被阻止。",
-                )}
-              </p>
-            </DialogHeader>
-            <div className="mt-4">
+        <div className="fixed inset-0 z-[60] flex">
+          {/* Backdrop */}
+          <div
+            className="flex-shrink-0 bg-black/50"
+            onClick={() => setEditingContentId(null)}
+          />
+          {/* Panel */}
+          <div className="flex-1 bg-white flex flex-col min-w-0">
+            {/* Header */}
+            <div className="flex items-center justify-between px-6 py-4 border-b bg-gray-50">
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">
+                  {t("assignmentDetail.labels.editContent") || "編輯作業內容"}
+                </h2>
+                <p className="text-sm text-amber-600 mt-1">
+                  ⚠️{" "}
+                  {t(
+                    "assignmentDetail.sheet.editContentWarning",
+                    "注意：此為作業副本。刪除已有學生進度的題目將被阻止。",
+                  )}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                {(() => {
+                  const contentType =
+                    contentDetails[editingContentId]?.type?.toUpperCase();
+                  const isVocabSet =
+                    contentType === "VOCABULARY_SET" ||
+                    contentType === "SENTENCE_MAKING";
+                  return isVocabSet ? (
+                    <RefSaveButton panelRef={vocabPanelRef} />
+                  ) : (
+                    <RefSaveButton panelRef={readingPanelRef} />
+                  );
+                })()}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setEditingContentId(null)}
+                  className="hover:bg-gray-200"
+                >
+                  <X className="h-5 w-5" />
+                </Button>
+              </div>
+            </div>
+            {/* Content */}
+            <div className="flex-1 overflow-y-auto p-6">
               {(() => {
                 const contentType =
                   contentDetails[editingContentId]?.type?.toUpperCase();
@@ -1180,6 +1207,7 @@ export function AssignmentDetailSheet({
                 if (isVocabSet) {
                   return (
                     <VocabularySetPanel
+                      ref={vocabPanelRef}
                       content={{
                         id: editingContentId,
                         title: contentDetails[editingContentId].title || "",
@@ -1196,6 +1224,7 @@ export function AssignmentDetailSheet({
 
                 return (
                   <ReadingAssessmentPanel
+                    ref={readingPanelRef}
                     content={{
                       id: editingContentId,
                       title: contentDetails[editingContentId].title || "",
@@ -1210,16 +1239,8 @@ export function AssignmentDetailSheet({
                 );
               })()}
             </div>
-            <DialogFooter>
-              <Button
-                variant="outline"
-                onClick={() => setEditingContentId(null)}
-              >
-                {t("common.cancel")}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+          </div>
+        </div>
       )}
     </>
   );

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -119,6 +119,16 @@ export function AssignmentDetailSheet({
   const vocabPanelRef = useRef<VocabularySetPanelHandle>(null);
   const loadingRef = useRef<Set<number>>(new Set());
 
+  // When content edit overlay is open, override Radix Sheet's body pointer-events lock
+  useEffect(() => {
+    if (editingContentId) {
+      document.body.style.pointerEvents = "auto";
+      return () => {
+        document.body.style.pointerEvents = "";
+      };
+    }
+  }, [editingContentId]);
+
   // Detail data from API (includes advanced settings)
   const [detailData, setDetailData] = useState<Record<string, unknown> | null>(
     null,

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -1144,110 +1144,99 @@ export function AssignmentDetailSheet({
             className="fixed inset-0 z-[60] bg-black/50 pointer-events-auto"
             role="button"
             tabIndex={0}
+            aria-label={t("common.close", "關閉")}
             onClick={() => setEditingContentId(null)}
             onKeyDown={(e) => {
               if (e.key === "Escape") setEditingContentId(null);
             }}
           />
-          <div
-            className="fixed top-0 right-0 h-full z-[61] bg-white shadow-xl border-l flex flex-col pointer-events-auto"
-            style={{ left: `${sidebarWidth}px` }}
-          >
-            {/* Header */}
-            <div className="flex items-center justify-between px-6 py-4 border-b bg-gray-50">
-              <div>
-                <h2 className="text-lg font-semibold text-gray-900">
-                  {t("assignmentDetail.labels.editContent") || "編輯作業內容"}
-                </h2>
-                <p className="text-sm text-amber-600 mt-1">
-                  ⚠️{" "}
-                  {t(
-                    "assignmentDetail.sheet.editContentWarning",
-                    "注意：此為作業副本。刪除已有學生進度的題目將被阻止。",
-                  )}
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                {(() => {
-                  const contentType =
-                    contentDetails[editingContentId]?.type?.toUpperCase();
-                  const isVocabSet =
-                    contentType === "VOCABULARY_SET" ||
-                    contentType === "SENTENCE_MAKING";
-                  return isVocabSet ? (
-                    <RefSaveButton panelRef={vocabPanelRef} />
-                  ) : (
-                    <RefSaveButton panelRef={readingPanelRef} />
-                  );
-                })()}
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setEditingContentId(null)}
-                  className="hover:bg-gray-200"
-                >
-                  <X className="h-5 w-5" />
-                </Button>
-              </div>
-            </div>
-            {/* Content */}
-            <div className="flex-1 overflow-y-auto p-6">
-              {(() => {
-                const contentType =
-                  contentDetails[editingContentId]?.type?.toUpperCase();
-                const isVocabSet =
-                  contentType === "VOCABULARY_SET" ||
-                  contentType === "SENTENCE_MAKING";
+          {(() => {
+            const editingDetail = contentDetails[editingContentId];
+            const isVocabSet = ["VOCABULARY_SET", "SENTENCE_MAKING"].includes(
+              editingDetail?.type?.toUpperCase() ?? "",
+            );
+            const handleEditSave = async () => {
+              const savedContentId = editingContentId;
+              setEditingContentId(null);
+              if (savedContentId) {
+                setContentDetails((prev) => {
+                  const updated = { ...prev };
+                  delete updated[savedContentId];
+                  return updated;
+                });
+                await loadContentDetail(savedContentId, true);
+              }
+            };
 
-                const handleEditSave = async () => {
-                  const savedContentId = editingContentId;
-                  setEditingContentId(null);
-                  if (savedContentId) {
-                    setContentDetails((prev) => {
-                      const updated = { ...prev };
-                      delete updated[savedContentId];
-                      return updated;
-                    });
-                    await loadContentDetail(savedContentId, true);
-                  }
-                };
-
-                if (isVocabSet) {
-                  return (
+            return (
+              <div
+                className="fixed top-0 right-0 h-full z-[61] bg-white shadow-xl border-l flex flex-col pointer-events-auto"
+                style={{ left: `${sidebarWidth}px` }}
+              >
+                {/* Header */}
+                <div className="flex items-center justify-between px-6 py-4 border-b bg-gray-50">
+                  <div>
+                    <h2 className="text-lg font-semibold text-gray-900">
+                      {t("assignmentDetail.labels.editContent") ||
+                        "編輯作業內容"}
+                    </h2>
+                    <p className="text-sm text-amber-600 mt-1">
+                      ⚠️{" "}
+                      {t(
+                        "assignmentDetail.sheet.editContentWarning",
+                        "注意：此為作業副本。刪除已有學生進度的題目將被阻止。",
+                      )}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <RefSaveButton
+                      panelRef={isVocabSet ? vocabPanelRef : readingPanelRef}
+                    />
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setEditingContentId(null)}
+                      className="hover:bg-gray-200"
+                    >
+                      <X className="h-5 w-5" />
+                    </Button>
+                  </div>
+                </div>
+                {/* Content */}
+                <div className="flex-1 overflow-y-auto p-6">
+                  {isVocabSet ? (
                     <VocabularySetPanel
                       ref={vocabPanelRef}
                       content={{
                         id: editingContentId,
-                        title: contentDetails[editingContentId].title || "",
+                        title: editingDetail.title || "",
                       }}
-                      editingContent={contentDetails[editingContentId] as never}
+                      editingContent={editingDetail as never}
                       onUpdateContent={async () => {}}
                       onSave={handleEditSave}
                       lessonId={0}
                       isCreating={false}
                       isAssignmentCopy={true}
                     />
-                  );
-                }
-
-                return (
-                  <ReadingAssessmentPanel
-                    ref={readingPanelRef}
-                    content={{
-                      id: editingContentId,
-                      title: contentDetails[editingContentId].title || "",
-                    }}
-                    editingContent={contentDetails[editingContentId] as never}
-                    onUpdateContent={async () => {}}
-                    onSave={handleEditSave}
-                    lessonId={0}
-                    isCreating={false}
-                    isAssignmentCopy={true}
-                  />
-                );
-              })()}
-            </div>
-          </div>
+                  ) : (
+                    <ReadingAssessmentPanel
+                      ref={readingPanelRef}
+                      content={{
+                        id: editingContentId,
+                        title: editingDetail.title || "",
+                      }}
+                      editingContent={editingDetail as never}
+                      onUpdateContent={async () => {}}
+                      onSave={handleEditSave}
+                      lessonId={0}
+                      isCreating={false}
+                      isAssignmentCopy={true}
+                    />
+                  )}
+                </div>
+              </div>
+            );
+          })()}
         </>
       )}
     </>

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -120,11 +120,19 @@ export function AssignmentDetailSheet({
   const loadingRef = useRef<Set<number>>(new Set());
 
   // When content edit overlay is open, override Radix Sheet's body pointer-events lock
+  const contentEditPanelRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (editingContentId) {
-      document.body.style.pointerEvents = "auto";
+      // Radix Sheet sets pointer-events:none on body; override it
+      const style = document.createElement("style");
+      style.textContent = "body { pointer-events: auto !important; }";
+      document.head.appendChild(style);
+      // Auto-focus the panel so scroll works immediately
+      requestAnimationFrame(() => {
+        contentEditPanelRef.current?.focus();
+      });
       return () => {
-        document.body.style.pointerEvents = "";
+        document.head.removeChild(style);
       };
     }
   }, [editingContentId]);
@@ -1180,7 +1188,9 @@ export function AssignmentDetailSheet({
 
             return (
               <div
-                className="fixed top-0 right-0 h-full z-[61] bg-white shadow-xl border-l flex flex-col pointer-events-auto"
+                ref={contentEditPanelRef}
+                tabIndex={-1}
+                className="fixed top-0 right-0 h-full z-[61] bg-white shadow-xl border-l flex flex-col pointer-events-auto outline-none"
                 style={{ left: `${sidebarWidth}px` }}
               >
                 {/* Header */}

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -1201,17 +1201,16 @@ export function AssignmentDetailSheet({
                     </p>
                   </div>
                   <div className="flex items-center gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setEditingContentId(null)}
+                    >
+                      {t("common.cancel", "取消")}
+                    </Button>
                     <RefSaveButton
                       panelRef={isVocabSet ? vocabPanelRef : readingPanelRef}
                     />
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setEditingContentId(null)}
-                      className="hover:bg-gray-200"
-                    >
-                      <X className="h-5 w-5" />
-                    </Button>
                   </div>
                 </div>
                 {/* Content */}

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -119,13 +119,22 @@ export function AssignmentDetailSheet({
   const vocabPanelRef = useRef<VocabularySetPanelHandle>(null);
   const loadingRef = useRef<Set<number>>(new Set());
 
-  // Auto-focus content edit panel so scroll works immediately
+  // When content edit overlay is open: disable Sheet's focus trap + auto-focus panel
   const contentEditPanelRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (editingContentId) {
+      // Disable Radix Sheet's pointer-events lock and focus trap
+      const style = document.createElement("style");
+      style.setAttribute("data-content-edit-override", "true");
+      style.textContent =
+        "body { pointer-events: auto !important; } [data-radix-focus-guard] { display: none !important; }";
+      document.head.appendChild(style);
       requestAnimationFrame(() => {
         contentEditPanelRef.current?.focus();
       });
+      return () => {
+        style.remove();
+      };
     }
   }, [editingContentId]);
 
@@ -439,7 +448,7 @@ export function AssignmentDetailSheet({
 
   return (
     <>
-      <Sheet open={open} onOpenChange={onOpenChange} modal={!editingContentId}>
+      <Sheet open={open} onOpenChange={onOpenChange}>
         <SheetContent
           side="right"
           className="w-full sm:max-w-lg md:max-w-xl lg:max-w-2xl p-0 flex flex-col"
@@ -1211,6 +1220,17 @@ export function AssignmentDetailSheet({
                     <RefSaveButton
                       panelRef={isVocabSet ? vocabPanelRef : readingPanelRef}
                     />
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => {
+                        setEditingContentId(null);
+                        onOpenChange(false);
+                      }}
+                      className="hover:bg-gray-200"
+                    >
+                      <X className="h-5 w-5" />
+                    </Button>
                   </div>
                 </div>
                 {/* Content */}

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -119,21 +119,13 @@ export function AssignmentDetailSheet({
   const vocabPanelRef = useRef<VocabularySetPanelHandle>(null);
   const loadingRef = useRef<Set<number>>(new Set());
 
-  // When content edit overlay is open, override Radix Sheet's body pointer-events lock
+  // Auto-focus content edit panel so scroll works immediately
   const contentEditPanelRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (editingContentId) {
-      // Radix Sheet sets pointer-events:none on body; override it
-      const style = document.createElement("style");
-      style.textContent = "body { pointer-events: auto !important; }";
-      document.head.appendChild(style);
-      // Auto-focus the panel so scroll works immediately
       requestAnimationFrame(() => {
         contentEditPanelRef.current?.focus();
       });
-      return () => {
-        document.head.removeChild(style);
-      };
     }
   }, [editingContentId]);
 
@@ -447,7 +439,7 @@ export function AssignmentDetailSheet({
 
   return (
     <>
-      <Sheet open={open} onOpenChange={onOpenChange}>
+      <Sheet open={open} onOpenChange={onOpenChange} modal={!editingContentId}>
         <SheetContent
           side="right"
           className="w-full sm:max-w-lg md:max-w-xl lg:max-w-2xl p-0 flex flex-col"

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -451,7 +451,7 @@ export function AssignmentDetailSheet({
                   className="gap-1.5 mr-6"
                 >
                   <Pencil className="h-3.5 w-3.5" />
-                  {t("assignmentDetail.sheet.viewDetailsButton", "查看詳情")}
+                  {t("assignmentDetail.sheet.editButton", "編輯")}
                 </Button>
               )}
             </div>

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -1140,10 +1140,14 @@ export function AssignmentDetailSheet({
       {/* Content Edit - Right-side sheet with sidebar offset */}
       {editingContentId && contentDetails[editingContentId] && (
         <>
-          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
           <div
             className="fixed inset-0 z-[60] bg-black/50 pointer-events-auto"
+            role="button"
+            tabIndex={0}
             onClick={() => setEditingContentId(null)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") setEditingContentId(null);
+            }}
           />
           <div
             className="fixed top-0 right-0 h-full z-[61] bg-white shadow-xl border-l flex flex-col pointer-events-auto"

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -1192,8 +1192,10 @@ export function AssignmentDetailSheet({
                     <div className="flex items-center justify-between px-6 py-4 border-b bg-gray-50 dark:bg-gray-800">
                       <div>
                         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                          {t("assignmentDetail.labels.editContent") ||
-                            "編輯作業內容"}
+                          {t(
+                            "assignmentDetail.labels.editContent",
+                            "編輯作業內容",
+                          )}
                         </h2>
                         <p className="text-sm text-amber-600 mt-1">
                           ⚠️{" "}

--- a/frontend/src/components/shared/RefSaveButton.tsx
+++ b/frontend/src/components/shared/RefSaveButton.tsx
@@ -38,7 +38,7 @@ export function RefSaveButton({ panelRef }: RefSaveButtonProps) {
     <Button
       size="sm"
       className="bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50"
-      disabled={isSaving}
+      disabled={isSaving || (panelRef.current?.isBusy ?? false)}
       onClick={handleClick}
     >
       {isSaving ? (

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -2981,7 +2981,8 @@
       "instructionsPlaceholder": "Enter assignment instructions...",
       "noInstructions": "No instructions",
       "notSet": "Not set",
-      "people": "people"
+      "people": "people",
+      "editContent": "Edit Assignment Content"
     },
     "sheet": {
       "viewTitle": "Assignment Details",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -16,6 +16,7 @@
     "next": "Next",
     "previous": "Previous",
     "close": "Close",
+    "expand": "Expand",
     "search": "Search",
     "filter": "Filter",
     "reset": "Reset",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -2775,7 +2775,7 @@
       "createProgram": "建立課程",
       "assignNewHomework": "指派新作業",
       "batchArchive": "批次封存",
-      "viewDetails": "編輯",
+      "viewDetails": "查看詳情",
       "editContent": "編輯內容",
       "previewDemo": "預覽",
       "viewSubmissions": "查看學生提交",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -16,6 +16,7 @@
     "next": "下一步",
     "previous": "上一步",
     "close": "關閉",
+    "expand": "展開",
     "search": "搜尋",
     "filter": "篩選",
     "reset": "重置",

--- a/frontend/src/pages/teacher/AssignmentManagementPage.tsx
+++ b/frontend/src/pages/teacher/AssignmentManagementPage.tsx
@@ -263,7 +263,7 @@ export default function AssignmentManagementPage() {
   const handleViewDetails = (assignment: Assignment) => {
     if (assignment.classroom_id) {
       navigate(
-        `/teacher/classroom/${assignment.classroom_id}/assignment/${assignment.id}/preview`,
+        `/teacher/classroom/${assignment.classroom_id}?tab=assignments&assignment=${assignment.id}`,
       );
     } else {
       navigate(`/teacher/assignment/${assignment.id}/preview`);

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -2799,12 +2799,15 @@ export default function ClassroomDetail({
                   {t("classroomDetail.labels.editContent")}
                 </h2>
                 <div className="flex items-center gap-2">
-                  {(selectedContent.type?.toLowerCase() === "reading_assessment" ||
-                    selectedContent.type?.toLowerCase() === "example_sentences") && (
+                  {(selectedContent.type?.toLowerCase() ===
+                    "reading_assessment" ||
+                    selectedContent.type?.toLowerCase() ===
+                      "example_sentences") && (
                     <RefSaveButton panelRef={readingPanelRef} />
                   )}
                   {(selectedContent.type?.toLowerCase() === "sentence_making" ||
-                    selectedContent.type?.toLowerCase() === "vocabulary_set") && (
+                    selectedContent.type?.toLowerCase() ===
+                      "vocabulary_set") && (
                     <RefSaveButton panelRef={vocabPanelRef} />
                   )}
                   <Button

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -491,13 +491,21 @@ export default function ClassroomDetail({
   }, [id, isTemplateMode]);
 
   useEffect(() => {
-    // Check URL parameters for tab switching
+    // Check URL parameters for tab switching and auto-opening assignment
     const searchParams = new URLSearchParams(location.search);
     const tab = searchParams.get("tab");
     if (tab === "assignments") {
       setActiveTab("assignments");
     }
-  }, [location.search]);
+    const assignmentId = searchParams.get("assignment");
+    if (assignmentId && assignments.length > 0) {
+      const target = assignments.find((a) => a.id === Number(assignmentId));
+      if (target) {
+        setSheetAssignment(target);
+        setShowAssignmentSheet(true);
+      }
+    }
+  }, [location.search, assignments]);
 
   // Issue #150: Smart default tab based on student count
   // When class has students, default to "assignments" tab

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -19,8 +19,13 @@ import { ProgramDialog } from "@/components/ProgramDialog";
 import { LessonDialog } from "@/components/LessonDialog";
 import CreateProgramDialog from "@/components/CreateProgramDialog";
 import ContentTypeDialog from "@/components/ContentTypeDialog";
-import ReadingAssessmentPanel from "@/components/ReadingAssessmentPanel";
-import VocabularySetPanel from "@/components/VocabularySetPanel";
+import ReadingAssessmentPanel, {
+  type ReadingAssessmentPanelHandle,
+} from "@/components/ReadingAssessmentPanel";
+import VocabularySetPanel, {
+  type VocabularySetPanelHandle,
+} from "@/components/VocabularySetPanel";
+import { RefSaveButton } from "@/components/shared/RefSaveButton";
 import ContentCopyDialog from "@/components/ContentCopyDialog";
 import { AssignmentDialog, CartItem } from "@/components/AssignmentDialog";
 import { InstantPracticeDialog } from "@/components/InstantPracticeDialog";
@@ -466,6 +471,8 @@ export default function ClassroomDetail({
   };
 
   const hasFetchedData = useRef<string | null>(null);
+  const readingPanelRef = useRef<ReadingAssessmentPanelHandle>(null);
+  const vocabPanelRef = useRef<VocabularySetPanelHandle>(null);
 
   useEffect(() => {
     const key = `${id}-${isTemplateMode}`;
@@ -2791,23 +2798,32 @@ export default function ClassroomDetail({
                 <h2 className="text-lg font-semibold text-gray-900">
                   {t("classroomDetail.labels.editContent")}
                 </h2>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={closePanel}
-                  className="hover:bg-gray-200"
-                >
-                  <X className="h-5 w-5" />
-                </Button>
+                <div className="flex items-center gap-2">
+                  {(selectedContent.type?.toLowerCase() === "reading_assessment" ||
+                    selectedContent.type?.toLowerCase() === "example_sentences") && (
+                    <RefSaveButton panelRef={readingPanelRef} />
+                  )}
+                  {(selectedContent.type?.toLowerCase() === "sentence_making" ||
+                    selectedContent.type?.toLowerCase() === "vocabulary_set") && (
+                    <RefSaveButton panelRef={vocabPanelRef} />
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={closePanel}
+                    className="hover:bg-gray-200"
+                  >
+                    <X className="h-5 w-5" />
+                  </Button>
+                </div>
               </div>
 
               {/* Panel Content */}
               <div className="flex-1 overflow-y-auto p-4">
                 {selectedContent.type?.toLowerCase() === "reading_assessment" ||
                 selectedContent.type?.toLowerCase() === "example_sentences" ? (
-                  /* ReadingAssessmentPanel has its own save button */
-                  /* EXAMPLE_SENTENCES uses the same panel as READING_ASSESSMENT */
                   <ReadingAssessmentPanel
+                    ref={readingPanelRef}
                     content={selectedContent as ReadingAssessmentContent}
                     editingContent={
                       editingContent as ReadingAssessmentContent | undefined
@@ -2821,8 +2837,8 @@ export default function ClassroomDetail({
                   />
                 ) : selectedContent.type?.toLowerCase() === "sentence_making" ||
                   selectedContent.type?.toLowerCase() === "vocabulary_set" ? (
-                  /* VocabularySetPanel has its own save button */
                   <VocabularySetPanel
+                    ref={vocabPanelRef}
                     content={selectedContent as ReadingAssessmentContent}
                     editingContent={
                       editingContent as ReadingAssessmentContent | undefined

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -490,6 +490,7 @@ export default function ClassroomDetail({
     }
   }, [id, isTemplateMode]);
 
+  const autoOpenedAssignmentRef = useRef<string | null>(null);
   useEffect(() => {
     // Check URL parameters for tab switching and auto-opening assignment
     const searchParams = new URLSearchParams(location.search);
@@ -498,9 +499,14 @@ export default function ClassroomDetail({
       setActiveTab("assignments");
     }
     const assignmentId = searchParams.get("assignment");
-    if (assignmentId && assignments.length > 0) {
+    if (
+      assignmentId &&
+      assignmentId !== autoOpenedAssignmentRef.current &&
+      assignments.length > 0
+    ) {
       const target = assignments.find((a) => a.id === Number(assignmentId));
       if (target) {
+        autoOpenedAssignmentRef.current = assignmentId;
         setSheetAssignment(target);
         setShowAssignmentSheet(true);
       }

--- a/frontend/src/pages/teacher/TeacherAssignmentDetailPage.tsx
+++ b/frontend/src/pages/teacher/TeacherAssignmentDetailPage.tsx
@@ -1353,7 +1353,7 @@ export default function TeacherAssignmentDetailPage() {
             <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
               <DialogHeader>
                 <DialogTitle>
-                  {t("assignmentDetail.labels.editContent") || "編輯作業內容"}
+                  {t("assignmentDetail.labels.editContent", "編輯作業內容")}
                 </DialogTitle>
                 <p className="text-sm text-amber-600 mt-2">
                   ⚠️ 注意：此為作業副本。刪除已有學生進度的題目將被阻止。


### PR DESCRIPTION
## Summary
- 修復單字選擇作業副本編輯後儲存失敗（409 錯誤）
- 根因：`practice_answers.content_item_id` FK 缺少 `ON DELETE CASCADE`，導致刪除 `content_items` 時違反外鍵約束
- 更新前先清除關聯的 `practice_answers`，並補上 migration 將 FK 加上 CASCADE

## Changes
- `backend/routers/teachers/content_ops.py` — 刪除 content_items 前先清除 practice_answers
- `backend/models/progress.py` — PracticeAnswer FK 加上 `ondelete="CASCADE"`
- 新增冪等 migration `20260415_1000`
- 新增 2 個測試案例

## Test plan
- [x] 有 practice_answers 的內容副本編輯後儲存成功
- [x] 只改 title（不改 items）時不影響現有資料
- [x] 既有 content CRUD 測試全數通過（無 regression）

Fixes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)