### PR TITLE
fix: 單字集預覽與三點選單被卡片遮擋 (Fixes #600)

### DIFF
--- a/backend/routers/teachers/content_ops.py
+++ b/backend/routers/teachers/content_ops.py
@@ -221,9 +221,13 @@ async def create_content(
                 metadata["audio_settings"] = item_data["audio_settings"]
 
             # 根據前端傳來的資料決定存儲到 translation 欄位的內容
-            # 優先使用 definition (中文翻譯)，如果沒有則使用 translation
-            translation_value = item_data.get("definition") or item_data.get(
-                "translation", ""
+            # 優先使用語言感知的 vocabulary_translation（前端目前選擇語言的翻譯，
+            # 中/英/日/韓），舊欄位作為相容性 fallback。
+            translation_value = (
+                item_data.get("vocabulary_translation")
+                or item_data.get("definition")
+                or item_data.get("translation", "")
+                or ""
             )
 
             # 處理 part_of_speech：前端可能傳送 parts_of_speech (plural, array)
@@ -508,9 +512,13 @@ async def update_content(
                     metadata["audio_settings"] = item_data["audio_settings"]
 
                 # 根據前端傳來的資料決定存儲到 translation 欄位的內容
-                # 優先使用 definition (中文翻譯)，如果沒有則使用 translation
-                translation_value = item_data.get("definition") or item_data.get(
-                    "translation", ""
+                # 優先使用語言感知的 vocabulary_translation（前端目前選擇語言的翻譯，
+                # 中/英/日/韓），舊欄位作為相容性 fallback。
+                translation_value = (
+                    item_data.get("vocabulary_translation")
+                    or item_data.get("definition")
+                    or item_data.get("translation", "")
+                    or ""
                 )
 
                 # 計算 word_count（如果有 example_sentence）

--- a/backend/tests/unit/test_content_crud_api.py
+++ b/backend/tests/unit/test_content_crud_api.py
@@ -410,6 +410,99 @@ class TestContentCRUD:
 
         db.close()
 
+    def test_update_content_prefers_vocabulary_translation_over_definition(
+        self, auth_token
+    ):
+        """Issue #600: Preview 卡顯示的 translation 應該是使用者當前選擇語言的翻譯。
+
+        前端 VocabularySetPanel 在英英模式下送出：
+          - vocabulary_translation = "Hello" (英文定義)
+          - vocabulary_translation_lang = "english"
+          - definition = "你好"  (殘留的中文欄位)
+        後端應存入 item.translation = "Hello"（vocabulary_translation 優先），
+        而非中文的 definition。"""
+        create_response = client.post(
+            "/api/teachers/lessons/1/contents",
+            headers={"Authorization": f"Bearer {auth_token}"},
+            json={
+                "title": "Lang-aware translation content",
+                "items": [
+                    {
+                        "text": "greet",
+                        "vocabulary_translation": "a friendly word of welcome",
+                        "vocabulary_translation_lang": "english",
+                        "definition": "你好",
+                    }
+                ],
+                "target_wpm": 100,
+                "target_accuracy": 90.0,
+                "order_index": 1,
+            },
+        )
+        assert create_response.status_code == 200
+        content_id = create_response.json()["id"]
+
+        # CREATE 路徑：translation 欄位應存英文（vocabulary_translation）
+        detail_response = client.get(
+            f"/api/teachers/contents/{content_id}",
+            headers={"Authorization": f"Bearer {auth_token}"},
+        )
+        assert detail_response.status_code == 200
+        created_items = detail_response.json()["items"]
+        assert len(created_items) == 1
+        assert created_items[0]["translation"] == "a friendly word of welcome"
+
+        # UPDATE 路徑：切換語言到日文後，translation 欄位也要同步
+        update_response = client.put(
+            f"/api/teachers/contents/{content_id}",
+            headers={"Authorization": f"Bearer {auth_token}"},
+            json={
+                "title": "Lang-aware translation content",
+                "items": [
+                    {
+                        "text": "greet",
+                        "vocabulary_translation": "こんにちは",
+                        "vocabulary_translation_lang": "japanese",
+                        "definition": "你好",
+                    }
+                ],
+            },
+        )
+        assert update_response.status_code == 200
+
+        detail_response_2 = client.get(
+            f"/api/teachers/contents/{content_id}",
+            headers={"Authorization": f"Bearer {auth_token}"},
+        )
+        updated_items = detail_response_2.json()["items"]
+        assert updated_items[0]["translation"] == "こんにちは"
+
+    def test_update_content_falls_back_to_definition_when_no_vocab_translation(
+        self, auth_token
+    ):
+        """相容性：若前端未送 vocabulary_translation（舊 ReadingAssessmentPanel 流程），
+        應沿用舊行為從 definition → translation fallback。"""
+        create_response = client.post(
+            "/api/teachers/lessons/1/contents",
+            headers={"Authorization": f"Bearer {auth_token}"},
+            json={
+                "title": "Legacy definition content",
+                "items": [{"text": "hello", "definition": "你好"}],
+                "target_wpm": 100,
+                "target_accuracy": 90.0,
+                "order_index": 1,
+            },
+        )
+        assert create_response.status_code == 200
+        content_id = create_response.json()["id"]
+
+        detail_response = client.get(
+            f"/api/teachers/contents/{content_id}",
+            headers={"Authorization": f"Bearer {auth_token}"},
+        )
+        items = detail_response.json()["items"]
+        assert items[0]["translation"] == "你好"
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/frontend/src/components/shared/ProgramFolderView.tsx
+++ b/frontend/src/components/shared/ProgramFolderView.tsx
@@ -32,6 +32,12 @@ import {
   SendHorizontal,
 } from "lucide-react";
 import {
+  DropdownMenu as ShadcnDropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import {
   DndContext,
   closestCenter,
   PointerSensor,
@@ -108,7 +114,9 @@ const TYPE_BADGE: Record<string, { label: string; bg: string; text: string }> =
     SENTENCE_MAKING: { label: "造句", bg: "#F5F3FF", text: "#7C3AED" },
   };
 
-/* ── Dropdown Menu ── */
+/* ── Dropdown Menu ──
+ * 使用 Radix DropdownMenu + Portal 避免被鄰近卡片遮擋，
+ * collisionPadding 讓選單在貼近視窗邊緣時自動翻轉到上方。 */
 interface MenuAction {
   label: string;
   icon: React.ReactNode;
@@ -117,52 +125,47 @@ interface MenuAction {
   disabled?: boolean;
 }
 
-function DropdownMenu({
-  actions,
-  onClose,
-}: {
-  actions: MenuAction[];
-  onClose: () => void;
-}) {
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
-    };
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [onClose]);
-
+function ActionDropdown({ actions }: { actions: MenuAction[] }) {
   return (
-    <div
-      ref={ref}
-      className="absolute right-0 top-full mt-1 z-20 w-[100px] bg-white rounded-2xl shadow-lg border border-gray-100 py-[3px]"
-    >
-      {actions.map((a, i) => (
-        <button
-          key={i}
-          disabled={a.disabled}
-          onClick={(e) => {
-            e.stopPropagation();
-            if (!a.disabled) {
-              a.onClick();
-              onClose();
-            }
-          }}
-          className={`flex items-center gap-1.5 w-full px-2.5 py-1.5 rounded-md text-xs transition-colors ${
-            a.disabled
-              ? "text-gray-300 cursor-not-allowed"
-              : a.danger
-                ? "text-red-500 hover:bg-gray-50"
-                : "text-gray-700 hover:bg-gray-50"
-          }`}
-        >
-          {a.icon}
-          {a.label}
+    <ShadcnDropdownMenu>
+      <DropdownMenuTrigger
+        asChild
+        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+      >
+        <button className="absolute right-3 bottom-3 p-1 opacity-70 hover:opacity-100 transition-opacity">
+          <Ellipsis size={18} className="text-gray-500" />
         </button>
-      ))}
-    </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        sideOffset={6}
+        collisionPadding={16}
+        onClick={(e) => e.stopPropagation()}
+        className="z-[60] min-w-[100px] bg-white rounded-2xl shadow-lg border border-gray-100 py-[3px]"
+      >
+        {actions.map((a, i) => (
+          <DropdownMenuItem
+            key={i}
+            disabled={a.disabled}
+            onSelect={(e) => {
+              e.preventDefault();
+              if (!a.disabled) a.onClick();
+            }}
+            onClick={(e) => e.stopPropagation()}
+            className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs cursor-pointer transition-colors ${
+              a.disabled
+                ? "text-gray-300 cursor-not-allowed"
+                : a.danger
+                  ? "text-red-500 focus:bg-gray-50 focus:text-red-500"
+                  : "text-gray-700 focus:bg-gray-50 focus:text-gray-700"
+            }`}
+          >
+            {a.icon}
+            {a.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </ShadcnDropdownMenu>
   );
 }
 
@@ -181,7 +184,6 @@ function ProgramCard({
   onDelete: () => void;
 }) {
   const { t } = useTranslation();
-  const [showMenu, setShowMenu] = useState(false);
   const lessons = program.lessons ?? [];
   const contentCount = lessons.reduce(
     (sum, l) => sum + (l.contents?.length ?? 0),
@@ -222,35 +224,21 @@ function ProgramCard({
           {contentCount} {t("programFolderView.contents", "內容")}
         </p>
 
-        {/* Ellipsis menu trigger */}
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            setShowMenu(!showMenu);
-          }}
-          className="absolute right-3 bottom-3 p-1 opacity-70 hover:opacity-100 transition-opacity"
-        >
-          <Ellipsis size={18} className="text-gray-500" />
-        </button>
-
-        {showMenu && (
-          <DropdownMenu
-            onClose={() => setShowMenu(false)}
-            actions={[
-              {
-                label: t("common.edit", "編輯"),
-                icon: <Pencil size={13} />,
-                onClick: onEdit,
-              },
-              {
-                label: t("common.delete", "刪除"),
-                icon: <Trash2 size={13} />,
-                onClick: onDelete,
-                danger: true,
-              },
-            ]}
-          />
-        )}
+        <ActionDropdown
+          actions={[
+            {
+              label: t("common.edit", "編輯"),
+              icon: <Pencil size={13} />,
+              onClick: onEdit,
+            },
+            {
+              label: t("common.delete", "刪除"),
+              icon: <Trash2 size={13} />,
+              onClick: onDelete,
+              danger: true,
+            },
+          ]}
+        />
       </div>
     </div>
   );
@@ -271,7 +259,6 @@ function LessonCard({
   onDelete: () => void;
 }) {
   const { t } = useTranslation();
-  const [showMenu, setShowMenu] = useState(false);
   const contents = lesson.contents ?? [];
 
   return (
@@ -299,35 +286,21 @@ function LessonCard({
           {contents.length} {t("programFolderView.contents", "內容")}
         </p>
 
-        {/* Ellipsis menu trigger */}
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            setShowMenu(!showMenu);
-          }}
-          className="absolute right-3 bottom-3 p-1 opacity-70 hover:opacity-100 transition-opacity"
-        >
-          <Ellipsis size={18} className="text-gray-500" />
-        </button>
-
-        {showMenu && (
-          <DropdownMenu
-            onClose={() => setShowMenu(false)}
-            actions={[
-              {
-                label: t("common.edit", "編輯"),
-                icon: <Pencil size={13} />,
-                onClick: onEdit,
-              },
-              {
-                label: t("common.delete", "刪除"),
-                icon: <Trash2 size={13} />,
-                onClick: onDelete,
-                danger: true,
-              },
-            ]}
-          />
-        )}
+        <ActionDropdown
+          actions={[
+            {
+              label: t("common.edit", "編輯"),
+              icon: <Pencil size={13} />,
+              onClick: onEdit,
+            },
+            {
+              label: t("common.delete", "刪除"),
+              icon: <Trash2 size={13} />,
+              onClick: onDelete,
+              danger: true,
+            },
+          ]}
+        />
       </div>
     </div>
   );
@@ -350,7 +323,6 @@ function ContentCard({
   onAssign?: () => void;
 }) {
   const { t } = useTranslation();
-  const [showMenu, setShowMenu] = useState(false);
   const items = content.items ?? [];
   const badge = TYPE_BADGE[content.type ?? ""] ?? {
     label: content.type ?? "其他",
@@ -473,51 +445,37 @@ function ContentCard({
           {t("programFolderView.questions", "題")}
         </span>
 
-        {/* Ellipsis menu trigger */}
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            setShowMenu(!showMenu);
-          }}
-          className="absolute right-3 bottom-3 p-1 opacity-70 hover:opacity-100 transition-opacity"
-        >
-          <Ellipsis size={18} className="text-gray-500" />
-        </button>
-
-        {showMenu && (
-          <DropdownMenu
-            onClose={() => setShowMenu(false)}
-            actions={[
-              ...(onCopy
-                ? [
-                    {
-                      label: t("common.copy", "複製"),
-                      icon: <Copy size={13} />,
-                      onClick: onCopy,
-                    },
-                  ]
-                : []),
-              {
-                label: t("common.move", "移動"),
-                icon: <ArrowRightLeft size={13} />,
-                onClick: () => {
-                  // TODO: 等工程師實作移動功能
-                },
-                disabled: true,
+        <ActionDropdown
+          actions={[
+            ...(onCopy
+              ? [
+                  {
+                    label: t("common.copy", "複製"),
+                    icon: <Copy size={13} />,
+                    onClick: onCopy,
+                  },
+                ]
+              : []),
+            {
+              label: t("common.move", "移動"),
+              icon: <ArrowRightLeft size={13} />,
+              onClick: () => {
+                // TODO: 等工程師實作移動功能
               },
-              ...(onDelete
-                ? [
-                    {
-                      label: t("common.delete", "刪除"),
-                      icon: <Trash2 size={13} />,
-                      onClick: onDelete,
-                      danger: true,
-                    },
-                  ]
-                : []),
-            ]}
-          />
-        )}
+              disabled: true,
+            },
+            ...(onDelete
+              ? [
+                  {
+                    label: t("common.delete", "刪除"),
+                    icon: <Trash2 size={13} />,
+                    onClick: onDelete,
+                    danger: true,
+                  },
+                ]
+              : []),
+          ]}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- **#600 單字集預覽顯示舊翻譯**：後端 `create_content` / `update_content` 改成優先使用 `vocabulary_translation`（前端當前選擇語言的翻譯）寫入 DB `item.translation`，舊的 `definition` / `translation` 欄位保留為相容性 fallback。切換翻譯語言儲存後，`/programs` 列表的預覽卡會即時顯示新語言。
- **三點選單被鄰近卡片遮擋**：`ProgramFolderView` 原本手刻的 `<div absolute z-20>` dropdown 在 grid 中會被後續 DOM 順序的卡片蓋過。改用 shadcn/Radix `DropdownMenu` + `DropdownMenuPortal` 把選單掛到 `body`，並加 `collisionPadding={16}` 讓選單在貼近視窗邊緣時自動往上翻轉。
- 補 2 個 pytest case 涵蓋 create / update 兩條語言感知寫入路徑與舊流程 fallback。

## Test plan
- [x] `backend/tests/unit/test_content_crud_api.py` 全檔 10/10 通過
- [x] `npm run typecheck` 無錯
- [ ] Staging 實測：建立單字集「中文」→ 存檔 → 預覽顯示中文
- [ ] Staging 實測：把該內容複製到另一 Lesson → 改成「英英」→ 存檔 → 預覽顯示英文
- [ ] Staging 實測：日文 / 韓文 同樣驗證
- [ ] Staging 實測：在 `/teacher/programs` 視窗縮到出現多列，點最下列 Content 卡的三點選單，確認可正常點擊且不被下方卡片遮擋

## 存量資料
既有 content 的 `item.translation` 仍是舊的中文值，修法後使用者下次進編輯器儲存即會自動同步到選擇語言。暫不做 migration backfill（之後視需要再處理）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)