### PR TITLE
Release: staging → main (audio min size 500B + 段落集例句重組)

### DIFF
--- a/backend/services/audio_upload.py
+++ b/backend/services/audio_upload.py
@@ -136,8 +136,8 @@ class AudioUploadService:
             # 讀取檔案內容
             content = await file.read()
 
-            # 檢查檔案大小（至少 1KB，最多 2MB）
-            min_file_size = 1 * 1024  # 1KB
+            # 檢查檔案大小（至少 500B，最多 2MB）
+            min_file_size = 500  # 500B
             if len(content) < min_file_size:
                 # 記錄到 BigQuery
                 from services.bigquery_logger import get_bigquery_logger
@@ -159,7 +159,7 @@ class AudioUploadService:
                     status_code=400,
                     detail=(
                         f"Recording file too small ({len(content)} bytes). "
-                        f"Must be at least {min_file_size / 1024}KB for valid audio."
+                        f"Must be at least {min_file_size} bytes for valid audio."
                     ),
                 )
 

--- a/backend/tests/unit/test_audio_upload.py
+++ b/backend/tests/unit/test_audio_upload.py
@@ -146,6 +146,68 @@ class TestAudioUploadService:
         assert "File too large" in exc_info.value.detail
 
     @pytest.mark.asyncio
+    @patch("services.bigquery_logger.get_bigquery_logger")
+    async def test_upload_audio_file_too_small(self, mock_get_bq_logger, service):
+        """測試檔案過小（邊界：499 bytes < 500 bytes 最小值）"""
+        mock_bq_logger = AsyncMock()
+        mock_bq_logger.log_audio_error = AsyncMock()
+        mock_get_bq_logger.return_value = mock_bq_logger
+
+        mock_file = Mock(spec=UploadFile)
+        mock_file.content_type = "audio/webm"
+        mock_file.filename = "test.webm"
+        mock_file.read = AsyncMock(return_value=b"x" * 499)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.upload_audio(mock_file)
+
+        assert exc_info.value.status_code == 400
+        assert "too small" in exc_info.value.detail
+        mock_bq_logger.log_audio_error.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("services.audio_upload.uuid.uuid4")
+    @patch("services.audio_upload.datetime")
+    @patch("services.bigquery_logger.get_bigquery_logger")
+    async def test_upload_audio_file_at_min_boundary(
+        self, mock_get_bq_logger, mock_datetime, mock_uuid, service
+    ):
+        """測試檔案剛好達到最小值（邊界：500 bytes 應通過大小檢查並成功上傳）"""
+        mock_bq_logger = AsyncMock()
+        mock_bq_logger.log_audio_error = AsyncMock()
+        mock_get_bq_logger.return_value = mock_bq_logger
+
+        # Deterministic uuid / timestamp
+        mock_uuid.return_value = "test-uuid-boundary"
+        mock_now = Mock()
+        mock_now.strftime.return_value = "20240101_120000"
+        mock_datetime.now.return_value = mock_now
+
+        # Mock GCS client so upload path is deterministic (no real credentials needed)
+        mock_client = Mock()
+        mock_bucket = Mock()
+        mock_blob = Mock()
+        service.storage_client = mock_client
+        mock_client.bucket.return_value = mock_bucket
+        mock_bucket.blob.return_value = mock_blob
+
+        mock_file = Mock(spec=UploadFile)
+        mock_file.content_type = "audio/webm"
+        mock_file.filename = "test.webm"
+        mock_file.read = AsyncMock(return_value=b"x" * 500)
+
+        result = await service.upload_audio(mock_file, duration_seconds=20)
+
+        # Unconditional positive assertions: upload must succeed
+        assert result is not None
+        assert "https://storage.googleapis.com/duotopia-audio/recordings/" in result
+        mock_blob.upload_from_string.assert_called_once_with(
+            b"x" * 500, content_type="audio/webm"
+        )
+        # The too-small path must NOT have been taken
+        mock_bq_logger.log_audio_error.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_upload_audio_duration_too_long(self, service):
         """測試音檔過長"""
         mock_file = Mock(spec=UploadFile)

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -568,11 +568,10 @@ export function AssignmentDialog({
   }, [open, classroomId, students, showOrgTab]);
 
   // 當練習模式改變時，清除不相容的購物車項目
-  // 例句重組 / 單字模式只能選單字集，需要移除例句集項目
-  // 例句朗讀可以選全部，不需要清除
+  // 單字模式只能選單字集，需要移除例句集項目
+  // 例句模式（朗讀 / 重組）可以選全部，不需要清除
   useEffect(() => {
     if (
-      formData.practice_mode === "rearrangement" ||
       formData.practice_mode === "word_reading" ||
       formData.practice_mode === "word_selection"
     ) {
@@ -834,13 +833,9 @@ export function AssignmentDialog({
     const mode = formData.practice_mode;
     if (!mode) return true; // 未選模式，全部可選
 
-    // 例句朗讀：例句集 + 單字集都可選（單字集用 example_sentence 出題）
-    if (mode === "reading") {
+    // 例句模式（朗讀 / 重組）：例句集 + 單字集都可選（單字集用 example_sentence 出題）
+    if (mode === "reading" || mode === "rearrangement") {
       return true;
-    }
-    // 例句重組：只能選單字集（例句集每題是段落，不適合重組）
-    if (mode === "rearrangement") {
-      return isVocabularySetType(contentType);
     }
     // 單字模式：只能選單字集
     if (mode === "word_reading" || mode === "word_selection") {

--- a/frontend/src/components/InstantPracticeDialog.tsx
+++ b/frontend/src/components/InstantPracticeDialog.tsx
@@ -59,7 +59,7 @@ const PRACTICE_MODES: PracticeModeOption[] = [
     labelKey: "instantPractice.modes.rearrangement.label",
     descriptionKey: "instantPractice.modes.rearrangement.description",
     icon: Shuffle,
-    contentTypes: ["VOCABULARY_SET", "vocabulary_set"],
+    contentTypes: ["EXAMPLE_SENTENCES", "example_sentences"],
   },
   {
     value: "word_reading",

--- a/frontend/src/components/ReadingAssessmentPanel.tsx
+++ b/frontend/src/components/ReadingAssessmentPanel.tsx
@@ -76,9 +76,40 @@ const TRANSLATION_LANGUAGES = [
 ];
 
 // 每個例句集的題目上限
-const MAX_ROWS = 8;
+const MAX_ROWS = 15;
 // 批次貼上/翻譯的項目上限
 const MAX_BATCH_ITEMS = MAX_ROWS;
+// 每題單字數範圍
+const MIN_WORDS_PER_ITEM = 2;
+const MAX_WORDS_PER_ITEM = 25;
+// 整個例句集最少題數
+const MIN_ITEMS_PER_SET = 3;
+
+// 檢測重複的行 index（text 完全相同，忽略大小寫與前後空白）
+// 回傳 Map<index, reasons[]>，給 UI 用來標紅 + 顯示重複內容
+function findDuplicates(rows: { text: string }[]): Map<number, string[]> {
+  const dupes = new Map<number, string[]>();
+  const textMap = new Map<string, number[]>();
+
+  rows.forEach((row, i) => {
+    const text = row.text?.trim().toLowerCase();
+    if (text) {
+      if (!textMap.has(text)) textMap.set(text, []);
+      textMap.get(text)!.push(i);
+    }
+  });
+
+  for (const [text, indices] of textMap.entries()) {
+    if (indices.length > 1) {
+      indices.forEach((i) => {
+        if (!dupes.has(i)) dupes.set(i, []);
+        dupes.get(i)!.push(text);
+      });
+    }
+  }
+
+  return dupes;
+}
 
 interface ContentRow {
   id: string | number;
@@ -847,6 +878,7 @@ interface SortableRowInnerProps {
   rowsLength: number;
   panelTranslateLang?: TranslationLanguage | "";
   panelCustomLang?: string;
+  duplicateReasons?: string[];
 }
 
 function SortableRowInner({
@@ -857,10 +889,11 @@ function SortableRowInner({
   handleDuplicateRow,
   handleOpenTTSModal,
   handleRemoveAudio,
-  handleGenerateSingleDefinition,
+  handleGenerateSingleDefinition: _handleGenerateSingleDefinition,
   rowsLength,
   panelTranslateLang = "",
   panelCustomLang = "",
+  duplicateReasons,
 }: SortableRowInnerProps) {
   const { t } = useTranslation();
   const {
@@ -885,35 +918,97 @@ function SortableRowInner({
     }
   }, []);
 
+  const hasDuplicate = !!duplicateReasons && duplicateReasons.length > 0;
+  // 只有當 row 有內容但單字數不在範圍內才標記（空 row 不標）
+  const rowWordCount =
+    row.text?.trim().split(/\s+/).filter(Boolean).length ?? 0;
+  const tooFewWords = rowWordCount > 0 && rowWordCount < MIN_WORDS_PER_ITEM;
+  const tooManyWords = rowWordCount > MAX_WORDS_PER_ITEM;
+  const hasError = hasDuplicate || tooFewWords || tooManyWords;
+
   return (
     <div
       ref={setNodeRef}
       style={style}
-      className="flex flex-col sm:flex-row items-start sm:items-center gap-2 p-3 bg-gray-50 rounded-lg"
+      className={`p-3 rounded-lg ${
+        hasError ? "bg-red-50 border-2 border-red-400" : "bg-gray-50"
+      }`}
     >
-      <div className="flex items-center gap-1 w-full sm:w-auto">
-        {/* Drag handle - ONLY this triggers drag */}
-        <div
-          {...attributes}
-          {...listeners}
-          className="cursor-grab active:cursor-grabbing touch-none"
-          title={t("contentEditor.tooltips.dragToReorder")}
-        >
-          <GripVertical className="h-5 w-5 text-gray-400 hover:text-gray-700 transition-colors" />
+      {/* Header: drag + index + error labels | Copy + Delete */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2 flex-wrap">
+          {/* Drag handle - ONLY this triggers drag */}
+          <div
+            {...attributes}
+            {...listeners}
+            className="cursor-grab active:cursor-grabbing touch-none"
+            title={t("contentEditor.tooltips.dragToReorder")}
+          >
+            <GripVertical className="h-5 w-5 text-gray-400 hover:text-gray-700 transition-colors" />
+          </div>
+          <span className="text-sm font-medium text-gray-600">{index + 1}</span>
+          {hasDuplicate && (
+            <span className="text-xs text-red-600 font-medium">
+              {t("contentEditor.messages.duplicateWord")}
+            </span>
+          )}
+          {tooFewWords && (
+            <span className="text-xs text-red-600 font-medium">
+              {t("contentEditor.messages.wordsTooFewLabel", {
+                limit: MIN_WORDS_PER_ITEM,
+              })}
+            </span>
+          )}
+          {tooManyWords && (
+            <span className="text-xs text-red-600 font-medium">
+              {t("contentEditor.messages.wordsTooManyLabel", {
+                limit: MAX_WORDS_PER_ITEM,
+              })}
+            </span>
+          )}
         </div>
-        <span className="text-sm font-medium text-gray-600 w-6">
-          {index + 1}
-        </span>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => handleDuplicateRow(index)}
+            className="p-1 rounded hover:bg-gray-200"
+            title={t("contentEditor.tooltips.duplicate")}
+          >
+            <Copy className="h-4 w-4 text-gray-600" />
+          </button>
+          <button
+            onClick={() => handleRemoveRow(index)}
+            className={`p-1 rounded ${
+              row.has_student_progress || rowsLength <= 1
+                ? "cursor-not-allowed"
+                : "hover:bg-gray-200"
+            }`}
+            title={
+              row.has_student_progress
+                ? t("contentEditor.tooltips.cannotDeleteWithProgress")
+                : t("contentEditor.tooltips.delete")
+            }
+            disabled={rowsLength <= 1 || row.has_student_progress}
+          >
+            <Trash2
+              className={`h-4 w-4 ${
+                rowsLength <= 1 || row.has_student_progress
+                  ? "text-gray-300"
+                  : "text-gray-600"
+              }`}
+            />
+          </button>
+        </div>
       </div>
 
-      <div className="flex-1 w-full space-y-2">
+      {/* Body: text + translation inputs */}
+      <div className="space-y-2">
         {/* Text input */}
         <div className="relative">
           <textarea
             value={row.text}
             onChange={(e) => {
               const words = e.target.value.trim().split(/\s+/).filter(Boolean);
-              if (words.length > 150) return;
+              if (words.length > MAX_WORDS_PER_ITEM) return;
               handleUpdateRow(index, "text", e.target.value);
               e.target.style.height = "auto";
               e.target.style.height = e.target.scrollHeight + "px";
@@ -1016,11 +1111,17 @@ function SortableRowInner({
               rows={2}
               maxLength={500}
             />
+            {/*
+              Per-row 翻譯按鈕暫時停用：後端 /translate endpoint 的 prompt
+              以「英文單字」為主體，整句例句翻譯會走壞。待後端新增句子
+              專用 translate endpoint 後再恢復 onClick。仍顯示目前選定
+              語言 label 讓使用者看得出語言脈絡。
+            */}
             <div className="absolute right-2 top-2">
               <button
-                onClick={() => handleGenerateSingleDefinition(index)}
-                className="text-xs text-gray-400 hover:text-blue-500 hover:underline cursor-pointer transition-colors"
-                title={t("contentEditor.messages.generatingTranslation")}
+                disabled
+                className="text-xs text-gray-400 cursor-not-allowed"
+                title={t("contentEditor.messages.translationDisabled")}
               >
                 {(() => {
                   const lang = panelTranslateLang || row.selectedLanguage || "";
@@ -1042,39 +1143,6 @@ function SortableRowInner({
             </div>
           </div>
         </div>
-      </div>
-
-      {/* Action buttons */}
-      <div className="flex items-center gap-1 w-full sm:w-auto justify-end">
-        <button
-          onClick={() => handleDuplicateRow(index)}
-          className="p-1 rounded hover:bg-gray-200"
-          title={t("contentEditor.tooltips.duplicate")}
-        >
-          <Copy className="h-4 w-4 text-gray-600" />
-        </button>
-        <button
-          onClick={() => handleRemoveRow(index)}
-          className={`p-1 rounded ${
-            row.has_student_progress || rowsLength <= 1
-              ? "cursor-not-allowed"
-              : "hover:bg-gray-200"
-          }`}
-          title={
-            row.has_student_progress
-              ? t("contentEditor.tooltips.cannotDeleteWithProgress")
-              : t("contentEditor.tooltips.delete")
-          }
-          disabled={rowsLength <= 1 || row.has_student_progress}
-        >
-          <Trash2
-            className={`h-4 w-4 ${
-              rowsLength <= 1 || row.has_student_progress
-                ? "text-gray-300"
-                : "text-gray-600"
-            }`}
-          />
-        </button>
       </div>
     </div>
   );
@@ -1120,6 +1188,9 @@ const ReadingAssessmentPanel = forwardRef<
   const { setEditorBusy } = useSidebar();
 
   const [title, setTitle] = useState("");
+  const [duplicateMap, setDuplicateMap] = useState<Map<number, string[]>>(
+    new Map(),
+  );
   const [rows, setRows] = useState<ContentRow[]>([
     {
       id: "1",
@@ -1186,6 +1257,11 @@ const ReadingAssessmentPanel = forwardRef<
     return () => setEditorBusy(false);
   }, [isBatchProcessing, setEditorBusy]);
 
+  // Recalculate duplicates whenever rows change
+  useEffect(() => {
+    setDuplicateMap(findDuplicates(rows));
+  }, [rows]);
+
   // dnd-kit sensors
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -1202,8 +1278,12 @@ const ReadingAssessmentPanel = forwardRef<
   const handleSave = async () => {
     const validRows = rows.filter((row) => row.text && row.text.trim());
 
-    if (validRows.length === 0) {
-      toast.error(t("contentEditor.messages.addAtLeastOneItem"));
+    if (validRows.length < MIN_ITEMS_PER_SET) {
+      toast.error(
+        t("contentEditor.messages.addAtLeastNItems", {
+          limit: MIN_ITEMS_PER_SET,
+        }),
+      );
       return;
     }
 
@@ -1212,15 +1292,39 @@ const ReadingAssessmentPanel = forwardRef<
       return;
     }
 
+    // 檢查單字數下限
+    const underLimitRow = validRows.find((row) => {
+      const words = row.text.trim().split(/\s+/).filter(Boolean);
+      return words.length < MIN_WORDS_PER_ITEM;
+    });
+    if (underLimitRow) {
+      toast.error(
+        t("contentEditor.messages.wordLimitTooFew", {
+          limit: MIN_WORDS_PER_ITEM,
+        }),
+      );
+      return;
+    }
+
     // 檢查單字數上限
     const overLimitRow = validRows.find((row) => {
       const words = row.text.trim().split(/\s+/).filter(Boolean);
-      return words.length > 150;
+      return words.length > MAX_WORDS_PER_ITEM;
     });
     if (overLimitRow) {
       toast.error(
-        t("contentEditor.messages.wordLimitExceeded", { limit: 150 }),
+        t("contentEditor.messages.wordLimitExceeded", {
+          limit: MAX_WORDS_PER_ITEM,
+        }),
       );
+      return;
+    }
+
+    // 檢查重複
+    const dupes = findDuplicates(validRows);
+    if (dupes.size > 0) {
+      setDuplicateMap(dupes);
+      toast.error(t("contentEditor.messages.duplicateItems"));
       return;
     }
 
@@ -2034,51 +2138,59 @@ const ReadingAssessmentPanel = forwardRef<
     }
   };
 
-  // 將超過 150 單字的段落自動分段，保留句子完整性
-  const splitParagraphByWordLimit = (
-    text: string,
-    maxWords = 150,
-  ): string[] => {
-    const sentences = text.match(/[^.!?]*[.!?]+\s*/g) || [text];
-    const paragraphs: string[] = [];
-    let current = "";
-
-    for (const sentence of sentences) {
-      const combined = current + sentence;
-      const wordCount = combined.trim().split(/\s+/).filter(Boolean).length;
-
-      if (wordCount > maxWords && current.trim()) {
-        paragraphs.push(current.trim());
-        current = sentence;
-      } else {
-        current = combined;
-      }
-    }
-    if (current.trim()) {
-      paragraphs.push(current.trim());
-    }
-    return paragraphs;
-  };
-
   const handleBatchPaste = async (autoTTS: boolean, autoTranslate: boolean) => {
-    // 分割文字，每行一個項目，超過 150 單字的段落自動分段
+    // 分割文字，每行一個項目
     const rawLines = batchPasteText
       .split("\n")
       .map((line) => line.trim())
       .filter((line) => line.length > 0);
 
-    const lines: string[] = [];
-    for (const line of rawLines) {
-      const wordCount = line.split(/\s+/).filter(Boolean).length;
-      if (wordCount > 150) {
-        lines.push(...splitParagraphByWordLimit(line));
-      } else {
-        lines.push(line);
-      }
+    // 1. 貼上框內部去重（忽略大小寫）
+    const seen = new Set<string>();
+    const deduped = rawLines.filter((l) => {
+      const key = l.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+    const internalDupes = rawLines.length - deduped.length;
+
+    // 2. 跟右側已有 row 去重
+    const existingTexts = new Set(
+      rows
+        .filter((r) => r.text && r.text.trim())
+        .map((r) => r.text.trim().toLowerCase()),
+    );
+    const lines = deduped.filter((l) => !existingTexts.has(l.toLowerCase()));
+    const existingDupes = deduped.length - lines.length;
+
+    // 提醒去重結果
+    if (internalDupes > 0 || existingDupes > 0) {
+      const msgs: string[] = [];
+      if (internalDupes > 0)
+        msgs.push(
+          t("contentEditor.messages.removedInternalDupes", {
+            count: internalDupes,
+          }),
+        );
+      if (existingDupes > 0)
+        msgs.push(
+          t("contentEditor.messages.removedExistingDupes", {
+            count: existingDupes,
+          }),
+        );
+      toast.info(msgs.join("、"));
     }
 
-    // === Backfill 模式：textarea 空白時，補齊已有段落缺少的翻譯/TTS ===
-    const isBackfillMode = lines.length === 0;
+    // === Backfill 模式：textarea 空白時，補齊已有項目缺少的翻譯/TTS ===
+    // Backfill 模式只在貼上框本來就空白時觸發；若使用者有貼內容但全被去重掉，
+    // 應顯示空結果提示而非進 Backfill。
+    const isBackfillMode = lines.length === 0 && rawLines.length === 0;
+
+    if (!isBackfillMode && lines.length === 0) {
+      // 全部都是重複，前面的 toast.info 已顯示；直接結束
+      return;
+    }
 
     if (isBackfillMode) {
       const existingRows = rows.filter((r) => r.text && r.text.trim());
@@ -2285,6 +2397,19 @@ const ReadingAssessmentPanel = forwardRef<
       example_sentence_definition: "",
     }));
 
+    // 只對字數合法（2–25）的 item 執行 TTS / 翻譯，避免浪費 token
+    // 字數不符的 item 仍會被加進 rows，但跳過外部 API 呼叫；
+    // 使用者修正字數後可用單一 mic 按鈕或批次工具列補產 TTS / 翻譯。
+    const validForProcessingIndices: number[] = [];
+    const validForProcessingTexts: string[] = [];
+    newItems.forEach((item, i) => {
+      const wc = item.text.trim().split(/\s+/).filter(Boolean).length;
+      if (wc >= MIN_WORDS_PER_ITEM && wc <= MAX_WORDS_PER_ITEM) {
+        validForProcessingIndices.push(i);
+        validForProcessingTexts.push(item.text);
+      }
+    });
+
     // 批次處理 TTS 和翻譯
     if (autoTTS || autoTranslate) {
       try {
@@ -2296,7 +2421,8 @@ const ReadingAssessmentPanel = forwardRef<
 
           if (isRandom) {
             // Random 模式：每題個別生成，確保口音/性別不同
-            for (let i = 0; i < newItems.length; i++) {
+            // 只對字數合法的 item 呼叫 TTS API
+            for (const i of validForProcessingIndices) {
               const { voice, rate } = getVoiceAndRate(
                 batchTTSAccent,
                 batchTTSGender,
@@ -2319,15 +2445,15 @@ const ReadingAssessmentPanel = forwardRef<
                 };
               }
             }
-          } else {
-            // 固定口音/性別：批次生成
+          } else if (validForProcessingTexts.length > 0) {
+            // 固定口音/性別：批次生成（只送字數合法的 text）
             const { voice, rate } = getVoiceAndRate(
               batchTTSAccent,
               batchTTSGender,
               batchTTSSpeed,
             );
             const ttsResult = await apiClient.batchGenerateTTS(
-              lines,
+              validForProcessingTexts,
               voice,
               rate,
               "+0%",
@@ -2339,35 +2465,49 @@ const ReadingAssessmentPanel = forwardRef<
             ) {
               const audioUrls = (ttsResult as { audio_urls: string[] })
                 .audio_urls;
-              newItems = newItems.map((item, i) => ({
-                ...item,
-                audioUrl: audioUrls[i]?.startsWith("http")
-                  ? audioUrls[i]
-                  : `${import.meta.env.VITE_API_URL}${audioUrls[i]}`,
-                audio_url: audioUrls[i]?.startsWith("http")
-                  ? audioUrls[i]
-                  : `${import.meta.env.VITE_API_URL}${audioUrls[i]}`,
-              }));
+              // audioUrls 的 index 對應 validForProcessingIndices，map 回 newItems
+              validForProcessingIndices.forEach((itemIdx, resultIdx) => {
+                const url = audioUrls[resultIdx];
+                if (url) {
+                  const fullUrl = url.startsWith("http")
+                    ? url
+                    : `${import.meta.env.VITE_API_URL}${url}`;
+                  newItems[itemIdx] = {
+                    ...newItems[itemIdx],
+                    audioUrl: fullUrl,
+                    audio_url: fullUrl,
+                  };
+                }
+              });
             }
           }
         }
 
-        if (autoTranslate && selectedTranslateLang) {
+        if (
+          autoTranslate &&
+          selectedTranslateLang &&
+          validForProcessingTexts.length > 0
+        ) {
           const langCode =
             selectedTranslateLang === "other"
               ? customTranslateLang || ""
               : TRANSLATION_LANGUAGES.find(
                   (l) => l.value === selectedTranslateLang,
                 )?.code || "zh-TW";
-          const result = await apiClient.batchTranslate(lines, langCode);
+          const result = await apiClient.batchTranslate(
+            validForProcessingTexts,
+            langCode,
+          );
           const translations =
             (result as { translations?: string[] }).translations || result;
           if (Array.isArray(translations)) {
-            newItems = newItems.map((item, i) => ({
-              ...item,
-              definition: translations[i] || "",
-              selectedLanguage: selectedTranslateLang,
-            }));
+            validForProcessingIndices.forEach((itemIdx, resultIdx) => {
+              newItems[itemIdx] = {
+                ...newItems[itemIdx],
+                definition: translations[resultIdx] || "",
+                selectedLanguage: selectedTranslateLang,
+              };
+            });
           }
         }
       } catch (error) {
@@ -2384,7 +2524,29 @@ const ReadingAssessmentPanel = forwardRef<
     // 更新前端狀態
     setRows(updatedRows);
 
+    // 檢查新 rows 是否有 validation error（字數不符 / 重複），
+    // 有錯誤就跳過自動寫 DB，讓使用者看到紅色標記後手動修正
+    const updatedValidRows = updatedRows.filter((r) => r.text?.trim());
+    const hasWordCountError = updatedValidRows.some((r) => {
+      const words = r.text.trim().split(/\s+/).filter(Boolean);
+      return (
+        words.length < MIN_WORDS_PER_ITEM || words.length > MAX_WORDS_PER_ITEM
+      );
+    });
+    const hasDupeError = findDuplicates(updatedValidRows).size > 0;
+    const tooFewItemsAfterPaste = updatedValidRows.length < MIN_ITEMS_PER_SET;
+    const skipAutoSave =
+      hasWordCountError || hasDupeError || tooFewItemsAfterPaste;
+
     const existingContentId = editingContent?.id || content?.id;
+
+    if (skipAutoSave) {
+      toast.warning(t("contentEditor.messages.batchPasteHasErrors"));
+      setIsPasting(false);
+      setBatchPasteDialogOpen(false);
+      setBatchPasteText("");
+      return;
+    }
 
     if (existingContentId) {
       // 編輯模式：直接儲存到資料庫
@@ -2639,6 +2801,7 @@ const ReadingAssessmentPanel = forwardRef<
                       rowsLength={rows.length}
                       panelTranslateLang={selectedTranslateLang}
                       panelCustomLang={customTranslateLang}
+                      duplicateReasons={duplicateMap.get(index)}
                     />
                   );
                 })}

--- a/frontend/src/components/shared/ProgramFolderView.tsx
+++ b/frontend/src/components/shared/ProgramFolderView.tsx
@@ -99,9 +99,9 @@ function getCoverImage(level?: string): string {
 /* ── Content type badge config ── */
 const TYPE_BADGE: Record<string, { label: string; bg: string; text: string }> =
   {
-    example_sentences: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
-    EXAMPLE_SENTENCES: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
-    reading_assessment: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
+    example_sentences: { label: "例句集", bg: "#F0FDF4", text: "#059669" },
+    EXAMPLE_SENTENCES: { label: "例句集", bg: "#F0FDF4", text: "#059669" },
+    reading_assessment: { label: "例句集", bg: "#F0FDF4", text: "#059669" },
     vocabulary_set: { label: "單字集", bg: "#FFFBEB", text: "#D97706" },
     VOCABULARY_SET: { label: "單字集", bg: "#FFFBEB", text: "#D97706" },
     sentence_making: { label: "造句", bg: "#F5F3FF", text: "#7C3AED" },

--- a/frontend/src/components/shared/ResourceFolderView.tsx
+++ b/frontend/src/components/shared/ResourceFolderView.tsx
@@ -44,9 +44,9 @@ function getCoverImage(level?: string | null): string {
 /* ── Content type badge config ── */
 const TYPE_BADGE: Record<string, { label: string; bg: string; text: string }> =
   {
-    example_sentences: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
-    EXAMPLE_SENTENCES: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
-    reading_assessment: { label: "段落集", bg: "#F0FDF4", text: "#059669" },
+    example_sentences: { label: "例句集", bg: "#F0FDF4", text: "#059669" },
+    EXAMPLE_SENTENCES: { label: "例句集", bg: "#F0FDF4", text: "#059669" },
+    reading_assessment: { label: "例句集", bg: "#F0FDF4", text: "#059669" },
     vocabulary_set: { label: "單字集", bg: "#FFFBEB", text: "#D97706" },
     VOCABULARY_SET: { label: "單字集", bg: "#FFFBEB", text: "#D97706" },
     sentence_making: { label: "造句", bg: "#F5F3FF", text: "#7C3AED" },

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1717,10 +1717,10 @@
         "partialCreated": "Partial success: {{successCount}}/{{totalCount}} classrooms created ({{studentCount}} students). Failed: {{failedNames}}"
       },
       "contentTypes": {
-        "reading_assessment": "Paragraph Set",
-        "READING_ASSESSMENT": "Paragraph Set",
-        "example_sentences": "Paragraph Set",
-        "EXAMPLE_SENTENCES": "Paragraph Set",
+        "reading_assessment": "Example Sentences",
+        "READING_ASSESSMENT": "Example Sentences",
+        "example_sentences": "Example Sentences",
+        "EXAMPLE_SENTENCES": "Example Sentences",
         "vocabulary_set": "Vocabulary Set",
         "VOCABULARY_SET": "Vocabulary Set",
         "sentence_making": "Vocabulary Set",
@@ -1818,8 +1818,8 @@
       "cancel": "Cancel",
       "types": {
         "example_sentences": {
-          "name": "Paragraph Set",
-          "description": "Create paragraphs for reading or ordering practice. Paste multiple paragraphs from an article, up to 120 words each",
+          "name": "Example Sentences",
+          "description": "Create sentences for reading or rearrangement practice (2-25 words)",
           "recommended": "Recommended"
         },
         "vocabulary_set": {
@@ -2790,7 +2790,7 @@
       "noDescription": "No Description",
       "unknownType": "Unknown Type",
       "notSet": "Not Set",
-      "readingAssessmentSettings": "Add Paragraph Set",
+      "readingAssessmentSettings": "Add Example Sentences",
       "subscriptionExpiredWarning": "⚠️ Subscription Expired",
       "daysRemaining": "{{days}} days remaining",
       "requiresSubscription": "Subscription required to assign homework",
@@ -3040,10 +3040,10 @@
       "resubmitted": "Resubmitted"
     },
     "contentTypes": {
-      "readingAssessment": "Paragraph Set",
-      "reading_assessment": "Paragraph Set",
-      "READING_ASSESSMENT": "Paragraph Set",
-      "EXAMPLE_SENTENCES": "Paragraph Set",
+      "readingAssessment": "Example Sentences",
+      "reading_assessment": "Example Sentences",
+      "READING_ASSESSMENT": "Example Sentences",
+      "EXAMPLE_SENTENCES": "Example Sentences",
       "speakingPractice": "Speaking Practice",
       "speaking_practice": "Speaking Practice",
       "SPEAKING_PRACTICE": "Speaking Practice",
@@ -3295,7 +3295,7 @@
       "featureInDevelopment": "{{type}} feature in development"
     },
     "dialogs": {
-      "addReadingTitle": "Add Paragraph Set",
+      "addReadingTitle": "Add Example Sentences",
       "editContentTitle": "Edit Content"
     },
     "toolbar": {
@@ -4348,8 +4348,6 @@
       "enterCustomLanguage": "Please enter a custom language name",
       "translationLanguageMismatch": "This vocabulary set already uses \"{{lang}}\" for translation. Please keep the translation language consistent.",
       "exampleTranslationLanguageMismatch": "Example sentence translations already use \"{{lang}}\". Please keep the translation language consistent.",
-      "removedInternalDupes": "Removed {{count}} duplicate(s)",
-      "removedExistingDupes": "Skipped {{count}} existing word(s)",
       "unsavedChangesConfirm": "You have unsaved changes. Are you sure you want to close?"
     },
     "placeholders": {
@@ -4404,8 +4402,14 @@
       "loadingContentFailed": "Failed to load content",
       "enterTitle": "Please enter a title",
       "addAtLeastOneItem": "Please add at least one content item",
+      "addAtLeastNItems": "Example sentences set requires at least {{limit}} items",
       "addAtLeastFiveItems": "Vocabulary set requires at least 5 words",
       "wordLimitExceeded": "Each item must not exceed {{limit}} words",
+      "wordLimitTooFew": "Each item must have at least {{limit}} words",
+      "wordsTooFewLabel": "< {{limit}} words",
+      "wordsTooManyLabel": "> {{limit}} words",
+      "batchPasteHasErrors": "Items added but have errors (word count or duplicates). Please fix the highlighted rows before saving.",
+      "translationDisabled": "Sentence translation is temporarily disabled. Please enter translation manually.",
       "duplicateItems": "Duplicate words or translations found. Please resolve duplicates before saving.",
       "duplicateWord": "Duplicate",
       "maxRowsReached": "Maximum 15 rows allowed",
@@ -4460,7 +4464,9 @@
       "batchLimitTruncated": "Exceeded limit, only the first {{count}} items will be processed",
       "batchLimitWarning": "Exceeded {{count}} item limit, only the first {{count}} will be processed",
       "batchPasteLimit": "Batch paste limit is {{count}} items, please reduce and try again",
-      "batchPasteLimitShort": "max {{count}} items"
+      "batchPasteLimitShort": "max {{count}} items",
+      "removedInternalDupes": "Removed {{count}} duplicate(s)",
+      "removedExistingDupes": "Skipped {{count}} existing word(s)"
     },
     "translationLanguages": {
       "chinese": "Chinese",
@@ -4803,7 +4809,7 @@
     },
     "contentTypes": {
       "reading_assessment": "Reading Assessment",
-      "example_sentences": "Paragraph Set",
+      "example_sentences": "Example Sentences",
       "vocabulary_set": "Vocabulary Set",
       "sentence_making": "Sentence Making"
     },

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -1788,10 +1788,10 @@
         "partialCreated": "部分成功：{{successCount}}/{{totalCount}} 個班級已建立作業（{{studentCount}} 位學生），失敗：{{failedNames}}"
       },
       "contentTypes": {
-        "reading_assessment": "段落集",
-        "READING_ASSESSMENT": "段落集",
-        "example_sentences": "段落集",
-        "EXAMPLE_SENTENCES": "段落集",
+        "reading_assessment": "例句集",
+        "READING_ASSESSMENT": "例句集",
+        "example_sentences": "例句集",
+        "EXAMPLE_SENTENCES": "例句集",
         "vocabulary_set": "單字集",
         "VOCABULARY_SET": "單字集",
         "sentence_making": "造句練習",
@@ -1870,8 +1870,8 @@
       "cancel": "取消",
       "types": {
         "example_sentences": {
-          "name": "段落集",
-          "description": "建立段落供學生練習朗讀或排序，可將文章多個段落貼上，每段落最多120個單字",
+          "name": "例句集",
+          "description": "建立例句供學生練習朗讀或重組（2-25個單字）",
           "recommended": "推薦"
         },
         "vocabulary_set": {
@@ -2843,7 +2843,7 @@
       "noDescription": "無說明",
       "unknownType": "未知類型",
       "notSet": "未設定",
-      "readingAssessmentSettings": "新增段落集",
+      "readingAssessmentSettings": "新增例句集",
       "subscriptionExpiredWarning": "⚠️ 訂閱已過期",
       "daysRemaining": "剩餘 {{days}} 天",
       "requiresSubscription": "需要訂閱才能指派作業",
@@ -3044,10 +3044,10 @@
       "editContent": "編輯內容"
     },
     "contentTypes": {
-      "readingAssessment": "段落集",
-      "reading_assessment": "段落集",
-      "READING_ASSESSMENT": "段落集",
-      "EXAMPLE_SENTENCES": "段落集",
+      "readingAssessment": "例句集",
+      "reading_assessment": "例句集",
+      "READING_ASSESSMENT": "例句集",
+      "EXAMPLE_SENTENCES": "例句集",
       "speakingPractice": "口說練習",
       "speaking_practice": "口說練習",
       "SPEAKING_PRACTICE": "口說練習",
@@ -3299,7 +3299,7 @@
       "featureInDevelopment": "{{type}} 功能開發中"
     },
     "dialogs": {
-      "addReadingTitle": "新增段落集",
+      "addReadingTitle": "新增例句集",
       "editContentTitle": "編輯內容"
     },
     "toolbar": {
@@ -4366,8 +4366,6 @@
       "enterCustomLanguage": "請輸入自訂語言名稱",
       "translationLanguageMismatch": "此單字集已使用「{{lang}}」翻譯，請保持翻譯語言一致",
       "exampleTranslationLanguageMismatch": "例句翻譯已使用「{{lang}}」，請保持翻譯語言一致",
-      "removedInternalDupes": "已去除 {{count}} 個重複單字",
-      "removedExistingDupes": "已跳過 {{count}} 個已存在的單字",
       "unsavedChangesConfirm": "尚未儲存，確定要關閉嗎？"
     },
     "placeholders": {
@@ -4422,8 +4420,14 @@
       "loadingContentFailed": "載入內容失敗",
       "enterTitle": "請輸入標題",
       "addAtLeastOneItem": "請至少新增一個內容項目",
+      "addAtLeastNItems": "例句集至少需要 {{limit}} 個題目",
       "addAtLeastFiveItems": "單字集至少需要 5 個單字",
       "wordLimitExceeded": "單一題目的英文原文不可超過 {{limit}} 個單字",
+      "wordLimitTooFew": "單一題目的英文原文至少需要 {{limit}} 個單字",
+      "wordsTooFewLabel": "少於 {{limit}} 字",
+      "wordsTooManyLabel": "超過 {{limit}} 字",
+      "batchPasteHasErrors": "已加入題目但有錯誤（字數不符或重複），請先修正標紅的題目才能儲存",
+      "translationDisabled": "例句翻譯功能暫時停用，請手動輸入翻譯",
       "duplicateItems": "有重複的單字或翻譯，請先處理重複項目",
       "duplicateWord": "重複",
       "maxRowsReached": "最多只能新增 15 列",
@@ -4478,7 +4482,9 @@
       "batchLimitTruncated": "已超過上限，僅前 {{count}} 個項目會被處理",
       "batchLimitWarning": "超過 {{count}} 個項目上限，僅前 {{count}} 個會被處理",
       "batchPasteLimit": "批次貼上上限為 {{count}} 個項目，請減少後重試",
-      "batchPasteLimitShort": "上限 {{count}} 個"
+      "batchPasteLimitShort": "上限 {{count}} 個",
+      "removedInternalDupes": "已去除 {{count}} 個重複單字",
+      "removedExistingDupes": "已跳過 {{count}} 個已存在的單字"
     },
     "translationLanguages": {
       "chinese": "中文",
@@ -4821,7 +4827,7 @@
     },
     "contentTypes": {
       "reading_assessment": "閱讀評量",
-      "example_sentences": "段落集",
+      "example_sentences": "例句集",
       "vocabulary_set": "單字集",
       "sentence_making": "造句"
     },

--- a/frontend/src/utils/__tests__/audioRecordingStrategy.test.ts
+++ b/frontend/src/utils/__tests__/audioRecordingStrategy.test.ts
@@ -16,7 +16,7 @@ describe("audioRecordingStrategy", () => {
       expect(strategy.useTimeslice).toBe(false);
       expect(strategy.useRequestData).toBe(true);
       expect(strategy.durationValidation).toBe("lenient");
-      expect(strategy.minFileSize).toBe(10000);
+      expect(strategy.minFileSize).toBe(500);
       expect(strategy.platformName).toBe("iOS Safari");
     });
 
@@ -41,7 +41,7 @@ describe("audioRecordingStrategy", () => {
       expect(strategy.fallbackMimeTypes).toContain("audio/mp4");
       expect(strategy.useRequestData).toBe(true);
       expect(strategy.durationValidation).toBe("metadata-first");
-      expect(strategy.minFileSize).toBe(1000);
+      expect(strategy.minFileSize).toBe(500);
     });
 
     it("應該為 Firefox 返回正確策略", () => {
@@ -61,7 +61,7 @@ describe("audioRecordingStrategy", () => {
 
       expect(strategy.preferredMimeType).toBe("audio/mp4");
       expect(strategy.durationValidation).toBe("lenient");
-      expect(strategy.minFileSize).toBe(5000);
+      expect(strategy.minFileSize).toBe(500);
       expect(strategy.platformName).toBe("Unknown Browser");
     });
   });

--- a/frontend/src/utils/audioRecordingStrategy.ts
+++ b/frontend/src/utils/audioRecordingStrategy.ts
@@ -46,7 +46,7 @@ export function getRecordingStrategy(
       maxDuration: 45,
       minDuration: 1,
       durationValidation: "lenient", // WebM metadata 不可靠，使用寬鬆模式（只檢查檔案大小）
-      minFileSize: 5000, // 5KB (統一門檻)
+      minFileSize: 500, // 500B (統一門檻)
       platformName: `iOS ${device.browser}`,
       notes:
         "iOS Safari 支援 WebM 錄音但 metadata 不準確，使用檔案大小判斷有效性",
@@ -63,7 +63,7 @@ export function getRecordingStrategy(
       maxDuration: 45,
       minDuration: 1,
       durationValidation: "lenient", // MP4 metadata 可靠但仍用寬鬆模式
-      minFileSize: 5000, // 5KB (統一門檻)
+      minFileSize: 500, // 500B (統一門檻)
       platformName: "macOS Safari",
       notes: "macOS Safari 只支援 MP4 格式，metadata 準確",
     };
@@ -82,7 +82,7 @@ export function getRecordingStrategy(
       maxDuration: 45,
       minDuration: 1,
       durationValidation: isIOS ? "lenient" : "metadata-first", // iOS Chrome metadata 不可靠
-      minFileSize: 5000, // 5KB (統一門檻)
+      minFileSize: 500, // 500B (統一門檻)
       platformName: device.browser + (device.isMobile ? " Mobile" : " Desktop"),
       notes: isIOS
         ? "iOS Chrome 使用 WebKit，metadata 不可靠，使用檔案大小判斷"
@@ -100,7 +100,7 @@ export function getRecordingStrategy(
       maxDuration: 45,
       minDuration: 1,
       durationValidation: "metadata-first",
-      minFileSize: 5000, // 5KB (統一門檻)
+      minFileSize: 500, // 500B (統一門檻)
       platformName: "Firefox",
       notes: "WebM/OGG 支援良好",
     };
@@ -115,7 +115,7 @@ export function getRecordingStrategy(
     maxDuration: 45,
     minDuration: 1,
     durationValidation: "lenient", // 寬鬆驗證
-    minFileSize: 5000, // 5KB (統一門檻)
+    minFileSize: 500, // 500B (統一門檻)
     platformName: "Unknown Browser",
     notes: "未知瀏覽器，使用保守策略",
   };


### PR DESCRIPTION
## Release PR: staging → main

本次 release 包含 2 個已在 staging 驗證的變更：

### Included PRs
| PR | Title | Issue |
|---|---|---|
| #664 | fix(audio): lower min audio file size from 1KB/5KB to 500B | - |
| #667 | Release: [Feature]: 段落集恢復例句重組功能 | Fixes #665 |

### Summary of changes

#### #664 — 音檔最小限制降為 500B
- Backend `min_file_size` 1024 → 500
- Frontend 五平台 `minFileSize` 5000 → 500
- 解決短單字（Yes / No / cat）被 `recording_too_small` 誤殺
- 保留 <500B 的 BigQuery logging 以維持監控

#### #667 — 段落集例句重組 (#665)
- `AssignmentDialog` / `ReadingAssessmentPanel` 恢復例句重組
- 批次貼上跳過 TTS / 翻譯對字數不符的題目
- 暫時停用例句集 per-row 翻譯按鈕
- 補齊 i18n key（`removedInternalDupes` / `removedExistingDupes`）

### Files changed
```
backend/services/audio_upload.py                   |   6 +-
backend/tests/unit/test_audio_upload.py            |  62 ++
frontend/src/components/AssignmentDialog.tsx       |  13 +-
frontend/src/components/InstantPracticeDialog.tsx  |   2 +-
frontend/src/components/ReadingAssessmentPanel.tsx | 391 +++++++++++++------
frontend/src/components/shared/ProgramFolderView.tsx  |   6 +-
frontend/src/components/shared/ResourceFolderView.tsx |   6 +-
frontend/src/i18n/locales/{en,zh-TW}/translation.json |  76 +-
frontend/src/utils/audioRecordingStrategy.ts       |  10 +-
frontend/src/utils/__tests__/audioRecordingStrategy.test.ts | 6 +-
```

### Test plan
- [x] Backend unit tests (test_audio_upload.py) 16/16 passed
- [x] Frontend typecheck / lint clean
- [x] Staging 已驗證 #664 與 #667
- [ ] Production smoke test after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)