### PR TITLE
migration: fix fk_students_identity to reference identities (not legacy table)

### DIFF
--- a/backend/alembic/versions/20260422_1200_fix_students_identity_fk.py
+++ b/backend/alembic/versions/20260422_1200_fix_students_identity_fk.py
@@ -53,11 +53,17 @@ def upgrade() -> None:
     )
 
     # Create the correct FK if it's not already in place.
+    # Scoped to the `students` table — PostgreSQL constraint names are unique
+    # per-table, not globally, so `conname` alone could miss.
     op.execute(
         """
         DO $$ BEGIN
             IF NOT EXISTS (
-                SELECT 1 FROM pg_constraint WHERE conname = 'fk_students_identity'
+                SELECT 1
+                  FROM pg_constraint c
+                  JOIN pg_class cls ON c.conrelid = cls.oid
+                 WHERE c.conname = 'fk_students_identity'
+                   AND cls.relname = 'students'
             ) THEN
                 ALTER TABLE students
                     ADD CONSTRAINT fk_students_identity
@@ -70,4 +76,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Intentionally no-op: restoring the wrong FK would reintroduce the bug.
     pass

--- a/backend/alembic/versions/20260422_1200_fix_students_identity_fk.py
+++ b/backend/alembic/versions/20260422_1200_fix_students_identity_fk.py
@@ -1,0 +1,73 @@
+"""Fix fk_students_identity to reference identities (not legacy student_identities)
+
+Migration 20260225_1600 intended to add `students.identity_id -> identities.id`
+but prod had a pre-existing `fk_students_identity` constraint pointing to the
+legacy `student_identities` table. The `IF NOT EXISTS (... conname = 'fk_students_identity')`
+idempotency check passed on the existing (wrong) constraint, so the migration
+silently skipped creating the correct FK.
+
+Symptom: all email-bind / 1Campus SSO identity flows failed with
+    Key (identity_id)=(N) is not present in table "student_identities"
+after `identity_service.py` inserted into `identities` (returning id=N) and
+tried to set `students.identity_id = N`.
+
+Data safety: verified in prod before writing this migration —
+    identities:         0 rows
+    student_identities: 0 rows
+    students with non-null identity_id:  0
+    teachers with non-null identity_id:  0
+No identity data exists yet; swapping the FK affects no live bindings.
+
+Revision ID: 20260422_1200
+Revises: 20260420_1100
+Create Date: 2026-04-22
+"""
+
+from alembic import op
+
+revision = "20260422_1200"
+down_revision = "20260420_1100"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop the constraint only if it points to the WRONG table (student_identities).
+    # If it's already correct (identities), or doesn't exist, leave it alone.
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1
+                  FROM pg_constraint c
+                  JOIN pg_class cls_from ON c.conrelid = cls_from.oid
+                  JOIN pg_class cls_to   ON c.confrelid = cls_to.oid
+                 WHERE c.conname = 'fk_students_identity'
+                   AND cls_from.relname = 'students'
+                   AND cls_to.relname = 'student_identities'
+            ) THEN
+                ALTER TABLE students DROP CONSTRAINT fk_students_identity;
+            END IF;
+        END $$;
+        """
+    )
+
+    # Create the correct FK if it's not already in place.
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint WHERE conname = 'fk_students_identity'
+            ) THEN
+                ALTER TABLE students
+                    ADD CONSTRAINT fk_students_identity
+                    FOREIGN KEY (identity_id) REFERENCES identities(id)
+                    ON DELETE SET NULL;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

Fixes the root cause of 1Campus SSO / email-bind failures — `students.identity_id` FK points to the legacy `student_identities` table in prod instead of the current `identities` table that the app actually uses.

## Problem

Migration `20260225_1600` intended to add:

```sql
ALTER TABLE students
    ADD CONSTRAINT fk_students_identity
    FOREIGN KEY (identity_id) REFERENCES identities(id) ...
```

but used this idempotency guard:

```sql
IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_students_identity')
```

Prod already had a `fk_students_identity` with the same name, left over from a prior iteration, pointing to the legacy `student_identities` table. The guard matched by name only, so the correct FK was silently skipped.

## Symptom (observed 2026-04-22 11:18–11:20 TPE)

```
ERROR  Failed to ensure identity for student <id>:
(psycopg2.errors.ForeignKeyViolation) insert or update on table "students"
violates foreign key constraint "fk_students_identity"
DETAIL:  Key (identity_id)=(29) is not present in table "student_identities".
```

`identity_service.ensure_identity_on_email_bind` inserts into `identities` (new row, id=29), then sets `students.identity_id = 29`. The FK resolves against the wrong table (empty legacy `student_identities`) and rejects.

This same error pattern predates yesterday's `20260420_1000` / `20260420_1100` deploys — it was masked earlier by the `UndefinedColumn: column identities.one_campus_uuid does not exist` error that blocked the flow sooner (see PR #647, #649 for the column fix).

## Data safety

Verified in prod before writing this migration:

| Table / Column | Rows |
|---|---|
| `identities` | 0 |
| `student_identities` | 0 |
| `students.identity_id` (non-null) | 0 |
| `teachers.identity_id` (non-null) | 0 |

No live identity binding exists. Swapping the FK breaks no data.

## Migration behavior (idempotent)

- **Drops** `fk_students_identity` **only if it currently points to `student_identities`** (narrow join on `pg_constraint` + `pg_class`).
- **Creates** `fk_students_identity` pointing to `identities(id)` only if it's missing.
- Safe on environments where the FK is already correct (no-op) and on fresh environments (creates it once).

## Test plan

- [ ] CI migration check runs `alembic upgrade head` against a fresh PG
- [ ] Staging deploy runs the migration (expect `Running upgrade 20260420_1100 -> 20260422_1200`)
- [ ] After release to prod, verify: `fk_students_identity` references `identities.id` (query `pg_constraint`)
- [ ] Trigger a 1Campus SSO login for student 666 or 670 and confirm no more `Failed to ensure identity` errors in Cloud Run logs

## Related

- PR #647 — workflow silent-failure fix
- PR #649 — release including `20260420_1000` (one_campus_uuid) + `20260420_1100` (email unique index)
- Issue #648 — email login case-insensitive (still pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)