### PR TITLE
fix: make email login / lookup case-insensitive across auth paths (Fixes #648)

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -161,10 +161,13 @@ def authenticate_teacher(db: Session, email: str, password: str):
 
 
 def authenticate_student(db: Session, email: str, password: str):
-    """學生認證（支援 Identity 統一密碼）"""
-    student = (
-        db.query(Student).filter(func.lower(Student.email) == email.lower()).first()
-    )
+    """學生認證（支援 Identity 統一密碼）
+
+    Note: `Student.email` 查詢維持 case-sensitive 直到 students 表完成資料
+    正規化 (4 筆大小寫重複 + 119 筆空字串) 並建立 ix_students_email_lower
+    functional index；見 #648 的 follow-up issue。
+    """
+    student = db.query(Student).filter(Student.email == email).first()
     if not student:
         logger.info(
             f"[LOGIN-DEBUG] authenticate_student | email={email} | student_found=False"

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta  # noqa: F401
 from typing import Optional, Dict, Any  # noqa: F401
 from jose import JWTError, jwt
 import bcrypt
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
@@ -149,7 +150,9 @@ def verify_token(token: str):
 
 def authenticate_teacher(db: Session, email: str, password: str):
     """教師認證"""
-    teacher = db.query(Teacher).filter(Teacher.email == email).first()
+    teacher = (
+        db.query(Teacher).filter(func.lower(Teacher.email) == email.lower()).first()
+    )
     if not teacher:
         return None
     if not verify_password(password, teacher.password_hash):
@@ -159,7 +162,9 @@ def authenticate_teacher(db: Session, email: str, password: str):
 
 def authenticate_student(db: Session, email: str, password: str):
     """學生認證（支援 Identity 統一密碼）"""
-    student = db.query(Student).filter(Student.email == email).first()
+    student = (
+        db.query(Student).filter(func.lower(Student.email) == email.lower()).first()
+    )
     if not student:
         logger.info(
             f"[LOGIN-DEBUG] authenticate_student | email={email} | student_found=False"

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -687,11 +687,13 @@ async def verify_reset_token(token: str, db: Session = Depends(get_db)):
 async def student_forgot_password(
     request: Request, email: str = Body(..., embed=True), db: Session = Depends(get_db)
 ):
-    """學生忘記密碼 - 發送重設郵件（僅限已驗證 email 的學生）"""
+    """學生忘記密碼 - 發送重設郵件（僅限已驗證 email 的學生）
+
+    Note: `Student.email` 查詢維持 case-sensitive 直到 students 表完成資料
+    正規化並建立 ix_students_email_lower functional index；見 #648 的 follow-up。
+    """
     # 查找學生
-    student = (
-        db.query(Student).filter(func.lower(Student.email) == email.lower()).first()
-    )
+    student = db.query(Student).filter(Student.email == email).first()
 
     # 不論是否找到都返回相同訊息（安全性考量）
     if not student:

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -2,6 +2,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status, Body, Request
 from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 from typing import Optional  # noqa: F401
 from pydantic import BaseModel, EmailStr, field_validator
@@ -93,7 +94,11 @@ async def teacher_login(
     logger = logging.getLogger(__name__)
 
     logger.info(f"🔍 Login attempt for email: {login_req.email}")
-    teacher = db.query(Teacher).filter(Teacher.email == login_req.email).first()
+    teacher = (
+        db.query(Teacher)
+        .filter(func.lower(Teacher.email) == login_req.email.lower())
+        .first()
+    )
 
     # 🔐 Security: 統一錯誤訊息，不洩漏帳號是否存在
     if not teacher:
@@ -220,8 +225,12 @@ async def teacher_register(
     if not is_valid:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=error_msg)
 
-    # Check if email exists
-    existing = db.query(Teacher).filter(Teacher.email == register_req.email).first()
+    # Check if email exists (case-insensitive, matches the unique functional index)
+    existing = (
+        db.query(Teacher)
+        .filter(func.lower(Teacher.email) == register_req.email.lower())
+        .first()
+    )
     if existing:
         # 如果已經驗證，不允許重複註冊
         if existing.email_verified:
@@ -334,7 +343,9 @@ async def resend_verification_email(request: dict, db: Session = Depends(get_db)
             status_code=status.HTTP_400_BAD_REQUEST, detail="Email is required"
         )
 
-    teacher = db.query(Teacher).filter(Teacher.email == email).first()
+    teacher = (
+        db.query(Teacher).filter(func.lower(Teacher.email) == email.lower()).first()
+    )
     if not teacher:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Teacher not found"
@@ -554,7 +565,9 @@ async def forgot_password(
 ):
     """教師忘記密碼 - 發送重設郵件"""
     # 查找教師
-    teacher = db.query(Teacher).filter(Teacher.email == email).first()
+    teacher = (
+        db.query(Teacher).filter(func.lower(Teacher.email) == email.lower()).first()
+    )
 
     # 不論是否找到都返回相同訊息（安全性考量）
     if not teacher:
@@ -676,7 +689,9 @@ async def student_forgot_password(
 ):
     """學生忘記密碼 - 發送重設郵件（僅限已驗證 email 的學生）"""
     # 查找學生
-    student = db.query(Student).filter(Student.email == email).first()
+    student = (
+        db.query(Student).filter(func.lower(Student.email) == email.lower()).first()
+    )
 
     # 不論是否找到都返回相同訊息（安全性考量）
     if not student:

--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -17,6 +17,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, EmailStr
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from auth import create_access_token, get_current_user
@@ -441,11 +442,13 @@ async def verify_teacher_bind(
         db, sso_identity, target_email, user_type="teacher"
     )
 
-    # Update teacher email — check uniqueness first to avoid constraint violation
+    # Update teacher email — check uniqueness first to avoid constraint violation.
+    # Case-insensitive match so we don't collide with the unique functional index
+    # ix_teachers_email_lower (see migration 20260420_1100).
     existing_teacher_with_email = (
         db.query(Teacher)
         .filter(
-            Teacher.email == target_email,
+            func.lower(Teacher.email) == target_email.lower(),
             Teacher.id != teacher.id,
             Teacher.is_active.is_(True),
         )

--- a/backend/routers/students/auth.py
+++ b/backend/routers/students/auth.py
@@ -3,6 +3,7 @@
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 from datetime import timedelta, datetime, timezone
 
@@ -113,7 +114,10 @@ async def validate_student(
     # 查詢 Identity（Email 流程直接用 Identity 密碼驗證）
     identity = (
         db.query(Identity)
-        .filter(Identity.email == request.email, Identity.is_active.is_(True))
+        .filter(
+            func.lower(Identity.email) == request.email.lower(),
+            Identity.is_active.is_(True),
+        )
         .first()
     )
 

--- a/backend/tests/integration/auth/test_email_case_insensitive.py
+++ b/backend/tests/integration/auth/test_email_case_insensitive.py
@@ -1,0 +1,259 @@
+"""Integration tests for Issue #648 — case-insensitive email lookup across auth paths.
+
+Covers teacher login / register / forgot-password / resend-verification,
+student Identity-based login, and student forgot-password. Each test stores
+an account with one casing and hits the endpoint with a different casing;
+the endpoint must still resolve to the same account.
+
+Rate-limit note: the login endpoint is throttled to 3/minute per IP. Tests use
+different endpoints per test method and keep login attempts minimal to avoid
+cross-test interference.
+"""
+from datetime import date
+
+from fastapi import status
+
+from auth import get_password_hash
+from models import Student, Teacher
+from models.user import Identity
+
+
+PASSWORD = "Password1!"
+
+
+class TestTeacherLoginCaseInsensitive:
+    def test_login_with_uppercase_variant_resolves_to_lowercase_account(
+        self, test_client, shared_test_session
+    ):
+        teacher = Teacher(
+            email="kelly@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            name="Kelly",
+            is_active=True,
+            email_verified=True,
+        )
+        shared_test_session.add(teacher)
+        shared_test_session.commit()
+
+        response = test_client.post(
+            "/api/auth/teacher/login",
+            json={"email": "KELLY@example.com", "password": PASSWORD},
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        body = response.json()
+        assert body.get("access_token"), "login must return an access token"
+        assert body["user"]["email"] == "kelly@example.com", (
+            "login with uppercase variant must resolve to the lowercase-stored "
+            "account"
+        )
+
+
+class TestTeacherRegisterCaseInsensitive:
+    def test_register_rejects_case_variant_of_verified_email(
+        self, test_client, shared_test_session
+    ):
+        existing = Teacher(
+            email="alice@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            name="Alice",
+            is_active=True,
+            email_verified=True,
+        )
+        shared_test_session.add(existing)
+        shared_test_session.commit()
+
+        response = test_client.post(
+            "/api/auth/teacher/register",
+            json={
+                "email": "ALICE@example.com",
+                "password": PASSWORD,
+                "name": "Alice Dup",
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "already registered" in response.json()["detail"].lower()
+
+    def test_register_replaces_unverified_case_variant(
+        self, test_client, shared_test_session
+    ):
+        existing = Teacher(
+            email="bob@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            name="Bob",
+            is_active=False,
+            email_verified=False,
+        )
+        shared_test_session.add(existing)
+        shared_test_session.commit()
+
+        response = test_client.post(
+            "/api/auth/teacher/register",
+            json={
+                "email": "Bob@Example.com",
+                "password": PASSWORD,
+                "name": "Bob Fresh",
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        shared_test_session.expire_all()
+        # The original unverified "Bob" row must be gone; the only remaining
+        # teacher matching the case-variant email should be the new "Bob Fresh".
+        remaining = (
+            shared_test_session.query(Teacher)
+            .filter(Teacher.name.in_(["Bob", "Bob Fresh"]))
+            .all()
+        )
+        assert len(remaining) == 1, (
+            f"Exactly one teacher row should remain after case-variant "
+            f"re-registration, got {[(t.name, t.email) for t in remaining]}"
+        )
+        assert remaining[0].name == "Bob Fresh"
+
+
+class TestResendVerificationCaseInsensitive:
+    def test_resend_verification_finds_case_variant_teacher(
+        self, test_client, shared_test_session
+    ):
+        teacher = Teacher(
+            email="dan@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            name="Dan",
+            is_active=False,
+            email_verified=False,
+        )
+        shared_test_session.add(teacher)
+        shared_test_session.commit()
+
+        response = test_client.post(
+            "/api/auth/resend-verification",
+            json={"email": "DAN@example.com"},
+        )
+
+        assert response.status_code != status.HTTP_404_NOT_FOUND, response.text
+
+
+class TestForgotPasswordCaseInsensitive:
+    def test_teacher_forgot_password_accepts_case_variant(
+        self, test_client, shared_test_session
+    ):
+        teacher = Teacher(
+            email="carol@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            name="Carol",
+            is_active=True,
+            email_verified=True,
+        )
+        shared_test_session.add(teacher)
+        shared_test_session.commit()
+
+        response = test_client.post(
+            "/api/auth/teacher/forgot-password",
+            json={"email": "CAROL@example.com"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        shared_test_session.refresh(teacher)
+        assert (
+            teacher.password_reset_token is not None
+        ), "forgot-password must locate the teacher regardless of email casing"
+
+    def test_student_forgot_password_accepts_case_variant(
+        self, test_client, shared_test_session
+    ):
+        student = Student(
+            email="kid@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            name="Kid",
+            birthdate=date(2010, 1, 1),
+            email_verified=True,
+        )
+        shared_test_session.add(student)
+        shared_test_session.commit()
+
+        response = test_client.post(
+            "/api/auth/student/forgot-password",
+            json={"email": "Kid@EXAMPLE.COM"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        shared_test_session.refresh(student)
+        assert (
+            student.password_reset_token is not None
+        ), "student forgot-password must locate the student regardless of email casing"
+
+
+class TestStudentIdentityValidateCaseInsensitive:
+    def test_validate_finds_identity_regardless_of_casing(
+        self, test_client, shared_test_session
+    ):
+        identity = Identity(
+            email="learner@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            email_verified=True,
+            is_active=True,
+        )
+        shared_test_session.add(identity)
+        shared_test_session.flush()
+
+        student = Student(
+            email="learner@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            name="Learner",
+            birthdate=date(2010, 1, 1),
+            email_verified=True,
+            is_active=True,
+            identity_id=identity.id,
+            is_primary_account=True,
+        )
+        shared_test_session.add(student)
+        shared_test_session.commit()
+
+        response = test_client.post(
+            "/api/students/validate",
+            json={"email": "LEARNER@example.com", "password": PASSWORD},
+        )
+
+        assert response.status_code != status.HTTP_401_UNAUTHORIZED, response.text
+
+
+class TestOneCampusBindCaseInsensitive:
+    """The 1Campus bind code checks whether a different Teacher already has the
+    target email (so we don't violate the unique constraint). That check must
+    also be case-insensitive — otherwise we could still collide on insert.
+
+    Here we verify the underlying query pattern directly rather than driving
+    the full SSO flow (which requires multiple upstream mocks).
+    """
+
+    def test_teacher_email_collision_check_is_case_insensitive(
+        self, shared_test_session
+    ):
+        from sqlalchemy import func
+
+        existing = Teacher(
+            email="sso.user@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            name="SSO User",
+            is_active=True,
+            email_verified=True,
+        )
+        shared_test_session.add(existing)
+        shared_test_session.commit()
+
+        target_email = "SSO.User@example.com"
+        collision = (
+            shared_test_session.query(Teacher)
+            .filter(
+                func.lower(Teacher.email) == target_email.lower(),
+                Teacher.id != 0,
+                Teacher.is_active.is_(True),
+            )
+            .first()
+        )
+        assert collision is not None, (
+            "Case-insensitive collision check must find the existing teacher; "
+            "otherwise 1Campus bind would create a duplicate row."
+        )

--- a/backend/tests/integration/auth/test_email_case_insensitive.py
+++ b/backend/tests/integration/auth/test_email_case_insensitive.py
@@ -1,17 +1,22 @@
 """Integration tests for Issue #648 — case-insensitive email lookup across auth paths.
 
-Covers teacher login / register / forgot-password / resend-verification,
-student Identity-based login, and student forgot-password. Each test stores
-an account with one casing and hits the endpoint with a different casing;
-the endpoint must still resolve to the same account.
+Covers teacher login / register / forgot-password / resend-verification, the
+Identity-based student login path, and the 1Campus SSO bind collision check.
+Each test stores an account with one casing and hits the endpoint with a
+different casing; the endpoint must still resolve to the same account.
 
 Rate-limit note: the login endpoint is throttled to 3/minute per IP. Tests use
 different endpoints per test method and keep login attempts minimal to avoid
 cross-test interference.
+
+Scope note: direct `Student.email` queries (authenticate_student and
+student_forgot_password) intentionally remain case-sensitive until the
+follow-up issue lands (data cleanup + ix_students_email_lower migration).
 """
 from datetime import date
 
 from fastapi import status
+from sqlalchemy import func
 
 from auth import get_password_hash
 from models import Student, Teacher
@@ -132,7 +137,13 @@ class TestResendVerificationCaseInsensitive:
             json={"email": "DAN@example.com"},
         )
 
-        assert response.status_code != status.HTTP_404_NOT_FOUND, response.text
+        # Legitimate outcomes once the teacher is located: 200 (email sent) or
+        # 429 (resend cooldown). 404 means the case-variant lookup failed, which
+        # is the regression this test guards against.
+        assert response.status_code in (
+            status.HTTP_200_OK,
+            status.HTTP_429_TOO_MANY_REQUESTS,
+        ), response.text
 
 
 class TestForgotPasswordCaseInsensitive:
@@ -159,30 +170,6 @@ class TestForgotPasswordCaseInsensitive:
         assert (
             teacher.password_reset_token is not None
         ), "forgot-password must locate the teacher regardless of email casing"
-
-    def test_student_forgot_password_accepts_case_variant(
-        self, test_client, shared_test_session
-    ):
-        student = Student(
-            email="kid@example.com",
-            password_hash=get_password_hash(PASSWORD),
-            name="Kid",
-            birthdate=date(2010, 1, 1),
-            email_verified=True,
-        )
-        shared_test_session.add(student)
-        shared_test_session.commit()
-
-        response = test_client.post(
-            "/api/auth/student/forgot-password",
-            json={"email": "Kid@EXAMPLE.COM"},
-        )
-
-        assert response.status_code == status.HTTP_200_OK
-        shared_test_session.refresh(student)
-        assert (
-            student.password_reset_token is not None
-        ), "student forgot-password must locate the student regardless of email casing"
 
 
 class TestStudentIdentityValidateCaseInsensitive:
@@ -231,8 +218,6 @@ class TestOneCampusBindCaseInsensitive:
     def test_teacher_email_collision_check_is_case_insensitive(
         self, shared_test_session
     ):
-        from sqlalchemy import func
-
         existing = Teacher(
             email="sso.user@example.com",
             password_hash=get_password_hash(PASSWORD),


### PR DESCRIPTION
## 🎯 Purpose

Make Teacher and Identity email lookups in the auth layer case-insensitive so login, register, password-reset, and SSO merge behave consistently regardless of the casing the user types.

Fixes #648
Follow-up for student paths: #653

---

## 🔍 Problem Analysis

### Root Cause
1. **為什麼會發生？** → 使用者用與註冊時不同大小寫的 email 登入會失敗。
2. **為什麼會這樣？** → 所有 auth 查詢都用 `Table.email == input`，PostgreSQL 是 case-sensitive 比對。
3. **為什麼？** → 早期實作沒有把 email 當成 case-insensitive identifier。
4. **根本原因？** → 多個 auth 查詢點都以原始 string equality 查詢，而 DB 允許 `foo@x.com` 和 `Foo@x.com` 共存（參見 prod 的 teacher 69/70 事件）。
5. **為什麼系統允許？** → **根本原因：** 原本沒有 case-insensitive unique index；#640 已建立 `ix_teachers_email_lower` / `ix_identities_email_lower`，但 runtime 查詢還沒跟上。

### Code Location
7 call sites updated in this PR (see Changes). 2 `Student.email` call sites are intentionally deferred to follow-up issue #653.

---

## ✅ Solution

### Changes Made
- [x] `backend/auth.py` — `authenticate_teacher` 改為 `func.lower(...) == email.lower()` （`authenticate_student` 留待 #653 處理）
- [x] `backend/routers/auth.py` — teacher login / register / resend-verification / teacher forgot-password（4 處；student forgot-password 留待 #653）
- [x] `backend/routers/students/auth.py` — `/api/students/validate` 的 `Identity.email` 查詢
- [x] `backend/routers/auth_one_campus.py` — SSO bind 前的 teacher email 衝突檢查
- [x] 新增測試：`backend/tests/integration/auth/test_email_case_insensitive.py`（7 cases）

### Technical Decisions
- **用 `func.lower(col) == val.lower()` 而非正規化輸入**：PostgreSQL 會命中 migration `20260420_1100` 建立的 `ix_teachers_email_lower` / `ix_identities_email_lower` functional index，查詢仍是 O(log n)。
- **不動 JWT `sub` 格式**：`sub` 存的是 teacher/student id（不是 email），本來就不受影響。
- **不動 `Student.email` 兩條路徑**：`students` 表沒有 `ix_students_email_lower` 且 prod 有 4 筆大小寫重複 + 119 筆空字串需先清理，在 #653 另案處理。此次 PR 聚焦在造成 prod 事故的 Teacher/Identity 路徑。
- **不寫資料正規化 migration**：既有 `teachers.email` / `identities.email` 保留原大小寫；unique functional index 已足以阻擋後續重複。

---

## 🧪 Testing

### Test Coverage
`backend/tests/integration/auth/test_email_case_insensitive.py` — 7 integration cases:
  - Teacher login with uppercase variant resolves to lowercase-stored account
  - Register blocks case-variant of already-verified email (400)
  - Register replaces unverified case-variant (delete-then-insert flow)
  - `/resend-verification` finds case-variant teacher (asserts `in (200, 429)` so 5xx 會被抓到)
  - Teacher `/forgot-password` 產生 reset token with case-variant email
  - `/api/students/validate` 找得到 Identity regardless of casing
  - 1Campus SSO bind 衝突檢查為 case-insensitive

TDD 流程：先寫測試 (Red → 7 失敗 + 1 SQL-level 斷言通過)，實作後再跑 (Green → 7/7 通過)。

### Manual Testing
- [x] `black --check` 通過
- [x] `flake8` 通過
- [x] 既有 auth 測試套件無 regression（83 pass；19 pre-existing failures 已驗證為 origin/staging 本來就存在，與本 PR 無關）

---

## 🛡️ Prevention

### Preventive Tests Added
- [x] 邊界條件測試（全大寫、混合大小寫、已驗證 vs 未驗證）
- [x] Regression 測試（unverified case-variant 刪除→重新註冊流程）
- [x] resend-verification 斷言改為 `in (200, 429)`，擋掉 5xx 悄悄通過測試的可能

### Documentation Updated
- [x] 修改處有 inline comment 說明與 `ix_teachers_email_lower` 的對應關係
- [x] `authenticate_student` 和 `student_forgot_password` 加上 docstring 指向 #653

---

## 📊 Impact Analysis

### Affected Components
- [x] Backend: `/api/auth/teacher/*`、`/api/auth/resend-verification`、`/api/students/validate`、`/api/auth/one-campus/*`
- [ ] Database: 無 schema 變更（case-insensitive index 來自 #640）

### Risk Assessment
- **嚴重程度**: 🟡 Medium（觸及老師登入路徑與 Identity 路徑）
- **影響用戶**: 所有老師登入 / 註冊 / 密碼重設、Identity-based 學生登入
- **資料風險**: 否（只改查詢寫法，不改資料）
- **效能影響**: 否（functional index 已就位，查詢仍走 index）

### Rollback Plan
若發現問題，直接 revert 這個 PR 即可；既有 `20260420_1100` migration 與 DB 中的 functional index 可保留（對 runtime 沒影響）。

---

## 🚀 Deployment Notes

- **無需 migration**：`ix_teachers_email_lower` / `ix_identities_email_lower` 已於 `20260420_1100` 建立並部署於 staging。
- 部署後建議用 staging 帳號測一次混合大小寫老師登入。
- Student email case-insensitive 查詢在 #653 另案處理（需先做資料 cleanup 與加 index）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>