### PR TITLE
feat(db): allow Content to live directly under Program (Refs #587)

### DIFF
--- a/backend/alembic/versions/20260427_1000_make_content_unit_optional.py
+++ b/backend/alembic/versions/20260427_1000_make_content_unit_optional.py
@@ -1,0 +1,101 @@
+"""Make Content.lesson_id optional and add Content.program_id
+
+Issue #587: Allow Content to live directly under a Program (top-level folder)
+without being forced into a Lesson (sub-folder). Two-level folder structure
+where the second level is optional.
+
+Schema changes (all idempotent per project migration rules):
+- contents.lesson_id: drop NOT NULL
+- contents.program_id: new nullable FK to programs(id) ON DELETE CASCADE
+- index on contents.program_id
+- CHECK constraint: a content row must belong to at least one of lesson/program
+- Backfill: populate program_id for existing rows via their lesson's program
+
+Revision ID: 20260427_1000
+Revises: 20260422_1500
+Create Date: 2026-04-27
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "20260427_1000"
+down_revision = "20260422_1500"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Add program_id column (nullable FK to programs)
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'contents' AND column_name = 'program_id'
+            ) THEN
+                ALTER TABLE contents
+                    ADD COLUMN program_id INTEGER
+                    REFERENCES programs(id) ON DELETE CASCADE;
+            END IF;
+        END $$;
+        """
+    )
+
+    # 2. Index on program_id
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_contents_program_id ON contents (program_id)"
+    )
+
+    # 3. Backfill program_id from lesson.program_id for existing rows
+    op.execute(
+        """
+        UPDATE contents AS c
+        SET program_id = l.program_id
+        FROM lessons AS l
+        WHERE c.lesson_id = l.id
+          AND c.program_id IS NULL
+        """
+    )
+
+    # 4. Drop NOT NULL on lesson_id (safe to repeat)
+    op.execute("ALTER TABLE contents ALTER COLUMN lesson_id DROP NOT NULL")
+
+    # 5. CHECK constraint: must belong to a lesson OR a program
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'ck_contents_lesson_or_program'
+            ) THEN
+                ALTER TABLE contents
+                    ADD CONSTRAINT ck_contents_lesson_or_program
+                    CHECK (lesson_id IS NOT NULL OR program_id IS NOT NULL);
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Conservative downgrade: drop the new constraint/index/column only.
+    # We do NOT restore NOT NULL on lesson_id because rows created after
+    # this migration may legitimately have lesson_id IS NULL, and reinstating
+    # NOT NULL would fail on real data.
+    op.execute(
+        "ALTER TABLE contents DROP CONSTRAINT IF EXISTS ck_contents_lesson_or_program"
+    )
+    op.execute("DROP INDEX IF EXISTS ix_contents_program_id")
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'contents' AND column_name = 'program_id'
+            ) THEN
+                ALTER TABLE contents DROP COLUMN program_id;
+            END IF;
+        END $$;
+        """
+    )

--- a/backend/models/program.py
+++ b/backend/models/program.py
@@ -147,7 +147,14 @@ class Content(Base):
     __tablename__ = "contents"
 
     id = Column(Integer, primary_key=True, index=True)
-    lesson_id = Column(Integer, ForeignKey("lessons.id"), nullable=False)
+    # Issue #587: lesson_id 可為 null（內容直接掛在 program 下時）
+    lesson_id = Column(Integer, ForeignKey("lessons.id"), nullable=True)
+    program_id = Column(
+        Integer,
+        ForeignKey("programs.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
     type = Column(Enum(ContentType), default=ContentType.EXAMPLE_SENTENCES)
     title = Column(String(200), nullable=False)
     order_index = Column(Integer, default=0)
@@ -179,6 +186,7 @@ class Content(Base):
 
     # Relationships
     lesson = relationship("Lesson", back_populates="contents")
+    program = relationship("Program", foreign_keys=[program_id])
     content_items = relationship(
         "ContentItem", back_populates="content", cascade="all, delete-orphan"
     )


### PR DESCRIPTION
## Summary

Schema-only groundwork for [#587](https://github.com/myduotopia/duotopia/issues/587). Lets `Content` belong to a `Program` (top-level folder / 教材) without a `Lesson` (sub-folder / 單元), so the planned two-level folder UX can have content directly at the outer level.

**Scope is intentionally narrow** — this PR only changes DB schema + SQLAlchemy model. API endpoints, services, and frontend will be handled in follow-up work.

## Changes

### Migration `20260427_1000_make_content_unit_optional.py`
- Add `contents.program_id` (nullable, FK → `programs.id` ON DELETE CASCADE)
- Index `ix_contents_program_id`
- Drop NOT NULL on `contents.lesson_id`
- Add CHECK `ck_contents_lesson_or_program`: a content row must reference a lesson OR a program (or both)
- Backfill: copy `program_id` from each row's `lesson.program_id` so existing data has a direct program reference

All operations are **idempotent** (DO $$ + IF [NOT] EXISTS), per the project's migration rules in [CLAUDE.md](../blob/staging/CLAUDE.md#database-migration-鐵則).

### Model `backend/models/program.py`
- `Content.lesson_id` → `nullable=True`
- `Content.program_id` (new), with `program` relationship

## What is NOT in this PR

- API routes (`/programs/{id}/contents`, etc.) — still assume `lesson_id`
- `_copy_content_with_items` and assignment-copy logic
- Pydantic schemas
- Frontend tree, ContentEditor, AssignmentDialog
- Renaming 教材/單元 → 資料夾 in UI

These are deliberately left for a follow-up PR by another teammate.

## Downgrade

`downgrade()` drops the new constraint/index/column but does **not** restore `NOT NULL` on `lesson_id`, since rows created after this migration may legitimately have `lesson_id IS NULL` and re-imposing NOT NULL would fail on real data.

## Test plan

- [ ] CI passes
- [ ] `alembic upgrade head` succeeds against staging DB
- [ ] Re-running `alembic upgrade head` is a no-op (idempotency)
- [ ] Existing `contents.lesson_id` rows get their `program_id` populated by backfill
- [ ] Existing API endpoints (still using `lesson_id`) keep working — no behavioral regression expected from schema change alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)