### PR TITLE
feat: 系統管理員介面更新 (Fixes #456)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -4,8 +4,9 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
 from sqlalchemy import or_, func
 from typing import Dict, Any, Optional
-from pydantic import BaseModel, EmailStr
-from datetime import datetime, timezone
+from pydantic import BaseModel, EmailStr, Field
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
 import logging
 
 from database import get_db, get_engine, Base
@@ -95,9 +96,9 @@ class AdminGrantCreditRequest(BaseModel):
     """管理員贈送點數包請求"""
 
     teacher_email: EmailStr
-    points: int  # 點數數量
-    reason: str  # 贈送原因
-    expires_days: int = 365  # 有效天數，預設 365 天
+    points: int = Field(gt=0, le=100_000)  # 點數數量，上限 100,000 防誤填
+    reason: str = Field(max_length=500)  # 贈送原因
+    expires_days: int = Field(default=365, gt=0, le=3650)  # 有效天數
 
 
 class ExtensionHistoryRecord(BaseModel):
@@ -358,10 +359,8 @@ async def list_teachers(
         )
         .all()
     )
-    credit_packages_by_teacher = {}
+    credit_packages_by_teacher = defaultdict(list)
     for pkg in all_credit_packages:
-        if pkg.teacher_id not in credit_packages_by_teacher:
-            credit_packages_by_teacher[pkg.teacher_id] = []
         credit_packages_by_teacher[pkg.teacher_id].append(pkg)
 
     # Build maps: teacher_id -> [periods] and teacher_id -> latest_period
@@ -1240,22 +1239,9 @@ async def grant_credit_package(
     """
     管理員贈送點數包給教師
 
-    建立一個 source=admin_grant 的 CreditPackage
+    建立一個 source=admin_grant 的 CreditPackage。
+    輸入驗證由 AdminGrantCreditRequest 的 Pydantic Field 處理。
     """
-    from datetime import timedelta
-
-    if grant_req.points <= 0:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Points must be greater than 0",
-        )
-
-    if grant_req.expires_days <= 0:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Expires days must be greater than 0",
-        )
-
     # 🔒 Case-insensitive email lookup
     teacher = (
         db.query(Teacher)

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -29,6 +29,7 @@ from models import (
     Organization,
     TeacherOrganization,
 )
+from models.credit_package import CreditPackage
 from routers.teachers import get_current_teacher
 from services.tappay_service import TapPayService
 from services.casbin_service import CasbinService
@@ -82,6 +83,21 @@ class TeacherSubscriptionInfo(BaseModel):
     status: str  # active/expired/cancelled/none
     total_periods: int  # 總共訂閱過幾期
     created_at: str
+    # Credit package (trial bonus / admin grant) info
+    credit_points_total: int = 0
+    credit_points_used: int = 0
+    credit_points_remaining: int = 0
+    has_trial_bonus: bool = False
+    email_verified: bool = False
+
+
+class AdminGrantCreditRequest(BaseModel):
+    """管理員贈送點數包請求"""
+
+    teacher_email: EmailStr
+    points: int  # 點數數量
+    reason: str  # 贈送原因
+    expires_days: int = 365  # 有效天數，預設 365 天
 
 
 class ExtensionHistoryRecord(BaseModel):
@@ -333,6 +349,21 @@ async def list_teachers(
         .all()
     )
 
+    # 🔥 Preload credit packages for all teachers (avoid N+1)
+    all_credit_packages = (
+        db.query(CreditPackage)
+        .filter(
+            CreditPackage.teacher_id.in_(teacher_ids),
+            CreditPackage.status == "active",
+        )
+        .all()
+    )
+    credit_packages_by_teacher = {}
+    for pkg in all_credit_packages:
+        if pkg.teacher_id not in credit_packages_by_teacher:
+            credit_packages_by_teacher[pkg.teacher_id] = []
+        credit_packages_by_teacher[pkg.teacher_id].append(pkg)
+
     # Build maps: teacher_id -> [periods] and teacher_id -> latest_period
     periods_by_teacher = {}
     latest_period_by_teacher = {}
@@ -398,6 +429,14 @@ async def list_teachers(
             if status_filter != subscription_status:
                 continue
 
+        # 🔥 Credit package info
+        teacher_credit_packages = credit_packages_by_teacher.get(teacher.id, [])
+        credit_points_total = sum(p.points_total for p in teacher_credit_packages)
+        credit_points_used = sum(p.points_used for p in teacher_credit_packages)
+        has_trial_bonus = any(
+            p.source == "trial_bonus" for p in teacher_credit_packages
+        )
+
         result.append(
             TeacherSubscriptionInfo(
                 id=teacher.id,
@@ -418,6 +457,11 @@ async def list_teachers(
                 created_at=teacher.created_at.isoformat()
                 if teacher.created_at
                 else None,
+                credit_points_total=credit_points_total,
+                credit_points_used=credit_points_used,
+                credit_points_remaining=credit_points_total - credit_points_used,
+                has_trial_bonus=has_trial_bonus,
+                email_verified=teacher.email_verified or False,
             )
         )
 
@@ -736,10 +780,13 @@ async def create_organization_as_admin(
     Returns organization ID and owner info.
     """
 
-    # Validate owner exists and is verified
+    # Validate owner exists and is verified (case-insensitive)
     owner = (
         db.query(Teacher)
-        .filter(Teacher.email == org_data.owner_email, Teacher.email_verified.is_(True))
+        .filter(
+            func.lower(Teacher.email) == org_data.owner_email.strip().lower(),
+            Teacher.email_verified.is_(True),
+        )
         .first()
     )
 
@@ -770,7 +817,10 @@ async def create_organization_as_admin(
         for staff_email in org_data.project_staff_emails:
             staff_teacher = (
                 db.query(Teacher)
-                .filter(Teacher.email == staff_email, Teacher.email_verified.is_(True))
+                .filter(
+                    func.lower(Teacher.email) == staff_email.strip().lower(),
+                    Teacher.email_verified.is_(True),
+                )
                 .first()
             )
 
@@ -1158,7 +1208,12 @@ async def get_teacher_by_email(
     - 404 if teacher not found
     - 403 if caller is not admin
     """
-    teacher = db.query(Teacher).filter(Teacher.email == email).first()
+    # 🔒 Email case-insensitive lookup
+    teacher = (
+        db.query(Teacher)
+        .filter(func.lower(Teacher.email) == email.strip().lower())
+        .first()
+    )
 
     if not teacher:
         raise HTTPException(
@@ -1173,3 +1228,84 @@ async def get_teacher_by_email(
         phone=teacher.phone,
         email_verified=teacher.email_verified,
     )
+
+
+# ============ 點數贈送 API ============
+@router.post("/credit-packages/grant")
+async def grant_credit_package(
+    grant_req: AdminGrantCreditRequest,
+    admin: Teacher = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    """
+    管理員贈送點數包給教師
+
+    建立一個 source=admin_grant 的 CreditPackage
+    """
+    from datetime import timedelta
+
+    if grant_req.points <= 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Points must be greater than 0",
+        )
+
+    if grant_req.expires_days <= 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Expires days must be greater than 0",
+        )
+
+    # 🔒 Case-insensitive email lookup
+    teacher = (
+        db.query(Teacher)
+        .filter(func.lower(Teacher.email) == grant_req.teacher_email.strip().lower())
+        .first()
+    )
+
+    if not teacher:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Teacher with email {grant_req.teacher_email} not found",
+        )
+
+    now = datetime.now(timezone.utc)
+
+    credit_package = CreditPackage(
+        teacher_id=teacher.id,
+        package_id="admin-grant",
+        points_total=grant_req.points,
+        points_used=0,
+        price_paid=0,
+        purchased_at=now,
+        expires_at=now + timedelta(days=grant_req.expires_days),
+        status="active",
+        source="admin_grant",
+    )
+
+    db.add(credit_package)
+    db.commit()
+    db.refresh(credit_package)
+
+    logger.info(
+        f"Admin {admin.email} granted {grant_req.points} points to {teacher.email}. "
+        f"Reason: {grant_req.reason}"
+    )
+
+    return {
+        "message": f"Successfully granted {grant_req.points} points to {teacher.email}",
+        "credit_package": {
+            "id": credit_package.id,
+            "teacher_id": teacher.id,
+            "teacher_email": teacher.email,
+            "teacher_name": teacher.name,
+            "points_total": credit_package.points_total,
+            "expires_at": credit_package.expires_at.isoformat(),
+            "source": credit_package.source,
+        },
+        "granted_by": {
+            "admin_id": admin.id,
+            "admin_email": admin.email,
+            "reason": grant_req.reason,
+        },
+    }

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -5,6 +5,7 @@ Admin Subscription Management API
 不依賴 teacher_subscription_transactions
 """
 
+from collections import defaultdict
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session, aliased
 from sqlalchemy import func
@@ -423,7 +424,8 @@ async def get_all_teachers_subscriptions(
     )
 
     # 🔥 Preload credit packages for all teachers (avoid N+1)
-    teacher_ids = [t.id for t, _ in teachers_with_subs]
+    # Deduplicate teacher_ids since the same teacher may appear with multiple periods
+    teacher_ids = list({t.id for t, _ in teachers_with_subs})
     all_credit_packages = (
         db.query(CreditPackage)
         .filter(
@@ -432,10 +434,8 @@ async def get_all_teachers_subscriptions(
         )
         .all()
     )
-    credit_packages_by_teacher = {}
+    credit_packages_by_teacher = defaultdict(list)
     for pkg in all_credit_packages:
-        if pkg.teacher_id not in credit_packages_by_teacher:
-            credit_packages_by_teacher[pkg.teacher_id] = []
         credit_packages_by_teacher[pkg.teacher_id].append(pkg)
 
     result = []
@@ -679,8 +679,6 @@ async def get_transaction_analytics(
         )
 
     # 計算月度統計
-    from collections import defaultdict
-
     monthly_stats = defaultdict(lambda: {"total": 0, "by_teacher": defaultdict(int)})
 
     for txn, teacher in transactions:
@@ -716,8 +714,6 @@ async def get_learning_analytics(
     """
     學習分析：獲取教師的班級、學生、作業、點數使用統計
     """
-    from collections import defaultdict
-
     # 1. 獲取所有教師的基本統計
     teachers = db.query(Teacher).all()
 

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -521,6 +521,36 @@ async def get_teacher_periods(
             }
         )
 
+    # 🔥 Approach A: 同時撈取 credit_packages（trial_bonus / admin_grant / 加購）
+    credit_packages = (
+        db.query(CreditPackage)
+        .filter(CreditPackage.teacher_id == teacher_id)
+        .order_by(CreditPackage.purchased_at.desc())
+        .all()
+    )
+
+    credit_package_list = []
+    for pkg in credit_packages:
+        credit_package_list.append(
+            {
+                "id": pkg.id,
+                "package_id": pkg.package_id,
+                "source": pkg.source,
+                "points_total": pkg.points_total,
+                "points_used": pkg.points_used,
+                "points_remaining": pkg.points_remaining,
+                "price_paid": pkg.price_paid,
+                "purchased_at": pkg.purchased_at.isoformat()
+                if pkg.purchased_at
+                else None,
+                "expires_at": pkg.expires_at.isoformat()
+                if pkg.expires_at
+                else None,
+                "status": pkg.status,
+                "payment_id": pkg.payment_id,
+            }
+        )
+
     return {
         "teacher": {
             "id": teacher.id,
@@ -528,7 +558,9 @@ async def get_teacher_periods(
             "email": teacher.email,
         },
         "periods": period_list,
+        "credit_packages": credit_package_list,
         "total": len(period_list),
+        "credit_packages_total": len(credit_package_list),
     }
 
 

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -543,9 +543,7 @@ async def get_teacher_periods(
                 "purchased_at": pkg.purchased_at.isoformat()
                 if pkg.purchased_at
                 else None,
-                "expires_at": pkg.expires_at.isoformat()
-                if pkg.expires_at
-                else None,
+                "expires_at": pkg.expires_at.isoformat() if pkg.expires_at else None,
                 "status": pkg.status,
                 "payment_id": pkg.payment_id,
             }

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -25,6 +25,7 @@ from models import (
     PointUsageLog,
     ClassroomStudent,
 )
+from models.credit_package import CreditPackage
 from routers.admin import get_current_admin
 
 router = APIRouter(prefix="/api/admin/subscription", tags=["admin-subscription"])
@@ -421,13 +422,40 @@ async def get_all_teachers_subscriptions(
         .all()
     )
 
+    # 🔥 Preload credit packages for all teachers (avoid N+1)
+    teacher_ids = [t.id for t, _ in teachers_with_subs]
+    all_credit_packages = (
+        db.query(CreditPackage)
+        .filter(
+            CreditPackage.teacher_id.in_(teacher_ids),
+            CreditPackage.status == "active",
+        )
+        .all()
+    )
+    credit_packages_by_teacher = {}
+    for pkg in all_credit_packages:
+        if pkg.teacher_id not in credit_packages_by_teacher:
+            credit_packages_by_teacher[pkg.teacher_id] = []
+        credit_packages_by_teacher[pkg.teacher_id].append(pkg)
+
     result = []
     for teacher, period in teachers_with_subs:
+        # Credit package info
+        teacher_pkgs = credit_packages_by_teacher.get(teacher.id, [])
+        credit_points_total = sum(p.points_total for p in teacher_pkgs)
+        credit_points_used = sum(p.points_used for p in teacher_pkgs)
+        has_trial_bonus = any(p.source == "trial_bonus" for p in teacher_pkgs)
+
         teacher_data = {
             "teacher_id": teacher.id,
             "teacher_name": teacher.name,
             "teacher_email": teacher.email,
+            "email_verified": teacher.email_verified or False,
             "current_subscription": None,
+            "credit_points_total": credit_points_total,
+            "credit_points_used": credit_points_used,
+            "credit_points_remaining": credit_points_total - credit_points_used,
+            "has_trial_bonus": has_trial_bonus,
         }
 
         if period:

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Body, Request
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy import func
 from sqlalchemy.orm import Session
+from sqlalchemy import func
 from typing import Optional  # noqa: F401
 from pydantic import BaseModel, EmailStr, field_validator
 from database import get_db
@@ -225,10 +226,13 @@ async def teacher_register(
     if not is_valid:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=error_msg)
 
+    # 🔒 Email case-insensitive: normalize to lowercase before storing
+    normalized_email = register_req.email.strip().lower()
+
     # Check if email exists (case-insensitive, matches the unique functional index)
     existing = (
         db.query(Teacher)
-        .filter(func.lower(Teacher.email) == register_req.email.lower())
+        .filter(func.lower(Teacher.email) == normalized_email)
         .first()
     )
     if existing:
@@ -245,7 +249,7 @@ async def teacher_register(
 
     # Create new teacher (未啟用，需要 email 驗證)
     new_teacher = Teacher(
-        email=register_req.email,
+        email=normalized_email,
         password_hash=get_password_hash(register_req.password),
         name=register_req.name,
         phone=register_req.phone,
@@ -564,7 +568,7 @@ async def forgot_password(
     request: Request, email: str = Body(..., embed=True), db: Session = Depends(get_db)
 ):
     """教師忘記密碼 - 發送重設郵件"""
-    # 查找教師
+    # 查找教師 (case-insensitive)
     teacher = (
         db.query(Teacher).filter(func.lower(Teacher.email) == email.lower()).first()
     )

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -4,7 +4,6 @@ from fastapi import APIRouter, Depends, HTTPException, status, Body, Request
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy import func
 from sqlalchemy.orm import Session
-from sqlalchemy import func
 from typing import Optional  # noqa: F401
 from pydantic import BaseModel, EmailStr, field_validator
 from database import get_db
@@ -231,9 +230,7 @@ async def teacher_register(
 
     # Check if email exists (case-insensitive, matches the unique functional index)
     existing = (
-        db.query(Teacher)
-        .filter(func.lower(Teacher.email) == normalized_email)
-        .first()
+        db.query(Teacher).filter(func.lower(Teacher.email) == normalized_email).first()
     )
     if existing:
         # 如果已經驗證，不允許重複註冊

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -3553,6 +3553,19 @@
       "payment": "Payment",
       "status": "Status"
     },
+    "creditPackageTable": {
+      "title": "Credit Packages",
+      "source": "Source",
+      "package": "Package",
+      "dates": "Purchased / Expires",
+      "points": "Used / Total",
+      "payment": "Payment",
+      "status": "Status",
+      "sourceTrial": "Trial",
+      "sourceGrant": "Grant",
+      "sourcePurchase": "Purchase",
+      "sourceOrgPurchase": "Org Purchase"
+    },
     "history": {
       "title": "Edit History",
       "noHistory": "No edit history",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -3511,7 +3511,18 @@
       "cancel": "Cancel",
       "processing": "Processing...",
       "cancelSubscription": "Cancel Subscription",
-      "updateSubscription": "Update Subscription"
+      "updateSubscription": "Update Subscription",
+      "grantPoints": "Grant"
+    },
+    "grant": {
+      "title": "Grant Points",
+      "points": "Points",
+      "pointsPlaceholder": "e.g. 2000",
+      "expiresDays": "Valid for (days)",
+      "reason": "Reason",
+      "reasonPlaceholder": "Why are these points being granted?",
+      "granting": "Granting...",
+      "confirm": "Confirm Grant"
     },
     "stats": {
       "totalTeachers": "Total Teachers",
@@ -3542,7 +3553,9 @@
     },
     "status": {
       "active": "Active",
-      "none": "None"
+      "none": "None",
+      "trial": "Free Trial",
+      "unverified": "Unverified"
     },
     "periodTable": {
       "title": "Subscription Periods",
@@ -3639,11 +3652,13 @@
       "operationFailed": "Failed: {{detail}}",
       "searchFailed": "Search failed: {{detail}}",
       "loadPeriodsFailed": "Failed to load subscription periods",
-      "loadHistoryFailed": "Failed to load edit history"
+      "loadHistoryFailed": "Failed to load edit history",
+      "grantFailed": "Failed to grant points"
     },
     "messages": {
       "operationSuccess": "Success! {{teacherName}} - {{message}}",
-      "completed": "Operation completed"
+      "completed": "Operation completed",
+      "grantSuccess": "Successfully granted {{points}} points to {{name}}"
     }
   },
   "adminMonitoring": {

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -3535,7 +3535,7 @@
       "plan": "Plan",
       "endDate": "End Date",
       "periods": "Periods",
-      "quota": "Quota",
+      "quota": "Used / Quota",
       "status": "Status",
       "actions": "Actions",
       "noData": "No data"

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -3539,7 +3539,7 @@
       "plan": "方案",
       "endDate": "到期日",
       "periods": "期數",
-      "quota": "配額",
+      "quota": "已使用 / 配額",
       "status": "狀態",
       "actions": "操作",
       "noData": "無資料"

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -3515,7 +3515,18 @@
       "cancel": "取消",
       "processing": "處理中...",
       "cancelSubscription": "取消訂閱",
-      "updateSubscription": "更新訂閱"
+      "updateSubscription": "更新訂閱",
+      "grantPoints": "贈送點數"
+    },
+    "grant": {
+      "title": "贈送點數",
+      "points": "點數",
+      "pointsPlaceholder": "例如：2000",
+      "expiresDays": "有效天數",
+      "reason": "贈送原因",
+      "reasonPlaceholder": "為何贈送這些點數？",
+      "granting": "贈送中...",
+      "confirm": "確認贈送"
     },
     "stats": {
       "totalTeachers": "總教師數",
@@ -3546,7 +3557,9 @@
     },
     "status": {
       "active": "啟用",
-      "none": "無"
+      "none": "無",
+      "trial": "免費試用",
+      "unverified": "未驗證"
     },
     "periodTable": {
       "title": "訂閱期數",
@@ -3643,11 +3656,13 @@
       "operationFailed": "操作失敗：{{detail}}",
       "searchFailed": "搜尋失敗：{{detail}}",
       "loadPeriodsFailed": "無法載入訂閱期數",
-      "loadHistoryFailed": "無法載入編輯歷史"
+      "loadHistoryFailed": "無法載入編輯歷史",
+      "grantFailed": "贈送點數失敗"
     },
     "messages": {
       "operationSuccess": "成功！{{teacherName}} - {{message}}",
-      "completed": "操作完成"
+      "completed": "操作完成",
+      "grantSuccess": "已成功贈送 {{points}} 點給 {{name}}"
     }
   },
   "adminMonitoring": {

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -3557,6 +3557,19 @@
       "payment": "付款",
       "status": "狀態"
     },
+    "creditPackageTable": {
+      "title": "點數包紀錄",
+      "source": "來源",
+      "package": "套餐",
+      "dates": "購買 / 到期",
+      "points": "已使用 / 總計",
+      "payment": "付款",
+      "status": "狀態",
+      "sourceTrial": "試用",
+      "sourceGrant": "贈送",
+      "sourcePurchase": "加購",
+      "sourceOrgPurchase": "機構購買"
+    },
     "history": {
       "title": "編輯歷史",
       "noHistory": "無編輯歷史",

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -21,10 +21,10 @@ export default function AdminDashboard() {
         onValueChange={setActiveTab}
         className="space-y-4 md:space-y-6"
       >
-        <TabsList className="grid w-full max-w-[1000px] grid-cols-4 h-auto md:h-14 bg-white border-2 border-gray-200 p-1">
+        <TabsList className="flex w-full max-w-[1000px] justify-start gap-1 h-auto bg-transparent border-b border-gray-200 rounded-none p-0">
           <TabsTrigger
             value="subscription"
-            className="flex items-center justify-center gap-1.5 md:gap-2 text-xs md:text-base font-semibold py-2 md:py-0 data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=active]:shadow-lg transition-all duration-200"
+            className="flex items-center gap-2 px-4 py-3 text-sm md:text-base font-medium text-gray-500 bg-transparent border-b-2 border-transparent rounded-none data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:border-blue-600 data-[state=active]:font-semibold data-[state=active]:shadow-none hover:text-gray-700 transition-colors"
           >
             <Crown className="h-4 w-4 md:h-5 md:w-5 flex-shrink-0" />
             <span className="hidden sm:inline">訂閱管理</span>
@@ -32,7 +32,7 @@ export default function AdminDashboard() {
           </TabsTrigger>
           <TabsTrigger
             value="billing"
-            className="flex items-center justify-center gap-1.5 md:gap-2 text-xs md:text-base font-semibold py-2 md:py-0 data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=active]:shadow-lg transition-all duration-200"
+            className="flex items-center gap-2 px-4 py-3 text-sm md:text-base font-medium text-gray-500 bg-transparent border-b-2 border-transparent rounded-none data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:border-blue-600 data-[state=active]:font-semibold data-[state=active]:shadow-none hover:text-gray-700 transition-colors"
           >
             <DollarSign className="h-4 w-4 md:h-5 md:w-5 flex-shrink-0" />
             <span className="hidden sm:inline">GCP 費用</span>
@@ -40,7 +40,7 @@ export default function AdminDashboard() {
           </TabsTrigger>
           <TabsTrigger
             value="audio-errors"
-            className="flex items-center justify-center gap-1.5 md:gap-2 text-xs md:text-base font-semibold py-2 md:py-0 data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=active]:shadow-lg transition-all duration-200"
+            className="flex items-center gap-2 px-4 py-3 text-sm md:text-base font-medium text-gray-500 bg-transparent border-b-2 border-transparent rounded-none data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:border-blue-600 data-[state=active]:font-semibold data-[state=active]:shadow-none hover:text-gray-700 transition-colors"
           >
             <AlertTriangle className="h-4 w-4 md:h-5 md:w-5 flex-shrink-0" />
             <span className="hidden sm:inline">錄音錯誤</span>
@@ -48,7 +48,7 @@ export default function AdminDashboard() {
           </TabsTrigger>
           <TabsTrigger
             value="organizations"
-            className="flex items-center justify-center gap-1.5 md:gap-2 text-xs md:text-base font-semibold py-2 md:py-0 data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=active]:shadow-lg transition-all duration-200"
+            className="flex items-center gap-2 px-4 py-3 text-sm md:text-base font-medium text-gray-500 bg-transparent border-b-2 border-transparent rounded-none data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:border-blue-600 data-[state=active]:font-semibold data-[state=active]:shadow-none hover:text-gray-700 transition-colors"
           >
             <Building className="h-4 w-4 md:h-5 md:w-5 flex-shrink-0" />
             <span className="hidden sm:inline">組織管理</span>

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -866,10 +866,10 @@ export default function AdminSubscriptionDashboard() {
       )}
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-        <TabsList className="grid w-full grid-cols-3 mb-4 md:mb-6 h-auto md:h-14 bg-white border-2 border-gray-200 p-1">
+        <TabsList className="flex w-full justify-start gap-1 mb-4 md:mb-6 h-auto bg-transparent border-b border-gray-200 rounded-none p-0">
           <TabsTrigger
             value="subscriptions"
-            className="flex items-center justify-center gap-1.5 md:gap-2 text-xs md:text-base font-semibold py-2 md:py-0 data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=active]:shadow-lg transition-all duration-200"
+            className="flex items-center gap-2 px-4 py-3 text-sm md:text-base font-medium text-gray-500 bg-transparent border-b-2 border-transparent rounded-none data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:border-blue-600 data-[state=active]:font-semibold data-[state=active]:shadow-none hover:text-gray-700 transition-colors"
           >
             <Users className="w-4 h-4 md:w-5 md:h-5 flex-shrink-0" />
             <span className="hidden sm:inline">
@@ -879,7 +879,7 @@ export default function AdminSubscriptionDashboard() {
           </TabsTrigger>
           <TabsTrigger
             value="transactions"
-            className="flex items-center justify-center gap-1.5 md:gap-2 text-xs md:text-base font-semibold py-2 md:py-0 data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=active]:shadow-lg transition-all duration-200"
+            className="flex items-center gap-2 px-4 py-3 text-sm md:text-base font-medium text-gray-500 bg-transparent border-b-2 border-transparent rounded-none data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:border-blue-600 data-[state=active]:font-semibold data-[state=active]:shadow-none hover:text-gray-700 transition-colors"
           >
             <Receipt className="w-4 h-4 md:w-5 md:h-5 flex-shrink-0" />
             <span className="hidden sm:inline">
@@ -889,7 +889,7 @@ export default function AdminSubscriptionDashboard() {
           </TabsTrigger>
           <TabsTrigger
             value="learning"
-            className="flex items-center justify-center gap-1.5 md:gap-2 text-xs md:text-base font-semibold py-2 md:py-0 data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=active]:shadow-lg transition-all duration-200"
+            className="flex items-center gap-2 px-4 py-3 text-sm md:text-base font-medium text-gray-500 bg-transparent border-b-2 border-transparent rounded-none data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:border-blue-600 data-[state=active]:font-semibold data-[state=active]:shadow-none hover:text-gray-700 transition-colors"
           >
             <GraduationCap className="w-4 h-4 md:w-5 md:h-5 flex-shrink-0" />
             <span className="hidden sm:inline">

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -104,6 +104,20 @@ interface SubscriptionPeriod {
   amount_paid?: number;
 }
 
+interface CreditPackageInfo {
+  id: number;
+  package_id: string;
+  source: string; // "trial_bonus" | "admin_grant" | "purchase" | "org_purchase"
+  points_total: number;
+  points_used: number;
+  points_remaining: number;
+  price_paid: number;
+  purchased_at: string;
+  expires_at: string;
+  status: string;
+  payment_id?: string;
+}
+
 interface EditHistoryRecord {
   action: string;
   admin_email: string;
@@ -218,6 +232,9 @@ export default function AdminSubscriptionDashboard() {
   const [expandedPeriodId, setExpandedPeriodId] = useState<number | null>(null);
   const [teacherPeriods, setTeacherPeriods] = useState<
     Record<number, SubscriptionPeriod[]>
+  >({});
+  const [teacherCreditPackages, setTeacherCreditPackages] = useState<
+    Record<number, CreditPackageInfo[]>
   >({});
   const [periodHistory, setPeriodHistory] = useState<
     Record<number, EditHistoryRecord[]>
@@ -609,26 +626,24 @@ export default function AdminSubscriptionDashboard() {
       setExpandedTeacherId(teacherId);
       setExpandedPeriodId(null);
 
-      // Fetch periods if not already loaded
+      // Fetch periods + credit_packages if not already loaded
       if (!teacherPeriods[teacherId]) {
         try {
           const response = await apiClient.get(
             `/api/admin/subscription/teacher/${teacherId}/periods`,
           );
-          const periods = (response as { periods: SubscriptionPeriod[] })
-            .periods;
-
-          // Debug: 檢查第一個 period 的資料
-          if (periods.length > 0) {
-            console.log("🔍 Period data:", periods[0]);
-            console.log("payment_id:", periods[0].payment_id);
-            console.log("payment_status:", periods[0].payment_status);
-            console.log("status:", periods[0].status);
-          }
+          const data = response as {
+            periods: SubscriptionPeriod[];
+            credit_packages?: CreditPackageInfo[];
+          };
 
           setTeacherPeriods((prev) => ({
             ...prev,
-            [teacherId]: periods,
+            [teacherId]: data.periods,
+          }));
+          setTeacherCreditPackages((prev) => ({
+            ...prev,
+            [teacherId]: data.credit_packages || [],
           }));
         } catch (error) {
           console.error("Failed to load periods:", error);
@@ -1565,6 +1580,161 @@ export default function AdminSubscriptionDashboard() {
                                       </TableBody>
                                     </Table>
                                   </div>
+
+                                  {/* Layer 2b: Credit Packages (trial / admin_grant / purchase) */}
+                                  {teacherCreditPackages[teacher.teacher_id] &&
+                                    teacherCreditPackages[teacher.teacher_id]
+                                      .length > 0 && (
+                                      <div className="p-4 pt-0">
+                                        <h4 className="font-semibold mb-3 text-sm">
+                                          {t(
+                                            "adminSubscription.creditPackageTable.title",
+                                            "點數包紀錄",
+                                          )}
+                                        </h4>
+                                        <Table>
+                                          <TableHeader>
+                                            <TableRow>
+                                              <TableHead>
+                                                {t(
+                                                  "adminSubscription.creditPackageTable.source",
+                                                  "來源",
+                                                )}
+                                              </TableHead>
+                                              <TableHead>
+                                                {t(
+                                                  "adminSubscription.creditPackageTable.package",
+                                                  "套餐",
+                                                )}
+                                              </TableHead>
+                                              <TableHead>
+                                                {t(
+                                                  "adminSubscription.creditPackageTable.dates",
+                                                  "購買 / 到期",
+                                                )}
+                                              </TableHead>
+                                              <TableHead>
+                                                {t(
+                                                  "adminSubscription.creditPackageTable.points",
+                                                  "已使用 / 總計",
+                                                )}
+                                              </TableHead>
+                                              <TableHead>
+                                                {t(
+                                                  "adminSubscription.creditPackageTable.payment",
+                                                  "付款",
+                                                )}
+                                              </TableHead>
+                                              <TableHead>
+                                                {t(
+                                                  "adminSubscription.creditPackageTable.status",
+                                                  "狀態",
+                                                )}
+                                              </TableHead>
+                                            </TableRow>
+                                          </TableHeader>
+                                          <TableBody>
+                                            {teacherCreditPackages[
+                                              teacher.teacher_id
+                                            ].map((pkg) => {
+                                              const sourceBadge = {
+                                                trial_bonus: {
+                                                  label: t(
+                                                    "adminSubscription.creditPackageTable.sourceTrial",
+                                                    "試用",
+                                                  ),
+                                                  className:
+                                                    "bg-purple-100 text-purple-700",
+                                                },
+                                                admin_grant: {
+                                                  label: t(
+                                                    "adminSubscription.creditPackageTable.sourceGrant",
+                                                    "贈送",
+                                                  ),
+                                                  className:
+                                                    "bg-orange-100 text-orange-700",
+                                                },
+                                                purchase: {
+                                                  label: t(
+                                                    "adminSubscription.creditPackageTable.sourcePurchase",
+                                                    "加購",
+                                                  ),
+                                                  className:
+                                                    "bg-green-100 text-green-700",
+                                                },
+                                                org_purchase: {
+                                                  label: t(
+                                                    "adminSubscription.creditPackageTable.sourceOrgPurchase",
+                                                    "機構購買",
+                                                  ),
+                                                  className:
+                                                    "bg-green-100 text-green-700",
+                                                },
+                                              }[pkg.source] || {
+                                                label: pkg.source,
+                                                className:
+                                                  "bg-gray-100 text-gray-700",
+                                              };
+
+                                              return (
+                                                <TableRow key={`pkg-${pkg.id}`}>
+                                                  <TableCell>
+                                                    <span
+                                                      className={`px-2 py-1 rounded text-xs font-semibold ${sourceBadge.className}`}
+                                                    >
+                                                      {sourceBadge.label}
+                                                    </span>
+                                                  </TableCell>
+                                                  <TableCell className="font-mono text-xs text-gray-600">
+                                                    {pkg.package_id}
+                                                  </TableCell>
+                                                  <TableCell className="text-sm text-gray-600">
+                                                    {formatDate(
+                                                      pkg.purchased_at,
+                                                    )}{" "}
+                                                    →{" "}
+                                                    {formatDate(pkg.expires_at)}
+                                                  </TableCell>
+                                                  <TableCell>
+                                                    <div className="space-y-1">
+                                                      <div className="text-sm">
+                                                        {pkg.points_used.toLocaleString()}{" "}
+                                                        /{" "}
+                                                        {pkg.points_total.toLocaleString()}
+                                                      </div>
+                                                      <div className="w-full bg-gray-200 rounded-full h-1.5">
+                                                        <div
+                                                          className="bg-purple-500 h-1.5 rounded-full"
+                                                          style={{
+                                                            width: `${Math.min((pkg.points_used / pkg.points_total) * 100 || 0, 100)}%`,
+                                                          }}
+                                                        />
+                                                      </div>
+                                                    </div>
+                                                  </TableCell>
+                                                  <TableCell className="text-sm">
+                                                    {pkg.price_paid > 0
+                                                      ? `NT$ ${pkg.price_paid.toLocaleString()}`
+                                                      : "-"}
+                                                  </TableCell>
+                                                  <TableCell>
+                                                    <span
+                                                      className={`px-2 py-1 rounded text-xs font-semibold ${
+                                                        pkg.status === "active"
+                                                          ? "bg-green-100 text-green-700"
+                                                          : "bg-gray-100 text-gray-600"
+                                                      }`}
+                                                    >
+                                                      {pkg.status}
+                                                    </span>
+                                                  </TableCell>
+                                                </TableRow>
+                                              );
+                                            })}
+                                          </TableBody>
+                                        </Table>
+                                      </div>
+                                    )}
                                 </TableCell>
                               </TableRow>
                             )}

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -47,6 +47,7 @@ import {
   ChevronRight,
   ChevronDown,
   Receipt,
+  Gift,
   GraduationCap,
   Download,
   RefreshCcw,
@@ -1107,7 +1108,7 @@ export default function AdminSubscriptionDashboard() {
                                   onClick={() => handleOpenGrantModal(teacher)}
                                   className="h-8 text-purple-600 border-purple-300 hover:bg-purple-50"
                                 >
-                                  <GraduationCap className="w-3 h-3 mr-1" />
+                                  <Gift className="w-3 h-3 mr-1" />
                                   {t(
                                     "adminSubscription.buttons.grantPoints",
                                     "Grant",
@@ -2532,7 +2533,7 @@ export default function AdminSubscriptionDashboard() {
                   </>
                 ) : (
                   <>
-                    <GraduationCap className="w-4 h-4 mr-2" />
+                    <Gift className="w-4 h-4 mr-2" />
                     {t("adminSubscription.grant.confirm", "Confirm Grant")}
                   </>
                 )}

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -75,6 +75,7 @@ interface TeacherSubscriptionInfo {
   teacher_id: number;
   teacher_name: string;
   teacher_email: string;
+  email_verified: boolean;
   current_subscription: {
     period_id: number;
     plan_name: string;
@@ -83,6 +84,10 @@ interface TeacherSubscriptionInfo {
     end_date: string;
     status: string;
   } | null;
+  credit_points_total: number;
+  credit_points_used: number;
+  credit_points_remaining: number;
+  has_trial_bonus: boolean;
 }
 
 interface SubscriptionPeriod {
@@ -246,6 +251,14 @@ export default function AdminSubscriptionDashboard() {
     notes: "",
   });
 
+  // Grant points modal state
+  const [grantModalOpen, setGrantModalOpen] = useState(false);
+  const [grantForm, setGrantForm] = useState({
+    points: undefined as number | undefined,
+    reason: "",
+    expires_days: 365,
+  });
+
   useEffect(() => {
     loadDashboardData();
   }, []);
@@ -339,6 +352,51 @@ export default function AdminSubscriptionDashboard() {
       reason: "",
     });
     setEditModalOpen(true);
+  };
+
+  const handleOpenGrantModal = (teacher: TeacherSubscriptionInfo) => {
+    setSelectedTeacher(teacher);
+    setGrantForm({
+      points: undefined,
+      reason: "",
+      expires_days: 365,
+    });
+    setGrantModalOpen(true);
+  };
+
+  const handleSubmitGrant = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedTeacher || !grantForm.points || !grantForm.reason) return;
+
+    try {
+      setLoading(true);
+      await apiClient.post("/api/admin/credit-packages/grant", {
+        teacher_email: selectedTeacher.teacher_email,
+        points: grantForm.points,
+        reason: grantForm.reason,
+        expires_days: grantForm.expires_days,
+      });
+
+      setSuccessMessage(
+        t("adminSubscription.messages.grantSuccess", {
+          points: grantForm.points,
+          name: selectedTeacher.teacher_name,
+          defaultValue: `Successfully granted ${grantForm.points} points to ${selectedTeacher.teacher_name}`,
+        }),
+      );
+      setGrantModalOpen(false);
+      loadDashboardData();
+    } catch (error: unknown) {
+      if (isApiError(error)) {
+        setErrorMessage(
+          error.response?.data?.detail ||
+            error.message ||
+            t("adminSubscription.errors.grantFailed", "Failed to grant points"),
+        );
+      }
+    } finally {
+      setLoading(false);
+    }
   };
 
   const handleOpenRefundModal = (period: SubscriptionPeriod) => {
@@ -977,6 +1035,22 @@ export default function AdminSubscriptionDashboard() {
                                     />
                                   </div>
                                 </div>
+                              ) : teacher.credit_points_total > 0 ? (
+                                <div className="space-y-1">
+                                  <div className="text-sm text-purple-700">
+                                    {teacher.credit_points_used.toLocaleString()}{" "}
+                                    /{" "}
+                                    {teacher.credit_points_total.toLocaleString()}
+                                  </div>
+                                  <div className="w-full bg-gray-200 rounded-full h-2">
+                                    <div
+                                      className="bg-purple-500 h-2 rounded-full"
+                                      style={{
+                                        width: `${Math.min((teacher.credit_points_used / teacher.credit_points_total) * 100 || 0, 100)}%`,
+                                      }}
+                                    />
+                                  </div>
+                                </div>
                               ) : (
                                 "-"
                               )}
@@ -987,6 +1061,14 @@ export default function AdminSubscriptionDashboard() {
                                 <span className="px-2 py-1 bg-green-100 text-green-800 rounded text-xs">
                                   {t("adminSubscription.status.active")}
                                 </span>
+                              ) : teacher.has_trial_bonus ? (
+                                <span className="px-2 py-1 bg-purple-100 text-purple-800 rounded text-xs">
+                                  {t("adminSubscription.status.trial", "Free Trial")}
+                                </span>
+                              ) : !teacher.email_verified ? (
+                                <span className="px-2 py-1 bg-yellow-100 text-yellow-800 rounded text-xs">
+                                  {t("adminSubscription.status.unverified", "Unverified")}
+                                </span>
                               ) : (
                                 <span className="px-2 py-1 bg-gray-100 text-gray-800 rounded text-xs">
                                   {t("adminSubscription.status.none")}
@@ -994,15 +1076,26 @@ export default function AdminSubscriptionDashboard() {
                               )}
                             </TableCell>
                             <TableCell onClick={(e) => e.stopPropagation()}>
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                onClick={() => handleOpenEditModal(teacher)}
-                                className="h-8"
-                              >
-                                <Edit className="w-3 h-3 mr-1" />
-                                {t("adminSubscription.buttons.edit")}
-                              </Button>
+                              <div className="flex gap-1">
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => handleOpenEditModal(teacher)}
+                                  className="h-8"
+                                >
+                                  <Edit className="w-3 h-3 mr-1" />
+                                  {t("adminSubscription.buttons.edit")}
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => handleOpenGrantModal(teacher)}
+                                  className="h-8 text-purple-600 border-purple-300 hover:bg-purple-50"
+                                >
+                                  <GraduationCap className="w-3 h-3 mr-1" />
+                                  {t("adminSubscription.buttons.grantPoints", "Grant")}
+                                </Button>
+                              </div>
                             </TableCell>
                           </TableRow>
 
@@ -2159,6 +2252,112 @@ export default function AdminSubscriptionDashboard() {
                   <>
                     <RefreshCcw className="w-4 h-4 mr-2" />
                     Confirm Refund
+                  </>
+                )}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Grant Points Modal */}
+      <Dialog open={grantModalOpen} onOpenChange={setGrantModalOpen}>
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle>
+              {t("adminSubscription.grant.title", "Grant Points")}
+            </DialogTitle>
+            <DialogDescription>
+              {selectedTeacher &&
+                `${selectedTeacher.teacher_name} (${selectedTeacher.teacher_email})`}
+            </DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={handleSubmitGrant} className="space-y-4 mt-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                {t("adminSubscription.grant.points", "Points")}{" "}
+                <span className="text-red-500">*</span>
+              </label>
+              <Input
+                type="number"
+                value={grantForm.points || ""}
+                onChange={(e) =>
+                  setGrantForm({
+                    ...grantForm,
+                    points: e.target.value
+                      ? parseInt(e.target.value)
+                      : undefined,
+                  })
+                }
+                placeholder={t(
+                  "adminSubscription.grant.pointsPlaceholder",
+                  "e.g. 2000",
+                )}
+                min="1"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                {t("adminSubscription.grant.expiresDays", "Valid for (days)")}{" "}
+              </label>
+              <Input
+                type="number"
+                value={grantForm.expires_days}
+                onChange={(e) =>
+                  setGrantForm({
+                    ...grantForm,
+                    expires_days: parseInt(e.target.value) || 365,
+                  })
+                }
+                min="1"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                {t("adminSubscription.grant.reason", "Reason")}{" "}
+                <span className="text-red-500">*</span>
+              </label>
+              <Textarea
+                value={grantForm.reason}
+                onChange={(e) =>
+                  setGrantForm({ ...grantForm, reason: e.target.value })
+                }
+                placeholder={t(
+                  "adminSubscription.grant.reasonPlaceholder",
+                  "Why are these points being granted?",
+                )}
+                required
+                rows={3}
+              />
+            </div>
+
+            <div className="flex gap-2 justify-end pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setGrantModalOpen(false)}
+                disabled={loading}
+              >
+                {t("common.cancel", "Cancel")}
+              </Button>
+              <Button
+                type="submit"
+                className="bg-purple-600 hover:bg-purple-700 text-white"
+                disabled={loading || !grantForm.points || !grantForm.reason}
+              >
+                {loading ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    {t("adminSubscription.grant.granting", "Granting...")}
+                  </>
+                ) : (
+                  <>
+                    <GraduationCap className="w-4 h-4 mr-2" />
+                    {t("adminSubscription.grant.confirm", "Confirm Grant")}
                   </>
                 )}
               </Button>

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -1078,11 +1078,17 @@ export default function AdminSubscriptionDashboard() {
                                 </span>
                               ) : teacher.has_trial_bonus ? (
                                 <span className="px-2 py-1 bg-purple-100 text-purple-800 rounded text-xs">
-                                  {t("adminSubscription.status.trial", "Free Trial")}
+                                  {t(
+                                    "adminSubscription.status.trial",
+                                    "Free Trial",
+                                  )}
                                 </span>
                               ) : !teacher.email_verified ? (
                                 <span className="px-2 py-1 bg-yellow-100 text-yellow-800 rounded text-xs">
-                                  {t("adminSubscription.status.unverified", "Unverified")}
+                                  {t(
+                                    "adminSubscription.status.unverified",
+                                    "Unverified",
+                                  )}
                                 </span>
                               ) : (
                                 <span className="px-2 py-1 bg-gray-100 text-gray-800 rounded text-xs">
@@ -1108,7 +1114,10 @@ export default function AdminSubscriptionDashboard() {
                                   className="h-8 text-purple-600 border-purple-300 hover:bg-purple-50"
                                 >
                                   <GraduationCap className="w-3 h-3 mr-1" />
-                                  {t("adminSubscription.buttons.grantPoints", "Grant")}
+                                  {t(
+                                    "adminSubscription.buttons.grantPoints",
+                                    "Grant",
+                                  )}
                                 </Button>
                               </div>
                             </TableCell>
@@ -2471,7 +2480,10 @@ export default function AdminSubscriptionDashboard() {
 
             <div className="space-y-2">
               <label className="text-sm font-medium">
-                {t("adminSubscription.grant.expiresDays", "Valid for (days)")}{" "}
+                {t(
+                  "adminSubscription.grant.expiresDays",
+                  "Valid for (days)",
+                )}{" "}
               </label>
               <Input
                 type="number"

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -448,12 +448,6 @@ export default function AdminSubscriptionDashboard() {
       return;
     }
 
-    console.log("🔄 Sending refund request:", {
-      rec_trade_id: selectedPeriod.payment_id,
-      amount: refundForm.amount,
-      reason: refundForm.reason,
-    });
-
     try {
       setLoading(true);
       await apiClient.post("/api/admin/refund", {
@@ -1177,7 +1171,7 @@ export default function AdminSubscriptionDashboard() {
                                       <TableBody>
                                         {teacherPeriods[teacher.teacher_id].map(
                                           (period) => (
-                                            <>
+                                            <React.Fragment key={period.id}>
                                               <TableRow
                                                 key={period.id}
                                                 className="cursor-pointer hover:bg-gray-100"
@@ -1583,7 +1577,7 @@ export default function AdminSubscriptionDashboard() {
                                                     </TableCell>
                                                   </TableRow>
                                                 )}
-                                            </>
+                                            </React.Fragment>
                                           ),
                                         )}
                                       </TableBody>


### PR DESCRIPTION
## Summary

實作 #456 系統管理員介面更新，涵蓋三個子任務：

### 1. 顯示新註冊用戶試用點數狀態
- 後端 admin teachers API 加入 credit package 資訊（`credit_points_total/used/remaining`、`has_trial_bonus`、`email_verified`）
- 前端列表用紫色配額條顯示試用點數，加上 Free Trial / Unverified 狀態 badge

### 2. Email 大小寫不敏感
- 註冊時 email 統一轉小寫存入
- 登入、忘記密碼、admin lookup 等改用 `func.lower()` case-insensitive 查詢
- DB migration 由 #640 獨立發 PR（已 merged）

### 3. 管理員贈送點數包
- 新增 `POST /api/admin/credit-packages/grant` 端點
- 前端教師列表加「Grant」按鈕 + Dialog（可設定點數、有效天數、原因）

### 額外改進
- **Tab UI 重設計**：四個 admin tabs + 三個 sub tabs 改為 underline 風格（取代原本厚重的填色 box）
- **配額欄位**：「配額」→「已使用 / 配額」，更明確
- **點數包紀錄子表（Approach A）**：展開老師詳細時，除訂閱期數外多顯示一個點數包子表（試用/贈送/加購）

## 拆出的後續 issues

| Issue | 內容 |
|-------|------|
| #637 | 推銷碼（Promo Code）系統 |
| #670 | Approach B 統一「點數紀錄」表 |
| #671 | 「已使用 / 配額」加總所有點數來源 |

## Test plan
- [ ] 用大寫 email 註冊 → 儲存為小寫
- [ ] 用不同大小寫重複註冊 → 被擋下（依賴 #640 migration）
- [ ] 管理員列表正確顯示新用戶 Free Trial 標籤與 0/2,000 配額
- [ ] 管理員點 Grant 按鈕能成功贈送點數
- [ ] 展開老師詳細看得到點數包紀錄子表（試用/贈送/加購）
- [ ] Underline tab 樣式在 desktop / mobile 正常顯示
- [ ] 既有付費訂閱用戶不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)