### PR TITLE
Release: staging → main (2026-04-21)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -257,6 +257,7 @@ jobs:
       env:
         DATABASE_URL: ${{ steps.db_env.outputs.ALEMBIC_DATABASE_URL }}
       run: |
+        set -euo pipefail
         echo "🔍 Installing dependencies for migrations..."
         pip install -r backend/requirements.txt
 
@@ -266,22 +267,7 @@ jobs:
         alembic current || true
 
         echo "🔄 Upgrading to latest migration..."
-        if ! alembic upgrade head 2>&1 | tee /tmp/alembic_output.txt; then
-          # Check if error is due to orphaned revision
-          if grep -q "Can't locate revision" /tmp/alembic_output.txt; then
-            echo "⚠️ Orphaned revision detected in database"
-            echo "🔧 Stamping database to latest head to recover..."
-            # Get the current head from the codebase
-            CURRENT_HEAD=$(alembic heads | head -1 | awk '{print $1}')
-            echo "📌 Stamping to revision: $CURRENT_HEAD"
-            alembic stamp "$CURRENT_HEAD"
-            echo "✅ Database stamped successfully"
-          else
-            echo "❌ Migration failed with unexpected error"
-            cat /tmp/alembic_output.txt
-            exit 1
-          fi
-        fi
+        alembic upgrade head
         echo "✅ Migrations completed"
 
     - name: 🔒 Verify RLS Configuration

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -157,7 +157,9 @@ jobs:
       run: |
         # 優先使用 GitHub secrets（gcloud status.url 仍回傳已停用的舊格式 URL）
         # See: https://github.com/myduotopia/duotopia/issues/548
-        if [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+        if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+          BACKEND_URL="${{ secrets.PRODUCTION_BACKEND_URL }}"
+        elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
           BACKEND_URL="${{ secrets.DEVELOP_BACKEND_URL }}"
         else
           BACKEND_URL="${{ secrets.STAGING_BACKEND_URL }}"

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -779,8 +779,9 @@ export function AssignmentDetailSheet({
                       </div>
                     </div>
 
-                    {/* 例句重組專用 - 顯示答案 */}
-                    {assignment.practice_mode === "rearrangement" && (
+                    {/* 例句重組 / 單字選擇 - 顯示答案 */}
+                    {(assignment.practice_mode === "rearrangement" ||
+                      assignment.practice_mode === "word_selection") && (
                       <div className="space-y-1.5">
                         <Label className="text-xs text-gray-600 dark:text-gray-400">
                           {t(
@@ -801,7 +802,9 @@ export function AssignmentDetailSheet({
                           />
                           <span className="ml-2 text-sm text-gray-600 dark:text-gray-400">
                             {t(
-                              "dialogs.assignmentDialog.practiceMode.showAnswerDesc",
+                              assignment.practice_mode === "word_selection"
+                                ? "dialogs.assignmentDialog.practiceMode.wordSelectionShowAnswerDesc"
+                                : "dialogs.assignmentDialog.practiceMode.showAnswerDesc",
                             )}
                           </span>
                         </div>

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -3125,6 +3125,35 @@ export function AssignmentDialog({
                           </div>
                         </div>
 
+                        {/* 單字選擇專用 - 答錯後顯示答案 */}
+                        {formData.practice_mode === "word_selection" && (
+                          <div className="space-y-1.5">
+                            <Label className="text-xs text-gray-600">
+                              {t(
+                                "dialogs.assignmentDialog.practiceMode.showAnswer",
+                              )}
+                            </Label>
+                            <div className="flex items-center h-9">
+                              <input
+                                type="checkbox"
+                                checked={formData.show_answer}
+                                onChange={(e) =>
+                                  setFormData((prev) => ({
+                                    ...prev,
+                                    show_answer: e.target.checked,
+                                  }))
+                                }
+                                className="h-4 w-4 rounded border-gray-300"
+                              />
+                              <span className="ml-2 text-sm text-gray-600">
+                                {t(
+                                  "dialogs.assignmentDialog.practiceMode.wordSelectionShowAnswerDesc",
+                                )}
+                              </span>
+                            </div>
+                          </div>
+                        )}
+
                         {/* 單字朗讀專用 - 顯示翻譯 */}
                         {formData.practice_mode === "word_reading" && (
                           <div className="space-y-1.5">

--- a/frontend/src/components/activities/WordSelectionActivity.tsx
+++ b/frontend/src/components/activities/WordSelectionActivity.tsx
@@ -65,6 +65,7 @@ interface WordSelectionActivityProps {
   isPreviewMode?: boolean;
   isDemoMode?: boolean; // Demo mode - uses public demo API endpoints
   initialPracticeMode?: boolean; // True when assignment is already GRADED (re-practice)
+  showAnswer?: boolean; // 答錯後是否揭示正確答案
   onComplete?: () => void;
 }
 
@@ -73,6 +74,7 @@ export default function WordSelectionActivity({
   isPreviewMode = false,
   isDemoMode = false,
   initialPracticeMode = false,
+  showAnswer = false,
   onComplete,
 }: WordSelectionActivityProps) {
   const { t } = useTranslation();
@@ -90,6 +92,9 @@ export default function WordSelectionActivity({
   const [completing, setCompleting] = useState(false);
   const [scoreOverlayOpen, setScoreOverlayOpen] = useState(false);
   const nextQuestionCalledRef = useRef(false);
+  const showAnswerTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   // Settings
   const [showWord, setShowWord] = useState(true);
@@ -281,6 +286,13 @@ export default function WordSelectionActivity({
     startPractice();
   }, [startPractice]);
 
+  useEffect(() => {
+    return () => {
+      if (showAnswerTimeoutRef.current)
+        clearTimeout(showAnswerTimeoutRef.current);
+    };
+  }, []);
+
   // Play audio for current word
   const playWordAudio = useCallback(() => {
     const currentWord = words[currentIndex];
@@ -369,7 +381,15 @@ export default function WordSelectionActivity({
     setSelectedAnswer(null); // No selection made
     setIsCorrect(false);
     setShowResult(true);
-    setScoreOverlayOpen(true);
+    // 答錯且老師開啟「顯示答案」時，跳過「再試一次」動畫避免遮擋揭示的正解
+    if (showAnswer) {
+      showAnswerTimeoutRef.current = setTimeout(
+        () => handleOverlayComplete(),
+        2000,
+      );
+    } else {
+      setScoreOverlayOpen(true);
+    }
     setSubmitting(true);
 
     // Skip API call in preview mode and demo mode, but track local stats (SM-2 simulation)
@@ -414,7 +434,15 @@ export default function WordSelectionActivity({
     setSelectedAnswer(answer);
     setIsCorrect(correct);
     setShowResult(true);
-    setScoreOverlayOpen(true);
+    // 答錯且老師開啟「顯示答案」時，跳過「再試一次」動畫避免遮擋揭示的正解
+    if (!correct && showAnswer) {
+      showAnswerTimeoutRef.current = setTimeout(
+        () => handleOverlayComplete(),
+        2000,
+      );
+    } else {
+      setScoreOverlayOpen(true);
+    }
     setSubmitting(true);
 
     // Skip API call in preview mode and demo mode, but track local stats (SM-2 simulation)
@@ -783,8 +811,12 @@ export default function WordSelectionActivity({
           {currentWord.options.map((option, index) => {
             const isSelected = selectedAnswer === option;
             const isCorrectAnswer = option === currentWord.translation;
-            const showCorrect = showResult && isCorrectAnswer && isCorrect;
+            // 答對時揭示；答錯時只有老師開啟 showAnswer 才揭示（Issue #538）
+            const showCorrect =
+              showResult && isCorrectAnswer && (isCorrect || showAnswer);
             const showIncorrect = showResult && isSelected && !isCorrectAnswer;
+            // 答錯後才揭示的正解需要打勾動畫引導注意
+            const animateReveal = showCorrect && !isCorrect;
 
             // 四個選項各用不同淺色
             const optionColors = [
@@ -818,7 +850,13 @@ export default function WordSelectionActivity({
                 disabled={showResult || submitting}
               >
                 {showCorrect && (
-                  <CheckCircle className="h-5 w-5 mr-2 shrink-0 text-green-600 inline" />
+                  <CheckCircle
+                    className={cn(
+                      "h-5 w-5 mr-2 shrink-0 text-green-600 inline",
+                      animateReveal &&
+                        "animate-in zoom-in-50 fade-in duration-500",
+                    )}
+                  />
                 )}
                 {showIncorrect && (
                   <XCircle className="h-5 w-5 mr-2 shrink-0 text-red-600 inline" />

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1767,6 +1767,7 @@
         "shuffleQuestionsDesc": "Randomize question order for each practice session",
         "showAnswer": "Show Answer",
         "showAnswerDesc": "Show correct answer after completing each question",
+        "wordSelectionShowAnswerDesc": "Reveal correct answer when student answers wrong",
         "playAudio": "Play Audio",
         "playAudioYes": "Yes (Listening Practice)",
         "playAudioNo": "No (Writing Practice)",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -1819,6 +1819,7 @@
         "shuffleQuestionsDesc": "每次練習時隨機排列題目順序",
         "showAnswer": "顯示答案",
         "showAnswerDesc": "答題結束後顯示正確答案",
+        "wordSelectionShowAnswerDesc": "學生答錯後揭示正確答案",
         "playAudio": "播放音檔",
         "playAudioYes": "是（聽力練習）",
         "playAudioNo": "否（寫作練習）",

--- a/frontend/src/pages/student/StudentActivityPageContent.tsx
+++ b/frontend/src/pages/student/StudentActivityPageContent.tsx
@@ -2033,6 +2033,7 @@ export default function StudentActivityPageContent({
             isPreviewMode={isPreviewMode}
             isDemoMode={isDemoMode}
             initialPracticeMode={assignmentStatus === "GRADED"}
+            showAnswer={showAnswer}
             onComplete={() => {
               toast.success(
                 t("wordSelection.toast.completed") || "作業已完成！",


### PR DESCRIPTION
## Summary

Release PR from staging to main.

### Changes included

- **#647** `fix: fail backend deploy on migration error instead of silently continuing`
  - Adds `set -euo pipefail` to the Alembic migration step.
  - Removes the `tee`/`grep` wrapper that masked alembic's exit status (root cause of last night's silent deploy failure where `identities.one_campus_uuid` and email unique indexes were never actually applied).
  - Removes the auto-`alembic stamp` fallback for "Can't locate revision" (too dangerous — silently advanced `alembic_version` without running migrations).

- **#642** `feat: 單字選擇>新增派發設定> 設定答錯後是否顯示答案 (Fixes #538)`

### Deploy prerequisites (done before this merge)

- ✅ Prod DB: teacher row 69 (`kellyhuang1228@gmail.com`) renamed to `kellyhuang1228+dup69@gmail.com` and deactivated, unblocking the case-insensitive unique index migration
- ✅ Verified no remaining case-insensitive duplicates in `teachers.email` / `identities.email`
- ✅ Staging deploy with the new workflow succeeded (run 24711611479)

### Expected behavior on merge → prod deploy

With data cleaned and new workflow in place, the prod deploy should successfully apply:

- `20260420_1000_add_one_campus_uuid` — adds `identities.one_campus_uuid` column (fixes 1Campus SSO for students 666/670 who have been hitting `UndefinedColumn` errors)
- `20260420_1100_add_email_case_insensitive_unique_index` — creates `ix_teachers_email_lower` and `ix_identities_email_lower`

### Follow-up

- #648 — Make email login / lookup case-insensitive across auth paths (so Kelly can use either casing to login to teacher 70)

## Test plan

- [x] Staging deploy succeeded with new workflow (run 24711611479)
- [ ] Monitor prod deploy after merge: expect to see "Running upgrade 20260415_1000 -> 20260420_1000" and "20260420_1000 -> 20260420_1100" in the alembic logs
- [ ] After deploy, verify `identities.one_campus_uuid` column exists
- [ ] Confirm students 666 李昱翰 and 670 陳冠維 can login via 1Campus SSO without `UndefinedColumn` error in Cloud Run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)