### PR TITLE
feat(#631): add show_option_images column to assignments (migration only)

### DIFF
--- a/backend/alembic/versions/20260428_1000_add_show_option_images_to_assignments.py
+++ b/backend/alembic/versions/20260428_1000_add_show_option_images_to_assignments.py
@@ -1,0 +1,34 @@
+"""add_show_option_images_to_assignments
+
+Revision ID: 20260428_1000
+Revises: 20260427_1000
+Create Date: 2026-04-28 10:00:00.000000
+
+Issue #631: 單字選擇作業新增「是否顯示選項圖片」欄位。
+與既有 show_image（題目單字圖片）為兩個獨立 toggle。
+預設 FALSE 以保留現有作業的純文字選項行為。
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260428_1000"
+down_revision: Union[str, None] = "20260427_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE assignments
+        ADD COLUMN IF NOT EXISTS show_option_images BOOLEAN DEFAULT FALSE
+        """
+    )
+
+
+def downgrade() -> None:
+    # Additive-only migration policy: do not drop columns on downgrade.
+    pass

--- a/backend/models/assignment.py
+++ b/backend/models/assignment.py
@@ -80,6 +80,9 @@ class Assignment(Base):
     # 是否顯示圖片（預設 true）- 單字集專用
     show_image = Column(Boolean, default=True)
 
+    # 是否顯示選項圖片（預設 false）- 單字選擇模式專用（Issue #631）
+    show_option_images = Column(Boolean, default=False)
+
     # 軟刪除標記
     is_active = Column(Boolean, default=True)
 


### PR DESCRIPTION
## Summary
- 為 issue #631「{單字選擇}新增作業條件欄位{是否顯示選項圖片}」預先把 schema 部分先合進 staging
- 新增 idempotent Alembic migration：`assignments.show_option_images BOOLEAN DEFAULT FALSE`
- 同步在 `Assignment` model 加對應欄位，避免後續 autogenerate 把它當 drift

## Why migration-only first
這支 PR 故意**只含 migration + model 欄位**，不動 validator / CRUD / 前端 / 答題渲染。理由：
1. 讓 staging 環境（以及後續所有 Per-Issue 測試環境）先擁有這個欄位
2. 之後的 feature PR（含前後端使用此欄位的邏輯）就能在已有 schema 的環境上開發、測試
3. 拆 PR 也讓 review 範圍小、風險低

## Field design
| 屬性 | 值 | 理由 |
|------|----|------|
| 欄位名 | `show_option_images` | 與既有 `show_image`（題目單字圖片）區分；複數表示控制四個選項 |
| 型別 | `BOOLEAN` | 跟兄弟 toggle (`show_word`, `show_image`, `show_translation`) 一致 |
| 預設值 | `FALSE` | 保留現有作業純文字選項行為；兄弟欄位預設 `TRUE` 是因為他們的功能本來就是預設啟用，這是「新行為」需 explicit opt-in |

## Migration safety (符合 CLAUDE.md 鐵則)
- ✅ `ADD COLUMN IF NOT EXISTS`
- ✅ 有 `DEFAULT FALSE`，現有 row 安全
- ✅ Additive-only，`downgrade()` 留 pass
- ✅ 鏈接乾淨：`20260427_1000` → `20260428_1000`，單一 head

## Test plan
- [ ] CI: alembic upgrade head 在 staging Supabase 跑過
- [ ] CI: backend pytest 全綠
- [ ] 部署到 staging 後 `\d assignments` 確認欄位存在且預設 FALSE
- [ ] 確認既有作業讀取 (`/api/teachers/assignments/{id}`) 不報錯（新欄位以 FALSE 回傳）

🤖 Generated with [Claude Code](https://claude.com/claude-code)