### PR TITLE
fix: fail backend deploy on migration error (silent failure)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -257,6 +257,7 @@ jobs:
       env:
         DATABASE_URL: ${{ steps.db_env.outputs.ALEMBIC_DATABASE_URL }}
       run: |
+        set -euo pipefail
         echo "🔍 Installing dependencies for migrations..."
         pip install -r backend/requirements.txt
 
@@ -266,22 +267,7 @@ jobs:
         alembic current || true
 
         echo "🔄 Upgrading to latest migration..."
-        if ! alembic upgrade head 2>&1 | tee /tmp/alembic_output.txt; then
-          # Check if error is due to orphaned revision
-          if grep -q "Can't locate revision" /tmp/alembic_output.txt; then
-            echo "⚠️ Orphaned revision detected in database"
-            echo "🔧 Stamping database to latest head to recover..."
-            # Get the current head from the codebase
-            CURRENT_HEAD=$(alembic heads | head -1 | awk '{print $1}')
-            echo "📌 Stamping to revision: $CURRENT_HEAD"
-            alembic stamp "$CURRENT_HEAD"
-            echo "✅ Database stamped successfully"
-          else
-            echo "❌ Migration failed with unexpected error"
-            cat /tmp/alembic_output.txt
-            exit 1
-          fi
-        fi
+        alembic upgrade head
         echo "✅ Migrations completed"
 
     - name: 🔒 Verify RLS Configuration


### PR DESCRIPTION
## Summary

Last night's prod deploy ([run 24678016122](https://github.com/myduotopia/duotopia/actions/runs/24678016122)) reported success but **failed to apply migrations**:

- `20260420_1000` — `identities.one_campus_uuid` (OAuth SSO)
- `20260420_1100` — case-insensitive unique email index

### Root cause

The migration step piped alembic output through `tee` without `pipefail`:

```bash
if ! alembic upgrade head 2>&1 | tee /tmp/alembic_output.txt; then ...
```

`tee` always exits 0, so the pipeline's overall status was 0. The `if !` branch never triggered — alembic's traceback was printed to the log, but the step then printed `✅ Migrations completed` anyway.

Log timeline from the failed run:
```
16:34:22.137  Running upgrade 20260415_1000 -> 20260420_1000, Add one_campus_uuid
16:34:22.522  Running upgrade 20260420_1000 -> 20260420_1100, Add case-insensitive unique index
16:34:22.752  psycopg2.errors.UniqueViolation: Key (lower(email))=(kellyhuang1228@gmail.com) is duplicated.
16:34:22.818  ✅ Migrations completed   ← FALSE
```

Transactional DDL rolled back both migrations. DB stayed at `20260415_1000`.

### Downstream impact

`identities.one_campus_uuid` column is missing in prod → every 1Campus SSO login triggers `column identities.one_campus_uuid does not exist`. Observed on at least students 666 (李昱翰) and 670 (陳冠維), both `@apps.ntpc.edu.tw`.

### Changes

1. Add `set -euo pipefail` at the top of the migration step.
2. Drop the `tee` wrapper — let alembic's exit code propagate naturally.
3. Remove the auto-stamp fallback for `Can't locate revision`. Silently stamping to head advances `alembic_version` without running pending migrations — that's how we'd mask future orphan-revision issues. Orphan revisions should be investigated manually.

## Test plan

- [ ] Trigger a staging deploy and confirm migrations run successfully
- [ ] (Manual) In a follow-up, intentionally introduce a migration failure locally and confirm the step exits non-zero
- [ ] Verify prod redeploy (after data cleanup) picks up both `20260420_1000` and `20260420_1100`

## Follow-up (not in this PR)

- [ ] Clean up duplicate `teachers` row blocking the email unique index (manual SQL by @cbtzeng)
- [ ] Consider making email login/lookup case-insensitive across `auth.py` / `routers/auth.py` / `auth_one_campus.py` / `students/auth.py` (~8 query sites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)