### PR TITLE
chore: add one_campus_uuid migration for SSO OAuth

### DIFF
--- a/backend/alembic/versions/20260420_1000_add_one_campus_uuid.py
+++ b/backend/alembic/versions/20260420_1000_add_one_campus_uuid.py
@@ -1,0 +1,45 @@
+"""Add one_campus_uuid field to identities table
+
+Revision ID: 20260420_1000
+Revises: 20260415_1000
+Create Date: 2026-04-20 10:00:00.000000
+
+Adds one_campus_uuid for OAuth-based 1Campus SSO matching.
+The uuid is returned by auth.ischool.com.tw/services/me.php.
+
+Related: #634
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260420_1000"
+down_revision = "20260415_1000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'identities'
+                AND column_name = 'one_campus_uuid'
+            ) THEN
+                ALTER TABLE identities
+                ADD COLUMN one_campus_uuid VARCHAR(100);
+            END IF;
+        END $$;
+        """
+    )
+
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_identities_one_campus_uuid "
+        "ON identities (one_campus_uuid) WHERE one_campus_uuid IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -48,6 +48,7 @@ class Identity(Base):
     email_verified_at = Column(DateTime(timezone=True), nullable=True)
 
     # 1Campus SSO 欄位
+    one_campus_uuid = Column(String(100), nullable=True, unique=True, index=True)
     one_campus_student_id = Column(String(100), nullable=True, index=True)
     one_campus_account = Column(String(255), nullable=True)
     national_id_hash = Column(String(64), nullable=True, index=True)


### PR DESCRIPTION
## Summary
- Add `one_campus_uuid` column to `identities` table for OAuth-based 1Campus SSO matching
- Add SQLAlchemy model field to `Identity`
- Migration is idempotent (`IF NOT EXISTS`) with partial unique index

This is a prerequisite for #634 (1Campus OAuth SSO integration).

## Test plan
- [ ] Migration runs without error on staging
- [ ] Migration is idempotent (can run twice safely)
- [ ] Existing Identity Code SSO flow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)