### PR TITLE
feat: 老師端批改朗讀作業可手動重新分析失敗音檔

### DIFF
--- a/backend/routers/assignments/grading.py
+++ b/backend/routers/assignments/grading.py
@@ -426,6 +426,10 @@ async def get_student_submission(
                     # 使用 content_item_id 來獲取對應的 StudentItemProgress 記錄
                     item_progress = progress_by_item_id.get(item.id)
 
+                    # 加入 item_progress_id 供前端呼叫 reanalyze API
+                    if item_progress:
+                        submission["item_progress_id"] = item_progress.id
+
                     # 從 StudentItemProgress 直接獲取資料
                     if item_progress:
                         # 加入老師批改的評語和通過狀態
@@ -1427,3 +1431,103 @@ async def finalize_batch_grade(
         unchanged_count=unchanged_count,
         total_count=len(student_assignments),
     )
+
+
+@router.post("/{assignment_id}/reanalyze-item/{item_progress_id}")
+@trace_function("Reanalyze Item")
+async def reanalyze_item(
+    assignment_id: int,
+    item_progress_id: int,
+    db: Session = Depends(get_db),
+    current_teacher: Teacher = Depends(get_current_teacher),
+):
+    """
+    老師端手動觸發單一題目的 AI 語音重新分析
+
+    條件：
+    - 該題目必須有 recording_url（音檔存在）
+    - 老師必須有權限存取該作業
+    """
+    # 1. 查詢 item_progress
+    item_progress = (
+        db.query(StudentItemProgress)
+        .filter(StudentItemProgress.id == item_progress_id)
+        .first()
+    )
+    if not item_progress:
+        raise HTTPException(status_code=404, detail="Item progress not found")
+
+    # 2. 驗證該 item 屬於正確的 assignment
+    student_assignment = (
+        db.query(StudentAssignment)
+        .filter(StudentAssignment.id == item_progress.student_assignment_id)
+        .first()
+    )
+    if not student_assignment or student_assignment.assignment_id != assignment_id:
+        raise HTTPException(status_code=404, detail="Item not found in this assignment")
+
+    # 3. 驗證老師有權限（透過 classroom ownership）
+    classroom = (
+        db.query(Classroom)
+        .filter(
+            Classroom.id == student_assignment.classroom_id,
+            Classroom.teacher_id == current_teacher.id,
+        )
+        .first()
+    )
+    if not classroom:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    # 4. 確認有錄音檔案
+    if not item_progress.recording_url:
+        raise HTTPException(
+            status_code=400, detail="No recording available for reanalysis"
+        )
+
+    # 5. 清除舊的評估結果，允許重新分析
+    item_progress.ai_assessed_at = None
+    db.flush()
+
+    # 6. 觸發重新分析
+    content_item = (
+        db.query(ContentItem)
+        .filter(ContentItem.id == item_progress.content_item_id)
+        .first()
+    )
+
+    success = await trigger_ai_assessment_for_item(item_progress, db, content_item)
+
+    if not success:
+        raise HTTPException(
+            status_code=500, detail="AI analysis failed, please try again later"
+        )
+
+    # 7. 回傳更新後的分數
+    ai_data = {}
+    if item_progress.ai_feedback:
+        try:
+            ai_data = (
+                json.loads(item_progress.ai_feedback)
+                if isinstance(item_progress.ai_feedback, str)
+                else item_progress.ai_feedback
+            )
+        except (json.JSONDecodeError, TypeError):
+            ai_data = {}
+
+    return {
+        "success": True,
+        "ai_scores": {
+            "accuracy_score": float(item_progress.accuracy_score or 0),
+            "fluency_score": float(item_progress.fluency_score or 0),
+            "pronunciation_score": float(item_progress.pronunciation_score or 0),
+            "completeness_score": float(item_progress.completeness_score or 0),
+            "overall_score": (
+                float(item_progress.accuracy_score or 0)
+                + float(item_progress.fluency_score or 0)
+                + float(item_progress.pronunciation_score or 0)
+                + float(item_progress.completeness_score or 0)
+            )
+            / 4,
+            "word_details": ai_data.get("word_details", []),
+        },
+    }

--- a/backend/routers/assignments/grading.py
+++ b/backend/routers/assignments/grading.py
@@ -1494,6 +1494,9 @@ async def reanalyze_item(
         raise HTTPException(status_code=404, detail="Content item not found")
 
     # 6. 清除舊的評估結果，觸發重新分析
+    # flush 使 ai_assessed_at=None 在當前 transaction 生效，
+    # 因為 trigger_ai_assessment_for_item 會檢查此欄位決定是否執行分析。
+    # 該函式內部已包含 db.commit()，成功時分數會被持久化。
     try:
         item_progress.ai_assessed_at = None
         db.flush()

--- a/backend/routers/assignments/grading.py
+++ b/backend/routers/assignments/grading.py
@@ -1478,7 +1478,10 @@ async def reanalyze_item(
     if not classroom:
         raise HTTPException(status_code=403, detail="Access denied")
 
-    # 4. 確認有錄音檔案
+    # 4. 確認作業未封存
+    _check_not_archived(student_assignment, db)
+
+    # 5. 確認有錄音檔案
     if not item_progress.recording_url:
         raise HTTPException(
             status_code=400, detail="No recording available for reanalysis"
@@ -1497,6 +1500,8 @@ async def reanalyze_item(
     # flush 使 ai_assessed_at=None 在當前 transaction 生效，
     # 因為 trigger_ai_assessment_for_item 會檢查此欄位決定是否執行分析。
     # 該函式內部已包含 db.commit()，成功時分數會被持久化。
+    # 若分析失敗，需手動恢復 ai_assessed_at（因為 commit 後 rollback 無效）。
+    original_ai_assessed_at = item_progress.ai_assessed_at
     try:
         item_progress.ai_assessed_at = None
         db.flush()
@@ -1504,14 +1509,18 @@ async def reanalyze_item(
         success = await trigger_ai_assessment_for_item(item_progress, db, content_item)
 
         if not success:
-            db.rollback()
+            # trigger 函式失敗時內部會 rollback，
+            # 但若它已 commit 了 ai_assessed_at=None，需手動恢復
+            item_progress.ai_assessed_at = original_ai_assessed_at
+            db.commit()
             raise HTTPException(
                 status_code=500, detail="AI analysis failed, please try again later"
             )
     except HTTPException:
         raise
     except Exception as e:
-        db.rollback()
+        item_progress.ai_assessed_at = original_ai_assessed_at
+        db.commit()
         logger.error(f"Reanalyze failed for item_progress {item_progress_id}: {e}")
         raise HTTPException(
             status_code=500, detail="AI analysis failed, please try again later"

--- a/backend/routers/assignments/grading.py
+++ b/backend/routers/assignments/grading.py
@@ -1484,20 +1484,32 @@ async def reanalyze_item(
             status_code=400, detail="No recording available for reanalysis"
         )
 
-    # 5. 清除舊的評估結果，允許重新分析
-    item_progress.ai_assessed_at = None
-    db.flush()
-
-    # 6. 觸發重新分析
+    # 5. 查詢對應的 content_item
     content_item = (
         db.query(ContentItem)
         .filter(ContentItem.id == item_progress.content_item_id)
         .first()
     )
+    if not content_item:
+        raise HTTPException(status_code=404, detail="Content item not found")
 
-    success = await trigger_ai_assessment_for_item(item_progress, db, content_item)
+    # 6. 清除舊的評估結果，觸發重新分析
+    try:
+        item_progress.ai_assessed_at = None
+        db.flush()
 
-    if not success:
+        success = await trigger_ai_assessment_for_item(item_progress, db, content_item)
+
+        if not success:
+            db.rollback()
+            raise HTTPException(
+                status_code=500, detail="AI analysis failed, please try again later"
+            )
+    except HTTPException:
+        raise
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Reanalyze failed for item_progress {item_progress_id}: {e}")
         raise HTTPException(
             status_code=500, detail="AI analysis failed, please try again later"
         )
@@ -1514,6 +1526,15 @@ async def reanalyze_item(
         except (json.JSONDecodeError, TypeError):
             ai_data = {}
 
+    scores = [
+        item_progress.accuracy_score,
+        item_progress.fluency_score,
+        item_progress.pronunciation_score,
+        item_progress.completeness_score,
+    ]
+    valid_scores = [float(s) for s in scores if s is not None]
+    overall = sum(valid_scores) / len(valid_scores) if valid_scores else 0
+
     return {
         "success": True,
         "ai_scores": {
@@ -1521,13 +1542,7 @@ async def reanalyze_item(
             "fluency_score": float(item_progress.fluency_score or 0),
             "pronunciation_score": float(item_progress.pronunciation_score or 0),
             "completeness_score": float(item_progress.completeness_score or 0),
-            "overall_score": (
-                float(item_progress.accuracy_score or 0)
-                + float(item_progress.fluency_score or 0)
-                + float(item_progress.pronunciation_score or 0)
-                + float(item_progress.completeness_score or 0)
-            )
-            / 4,
+            "overall_score": overall,
             "word_details": ai_data.get("word_details", []),
         },
     }

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -2835,7 +2835,8 @@
       "checkRecording": "Check Recording",
       "applyAISuggestions": "Apply AI Suggestions",
       "requestRevision": "Request Revision",
-      "completeGrading": "Complete Grading"
+      "completeGrading": "Complete Grading",
+      "reanalyze": "Re-analyze"
     },
     "labels": {
       "questionGroup": "Question Group",
@@ -2904,7 +2905,10 @@
       "aiGradingFailed": "AI grading failed, please try again",
       "noStudentToGrade": "No student to grade (status must be Submitted or Resubmitted)",
       "audioUploadFailed": "Recording upload failed",
-      "audioUploadFailedDetail": "Analysis results available, but recording file was not uploaded"
+      "audioUploadFailedDetail": "Analysis results available, but recording file was not uploaded",
+      "reanalyzing": "Analyzing...",
+      "reanalyzeSuccess": "Re-analysis completed",
+      "reanalyzeFailed": "Re-analysis failed, please try again later"
     },
     "status": {
       "notStarted": "Not Started",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -2888,7 +2888,8 @@
       "checkRecording": "檢查錄音",
       "applyAISuggestions": "套用 AI 建議",
       "requestRevision": "要求訂正",
-      "completeGrading": "完成批改"
+      "completeGrading": "完成批改",
+      "reanalyze": "重新分析"
     },
     "labels": {
       "questionGroup": "題組",
@@ -2957,7 +2958,10 @@
       "aiGradingFailed": "AI 批改失敗，請稍後再試",
       "noStudentToGrade": "沒有可批改的學生（狀態須為已提交或已訂正）",
       "audioUploadFailed": "錄音檔案上傳異常",
-      "audioUploadFailedDetail": "有分析結果，但錄音檔案未成功上傳"
+      "audioUploadFailedDetail": "有分析結果，但錄音檔案未成功上傳",
+      "reanalyzing": "分析中...",
+      "reanalyzeSuccess": "重新分析完成",
+      "reanalyzeFailed": "重新分析失敗，請稍後再試"
     },
     "status": {
       "notStarted": "未開始",

--- a/frontend/src/pages/teacher/GradingPage.tsx
+++ b/frontend/src/pages/teacher/GradingPage.tsx
@@ -23,6 +23,7 @@ import {
   ChevronDown,
   ChevronUp,
   Sparkles,
+  Loader2,
   Search,
 } from "lucide-react";
 import { Assignment } from "@/types";
@@ -432,10 +433,7 @@ export default function GradingPage() {
     }
   };
 
-  const handleReanalyzeItem = async (
-    itemProgressId: number,
-    itemIndex: number,
-  ) => {
+  const handleReanalyzeItem = async (itemProgressId: number) => {
     if (!assignmentId) return;
 
     setReanalyzingItems((prev: Set<number>) =>
@@ -450,8 +448,8 @@ export default function GradingPage() {
       if (response.success && submission) {
         // 更新 submission 中對應題目的 ai_scores
         const updatedSubmissions = submission.submissions.map(
-          (item: SubmissionItem, idx: number) =>
-            idx === itemIndex
+          (item: SubmissionItem) =>
+            item.item_progress_id === itemProgressId
               ? { ...item, ai_scores: response.ai_scores }
               : item,
         );
@@ -1337,7 +1335,6 @@ export default function GradingPage() {
                                             onClick={() =>
                                               handleReanalyzeItem(
                                                 item.item_progress_id!,
-                                                globalIndex,
                                               )
                                             }
                                           >
@@ -1345,7 +1342,7 @@ export default function GradingPage() {
                                               item.item_progress_id,
                                             ) ? (
                                               <>
-                                                <Sparkles className="h-3 w-3 mr-1 animate-spin" />
+                                                <Loader2 className="h-3 w-3 mr-1 animate-spin" />
                                                 {t(
                                                   "gradingPage.messages.reanalyzing",
                                                 )}

--- a/frontend/src/pages/teacher/GradingPage.tsx
+++ b/frontend/src/pages/teacher/GradingPage.tsx
@@ -71,6 +71,7 @@ interface SubmissionItem {
       latency_ms?: number;
     };
   };
+  item_progress_id?: number;
 }
 
 interface StudentSubmission {
@@ -133,6 +134,11 @@ export default function GradingPage() {
   const [activeTab, setActiveTab] = useState<
     "students" | "content" | "grading"
   >("content");
+
+  // 🎯 Issue #633: 重新分析狀態
+  const [reanalyzingItems, setReanalyzingItems] = useState<Set<number>>(
+    new Set(),
+  );
 
   // 學生列表相關
   const [studentList, setStudentList] = useState<StudentListItem[]>([]);
@@ -424,6 +430,58 @@ export default function GradingPage() {
           duration: 3000,
         },
       );
+    }
+  };
+
+  // 🎯 Issue #633: 老師端手動觸發重新分析
+  const handleReanalyzeItem = async (
+    itemProgressId: number,
+    itemIndex: number,
+  ) => {
+    if (!assignmentId) return;
+
+    setReanalyzingItems(
+      (prev: Set<number>) => new Set(prev).add(itemProgressId),
+    );
+
+    try {
+      const response = (await apiClient.post(
+        `/api/teachers/assignments/${assignmentId}/reanalyze-item/${itemProgressId}`,
+      )) as { success: boolean; ai_scores: SubmissionItem["ai_scores"] };
+
+      if (response.success && submission) {
+        // 更新 submission 中對應題目的 ai_scores
+        const updatedSubmissions = submission.submissions.map(
+          (item: SubmissionItem, idx: number) =>
+            idx === itemIndex
+              ? { ...item, ai_scores: response.ai_scores }
+              : item,
+        );
+        const updatedGroups = submission.content_groups?.map(
+          (group: NonNullable<StudentSubmission["content_groups"]>[number]) => ({
+            ...group,
+            submissions: group.submissions.map((item: SubmissionItem) =>
+              item.item_progress_id === itemProgressId
+                ? { ...item, ai_scores: response.ai_scores }
+                : item,
+            ),
+          }),
+        );
+        setSubmission({
+          ...submission,
+          submissions: updatedSubmissions,
+          content_groups: updatedGroups,
+        });
+        toast.success(t("gradingPage.messages.reanalyzeSuccess"));
+      }
+    } catch {
+      toast.error(t("gradingPage.messages.reanalyzeFailed"));
+    } finally {
+      setReanalyzingItems((prev: Set<number>) => {
+        const next = new Set(prev);
+        next.delete(itemProgressId);
+        return next;
+      });
     }
   };
 
@@ -1263,6 +1321,42 @@ export default function GradingPage() {
                                       {t("gradingPage.messages.noAIScore")}
                                       {!item.audio_url &&
                                         ` ${t("gradingPage.messages.missingRecordingFile")}`}
+                                      {/* 🎯 Issue #633: 有音檔但無分析結果時，顯示重新分析按鈕 */}
+                                      {item.audio_url &&
+                                        item.item_progress_id && (
+                                          <Button
+                                            variant="outline"
+                                            size="sm"
+                                            className="mt-2"
+                                            disabled={reanalyzingItems.has(
+                                              item.item_progress_id,
+                                            )}
+                                            onClick={() =>
+                                              handleReanalyzeItem(
+                                                item.item_progress_id!,
+                                                globalIndex,
+                                              )
+                                            }
+                                          >
+                                            {reanalyzingItems.has(
+                                              item.item_progress_id,
+                                            ) ? (
+                                              <>
+                                                <Sparkles className="h-3 w-3 mr-1 animate-spin" />
+                                                {t(
+                                                  "gradingPage.messages.reanalyzing",
+                                                )}
+                                              </>
+                                            ) : (
+                                              <>
+                                                <Mic className="h-3 w-3 mr-1" />
+                                                {t(
+                                                  "gradingPage.buttons.reanalyze",
+                                                )}
+                                              </>
+                                            )}
+                                          </Button>
+                                        )}
                                     </div>
                                   )}
                                 </div>

--- a/frontend/src/pages/teacher/GradingPage.tsx
+++ b/frontend/src/pages/teacher/GradingPage.tsx
@@ -436,9 +436,7 @@ export default function GradingPage() {
   const handleReanalyzeItem = async (itemProgressId: number) => {
     if (!assignmentId) return;
 
-    setReanalyzingItems((prev: Set<number>) =>
-      new Set(prev).add(itemProgressId),
-    );
+    setReanalyzingItems((prev) => new Set(prev).add(itemProgressId));
 
     try {
       const response = (await apiClient.post(
@@ -446,7 +444,6 @@ export default function GradingPage() {
       )) as { success: boolean; ai_scores: SubmissionItem["ai_scores"] };
 
       if (response.success && submission) {
-        // 更新 submission 中對應題目的 ai_scores
         const updatedSubmissions = submission.submissions.map(
           (item: SubmissionItem) =>
             item.item_progress_id === itemProgressId
@@ -471,11 +468,13 @@ export default function GradingPage() {
           content_groups: updatedGroups,
         });
         toast.success(t("gradingPage.messages.reanalyzeSuccess"));
+      } else {
+        toast.error(t("gradingPage.messages.reanalyzeFailed"));
       }
     } catch {
       toast.error(t("gradingPage.messages.reanalyzeFailed"));
     } finally {
-      setReanalyzingItems((prev: Set<number>) => {
+      setReanalyzingItems((prev) => {
         const next = new Set(prev);
         next.delete(itemProgressId);
         return next;

--- a/frontend/src/pages/teacher/GradingPage.tsx
+++ b/frontend/src/pages/teacher/GradingPage.tsx
@@ -1067,7 +1067,11 @@ export default function GradingPage() {
                         const itemFeedback = itemFeedbacks[globalIndex];
 
                         return (
-                          <div key={globalIndex} className="py-4">
+                          <div
+                            key={globalIndex}
+                            id={`item-${globalIndex}`}
+                            className="py-4"
+                          >
                             {/* 主要行 */}
                             <div
                               className="md:grid md:grid-cols-12 flex flex-col gap-3 items-start cursor-pointer hover:bg-gray-50 rounded-lg p-2 -mx-2"
@@ -1329,7 +1333,7 @@ export default function GradingPage() {
                                           <Button
                                             variant="outline"
                                             size="sm"
-                                            className="mt-2"
+                                            className="mt-3 block mx-auto"
                                             disabled={reanalyzingItems.has(
                                               item.item_progress_id,
                                             )}
@@ -1433,18 +1437,38 @@ export default function GradingPage() {
                                   key={localIndex}
                                   className={`
                                     w-8 h-8 rounded-md flex items-center justify-center text-xs font-medium
-                                    transition-all cursor-default
+                                    transition-all cursor-pointer
                                     ${
                                       isPassed
-                                        ? "bg-green-500 text-white shadow-sm"
+                                        ? "bg-green-500 text-white shadow-sm hover:bg-green-600"
                                         : isFailed
-                                          ? "bg-red-500 text-white shadow-sm"
+                                          ? "bg-red-500 text-white shadow-sm hover:bg-red-600"
                                           : hasRecording
                                             ? "bg-gray-200 text-gray-600 hover:bg-gray-300"
-                                            : "bg-gray-100 text-gray-400 border border-dashed border-gray-300"
+                                            : "bg-gray-100 text-gray-400 border border-dashed border-gray-300 hover:bg-gray-200"
                                     }
                                   `}
                                   title={`題目 ${localIndex + 1}: ${isPassed ? t("gradingPage.labels.passed") : isFailed ? t("gradingPage.labels.needsRevision") : hasRecording ? t("gradingPage.labels.hasRecording") : t("gradingPage.labels.noRecording")}`}
+                                  onClick={() => {
+                                    // 切換到對應題組
+                                    setSelectedGroupIndex(groupIndex);
+                                    // 展開對應題目
+                                    const newExpanded = new Set(expandedRows);
+                                    newExpanded.add(globalIndex);
+                                    setExpandedRows(newExpanded);
+                                    // 切換到內容 tab（手機版）
+                                    setActiveTab("content");
+                                    // 滾動到對應題目
+                                    setTimeout(() => {
+                                      const el = document.getElementById(
+                                        `item-${globalIndex}`,
+                                      );
+                                      el?.scrollIntoView({
+                                        behavior: "smooth",
+                                        block: "center",
+                                      });
+                                    }, 100);
+                                  }}
                                 >
                                   {isPassed
                                     ? "✓"

--- a/frontend/src/pages/teacher/GradingPage.tsx
+++ b/frontend/src/pages/teacher/GradingPage.tsx
@@ -135,7 +135,6 @@ export default function GradingPage() {
     "students" | "content" | "grading"
   >("content");
 
-  // 🎯 Issue #633: 重新分析狀態
   const [reanalyzingItems, setReanalyzingItems] = useState<Set<number>>(
     new Set(),
   );
@@ -433,7 +432,6 @@ export default function GradingPage() {
     }
   };
 
-  // 🎯 Issue #633: 老師端手動觸發重新分析
   const handleReanalyzeItem = async (
     itemProgressId: number,
     itemIndex: number,
@@ -1327,7 +1325,6 @@ export default function GradingPage() {
                                       {t("gradingPage.messages.noAIScore")}
                                       {!item.audio_url &&
                                         ` ${t("gradingPage.messages.missingRecordingFile")}`}
-                                      {/* 🎯 Issue #633: 有音檔但無分析結果時，顯示重新分析按鈕 */}
                                       {item.audio_url &&
                                         item.item_progress_id && (
                                           <Button
@@ -1459,15 +1456,14 @@ export default function GradingPage() {
                                     // 切換到內容 tab（手機版）
                                     setActiveTab("content");
                                     // 滾動到對應題目
-                                    setTimeout(() => {
-                                      const el = document.getElementById(
-                                        `item-${globalIndex}`,
-                                      );
-                                      el?.scrollIntoView({
-                                        behavior: "smooth",
-                                        block: "center",
-                                      });
-                                    }, 100);
+                                    requestAnimationFrame(() => {
+                                      document
+                                        .getElementById(`item-${globalIndex}`)
+                                        ?.scrollIntoView({
+                                          behavior: "smooth",
+                                          block: "center",
+                                        });
+                                    });
                                   }}
                                 >
                                   {isPassed

--- a/frontend/src/pages/teacher/GradingPage.tsx
+++ b/frontend/src/pages/teacher/GradingPage.tsx
@@ -440,8 +440,8 @@ export default function GradingPage() {
   ) => {
     if (!assignmentId) return;
 
-    setReanalyzingItems(
-      (prev: Set<number>) => new Set(prev).add(itemProgressId),
+    setReanalyzingItems((prev: Set<number>) =>
+      new Set(prev).add(itemProgressId),
     );
 
     try {
@@ -458,7 +458,9 @@ export default function GradingPage() {
               : item,
         );
         const updatedGroups = submission.content_groups?.map(
-          (group: NonNullable<StudentSubmission["content_groups"]>[number]) => ({
+          (
+            group: NonNullable<StudentSubmission["content_groups"]>[number],
+          ) => ({
             ...group,
             submissions: group.submissions.map((item: SubmissionItem) =>
               item.item_progress_id === itemProgressId

--- a/frontend/src/pages/teacher/GradingPage.tsx
+++ b/frontend/src/pages/teacher/GradingPage.tsx
@@ -1330,7 +1330,7 @@ export default function GradingPage() {
                                           <Button
                                             variant="outline"
                                             size="sm"
-                                            className="mt-3 block mx-auto"
+                                            className="mt-3 mx-auto flex"
                                             disabled={reanalyzingItems.has(
                                               item.item_progress_id,
                                             )}


### PR DESCRIPTION
## Summary
- 老師批改朗讀作業時，若學生音檔分析失敗，新增「重新分析」按鈕讓老師手動觸發伺服器端 Azure Speech 重新分析
- 後端新增 `POST /api/teachers/assignments/{id}/reanalyze-item/{item_progress_id}` endpoint
- 前端在無 AI 評分但有音檔時顯示重新分析按鈕，分析完成後即時更新 UI

Fixes #633

## Test plan
- [ ] 確認有音檔但無 AI 分數的題目顯示「重新分析」按鈕
- [ ] 確認無音檔的題目不顯示按鈕
- [ ] 點擊按鈕後確認 loading 狀態與成功後分數顯示
- [ ] 確認無權限老師無法呼叫 API（403）
- [ ] TypeScript type check 通過
- [ ] Frontend build 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)