### PR TITLE
Release: staging → main (#645, #648, #651)

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta  # noqa: F401
 from typing import Optional, Dict, Any  # noqa: F401
 from jose import JWTError, jwt
 import bcrypt
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
@@ -149,7 +150,9 @@ def verify_token(token: str):
 
 def authenticate_teacher(db: Session, email: str, password: str):
     """教師認證"""
-    teacher = db.query(Teacher).filter(Teacher.email == email).first()
+    teacher = (
+        db.query(Teacher).filter(func.lower(Teacher.email) == email.lower()).first()
+    )
     if not teacher:
         return None
     if not verify_password(password, teacher.password_hash):
@@ -158,7 +161,12 @@ def authenticate_teacher(db: Session, email: str, password: str):
 
 
 def authenticate_student(db: Session, email: str, password: str):
-    """學生認證（支援 Identity 統一密碼）"""
+    """學生認證（支援 Identity 統一密碼）
+
+    Note: `Student.email` 查詢維持 case-sensitive 直到 students 表完成資料
+    正規化 (4 筆大小寫重複 + 119 筆空字串) 並建立 ix_students_email_lower
+    functional index；見 #648 的 follow-up issue。
+    """
     student = db.query(Student).filter(Student.email == email).first()
     if not student:
         logger.info(

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -2,6 +2,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status, Body, Request
 from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 from typing import Optional  # noqa: F401
 from pydantic import BaseModel, EmailStr, field_validator
@@ -93,7 +94,11 @@ async def teacher_login(
     logger = logging.getLogger(__name__)
 
     logger.info(f"🔍 Login attempt for email: {login_req.email}")
-    teacher = db.query(Teacher).filter(Teacher.email == login_req.email).first()
+    teacher = (
+        db.query(Teacher)
+        .filter(func.lower(Teacher.email) == login_req.email.lower())
+        .first()
+    )
 
     # 🔐 Security: 統一錯誤訊息，不洩漏帳號是否存在
     if not teacher:
@@ -220,8 +225,12 @@ async def teacher_register(
     if not is_valid:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=error_msg)
 
-    # Check if email exists
-    existing = db.query(Teacher).filter(Teacher.email == register_req.email).first()
+    # Check if email exists (case-insensitive, matches the unique functional index)
+    existing = (
+        db.query(Teacher)
+        .filter(func.lower(Teacher.email) == register_req.email.lower())
+        .first()
+    )
     if existing:
         # 如果已經驗證，不允許重複註冊
         if existing.email_verified:
@@ -334,7 +343,9 @@ async def resend_verification_email(request: dict, db: Session = Depends(get_db)
             status_code=status.HTTP_400_BAD_REQUEST, detail="Email is required"
         )
 
-    teacher = db.query(Teacher).filter(Teacher.email == email).first()
+    teacher = (
+        db.query(Teacher).filter(func.lower(Teacher.email) == email.lower()).first()
+    )
     if not teacher:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Teacher not found"
@@ -554,7 +565,9 @@ async def forgot_password(
 ):
     """教師忘記密碼 - 發送重設郵件"""
     # 查找教師
-    teacher = db.query(Teacher).filter(Teacher.email == email).first()
+    teacher = (
+        db.query(Teacher).filter(func.lower(Teacher.email) == email.lower()).first()
+    )
 
     # 不論是否找到都返回相同訊息（安全性考量）
     if not teacher:
@@ -674,7 +687,11 @@ async def verify_reset_token(token: str, db: Session = Depends(get_db)):
 async def student_forgot_password(
     request: Request, email: str = Body(..., embed=True), db: Session = Depends(get_db)
 ):
-    """學生忘記密碼 - 發送重設郵件（僅限已驗證 email 的學生）"""
+    """學生忘記密碼 - 發送重設郵件（僅限已驗證 email 的學生）
+
+    Note: `Student.email` 查詢維持 case-sensitive 直到 students 表完成資料
+    正規化並建立 ix_students_email_lower functional index；見 #648 的 follow-up。
+    """
     # 查找學生
     student = db.query(Student).filter(Student.email == email).first()
 

--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -17,6 +17,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, EmailStr
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from auth import create_access_token, get_current_user
@@ -441,11 +442,13 @@ async def verify_teacher_bind(
         db, sso_identity, target_email, user_type="teacher"
     )
 
-    # Update teacher email — check uniqueness first to avoid constraint violation
+    # Update teacher email — check uniqueness first to avoid constraint violation.
+    # Case-insensitive match so we don't collide with the unique functional index
+    # ix_teachers_email_lower (see migration 20260420_1100).
     existing_teacher_with_email = (
         db.query(Teacher)
         .filter(
-            Teacher.email == target_email,
+            func.lower(Teacher.email) == target_email.lower(),
             Teacher.id != teacher.id,
             Teacher.is_active.is_(True),
         )

--- a/backend/routers/students/auth.py
+++ b/backend/routers/students/auth.py
@@ -3,6 +3,7 @@
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 from datetime import timedelta, datetime, timezone
 
@@ -113,7 +114,10 @@ async def validate_student(
     # 查詢 Identity（Email 流程直接用 Identity 密碼驗證）
     identity = (
         db.query(Identity)
-        .filter(Identity.email == request.email, Identity.is_active.is_(True))
+        .filter(
+            func.lower(Identity.email) == request.email.lower(),
+            Identity.is_active.is_(True),
+        )
         .first()
     )
 

--- a/backend/tests/integration/auth/test_email_case_insensitive.py
+++ b/backend/tests/integration/auth/test_email_case_insensitive.py
@@ -1,0 +1,244 @@
+"""Integration tests for Issue #648 — case-insensitive email lookup across auth paths.
+
+Covers teacher login / register / forgot-password / resend-verification, the
+Identity-based student login path, and the 1Campus SSO bind collision check.
+Each test stores an account with one casing and hits the endpoint with a
+different casing; the endpoint must still resolve to the same account.
+
+Rate-limit note: the login endpoint is throttled to 3/minute per IP. Tests use
+different endpoints per test method and keep login attempts minimal to avoid
+cross-test interference.
+
+Scope note: direct `Student.email` queries (authenticate_student and
+student_forgot_password) intentionally remain case-sensitive until the
+follow-up issue lands (data cleanup + ix_students_email_lower migration).
+"""
+from datetime import date
+
+from fastapi import status
+from sqlalchemy import func
+
+from auth import get_password_hash
+from models import Student, Teacher
+from models.user import Identity
+
+
+PASSWORD = "Password1!"
+
+
+class TestTeacherLoginCaseInsensitive:
+    def test_login_with_uppercase_variant_resolves_to_lowercase_account(
+        self, test_client, shared_test_session
+    ):
+        teacher = Teacher(
+            email="kelly@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            name="Kelly",
+            is_active=True,
+            email_verified=True,
+        )
+        shared_test_session.add(teacher)
+        shared_test_session.commit()
+
+        response = test_client.post(
+            "/api/auth/teacher/login",
+            json={"email": "KELLY@example.com", "password": PASSWORD},
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        body = response.json()
+        assert body.get("access_token"), "login must return an access token"
+        assert body["user"]["email"] == "kelly@example.com", (
+            "login with uppercase variant must resolve to the lowercase-stored "
+            "account"
+        )
+
+
+class TestTeacherRegisterCaseInsensitive:
+    def test_register_rejects_case_variant_of_verified_email(
+        self, test_client, shared_test_session
+    ):
+        existing = Teacher(
+            email="alice@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            name="Alice",
+            is_active=True,
+            email_verified=True,
+        )
+        shared_test_session.add(existing)
+        shared_test_session.commit()
+
+        response = test_client.post(
+            "/api/auth/teacher/register",
+            json={
+                "email": "ALICE@example.com",
+                "password": PASSWORD,
+                "name": "Alice Dup",
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "already registered" in response.json()["detail"].lower()
+
+    def test_register_replaces_unverified_case_variant(
+        self, test_client, shared_test_session
+    ):
+        existing = Teacher(
+            email="bob@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            name="Bob",
+            is_active=False,
+            email_verified=False,
+        )
+        shared_test_session.add(existing)
+        shared_test_session.commit()
+
+        response = test_client.post(
+            "/api/auth/teacher/register",
+            json={
+                "email": "Bob@Example.com",
+                "password": PASSWORD,
+                "name": "Bob Fresh",
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        shared_test_session.expire_all()
+        # The original unverified "Bob" row must be gone; the only remaining
+        # teacher matching the case-variant email should be the new "Bob Fresh".
+        remaining = (
+            shared_test_session.query(Teacher)
+            .filter(Teacher.name.in_(["Bob", "Bob Fresh"]))
+            .all()
+        )
+        assert len(remaining) == 1, (
+            f"Exactly one teacher row should remain after case-variant "
+            f"re-registration, got {[(t.name, t.email) for t in remaining]}"
+        )
+        assert remaining[0].name == "Bob Fresh"
+
+
+class TestResendVerificationCaseInsensitive:
+    def test_resend_verification_finds_case_variant_teacher(
+        self, test_client, shared_test_session
+    ):
+        teacher = Teacher(
+            email="dan@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            name="Dan",
+            is_active=False,
+            email_verified=False,
+        )
+        shared_test_session.add(teacher)
+        shared_test_session.commit()
+
+        response = test_client.post(
+            "/api/auth/resend-verification",
+            json={"email": "DAN@example.com"},
+        )
+
+        # Legitimate outcomes once the teacher is located: 200 (email sent) or
+        # 429 (resend cooldown). 404 means the case-variant lookup failed, which
+        # is the regression this test guards against.
+        assert response.status_code in (
+            status.HTTP_200_OK,
+            status.HTTP_429_TOO_MANY_REQUESTS,
+        ), response.text
+
+
+class TestForgotPasswordCaseInsensitive:
+    def test_teacher_forgot_password_accepts_case_variant(
+        self, test_client, shared_test_session
+    ):
+        teacher = Teacher(
+            email="carol@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            name="Carol",
+            is_active=True,
+            email_verified=True,
+        )
+        shared_test_session.add(teacher)
+        shared_test_session.commit()
+
+        response = test_client.post(
+            "/api/auth/teacher/forgot-password",
+            json={"email": "CAROL@example.com"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        shared_test_session.refresh(teacher)
+        assert (
+            teacher.password_reset_token is not None
+        ), "forgot-password must locate the teacher regardless of email casing"
+
+
+class TestStudentIdentityValidateCaseInsensitive:
+    def test_validate_finds_identity_regardless_of_casing(
+        self, test_client, shared_test_session
+    ):
+        identity = Identity(
+            email="learner@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            email_verified=True,
+            is_active=True,
+        )
+        shared_test_session.add(identity)
+        shared_test_session.flush()
+
+        student = Student(
+            email="learner@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            name="Learner",
+            birthdate=date(2010, 1, 1),
+            email_verified=True,
+            is_active=True,
+            identity_id=identity.id,
+            is_primary_account=True,
+        )
+        shared_test_session.add(student)
+        shared_test_session.commit()
+
+        response = test_client.post(
+            "/api/students/validate",
+            json={"email": "LEARNER@example.com", "password": PASSWORD},
+        )
+
+        assert response.status_code != status.HTTP_401_UNAUTHORIZED, response.text
+
+
+class TestOneCampusBindCaseInsensitive:
+    """The 1Campus bind code checks whether a different Teacher already has the
+    target email (so we don't violate the unique constraint). That check must
+    also be case-insensitive — otherwise we could still collide on insert.
+
+    Here we verify the underlying query pattern directly rather than driving
+    the full SSO flow (which requires multiple upstream mocks).
+    """
+
+    def test_teacher_email_collision_check_is_case_insensitive(
+        self, shared_test_session
+    ):
+        existing = Teacher(
+            email="sso.user@example.com",
+            password_hash=get_password_hash(PASSWORD),
+            name="SSO User",
+            is_active=True,
+            email_verified=True,
+        )
+        shared_test_session.add(existing)
+        shared_test_session.commit()
+
+        target_email = "SSO.User@example.com"
+        collision = (
+            shared_test_session.query(Teacher)
+            .filter(
+                func.lower(Teacher.email) == target_email.lower(),
+                Teacher.id != 0,
+                Teacher.is_active.is_(True),
+            )
+            .first()
+        )
+        assert collision is not None, (
+            "Case-insensitive collision check must find the existing teacher; "
+            "otherwise 1Campus bind would create a duplicate row."
+        )

--- a/frontend/src/components/ReadingAssessmentPanel.tsx
+++ b/frontend/src/components/ReadingAssessmentPanel.tsx
@@ -31,6 +31,7 @@ import {
   Loader2,
 } from "lucide-react";
 import { toast } from "sonner";
+import { useSidebar } from "@/contexts/SidebarContext";
 import { apiClient, ApiError } from "@/lib/api";
 import { retryAudioUpload } from "@/utils/retryHelper";
 import {
@@ -1116,6 +1117,7 @@ const ReadingAssessmentPanel = forwardRef<
   ref,
 ) {
   const { t } = useTranslation();
+  const { setEditorBusy } = useSidebar();
 
   const [title, setTitle] = useState("");
   const [rows, setRows] = useState<ContentRow[]>([
@@ -1175,6 +1177,14 @@ const ReadingAssessmentPanel = forwardRef<
   // 計算是否有批次操作正在進行
   const isBatchProcessing =
     isBatchGeneratingTTS || isBatchGeneratingTranslation || isPasting;
+
+  // Sync batch state to SidebarContext.editorBusy so that RefSaveButton (and
+  // sidebar close buttons) can reactively reflect busy state. Cleanup on
+  // unmount prevents lock-out if panel closes mid-operation. (#651)
+  useEffect(() => {
+    setEditorBusy(isBatchProcessing);
+    return () => setEditorBusy(false);
+  }, [isBatchProcessing, setEditorBusy]);
 
   // dnd-kit sensors
   const sensors = useSensors(

--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -1610,11 +1610,6 @@ const VocabularySetPanel = forwardRef<
   const { t } = useTranslation();
   const { setEditorBusy } = useSidebar();
 
-  // Reset editorBusy on unmount to prevent lock-out if panel closes mid-operation
-  useEffect(() => {
-    return () => setEditorBusy(false);
-  }, [setEditorBusy]);
-
   const [title, setTitle] = useState("");
   // 記住用戶最後選擇的翻譯語言，批次翻譯時使用
   const [lastSelectedWordLang, setLastSelectedWordLang] = useState<
@@ -1663,11 +1658,15 @@ const VocabularySetPanel = forwardRef<
   const [batchPasteText, setBatchPasteText] = useState("");
   const [batchPasteAutoTTS, setBatchPasteAutoTTS] = useState(true);
   const [batchPasteAutoTranslate, setBatchPasteAutoTranslate] = useState(true);
-  const [isBatchPasting, _setIsBatchPasting] = useState(false);
-  const setIsBatchPasting = (v: boolean) => {
-    _setIsBatchPasting(v);
-    setEditorBusy(v);
-  };
+  const [isBatchPasting, setIsBatchPasting] = useState(false);
+
+  // Sync batch-paste state to SidebarContext.editorBusy so that RefSaveButton
+  // (and sidebar close buttons) can reactively reflect busy state. Cleanup on
+  // unmount prevents lock-out if panel closes mid-operation. (#651)
+  useEffect(() => {
+    setEditorBusy(isBatchPasting);
+    return () => setEditorBusy(false);
+  }, [isBatchPasting, setEditorBusy]);
   const [batchProgress, setBatchProgress] = useState<{
     completedItems: number;
     totalItems: number;

--- a/frontend/src/components/__tests__/VocabularySetPanel.test.tsx
+++ b/frontend/src/components/__tests__/VocabularySetPanel.test.tsx
@@ -2,6 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ReactNode } from "react";
 import { render, waitFor } from "@testing-library/react";
 import VocabularySetPanel from "../VocabularySetPanel";
+import { SidebarProvider } from "@/contexts/SidebarContext";
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <SidebarProvider>{children}</SidebarProvider>
+);
 
 // Mock apiClient.getContentDetail
 const mockGetContentDetail = vi.fn();
@@ -72,7 +77,7 @@ describe("VocabularySetPanel data loading", () => {
       ],
     });
 
-    render(<VocabularySetPanel content={{ id: 123 }} />);
+    render(<VocabularySetPanel content={{ id: 123 }} />, { wrapper });
 
     await waitFor(() => {
       expect(mockGetContentDetail).toHaveBeenCalledWith(123);
@@ -80,7 +85,7 @@ describe("VocabularySetPanel data loading", () => {
   });
 
   it("should NOT call getContentDetail when content is undefined", async () => {
-    render(<VocabularySetPanel />);
+    render(<VocabularySetPanel />, { wrapper });
 
     // Give time for any potential async calls
     await new Promise((r) => setTimeout(r, 100));
@@ -89,7 +94,7 @@ describe("VocabularySetPanel data loading", () => {
   });
 
   it("should NOT call getContentDetail when content.id is undefined", async () => {
-    render(<VocabularySetPanel content={{}} />);
+    render(<VocabularySetPanel content={{}} />, { wrapper });
 
     await new Promise((r) => setTimeout(r, 100));
 
@@ -102,7 +107,9 @@ describe("VocabularySetPanel data loading", () => {
       items: [],
     });
 
-    const { container } = render(<VocabularySetPanel content={{ id: 456 }} />);
+    const { container } = render(<VocabularySetPanel content={{ id: 456 }} />, {
+      wrapper,
+    });
 
     await waitFor(() => {
       expect(mockGetContentDetail).toHaveBeenCalledWith(456);
@@ -115,7 +122,9 @@ describe("VocabularySetPanel data loading", () => {
   it("should handle API error gracefully", async () => {
     mockGetContentDetail.mockRejectedValue(new Error("Network error"));
 
-    const { container } = render(<VocabularySetPanel content={{ id: 789 }} />);
+    const { container } = render(<VocabularySetPanel content={{ id: 789 }} />, {
+      wrapper,
+    });
 
     await waitFor(() => {
       expect(mockGetContentDetail).toHaveBeenCalledWith(789);

--- a/frontend/src/components/shared/RefSaveButton.tsx
+++ b/frontend/src/components/shared/RefSaveButton.tsx
@@ -3,12 +3,15 @@
  *
  * 功能：
  * 1. 面板 busy 時（批次操作中）自動 disabled
+ *    - busy 狀態透過 SidebarContext.editorBusy 訂閱，確保 reactive 更新
+ *    - 避免讀取 panelRef.current?.isBusy 產生的 stale-ref 問題 (#651)
  * 2. 防止重複連續點擊（saving 中 disabled）
  */
 import { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
+import { useSidebar } from "@/contexts/SidebarContext";
 
 interface PanelHandle {
   save: () => Promise<void>;
@@ -21,6 +24,7 @@ interface RefSaveButtonProps {
 
 export function RefSaveButton({ panelRef }: RefSaveButtonProps) {
   const { t } = useTranslation();
+  const { editorBusy } = useSidebar();
   const [isSaving, setIsSaving] = useState(false);
 
   const handleClick = useCallback(async () => {
@@ -38,7 +42,7 @@ export function RefSaveButton({ panelRef }: RefSaveButtonProps) {
     <Button
       size="sm"
       className="bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50"
-      disabled={isSaving || (panelRef.current?.isBusy ?? false)}
+      disabled={isSaving || editorBusy}
       onClick={handleClick}
     >
       {isSaving ? (

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1027,6 +1027,7 @@
       "submitShort": "Submit",
       "submitting": "Submitting...",
       "submittingShort": "Submitting",
+      "submitDisabledTooltip": "Some items are missing recordings. Please complete them before submitting.",
       "next": "Next",
       "previous": "Previous",
       "cancel": "Cancel",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -1082,6 +1082,7 @@
       "submitShort": "提交",
       "submitting": "提交中...",
       "submittingShort": "提交中",
+      "submitDisabledTooltip": "尚有題目未上傳錄音，請完成後再提交",
       "next": "下一題",
       "previous": "上一題",
       "cancel": "取消",

--- a/frontend/src/pages/student/StudentActivityPageContent.tsx
+++ b/frontend/src/pages/student/StudentActivityPageContent.tsx
@@ -6,7 +6,7 @@
  * 2. 老師預覽示範頁面 (TeacherAssignmentPreviewPage)
  */
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -187,6 +187,94 @@ const isVocabularySetType = (type: string): boolean => {
   return ["SENTENCE_MAKING", "VOCABULARY_SET"].includes(normalizedType);
 };
 
+// API 回傳的 activity.type 可能為大寫 enum（EXAMPLE_SENTENCES）或舊資料的小寫，
+// 故所有比對一律 normalize 成大寫。
+const RECORDING_REQUIRED_TYPES = new Set([
+  "READING_ASSESSMENT",
+  "EXAMPLE_SENTENCES",
+  "GROUPED_QUESTIONS",
+  "SPEAKING",
+]);
+
+// 單字集搭配需要錄音的練習模式：
+// - reading       → 朗讀單字的例句
+// - word_reading  → 單字朗讀
+// rearrangement / word_selection 不需錄音。
+const VOCABULARY_RECORDING_PRACTICE_MODES = new Set([
+  "reading",
+  "word_reading",
+]);
+
+const activityNeedsRecording = (
+  activity: Activity,
+  practiceMode?: string | null,
+): boolean => {
+  // Rearrangement 是拖拉重組題，任何 content type 下都不使用麥克風，
+  // 因此 early-return，避免 content-type 檢查誤判為需要錄音。
+  if (practiceMode === "rearrangement") return false;
+
+  const normalizedType = activity.type?.toUpperCase() ?? "";
+  if (RECORDING_REQUIRED_TYPES.has(normalizedType)) return true;
+  if (
+    isVocabularySetType(activity.type) &&
+    !!practiceMode &&
+    VOCABULARY_RECORDING_PRACTICE_MODES.has(practiceMode)
+  ) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * 判斷是否有任何題目尚未完成錄音或尚未上傳到 GCS。
+ * - 空字串 / undefined / null：未錄音
+ * - blob: URL：已錄音但尚未上傳到 GCS
+ */
+const isRecordingMissingOrPending = (url?: string | null): boolean =>
+  !url || url.startsWith("blob:");
+
+const hasIncompleteRecordings = (
+  activities: Activity[],
+  practiceMode?: string | null,
+): boolean => {
+  return activities.some((activity) => {
+    if (!activityNeedsRecording(activity, practiceMode)) return false;
+
+    if (activity.items && activity.items.length > 0) {
+      return activity.items.some((item) =>
+        isRecordingMissingOrPending(item.recording_url),
+      );
+    }
+
+    return isRecordingMissingOrPending(activity.audio_url);
+  });
+};
+
+/**
+ * 是否屬於「逐題錄音、需要在跳題與提交前補做 Azure 發音分析」的朗讀活動。
+ * 範圍比 activityNeedsRecording 小：提交按鈕禁用可以涵蓋所有需要錄音的型別，
+ * 但自動分析流程僅針對例句集朗讀／單字集例句朗讀兩種情境。
+ *
+ * 注意：單字集 word_reading 模式雖然也有錄音，但其畫面走獨立的
+ * WordReadingActivity 組件、由它自己負責 Azure 分析，故這裡不納入，
+ * 避免在主流程重複分析。
+ */
+const needsPerItemAnalysis = (
+  activity: Activity,
+  practiceMode?: string | null,
+): boolean => {
+  if (
+    isExampleSentencesType(activity.type) &&
+    practiceMode !== "rearrangement"
+  ) {
+    return true;
+  }
+  if (isVocabularySetType(activity.type) && practiceMode === "reading") {
+    return true;
+  }
+  return false;
+};
+
 export default function StudentActivityPageContent({
   activities: initialActivities,
   assignmentTitle,
@@ -232,6 +320,12 @@ export default function StudentActivityPageContent({
   const [showSubmitDialog, setShowSubmitDialog] = useState(false);
   const [incompleteItems, setIncompleteItems] = useState<string[]>([]);
   const [isAnalyzing, setIsAnalyzing] = useState(false); // 🔒 GroupedQuestionsTemplate 錄音分析中狀態
+
+  // 任何題目未錄音 / 錄音未上傳到 GCS 時，禁用提交按鈕
+  const isSubmitBlockedByRecording = useMemo(
+    () => hasIncompleteRecordings(activities, practiceMode),
+    [activities, practiceMode],
+  );
 
   // 🎯 背景分析狀態管理
   type ItemAnalysisStatus =
@@ -1258,10 +1352,10 @@ export default function StudentActivityPageContent({
   ) => {
     const currentActivity = activities[currentActivityIndex];
 
-    // 檢查是否為例句朗讀模式（items 有值且非重組模式）
+    // 例句集朗讀 / 單字集例句朗讀才需要在跳題前做自動分析。
+    // 此處不使用 activityNeedsRecording，因它涵蓋範圍較廣（例如 GROUPED_QUESTIONS / word_reading）。
     const isReadingMode =
-      isExampleSentencesType(currentActivity.type) &&
-      practiceMode !== "rearrangement" &&
+      needsPerItemAnalysis(currentActivity, practiceMode) &&
       currentActivity.items &&
       currentActivity.items.length > 0;
 
@@ -1368,12 +1462,7 @@ export default function StudentActivityPageContent({
       }[] = [];
 
       activities.forEach((activity) => {
-        // 檢查是否是需要錄音的題型
-        const needsRecording = [
-          "reading_assessment",
-          "grouped_questions",
-          "speaking",
-        ].includes(activity.type);
+        const needsRecording = activityNeedsRecording(activity, practiceMode);
 
         if (needsRecording && activity.items && activity.items.length > 0) {
           // 逐題檢查
@@ -1527,11 +1616,7 @@ export default function StudentActivityPageContent({
 
       // 收集所有有錄音但未分析的題目（不限 blob URL）
       activities.forEach((activity) => {
-        if (
-          isExampleSentencesType(activity.type) &&
-          practiceMode !== "rearrangement" &&
-          activity.items
-        ) {
+        if (needsPerItemAnalysis(activity, practiceMode) && activity.items) {
           activity.items.forEach((item, itemIndex) => {
             const hasRecording =
               item.recording_url && item.recording_url !== "";
@@ -2228,7 +2313,12 @@ export default function StudentActivityPageContent({
                 practiceMode !== "word_selection" && (
                   <Button
                     onClick={handleSubmit}
-                    disabled={submitting}
+                    disabled={submitting || isSubmitBlockedByRecording}
+                    title={
+                      isSubmitBlockedByRecording
+                        ? t("studentActivityPage.buttons.submitDisabledTooltip")
+                        : undefined
+                    }
                     size="sm"
                     variant="default"
                     className="px-2 sm:px-3"
@@ -2687,7 +2777,14 @@ export default function StudentActivityPageContent({
                           variant="default"
                           size="sm"
                           onClick={handleSubmit}
-                          disabled={submitting} // 🔒 提交中禁用
+                          disabled={submitting || isSubmitBlockedByRecording} // 🔒 提交中 / 有題目未上傳音檔 時禁用
+                          title={
+                            isSubmitBlockedByRecording
+                              ? t(
+                                  "studentActivityPage.buttons.submitDisabledTooltip",
+                                )
+                              : undefined
+                          }
                           className="flex-1 sm:flex-none min-w-0"
                         >
                           <span className="hidden sm:inline">


### PR DESCRIPTION
## Summary
- **#645** 朗讀類作業（段落/例句/單字朗讀）未錄音時禁用提交按鈕，涵蓋 `VOCABULARY_SET + reading` 並排除 `rearrangement` 模式 (#652)
- **#648** Email 登入 / 查詢改為 case-insensitive，統一覆蓋所有 auth 路徑 (#650)
- **#651** 相關修正 (#654)

## Commits
- 2d5d6c76 Release: 禁止未上傳音檔時提交朗讀作業 (#652)
- 59e5905c Merge #654 (issue-651)
- 74f013fb fix: case-insensitive email login / lookup (#650)

## Test plan
- [ ] Staging 驗證朗讀作業缺音檔時提交按鈕正確禁用 + tooltip
- [ ] Staging 驗證 VOCABULARY_SET + reading / word_reading 行為
- [ ] Staging 驗證 EXAMPLE_SENTENCES + rearrangement 不誤判
- [ ] Staging 驗證 email 大小寫混用登入成功
- [ ] 確認 CI 全綠後再 merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)