### PR TITLE
fix(audio): lower min audio file size from 1KB/5KB to 500B

### DIFF
--- a/backend/services/audio_upload.py
+++ b/backend/services/audio_upload.py
@@ -136,8 +136,8 @@ class AudioUploadService:
             # 讀取檔案內容
             content = await file.read()
 
-            # 檢查檔案大小（至少 1KB，最多 2MB）
-            min_file_size = 1 * 1024  # 1KB
+            # 檢查檔案大小（至少 500B，最多 2MB）
+            min_file_size = 500  # 500B
             if len(content) < min_file_size:
                 # 記錄到 BigQuery
                 from services.bigquery_logger import get_bigquery_logger
@@ -159,7 +159,7 @@ class AudioUploadService:
                     status_code=400,
                     detail=(
                         f"Recording file too small ({len(content)} bytes). "
-                        f"Must be at least {min_file_size / 1024}KB for valid audio."
+                        f"Must be at least {min_file_size} bytes for valid audio."
                     ),
                 )
 

--- a/backend/tests/unit/test_audio_upload.py
+++ b/backend/tests/unit/test_audio_upload.py
@@ -166,31 +166,43 @@ class TestAudioUploadService:
         mock_bq_logger.log_audio_error.assert_called_once()
 
     @pytest.mark.asyncio
+    @patch("services.audio_upload.uuid.uuid4")
+    @patch("services.audio_upload.datetime")
     @patch("services.bigquery_logger.get_bigquery_logger")
-    async def test_upload_audio_file_at_min_boundary(self, mock_get_bq_logger, service):
-        """測試檔案剛好達到最小值（邊界：500 bytes 應通過大小檢查，不被 'too small' 拒絕）"""
+    async def test_upload_audio_file_at_min_boundary(
+        self, mock_get_bq_logger, mock_datetime, mock_uuid, service
+    ):
+        """測試檔案剛好達到最小值（邊界：500 bytes 應通過大小檢查並成功上傳）"""
         mock_bq_logger = AsyncMock()
         mock_bq_logger.log_audio_error = AsyncMock()
         mock_get_bq_logger.return_value = mock_bq_logger
+
+        # Deterministic uuid / timestamp
+        mock_uuid.return_value = "test-uuid-boundary"
+        mock_now = Mock()
+        mock_now.strftime.return_value = "20240101_120000"
+        mock_datetime.now.return_value = mock_now
+
+        # Mock GCS client so upload path is deterministic (no real credentials needed)
+        mock_client = Mock()
+        mock_bucket = Mock()
+        mock_blob = Mock()
+        service.storage_client = mock_client
+        mock_client.bucket.return_value = mock_bucket
+        mock_bucket.blob.return_value = mock_blob
 
         mock_file = Mock(spec=UploadFile)
         mock_file.content_type = "audio/webm"
         mock_file.filename = "test.webm"
         mock_file.read = AsyncMock(return_value=b"x" * 500)
 
-        # 500 bytes 應通過大小檢查，不被 "too small" 拒絕
-        # 後續行為視環境而定（有 GCS 憑證 → 成功返回 URL；無憑證 → 500 錯誤）
-        # 重點：不應因 "too small" 被擋
-        raised_exception = None
-        try:
-            await service.upload_audio(mock_file, duration_seconds=20)
-        except HTTPException as e:
-            raised_exception = e
+        result = await service.upload_audio(mock_file, duration_seconds=20)
 
-        if raised_exception is not None:
-            # 若有錯誤，確認不是因為檔案太小
-            assert "too small" not in raised_exception.detail
-        # 無論是否拋出例外，BigQuery logger 的 log_audio_error 都不應被呼叫（那是 too-small 路徑）
+        # Unconditional positive assertions: upload must succeed
+        assert result is not None
+        assert "https://storage.googleapis.com/duotopia-audio/recordings/" in result
+        mock_blob.upload_from_string.assert_called_once_with(b"x" * 500, content_type="audio/webm")
+        # The too-small path must NOT have been taken
         mock_bq_logger.log_audio_error.assert_not_called()
 
     @pytest.mark.asyncio

--- a/backend/tests/unit/test_audio_upload.py
+++ b/backend/tests/unit/test_audio_upload.py
@@ -146,6 +146,54 @@ class TestAudioUploadService:
         assert "File too large" in exc_info.value.detail
 
     @pytest.mark.asyncio
+    @patch("services.bigquery_logger.get_bigquery_logger")
+    async def test_upload_audio_file_too_small(self, mock_get_bq_logger, service):
+        """測試檔案過小（邊界：499 bytes < 500 bytes 最小值）"""
+        mock_bq_logger = AsyncMock()
+        mock_bq_logger.log_audio_error = AsyncMock()
+        mock_get_bq_logger.return_value = mock_bq_logger
+
+        mock_file = Mock(spec=UploadFile)
+        mock_file.content_type = "audio/webm"
+        mock_file.filename = "test.webm"
+        mock_file.read = AsyncMock(return_value=b"x" * 499)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.upload_audio(mock_file)
+
+        assert exc_info.value.status_code == 400
+        assert "too small" in exc_info.value.detail
+        mock_bq_logger.log_audio_error.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("services.bigquery_logger.get_bigquery_logger")
+    async def test_upload_audio_file_at_min_boundary(self, mock_get_bq_logger, service):
+        """測試檔案剛好達到最小值（邊界：500 bytes 應通過大小檢查，不被 'too small' 拒絕）"""
+        mock_bq_logger = AsyncMock()
+        mock_bq_logger.log_audio_error = AsyncMock()
+        mock_get_bq_logger.return_value = mock_bq_logger
+
+        mock_file = Mock(spec=UploadFile)
+        mock_file.content_type = "audio/webm"
+        mock_file.filename = "test.webm"
+        mock_file.read = AsyncMock(return_value=b"x" * 500)
+
+        # 500 bytes 應通過大小檢查，不被 "too small" 拒絕
+        # 後續行為視環境而定（有 GCS 憑證 → 成功返回 URL；無憑證 → 500 錯誤）
+        # 重點：不應因 "too small" 被擋
+        raised_exception = None
+        try:
+            await service.upload_audio(mock_file, duration_seconds=20)
+        except HTTPException as e:
+            raised_exception = e
+
+        if raised_exception is not None:
+            # 若有錯誤，確認不是因為檔案太小
+            assert "too small" not in raised_exception.detail
+        # 無論是否拋出例外，BigQuery logger 的 log_audio_error 都不應被呼叫（那是 too-small 路徑）
+        mock_bq_logger.log_audio_error.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_upload_audio_duration_too_long(self, service):
         """測試音檔過長"""
         mock_file = Mock(spec=UploadFile)

--- a/backend/tests/unit/test_audio_upload.py
+++ b/backend/tests/unit/test_audio_upload.py
@@ -201,7 +201,9 @@ class TestAudioUploadService:
         # Unconditional positive assertions: upload must succeed
         assert result is not None
         assert "https://storage.googleapis.com/duotopia-audio/recordings/" in result
-        mock_blob.upload_from_string.assert_called_once_with(b"x" * 500, content_type="audio/webm")
+        mock_blob.upload_from_string.assert_called_once_with(
+            b"x" * 500, content_type="audio/webm"
+        )
         # The too-small path must NOT have been taken
         mock_bq_logger.log_audio_error.assert_not_called()
 

--- a/frontend/src/utils/__tests__/audioRecordingStrategy.test.ts
+++ b/frontend/src/utils/__tests__/audioRecordingStrategy.test.ts
@@ -16,7 +16,7 @@ describe("audioRecordingStrategy", () => {
       expect(strategy.useTimeslice).toBe(false);
       expect(strategy.useRequestData).toBe(true);
       expect(strategy.durationValidation).toBe("lenient");
-      expect(strategy.minFileSize).toBe(10000);
+      expect(strategy.minFileSize).toBe(500);
       expect(strategy.platformName).toBe("iOS Safari");
     });
 
@@ -41,7 +41,7 @@ describe("audioRecordingStrategy", () => {
       expect(strategy.fallbackMimeTypes).toContain("audio/mp4");
       expect(strategy.useRequestData).toBe(true);
       expect(strategy.durationValidation).toBe("metadata-first");
-      expect(strategy.minFileSize).toBe(1000);
+      expect(strategy.minFileSize).toBe(500);
     });
 
     it("應該為 Firefox 返回正確策略", () => {
@@ -61,7 +61,7 @@ describe("audioRecordingStrategy", () => {
 
       expect(strategy.preferredMimeType).toBe("audio/mp4");
       expect(strategy.durationValidation).toBe("lenient");
-      expect(strategy.minFileSize).toBe(5000);
+      expect(strategy.minFileSize).toBe(500);
       expect(strategy.platformName).toBe("Unknown Browser");
     });
   });

--- a/frontend/src/utils/audioRecordingStrategy.ts
+++ b/frontend/src/utils/audioRecordingStrategy.ts
@@ -46,7 +46,7 @@ export function getRecordingStrategy(
       maxDuration: 45,
       minDuration: 1,
       durationValidation: "lenient", // WebM metadata 不可靠，使用寬鬆模式（只檢查檔案大小）
-      minFileSize: 5000, // 5KB (統一門檻)
+      minFileSize: 500, // 500B (統一門檻)
       platformName: `iOS ${device.browser}`,
       notes:
         "iOS Safari 支援 WebM 錄音但 metadata 不準確，使用檔案大小判斷有效性",
@@ -63,7 +63,7 @@ export function getRecordingStrategy(
       maxDuration: 45,
       minDuration: 1,
       durationValidation: "lenient", // MP4 metadata 可靠但仍用寬鬆模式
-      minFileSize: 5000, // 5KB (統一門檻)
+      minFileSize: 500, // 500B (統一門檻)
       platformName: "macOS Safari",
       notes: "macOS Safari 只支援 MP4 格式，metadata 準確",
     };
@@ -82,7 +82,7 @@ export function getRecordingStrategy(
       maxDuration: 45,
       minDuration: 1,
       durationValidation: isIOS ? "lenient" : "metadata-first", // iOS Chrome metadata 不可靠
-      minFileSize: 5000, // 5KB (統一門檻)
+      minFileSize: 500, // 500B (統一門檻)
       platformName: device.browser + (device.isMobile ? " Mobile" : " Desktop"),
       notes: isIOS
         ? "iOS Chrome 使用 WebKit，metadata 不可靠，使用檔案大小判斷"
@@ -100,7 +100,7 @@ export function getRecordingStrategy(
       maxDuration: 45,
       minDuration: 1,
       durationValidation: "metadata-first",
-      minFileSize: 5000, // 5KB (統一門檻)
+      minFileSize: 500, // 500B (統一門檻)
       platformName: "Firefox",
       notes: "WebM/OGG 支援良好",
     };
@@ -115,7 +115,7 @@ export function getRecordingStrategy(
     maxDuration: 45,
     minDuration: 1,
     durationValidation: "lenient", // 寬鬆驗證
-    minFileSize: 5000, // 5KB (統一門檻)
+    minFileSize: 500, // 500B (統一門檻)
     platformName: "Unknown Browser",
     notes: "未知瀏覽器，使用保守策略",
   };


### PR DESCRIPTION
## Summary
- Backend 1KB + Frontend 5KB 的音檔最小限制 → 統一降為 **500B**
- 解決短單字朗讀（如 Yes / No / cat）被 `recording_too_small` 誤殺的問題
- 保留 BigQuery logging（<500B 仍會記錄 + 擋下，維持監控）
- 順手修齊 `audioRecordingStrategy.test.ts` 3 個 stale assertion（test 值與實作早已脫節）

## Changes
| File | Change |
|---|---|
| `backend/services/audio_upload.py` | `min_file_size` 1024 → 500，錯誤訊息改顯示 bytes |
| `frontend/src/utils/audioRecordingStrategy.ts` | 5 個平台 `minFileSize` 5000 → 500 |
| `frontend/src/utils/__tests__/audioRecordingStrategy.test.ts` | iOS/Chrome/Unknown 3 個 `minFileSize` assertion 更新為 500 |

## Note on frontend tests alignment
`audioRecordingStrategy.test.ts` 的 `minFileSize` assertion 在本 PR 之前就已與實作脫節（test 期待 iOS=10000 / Chrome=1000 / Unknown=5000，但實作五個平台統一都是 5000）。本 PR 順手將 3 個 assertion 統一更新為 500，同時解決了這個 pre-existing 的測試漂移問題。

## Why 500B？
- 1 秒 Opus@24kbps ≈ 3–4KB，短單字（0.3–0.8 秒）常落在 1–4KB 區間
- 500B 仍能擋下純 header 空檔（< 0.2 秒等於沒錄到），但不會誤殺短單字

## Not in scope
`audioRecordingStrategy.test.ts` 還有 2 個 macOS Safari MIME type 失敗是 stale test（commit `be5a364b` 把實作改回 MP4 但沒更新 test），與本 PR 無關，另開 PR 處理。

## Test plan
- [x] `backend/tests/unit/test_audio_upload.py` 16/16 passed
- [x] `frontend audioRecordingStrategy.test.ts` 相關 assertion passed
- [x] TypeScript typecheck clean
- [x] ESLint on changed files clean
- [ ] Staging 人工驗證：短單字朗讀作業能正常提交

🤖 Generated with [Claude Code](https://claude.com/claude-code)