### PR TITLE
migration: add case-insensitive unique index on email

### DIFF
--- a/backend/alembic/versions/20260420_1000_add_email_case_insensitive_unique_index.py
+++ b/backend/alembic/versions/20260420_1000_add_email_case_insensitive_unique_index.py
@@ -1,0 +1,40 @@
+"""Add case-insensitive unique index on teachers.email
+
+Prevents duplicate registrations with different email casing
+(e.g. Test@email.com vs test@email.com).
+
+Revision ID: 20260420_1000
+Revises: 20260403_1000
+Create Date: 2026-04-20
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260420_1000"
+down_revision = "20260403_1000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Idempotent: CREATE INDEX IF NOT EXISTS
+    # Case-insensitive unique index on teachers.email
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS ix_teachers_email_lower
+        ON teachers (LOWER(email));
+    """
+    )
+
+    # Also add case-insensitive unique index on identities.email
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS ix_identities_email_lower
+        ON identities (LOWER(email));
+    """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/20260420_1100_add_email_case_insensitive_unique_index.py
+++ b/backend/alembic/versions/20260420_1100_add_email_case_insensitive_unique_index.py
@@ -3,16 +3,16 @@
 Prevents duplicate registrations with different email casing
 (e.g. Test@email.com vs test@email.com).
 
-Revision ID: 20260420_1000
-Revises: 20260403_1000
+Revision ID: 20260420_1100
+Revises: 20260420_1000
 Create Date: 2026-04-20
 """
 
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "20260420_1000"
-down_revision = "20260403_1000"
+revision = "20260420_1100"
+down_revision = "20260420_1000"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- 在 `teachers.email` 和 `identities.email` 上新增 `LOWER(email)` 的 UNIQUE INDEX
- 防止因 email 大小寫不同而建立重複帳號（例如 `Test@email.com` vs `test@email.com`）
- Idempotent：使用 `CREATE UNIQUE INDEX IF NOT EXISTS`，可安全重複執行

## Test plan
- [ ] Migration 在 develop 環境執行成功
- [ ] 確認已存在的 email 沒有大小寫衝突（如有衝突需先手動處理）
- [ ] 嘗試以不同大小寫 email 註冊相同帳號被資料庫層級阻擋

Related to #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)