### PR TITLE
fix(#697): 隔離學生/教師 redirect-after-login 防止跨角色跳轉到 /teacher/login

### DIFF
--- a/frontend/src/pages/OneCampusCallback.tsx
+++ b/frontend/src/pages/OneCampusCallback.tsx
@@ -103,7 +103,6 @@ export default function OneCampusCallback() {
             consumeRedirectTarget("/teacher/dashboard", [
               "/teacher/",
               "/organization/",
-              // /dashboard is the RoleBasedRedirect entry point (App.tsx).
               "/dashboard",
             ]),
             { replace: true },

--- a/frontend/src/pages/OneCampusCallback.tsx
+++ b/frontend/src/pages/OneCampusCallback.tsx
@@ -21,6 +21,7 @@ import {
 import { useStudentAuthStore } from "@/stores/studentAuthStore";
 import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
 import { consumeRedirectTarget } from "@/utils/redirectAfterLogin";
+import { getTeacherDashboardRoute } from "@/utils/authNavigation";
 import api from "@/services/api";
 
 export default function OneCampusCallback() {
@@ -100,7 +101,7 @@ export default function OneCampusCallback() {
             return;
           }
           navigate(
-            consumeRedirectTarget("/teacher/dashboard", [
+            consumeRedirectTarget(getTeacherDashboardRoute(), [
               "/teacher/",
               "/organization/",
               "/dashboard",
@@ -243,7 +244,9 @@ export default function OneCampusCallback() {
 
   function handleBindSkip() {
     const fallback =
-      bindRoleType === "teacher" ? "/teacher/dashboard" : "/student/dashboard";
+      bindRoleType === "teacher"
+        ? getTeacherDashboardRoute()
+        : "/student/dashboard";
     const allowedPrefixes =
       bindRoleType === "teacher"
         ? ["/teacher/", "/organization/", "/dashboard"]

--- a/frontend/src/pages/OneCampusCallback.tsx
+++ b/frontend/src/pages/OneCampusCallback.tsx
@@ -99,9 +99,14 @@ export default function OneCampusCallback() {
             setStatus("bind_prompt");
             return;
           }
-          navigate(consumeRedirectTarget("/teacher/dashboard"), {
-            replace: true,
-          });
+          navigate(
+            consumeRedirectTarget("/teacher/dashboard", [
+              "/teacher/",
+              "/organization/",
+              "/dashboard",
+            ]),
+            { replace: true },
+          );
         } else if (data.student) {
           studentLogin(data.access_token, {
             id: data.student.id,
@@ -124,7 +129,7 @@ export default function OneCampusCallback() {
             setStatus("bind_prompt");
             return;
           }
-          navigate(consumeRedirectTarget("/student/dashboard"), {
+          navigate(consumeRedirectTarget("/student/dashboard", ["/student/"]), {
             replace: true,
           });
         }
@@ -178,7 +183,7 @@ export default function OneCampusCallback() {
           classrooms: data.student.classrooms,
           classrooms_count: data.student.classrooms_count,
         });
-        navigate(consumeRedirectTarget("/student/dashboard"), {
+        navigate(consumeRedirectTarget("/student/dashboard", ["/student/"]), {
           replace: true,
         });
       }
@@ -239,7 +244,13 @@ export default function OneCampusCallback() {
   function handleBindSkip() {
     const fallback =
       bindRoleType === "teacher" ? "/teacher/dashboard" : "/student/dashboard";
-    navigate(consumeRedirectTarget(fallback), { replace: true });
+    const allowedPrefixes =
+      bindRoleType === "teacher"
+        ? ["/teacher/", "/organization/", "/dashboard"]
+        : ["/student/"];
+    navigate(consumeRedirectTarget(fallback, allowedPrefixes), {
+      replace: true,
+    });
   }
 
   return (

--- a/frontend/src/pages/OneCampusCallback.tsx
+++ b/frontend/src/pages/OneCampusCallback.tsx
@@ -103,6 +103,7 @@ export default function OneCampusCallback() {
             consumeRedirectTarget("/teacher/dashboard", [
               "/teacher/",
               "/organization/",
+              // /dashboard is the RoleBasedRedirect entry point (App.tsx).
               "/dashboard",
             ]),
             { replace: true },

--- a/frontend/src/pages/StudentLogin.tsx
+++ b/frontend/src/pages/StudentLogin.tsx
@@ -197,7 +197,7 @@ export default function StudentLogin() {
           teacher_name: teacherHistory.find((t) => t.email === teacherEmail)
             ?.name,
         } as StudentUser);
-        navigate(consumeRedirectTarget("/student/dashboard"), {
+        navigate(consumeRedirectTarget("/student/dashboard", ["/student/"]), {
           replace: true,
         });
       }
@@ -239,7 +239,7 @@ export default function StudentLogin() {
         classrooms: s.classrooms,
         classrooms_count: s.classrooms_count,
       } as StudentUser);
-      navigate(consumeRedirectTarget("/student/dashboard"), {
+      navigate(consumeRedirectTarget("/student/dashboard", ["/student/"]), {
         replace: true,
       });
     } catch (err) {

--- a/frontend/src/pages/StudentLogin.tsx
+++ b/frontend/src/pages/StudentLogin.tsx
@@ -41,10 +41,13 @@ export default function StudentLogin() {
   const { t } = useTranslation();
 
   // Mirror router state into sessionStorage so it survives the 4-step flow.
+  // Depend on the resolved `from` string (not the state object reference)
+  // so we don't re-run when React Router gives us a fresh state object with
+  // the same `from`, which could overwrite a still-valid saved target.
+  const fromState = (location.state as { from?: string } | null)?.from;
   useEffect(() => {
-    const from = (location.state as { from?: string } | null)?.from;
-    if (from) saveRedirectTarget(from);
-  }, [location.state]);
+    if (fromState) saveRedirectTarget(fromState);
+  }, [fromState]);
 
   // 檢查是否為 demo 模式 (通過 URL 參數 ?is_demo=true)
   const searchParams = new URLSearchParams(window.location.search);

--- a/frontend/src/pages/StudentLogin.tsx
+++ b/frontend/src/pages/StudentLogin.tsx
@@ -40,10 +40,8 @@ export default function StudentLogin() {
   const { login } = useStudentAuthStore();
   const { t } = useTranslation();
 
-  // Mirror router state into sessionStorage so it survives the 4-step flow.
-  // Depend on the resolved `from` string (not the state object reference)
-  // so we don't re-run when React Router gives us a fresh state object with
-  // the same `from`, which could overwrite a still-valid saved target.
+  // Depend on resolved `from` string (not state object) so a fresh state
+  // reference with the same `from` doesn't overwrite a still-valid save.
   const fromState = (location.state as { from?: string } | null)?.from;
   useEffect(() => {
     if (fromState) saveRedirectTarget(fromState);

--- a/frontend/src/pages/TeacherLogin.tsx
+++ b/frontend/src/pages/TeacherLogin.tsx
@@ -38,8 +38,8 @@ export default function TeacherLogin() {
     password: "",
   });
 
-  // Depend on the resolved `from` string (not the `location.state` object
-  // reference) so the effect doesn't re-fire and overwrite a still-valid save.
+  // Save and consume in the same effect so save-before-consume ordering is
+  // preserved when the user lands here already authenticated with a `from`.
   const fromState = (location.state as { from?: string } | null)?.from;
   useEffect(() => {
     if (fromState) saveRedirectTarget(fromState);

--- a/frontend/src/pages/TeacherLogin.tsx
+++ b/frontend/src/pages/TeacherLogin.tsx
@@ -43,9 +43,14 @@ export default function TeacherLogin() {
     const from = (location.state as { from?: string } | null)?.from;
     if (from) saveRedirectTarget(from);
     if (isAuthenticated && user) {
-      navigate(consumeRedirectTarget(getTeacherDashboardRoute()), {
-        replace: true,
-      });
+      navigate(
+        consumeRedirectTarget(getTeacherDashboardRoute(), [
+          "/teacher/",
+          "/organization/",
+          "/dashboard",
+        ]),
+        { replace: true },
+      );
     }
   }, [isAuthenticated, user, navigate, location.state]);
 

--- a/frontend/src/pages/TeacherLogin.tsx
+++ b/frontend/src/pages/TeacherLogin.tsx
@@ -38,10 +38,8 @@ export default function TeacherLogin() {
     password: "",
   });
 
-  // Depend on the resolved `from` string instead of `location.state` so the
-  // effect doesn't re-fire on a fresh state object reference with the same
-  // `from`. Combined into one effect so saveRedirectTarget always runs before
-  // consumeRedirectTarget.
+  // Depend on the resolved `from` string (not the `location.state` object
+  // reference) so the effect doesn't re-fire and overwrite a still-valid save.
   const fromState = (location.state as { from?: string } | null)?.from;
   useEffect(() => {
     if (fromState) saveRedirectTarget(fromState);
@@ -50,7 +48,6 @@ export default function TeacherLogin() {
         consumeRedirectTarget(getTeacherDashboardRoute(), [
           "/teacher/",
           "/organization/",
-          // /dashboard is the RoleBasedRedirect entry point (App.tsx).
           "/dashboard",
         ]),
         { replace: true },

--- a/frontend/src/pages/TeacherLogin.tsx
+++ b/frontend/src/pages/TeacherLogin.tsx
@@ -38,21 +38,25 @@ export default function TeacherLogin() {
     password: "",
   });
 
-  // Combined into one effect so saveRedirectTarget always runs before consumeRedirectTarget.
+  // Depend on the resolved `from` string instead of `location.state` so the
+  // effect doesn't re-fire on a fresh state object reference with the same
+  // `from`. Combined into one effect so saveRedirectTarget always runs before
+  // consumeRedirectTarget.
+  const fromState = (location.state as { from?: string } | null)?.from;
   useEffect(() => {
-    const from = (location.state as { from?: string } | null)?.from;
-    if (from) saveRedirectTarget(from);
+    if (fromState) saveRedirectTarget(fromState);
     if (isAuthenticated && user) {
       navigate(
         consumeRedirectTarget(getTeacherDashboardRoute(), [
           "/teacher/",
           "/organization/",
+          // /dashboard is the RoleBasedRedirect entry point (App.tsx).
           "/dashboard",
         ]),
         { replace: true },
       );
     }
-  }, [isAuthenticated, user, navigate, location.state]);
+  }, [isAuthenticated, user, navigate, fromState]);
 
   // 檢查是否為 demo 模式 (通過 URL 參數 ?is_demo=true)
   const searchParams = new URLSearchParams(window.location.search);

--- a/frontend/src/utils/__tests__/redirectAfterLogin.test.ts
+++ b/frontend/src/utils/__tests__/redirectAfterLogin.test.ts
@@ -95,3 +95,82 @@ describe("saveRedirectTarget / consumeRedirectTarget", () => {
     expect(consumeRedirectTarget("/safe-fallback")).toBe("/safe-fallback");
   });
 });
+
+describe("consumeRedirectTarget allowedPrefixes (role isolation)", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("returns fallback when stored target does not match any allowed prefix", () => {
+    saveRedirectTarget("/teacher/dashboard");
+    expect(consumeRedirectTarget("/student/dashboard", ["/student/"])).toBe(
+      "/student/dashboard",
+    );
+  });
+
+  it("returns stored target when it matches an allowed prefix", () => {
+    saveRedirectTarget("/student/assignment/42/activity");
+    expect(consumeRedirectTarget("/student/dashboard", ["/student/"])).toBe(
+      "/student/assignment/42/activity",
+    );
+  });
+
+  it("returns stored target when any allowed prefix matches", () => {
+    saveRedirectTarget("/organization/123/members");
+    expect(
+      consumeRedirectTarget("/teacher/dashboard", [
+        "/teacher/",
+        "/organization/",
+        "/dashboard",
+      ]),
+    ).toBe("/organization/123/members");
+  });
+
+  it("teacher target leaks to student login → falls back", () => {
+    saveRedirectTarget("/teacher/programs/5");
+    expect(consumeRedirectTarget("/student/dashboard", ["/student/"])).toBe(
+      "/student/dashboard",
+    );
+  });
+
+  it("student target leaks to teacher login → falls back", () => {
+    saveRedirectTarget("/student/dashboard");
+    expect(
+      consumeRedirectTarget("/teacher/dashboard", [
+        "/teacher/",
+        "/organization/",
+        "/dashboard",
+      ]),
+    ).toBe("/teacher/dashboard");
+  });
+
+  it("still consumes (clears storage) when prefix mismatch causes fallback", () => {
+    saveRedirectTarget("/teacher/dashboard");
+    consumeRedirectTarget("/student/dashboard", ["/student/"]);
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("backwards compatible: omitting allowedPrefixes returns stored target", () => {
+    saveRedirectTarget("/anything/at/all");
+    expect(consumeRedirectTarget("/fallback")).toBe("/anything/at/all");
+  });
+
+  it("matches /dashboard exactly via prefix", () => {
+    saveRedirectTarget("/dashboard");
+    expect(
+      consumeRedirectTarget("/teacher/dashboard", [
+        "/teacher/",
+        "/organization/",
+        "/dashboard",
+      ]),
+    ).toBe("/dashboard");
+  });
+
+  it("does not match a different role despite shared substring", () => {
+    saveRedirectTarget("/teacher/students/100");
+    // "/student/" prefix should NOT match "/teacher/students/..."
+    expect(consumeRedirectTarget("/student/dashboard", ["/student/"])).toBe(
+      "/student/dashboard",
+    );
+  });
+});

--- a/frontend/src/utils/__tests__/redirectAfterLogin.test.ts
+++ b/frontend/src/utils/__tests__/redirectAfterLogin.test.ts
@@ -196,4 +196,11 @@ describe("consumeRedirectTarget allowedPrefixes (role isolation)", () => {
       "/student/dashboard",
     );
   });
+
+  it("empty string in allowedPrefixes does not silently allow every path", () => {
+    saveRedirectTarget("/teacher/dashboard");
+    expect(consumeRedirectTarget("/student/dashboard", [""])).toBe(
+      "/student/dashboard",
+    );
+  });
 });

--- a/frontend/src/utils/__tests__/redirectAfterLogin.test.ts
+++ b/frontend/src/utils/__tests__/redirectAfterLogin.test.ts
@@ -203,4 +203,11 @@ describe("consumeRedirectTarget allowedPrefixes (role isolation)", () => {
       "/student/dashboard",
     );
   });
+
+  it("bare '/' in allowedPrefixes does not silently allow every path", () => {
+    saveRedirectTarget("/teacher/dashboard");
+    expect(consumeRedirectTarget("/student/dashboard", ["/"])).toBe(
+      "/student/dashboard",
+    );
+  });
 });

--- a/frontend/src/utils/__tests__/redirectAfterLogin.test.ts
+++ b/frontend/src/utils/__tests__/redirectAfterLogin.test.ts
@@ -3,9 +3,10 @@ import {
   isSafeRedirectPath,
   saveRedirectTarget,
   consumeRedirectTarget,
+  REDIRECT_STORAGE_KEY,
 } from "../redirectAfterLogin";
 
-const STORAGE_KEY = "auth_redirect_after_login";
+const STORAGE_KEY = REDIRECT_STORAGE_KEY;
 
 describe("isSafeRedirectPath", () => {
   it("accepts normal absolute paths", () => {
@@ -155,7 +156,7 @@ describe("consumeRedirectTarget allowedPrefixes (role isolation)", () => {
     expect(consumeRedirectTarget("/fallback")).toBe("/anything/at/all");
   });
 
-  it("matches /dashboard exactly via prefix", () => {
+  it("matches bare /dashboard exactly", () => {
     saveRedirectTarget("/dashboard");
     expect(
       consumeRedirectTarget("/teacher/dashboard", [
@@ -164,6 +165,28 @@ describe("consumeRedirectTarget allowedPrefixes (role isolation)", () => {
         "/dashboard",
       ]),
     ).toBe("/dashboard");
+  });
+
+  it("matches /dashboard sub-paths via bare prefix", () => {
+    saveRedirectTarget("/dashboard/teacher");
+    expect(
+      consumeRedirectTarget("/teacher/dashboard", [
+        "/teacher/",
+        "/organization/",
+        "/dashboard",
+      ]),
+    ).toBe("/dashboard/teacher");
+  });
+
+  it("bare prefix /dashboard does not over-match /dashboard-admin", () => {
+    saveRedirectTarget("/dashboard-admin/foo");
+    expect(
+      consumeRedirectTarget("/teacher/dashboard", [
+        "/teacher/",
+        "/organization/",
+        "/dashboard",
+      ]),
+    ).toBe("/teacher/dashboard");
   });
 
   it("does not match a different role despite shared substring", () => {

--- a/frontend/src/utils/redirectAfterLogin.ts
+++ b/frontend/src/utils/redirectAfterLogin.ts
@@ -42,7 +42,10 @@ export function saveRedirectTarget(path: unknown): void {
   }
 }
 
-export function consumeRedirectTarget(fallback: string): string {
+export function consumeRedirectTarget(
+  fallback: string,
+  allowedPrefixes?: string[],
+): string {
   let target: string | null = null;
   try {
     target = sessionStorage.getItem(STORAGE_KEY);
@@ -50,5 +53,12 @@ export function consumeRedirectTarget(fallback: string): string {
   } catch {
     // ignore
   }
-  return isSafeRedirectPath(target) ? target : fallback;
+  if (!isSafeRedirectPath(target)) return fallback;
+  // Role isolation: caller restricts which paths it'll honor so a teacher
+  // target saved in sessionStorage can't redirect a student-login flow into
+  // /teacher/*, which would bounce back to /teacher/login.
+  if (allowedPrefixes && !allowedPrefixes.some((p) => target.startsWith(p))) {
+    return fallback;
+  }
+  return target;
 }

--- a/frontend/src/utils/redirectAfterLogin.ts
+++ b/frontend/src/utils/redirectAfterLogin.ts
@@ -70,6 +70,7 @@ export function consumeRedirectTarget(
 }
 
 function matchesPrefix(target: string, prefix: string): boolean {
+  if (!prefix) return false; // empty prefix would match every absolute path
   if (prefix.endsWith("/")) return target.startsWith(prefix);
   return target === prefix || target.startsWith(prefix + "/");
 }

--- a/frontend/src/utils/redirectAfterLogin.ts
+++ b/frontend/src/utils/redirectAfterLogin.ts
@@ -1,6 +1,6 @@
 // sessionStorage-backed so the target survives multi-step flows, SSO round-trips, and 401 hard navigations.
 
-const STORAGE_KEY = "auth_redirect_after_login";
+export const REDIRECT_STORAGE_KEY = "auth_redirect_after_login";
 
 const LOGIN_PAGE_PREFIXES = [
   "/teacher/login",
@@ -36,7 +36,7 @@ export function saveRedirectTarget(path: unknown): void {
   if (!isSafeRedirectPath(path)) return;
   if (LOGIN_PAGE_PREFIXES.some((p) => path.startsWith(p))) return;
   try {
-    sessionStorage.setItem(STORAGE_KEY, path);
+    sessionStorage.setItem(REDIRECT_STORAGE_KEY, path);
   } catch {
     // sessionStorage may be unavailable (private mode, SSR); silently ignore.
   }
@@ -48,8 +48,8 @@ export function consumeRedirectTarget(
 ): string {
   let target: string | null = null;
   try {
-    target = sessionStorage.getItem(STORAGE_KEY);
-    sessionStorage.removeItem(STORAGE_KEY);
+    target = sessionStorage.getItem(REDIRECT_STORAGE_KEY);
+    sessionStorage.removeItem(REDIRECT_STORAGE_KEY);
   } catch {
     // ignore
   }
@@ -57,8 +57,19 @@ export function consumeRedirectTarget(
   // Role isolation: caller restricts which paths it'll honor so a teacher
   // target saved in sessionStorage can't redirect a student-login flow into
   // /teacher/*, which would bounce back to /teacher/login.
-  if (allowedPrefixes && !allowedPrefixes.some((p) => target.startsWith(p))) {
+  // Trailing-slash prefixes ("/teacher/") match any sub-path; bare paths
+  // ("/dashboard") match exact-or-sub-path so they don't over-match a future
+  // /dashboard-admin route.
+  if (
+    allowedPrefixes &&
+    !allowedPrefixes.some((p) => matchesPrefix(target, p))
+  ) {
     return fallback;
   }
   return target;
+}
+
+function matchesPrefix(target: string, prefix: string): boolean {
+  if (prefix.endsWith("/")) return target.startsWith(prefix);
+  return target === prefix || target.startsWith(prefix + "/");
 }

--- a/frontend/src/utils/redirectAfterLogin.ts
+++ b/frontend/src/utils/redirectAfterLogin.ts
@@ -72,7 +72,8 @@ export function consumeRedirectTarget(
 }
 
 function matchesPrefix(target: string, prefix: string): boolean {
-  if (!prefix) return false;
+  // Reject empty and bare "/" — both would silently allow every absolute path.
+  if (!prefix || prefix === "/") return false;
   if (prefix.endsWith("/")) return target.startsWith(prefix);
   return target === prefix || target.startsWith(prefix + "/");
 }

--- a/frontend/src/utils/redirectAfterLogin.ts
+++ b/frontend/src/utils/redirectAfterLogin.ts
@@ -1,5 +1,6 @@
 // sessionStorage-backed so the target survives multi-step flows, SSO round-trips, and 401 hard navigations.
 
+/** @internal — exported only so tests can read raw storage; do not use directly. */
 export const REDIRECT_STORAGE_KEY = "auth_redirect_after_login";
 
 const LOGIN_PAGE_PREFIXES = [
@@ -42,6 +43,13 @@ export function saveRedirectTarget(path: unknown): void {
   }
 }
 
+/**
+ * Consume the saved redirect target. Role-sensitive callers MUST pass
+ * `allowedPrefixes` to prevent a path saved by a different role from being
+ * honored (e.g., a `/teacher/*` target hijacking a student login flow).
+ * Prefix matching: trailing-slash prefix matches any sub-path; bare prefix
+ * matches exact-or-sub-path (so `/dashboard` does not match `/dashboard-admin`).
+ */
 export function consumeRedirectTarget(
   fallback: string,
   allowedPrefixes?: string[],
@@ -54,12 +62,6 @@ export function consumeRedirectTarget(
     // ignore
   }
   if (!isSafeRedirectPath(target)) return fallback;
-  // Role isolation: caller restricts which paths it'll honor so a teacher
-  // target saved in sessionStorage can't redirect a student-login flow into
-  // /teacher/*, which would bounce back to /teacher/login.
-  // Trailing-slash prefixes ("/teacher/") match any sub-path; bare paths
-  // ("/dashboard") match exact-or-sub-path so they don't over-match a future
-  // /dashboard-admin route.
   if (
     allowedPrefixes &&
     !allowedPrefixes.some((p) => matchesPrefix(target, p))
@@ -70,7 +72,7 @@ export function consumeRedirectTarget(
 }
 
 function matchesPrefix(target: string, prefix: string): boolean {
-  if (!prefix) return false; // empty prefix would match every absolute path
+  if (!prefix) return false;
   if (prefix.endsWith("/")) return target.startsWith(prefix);
   return target === prefix || target.startsWith(prefix + "/");
 }


### PR DESCRIPTION
## Summary

修正 PR #693 引入的 bug：`redirectAfterLogin` 用單一 sessionStorage key 跨角色共用 redirect target，導致學生登入後被踢到 `/teacher/login`。

- `consumeRedirectTarget` 加上 optional `allowedPrefixes` 參數，呼叫端宣告允許的 path prefix；不匹配時回 fallback（仍會清掉 sessionStorage 避免污染後續呼叫）
- `StudentLogin` 只接受 `/student/*`
- `TeacherLogin` 接受 `/teacher/*`、`/organization/*`、`/dashboard`
- `OneCampusCallback` 四處 consume 依 role/branch 套對應白名單（含 role-aware `handleBindSkip`）
- 向後相容：不帶 `allowedPrefixes` 維持原行為

## Root Cause

PR #693（Fixes #571）為了支援「未登入點分享連結 → 登入後回原頁」做了 sessionStorage redirect target，但 save/consume 都沒有角色檢查。當教師路徑（如 `/teacher/dashboard`，可能來自 `ProtectedRoute` bounce、`RoleBasedRedirect`、或 [api.ts 的 401 hard-navigation](frontend/src/lib/api.ts#L217-L230)）被存進 sessionStorage 後，學生在 `/student/login` 登入成功時 `consumeRedirectTarget` 會直接吃掉這個教師路徑，把學生送進 `/teacher/dashboard` → `ProtectedRoute` 看到沒有教師 auth 就回 `/teacher/login`。

學生 token 其實已寫入 localStorage，但 UX 完全壞掉——使用者得回首頁點「學生專區」（之前他們稱「學生登入」按鈕）才能進入 student 區。

## Test plan

### 自動化測試
- [x] 新增 8 個 role-isolation 單元測試（`redirectAfterLogin.test.ts` 22/22 pass）
- [x] `api.comprehensive.test.ts` 14/14 pass
- [x] `api.contract.test.ts` 3/3 pass
- [x] `ProtectedRoute.test.tsx` 2/2 pass
- [x] TypeScript typecheck clean
- [x] ESLint clean
- [x] Prettier formatted

### 手動驗證（建議在 per-issue 環境）
- [ ] **重現原 bug 不再發生**：直接訪問 `/teacher/dashboard` →（被導去 `/teacher/login`）→ 回首頁 → 點右上「學生登入」→ 用學生帳密登入 → 應正確進入 `/student/dashboard`，而非 `/teacher/login`
- [ ] **既有 PR #693 功能不退化（學生）**：未登入時訪問 `/student/assignment/123/activity` →（被導去 `/student/login`）→ 學生登入 → 應回到 `/student/assignment/123/activity`
- [ ] **既有 PR #693 功能不退化（教師）**：未登入時訪問 `/teacher/programs/5` →（被導去 `/teacher/login`）→ 教師登入 → 應回到 `/teacher/programs/5`
- [ ] **SSO 流程**：1Campus callback 走 teacher 與 student 兩條路徑都能正確 redirect
- [ ] **教師 token 過期 401**：教師頁觸發 401 → 跳 `/teacher/login` → 再次教師登入 → 回到原本頁面

Fixes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)