### PR TITLE
migration: allow word_spelling and word_cloze in check_practice_mode constraint

### DIFF
--- a/backend/alembic/versions/20260422_1500_add_word_spelling_cloze_to_practice_mode_constraint.py
+++ b/backend/alembic/versions/20260422_1500_add_word_spelling_cloze_to_practice_mode_constraint.py
@@ -1,0 +1,72 @@
+"""Add word_spelling and word_cloze to check_practice_mode constraint
+
+The practice_sessions table has a CHECK constraint on practice_mode.
+Issue #262 introduces two new modes (word_spelling, word_cloze) that
+must be allowed by the constraint.
+
+Idempotent: safely re-creates the constraint with the full set of
+known practice modes regardless of current state.
+
+Revision ID: 20260422_1500
+Revises: 20260422_1200
+Create Date: 2026-04-22
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "20260422_1500"
+down_revision = "20260422_1200"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Re-create check_practice_mode with word_spelling/word_cloze included."""
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'check_practice_mode'
+            ) THEN
+                ALTER TABLE practice_sessions
+                    DROP CONSTRAINT check_practice_mode;
+            END IF;
+
+            ALTER TABLE practice_sessions
+            ADD CONSTRAINT check_practice_mode
+            CHECK (practice_mode IN (
+                'listening',
+                'writing',
+                'word_selection',
+                'word_reading',
+                'word_spelling',
+                'word_cloze',
+                'rearrangement',
+                'tug_of_war'
+            ));
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    """Revert to the previous narrower set."""
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'check_practice_mode'
+            ) THEN
+                ALTER TABLE practice_sessions
+                    DROP CONSTRAINT check_practice_mode;
+            END IF;
+
+            ALTER TABLE practice_sessions
+            ADD CONSTRAINT check_practice_mode
+            CHECK (practice_mode IN ('listening', 'writing', 'word_selection'));
+        END $$;
+        """
+    )


### PR DESCRIPTION
## Summary

Standalone migration extracted from PR #641 so it can land on staging independently of the Issue #262 feature implementation.

The \`practice_sessions\` table has a \`check_practice_mode\` CHECK constraint that currently only allows \`listening\`, \`writing\`, \`word_selection\`. The new vocabulary practice modes (\`word_spelling\`, \`word_cloze\`) introduced in #641 fail with \`CheckViolation\` when inserting practice session rows.

This migration idempotently re-creates the constraint with the full set of known practice modes:
- \`listening\`
- \`writing\`
- \`word_selection\`
- \`word_reading\`
- \`word_spelling\` (new)
- \`word_cloze\` (new)
- \`rearrangement\`
- \`tug_of_war\`

## Why standalone

- The constraint update is database-level and applies to all environments
- It can be reviewed/merged independently from the feature
- Once on staging, all per-issue deployments (including #641) inherit it

## Test plan

- [ ] CI passes
- [ ] Migration runs cleanly on staging (idempotent — safe to re-run)
- [ ] After merge, PR #641 per-issue env stops returning 500 on \`/vocabulary/spelling/start\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)