### PR TITLE
Release: staging → main (2026-04-22) — fix_students_identity FK

### DIFF
--- a/backend/alembic/versions/20260422_1200_fix_students_identity_fk.py
+++ b/backend/alembic/versions/20260422_1200_fix_students_identity_fk.py
@@ -1,0 +1,80 @@
+"""Fix fk_students_identity to reference identities (not legacy student_identities)
+
+Migration 20260225_1600 intended to add `students.identity_id -> identities.id`
+but prod had a pre-existing `fk_students_identity` constraint pointing to the
+legacy `student_identities` table. The `IF NOT EXISTS (... conname = 'fk_students_identity')`
+idempotency check passed on the existing (wrong) constraint, so the migration
+silently skipped creating the correct FK.
+
+Symptom: all email-bind / 1Campus SSO identity flows failed with
+    Key (identity_id)=(N) is not present in table "student_identities"
+after `identity_service.py` inserted into `identities` (returning id=N) and
+tried to set `students.identity_id = N`.
+
+Data safety: verified in prod before writing this migration —
+    identities:         0 rows
+    student_identities: 0 rows
+    students with non-null identity_id:  0
+    teachers with non-null identity_id:  0
+No identity data exists yet; swapping the FK affects no live bindings.
+
+Revision ID: 20260422_1200
+Revises: 20260420_1100
+Create Date: 2026-04-22
+"""
+
+from alembic import op
+
+revision = "20260422_1200"
+down_revision = "20260420_1100"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop the constraint only if it points to the WRONG table (student_identities).
+    # If it's already correct (identities), or doesn't exist, leave it alone.
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1
+                  FROM pg_constraint c
+                  JOIN pg_class cls_from ON c.conrelid = cls_from.oid
+                  JOIN pg_class cls_to   ON c.confrelid = cls_to.oid
+                 WHERE c.conname = 'fk_students_identity'
+                   AND cls_from.relname = 'students'
+                   AND cls_to.relname = 'student_identities'
+            ) THEN
+                ALTER TABLE students DROP CONSTRAINT fk_students_identity;
+            END IF;
+        END $$;
+        """
+    )
+
+    # Create the correct FK if it's not already in place.
+    # Scoped to the `students` table — PostgreSQL constraint names are unique
+    # per-table, not globally, so `conname` alone could miss.
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                  FROM pg_constraint c
+                  JOIN pg_class cls ON c.conrelid = cls.oid
+                 WHERE c.conname = 'fk_students_identity'
+                   AND cls.relname = 'students'
+            ) THEN
+                ALTER TABLE students
+                    ADD CONSTRAINT fk_students_identity
+                    FOREIGN KEY (identity_id) REFERENCES identities(id)
+                    ON DELETE SET NULL;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Intentionally no-op: restoring the wrong FK would reintroduce the bug.
+    pass


### PR DESCRIPTION
## Summary

Release PR from staging to main. Single change: migration fix for the `fk_students_identity` FK target.

### Changes included

- **#661** `migration: fix fk_students_identity to reference identities (not legacy student_identities)`
  - Legacy prod FK pointed to empty `student_identities` table, so `identity_service.ensure_identity_on_email_bind` kept failing with `Key (identity_id)=(N) is not present in table "student_identities"` even after yesterday's `one_campus_uuid` fix.
  - The 2026-04-22 11:18–11:20 TPE SSO errors were caused by this (surfaced only after PR #649's column fix let the code path run past the previous `UndefinedColumn` error).
  - Migration idempotently drops the wrong FK (narrow 3-way join guard) and recreates it pointing to `identities(id) ON DELETE SET NULL`.

### Staging verification

- Staging deploy run 24768365596: ✅ all green
- Migration log: `Running upgrade 20260420_1100 -> 20260422_1200`
- Staging DB after migration:
  - `alembic_version` = `20260422_1200`
  - `fk_students_identity` → `students.identity_id → identities.id` ✓

### Data safety (prod)

Verified before writing the migration:
- `identities`: 0 rows
- `student_identities`: 0 rows
- `students.identity_id` (non-null): 0 rows
- `teachers.identity_id` (non-null): 0 rows

No live identity bindings affected by the FK swap.

### Expected behavior on merge → prod deploy

Prod deploy should apply `20260422_1200`, after which:
- `fk_students_identity` will reference `identities(id)` (currently points to `student_identities`)
- `identity_service.ensure_identity_on_email_bind` will succeed
- 1Campus SSO login flow fully restored for students 666, 670, and anyone else blocked by this error pattern

### Related

- PR #647 — deploy workflow silent-failure fix (merged)
- PR #649 — release with `20260420_1000` + `20260420_1100` (merged)
- PR #661 — this migration (merged to staging)
- Issue #648 — email login case-insensitive (still pending)

## Test plan

- [x] Staging migration applied cleanly (run 24768365596)
- [x] Staging `fk_students_identity` confirmed pointing to `identities`
- [ ] Prod deploy applies migration (expect `Running upgrade 20260420_1100 -> 20260422_1200`)
- [ ] Post-prod: `SELECT conname, cls_to.relname FROM pg_constraint c JOIN pg_class cls_to ON c.confrelid = cls_to.oid WHERE conname='fk_students_identity'` → should return `identities`
- [ ] Monitor Cloud Run logs for `Failed to ensure identity` — should drop to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)