### PR TITLE
feat(#676): add ai_analysis_count column to student_item_progress (Phase 2 schema)

### DIFF
--- a/backend/alembic/versions/20260428_1100_add_ai_analysis_count_to_progress.py
+++ b/backend/alembic/versions/20260428_1100_add_ai_analysis_count_to_progress.py
@@ -26,7 +26,7 @@ def upgrade() -> None:
     op.execute(
         """
         ALTER TABLE student_item_progress
-        ADD COLUMN IF NOT EXISTS ai_analysis_count INTEGER DEFAULT 0
+        ADD COLUMN IF NOT EXISTS ai_analysis_count INTEGER NOT NULL DEFAULT 0
         """
     )
 

--- a/backend/alembic/versions/20260428_1100_add_ai_analysis_count_to_progress.py
+++ b/backend/alembic/versions/20260428_1100_add_ai_analysis_count_to_progress.py
@@ -1,0 +1,36 @@
+"""add_ai_analysis_count_to_student_item_progress
+
+Revision ID: 20260428_1100
+Revises: 20260428_1000
+Create Date: 2026-04-28 11:00:00.000000
+
+Issue #676 Phase 2: server-authoritative AI analysis attempt counter.
+Phase 1 (issue #689) gates 3 attempts per item via localStorage on the
+frontend; this column adds the same counter on the backend so DevTools
+cannot bypass the limit. Default 0 — students mid-flight start fresh on
+the server side; the frontend takes max(server, local) when reconciling.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260428_1100"
+down_revision: Union[str, None] = "20260428_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE student_item_progress
+        ADD COLUMN IF NOT EXISTS ai_analysis_count INTEGER DEFAULT 0
+        """
+    )
+
+
+def downgrade() -> None:
+    # Additive-only migration policy: do not drop columns on downgrade.
+    pass

--- a/backend/models/progress.py
+++ b/backend/models/progress.py
@@ -133,7 +133,7 @@ class StudentItemProgress(Base):
     attempts = Column(Integer, default=0)
     # Issue #676 Phase 2: server-side AI analysis quota (max 3 per item).
     # Reset to 0 when assignment status transitions to RETURNED.
-    ai_analysis_count = Column(Integer, default=0, server_default="0")
+    ai_analysis_count = Column(Integer, nullable=False, default=0, server_default="0")
 
     # Rearrangement activity fields (例句重組專用)
     error_count = Column(Integer, default=0)  # 錯誤選擇次數

--- a/backend/models/progress.py
+++ b/backend/models/progress.py
@@ -131,6 +131,9 @@ class StudentItemProgress(Base):
         String(20), default="NOT_STARTED"
     )  # NOT_STARTED, IN_PROGRESS, COMPLETED, SUBMITTED
     attempts = Column(Integer, default=0)
+    # Issue #676 Phase 2: server-side AI analysis quota (max 3 per item).
+    # Reset to 0 when assignment status transitions to RETURNED.
+    ai_analysis_count = Column(Integer, default=0, server_default="0")
 
     # Rearrangement activity fields (例句重組專用)
     error_count = Column(Integer, default=0)  # 錯誤選擇次數


### PR DESCRIPTION
## Summary
- Phase 2 schema-only split for issue #676 — adds `ai_analysis_count INTEGER DEFAULT 0` to `student_item_progress` ahead of the enforcement logic PR.
- Idempotent migration (`ADD COLUMN IF NOT EXISTS`) per project migration rule; safe to re-run across develop / staging / prod.
- Model picks up the column so the upcoming Phase 2 logic PR can use `progress.ai_analysis_count` without attribute errors.

## Why schema-only?
Phase 1 frontend gate is live (#689 / PR #690). Phase 2 will add server-authoritative enforcement, but DB schema and code are deployed independently to avoid races between migration timing and code rollout. This PR ships the column first; the enforcement PR follows once this is merged.

## Behavior change
None at runtime. The new column has a `DEFAULT 0`, no business code reads or writes it, and the model field is purely additive. Existing rows are backfilled with `0` by Postgres at column-creation time.

## Test plan
- [ ] CI `alembic upgrade head` succeeds on Postgres
- [ ] CI re-runs migration → idempotent (no error second time)
- [ ] Existing test suite still green (additive change only)
- [ ] After merge to staging: verify `student_item_progress.ai_analysis_count` exists in Supabase staging

Refs #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)