### PR TITLE
Release: staging → main (3 fixes: redirect role isolation + 2 schema migrations)

### DIFF
--- a/backend/alembic/versions/20260428_1000_add_show_option_images_to_assignments.py
+++ b/backend/alembic/versions/20260428_1000_add_show_option_images_to_assignments.py
@@ -1,0 +1,34 @@
+"""add_show_option_images_to_assignments
+
+Revision ID: 20260428_1000
+Revises: 20260427_1000
+Create Date: 2026-04-28 10:00:00.000000
+
+Issue #631: 單字選擇作業新增「是否顯示選項圖片」欄位。
+與既有 show_image（題目單字圖片）為兩個獨立 toggle。
+預設 FALSE 以保留現有作業的純文字選項行為。
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260428_1000"
+down_revision: Union[str, None] = "20260427_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE assignments
+        ADD COLUMN IF NOT EXISTS show_option_images BOOLEAN DEFAULT FALSE
+        """
+    )
+
+
+def downgrade() -> None:
+    # Additive-only migration policy: do not drop columns on downgrade.
+    pass

--- a/backend/alembic/versions/20260428_1100_add_ai_analysis_count_to_progress.py
+++ b/backend/alembic/versions/20260428_1100_add_ai_analysis_count_to_progress.py
@@ -1,0 +1,36 @@
+"""add_ai_analysis_count_to_student_item_progress
+
+Revision ID: 20260428_1100
+Revises: 20260428_1000
+Create Date: 2026-04-28 11:00:00.000000
+
+Issue #676 Phase 2: server-authoritative AI analysis attempt counter.
+Phase 1 (issue #689) gates 3 attempts per item via localStorage on the
+frontend; this column adds the same counter on the backend so DevTools
+cannot bypass the limit. Default 0 — students mid-flight start fresh on
+the server side; the frontend takes max(server, local) when reconciling.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260428_1100"
+down_revision: Union[str, None] = "20260428_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE student_item_progress
+        ADD COLUMN IF NOT EXISTS ai_analysis_count INTEGER NOT NULL DEFAULT 0
+        """
+    )
+
+
+def downgrade() -> None:
+    # Additive-only migration policy: do not drop columns on downgrade.
+    pass

--- a/backend/models/assignment.py
+++ b/backend/models/assignment.py
@@ -80,6 +80,9 @@ class Assignment(Base):
     # 是否顯示圖片（預設 true）- 單字集專用
     show_image = Column(Boolean, default=True)
 
+    # 是否顯示選項圖片（預設 false）- 單字選擇模式專用（Issue #631）
+    show_option_images = Column(Boolean, default=False)
+
     # 軟刪除標記
     is_active = Column(Boolean, default=True)
 

--- a/backend/models/progress.py
+++ b/backend/models/progress.py
@@ -131,6 +131,9 @@ class StudentItemProgress(Base):
         String(20), default="NOT_STARTED"
     )  # NOT_STARTED, IN_PROGRESS, COMPLETED, SUBMITTED
     attempts = Column(Integer, default=0)
+    # Issue #676 Phase 2: server-side AI analysis quota (max 3 per item).
+    # Reset to 0 when assignment status transitions to RETURNED.
+    ai_analysis_count = Column(Integer, nullable=False, default=0, server_default="0")
 
     # Rearrangement activity fields (例句重組專用)
     error_count = Column(Integer, default=0)  # 錯誤選擇次數

--- a/frontend/src/pages/OneCampusCallback.tsx
+++ b/frontend/src/pages/OneCampusCallback.tsx
@@ -21,6 +21,7 @@ import {
 import { useStudentAuthStore } from "@/stores/studentAuthStore";
 import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
 import { consumeRedirectTarget } from "@/utils/redirectAfterLogin";
+import { getTeacherDashboardRoute } from "@/utils/authNavigation";
 import api from "@/services/api";
 
 export default function OneCampusCallback() {
@@ -99,9 +100,14 @@ export default function OneCampusCallback() {
             setStatus("bind_prompt");
             return;
           }
-          navigate(consumeRedirectTarget("/teacher/dashboard"), {
-            replace: true,
-          });
+          navigate(
+            consumeRedirectTarget(getTeacherDashboardRoute(), [
+              "/teacher/",
+              "/organization/",
+              "/dashboard",
+            ]),
+            { replace: true },
+          );
         } else if (data.student) {
           studentLogin(data.access_token, {
             id: data.student.id,
@@ -124,7 +130,7 @@ export default function OneCampusCallback() {
             setStatus("bind_prompt");
             return;
           }
-          navigate(consumeRedirectTarget("/student/dashboard"), {
+          navigate(consumeRedirectTarget("/student/dashboard", ["/student/"]), {
             replace: true,
           });
         }
@@ -178,7 +184,7 @@ export default function OneCampusCallback() {
           classrooms: data.student.classrooms,
           classrooms_count: data.student.classrooms_count,
         });
-        navigate(consumeRedirectTarget("/student/dashboard"), {
+        navigate(consumeRedirectTarget("/student/dashboard", ["/student/"]), {
           replace: true,
         });
       }
@@ -238,8 +244,16 @@ export default function OneCampusCallback() {
 
   function handleBindSkip() {
     const fallback =
-      bindRoleType === "teacher" ? "/teacher/dashboard" : "/student/dashboard";
-    navigate(consumeRedirectTarget(fallback), { replace: true });
+      bindRoleType === "teacher"
+        ? getTeacherDashboardRoute()
+        : "/student/dashboard";
+    const allowedPrefixes =
+      bindRoleType === "teacher"
+        ? ["/teacher/", "/organization/", "/dashboard"]
+        : ["/student/"];
+    navigate(consumeRedirectTarget(fallback, allowedPrefixes), {
+      replace: true,
+    });
   }
 
   return (

--- a/frontend/src/pages/StudentLogin.tsx
+++ b/frontend/src/pages/StudentLogin.tsx
@@ -40,11 +40,12 @@ export default function StudentLogin() {
   const { login } = useStudentAuthStore();
   const { t } = useTranslation();
 
-  // Mirror router state into sessionStorage so it survives the 4-step flow.
+  // Depend on resolved `from` string (not state object) so a fresh state
+  // reference with the same `from` doesn't overwrite a still-valid save.
+  const fromState = (location.state as { from?: string } | null)?.from;
   useEffect(() => {
-    const from = (location.state as { from?: string } | null)?.from;
-    if (from) saveRedirectTarget(from);
-  }, [location.state]);
+    if (fromState) saveRedirectTarget(fromState);
+  }, [fromState]);
 
   // 檢查是否為 demo 模式 (通過 URL 參數 ?is_demo=true)
   const searchParams = new URLSearchParams(window.location.search);
@@ -197,7 +198,7 @@ export default function StudentLogin() {
           teacher_name: teacherHistory.find((t) => t.email === teacherEmail)
             ?.name,
         } as StudentUser);
-        navigate(consumeRedirectTarget("/student/dashboard"), {
+        navigate(consumeRedirectTarget("/student/dashboard", ["/student/"]), {
           replace: true,
         });
       }
@@ -239,7 +240,7 @@ export default function StudentLogin() {
         classrooms: s.classrooms,
         classrooms_count: s.classrooms_count,
       } as StudentUser);
-      navigate(consumeRedirectTarget("/student/dashboard"), {
+      navigate(consumeRedirectTarget("/student/dashboard", ["/student/"]), {
         replace: true,
       });
     } catch (err) {

--- a/frontend/src/pages/TeacherLogin.tsx
+++ b/frontend/src/pages/TeacherLogin.tsx
@@ -38,16 +38,22 @@ export default function TeacherLogin() {
     password: "",
   });
 
-  // Combined into one effect so saveRedirectTarget always runs before consumeRedirectTarget.
+  // Save and consume in the same effect so save-before-consume ordering is
+  // preserved when the user lands here already authenticated with a `from`.
+  const fromState = (location.state as { from?: string } | null)?.from;
   useEffect(() => {
-    const from = (location.state as { from?: string } | null)?.from;
-    if (from) saveRedirectTarget(from);
+    if (fromState) saveRedirectTarget(fromState);
     if (isAuthenticated && user) {
-      navigate(consumeRedirectTarget(getTeacherDashboardRoute()), {
-        replace: true,
-      });
+      navigate(
+        consumeRedirectTarget(getTeacherDashboardRoute(), [
+          "/teacher/",
+          "/organization/",
+          "/dashboard",
+        ]),
+        { replace: true },
+      );
     }
-  }, [isAuthenticated, user, navigate, location.state]);
+  }, [isAuthenticated, user, navigate, fromState]);
 
   // 檢查是否為 demo 模式 (通過 URL 參數 ?is_demo=true)
   const searchParams = new URLSearchParams(window.location.search);

--- a/frontend/src/utils/__tests__/redirectAfterLogin.test.ts
+++ b/frontend/src/utils/__tests__/redirectAfterLogin.test.ts
@@ -3,9 +3,10 @@ import {
   isSafeRedirectPath,
   saveRedirectTarget,
   consumeRedirectTarget,
+  REDIRECT_STORAGE_KEY,
 } from "../redirectAfterLogin";
 
-const STORAGE_KEY = "auth_redirect_after_login";
+const STORAGE_KEY = REDIRECT_STORAGE_KEY;
 
 describe("isSafeRedirectPath", () => {
   it("accepts normal absolute paths", () => {
@@ -93,5 +94,120 @@ describe("saveRedirectTarget / consumeRedirectTarget", () => {
   it("consumeRedirectTarget returns fallback if stored value is unsafe", () => {
     sessionStorage.setItem(STORAGE_KEY, "//evil.com");
     expect(consumeRedirectTarget("/safe-fallback")).toBe("/safe-fallback");
+  });
+});
+
+describe("consumeRedirectTarget allowedPrefixes (role isolation)", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("returns fallback when stored target does not match any allowed prefix", () => {
+    saveRedirectTarget("/teacher/dashboard");
+    expect(consumeRedirectTarget("/student/dashboard", ["/student/"])).toBe(
+      "/student/dashboard",
+    );
+  });
+
+  it("returns stored target when it matches an allowed prefix", () => {
+    saveRedirectTarget("/student/assignment/42/activity");
+    expect(consumeRedirectTarget("/student/dashboard", ["/student/"])).toBe(
+      "/student/assignment/42/activity",
+    );
+  });
+
+  it("returns stored target when any allowed prefix matches", () => {
+    saveRedirectTarget("/organization/123/members");
+    expect(
+      consumeRedirectTarget("/teacher/dashboard", [
+        "/teacher/",
+        "/organization/",
+        "/dashboard",
+      ]),
+    ).toBe("/organization/123/members");
+  });
+
+  it("teacher target leaks to student login → falls back", () => {
+    saveRedirectTarget("/teacher/programs/5");
+    expect(consumeRedirectTarget("/student/dashboard", ["/student/"])).toBe(
+      "/student/dashboard",
+    );
+  });
+
+  it("student target leaks to teacher login → falls back", () => {
+    saveRedirectTarget("/student/dashboard");
+    expect(
+      consumeRedirectTarget("/teacher/dashboard", [
+        "/teacher/",
+        "/organization/",
+        "/dashboard",
+      ]),
+    ).toBe("/teacher/dashboard");
+  });
+
+  it("still consumes (clears storage) when prefix mismatch causes fallback", () => {
+    saveRedirectTarget("/teacher/dashboard");
+    consumeRedirectTarget("/student/dashboard", ["/student/"]);
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("backwards compatible: omitting allowedPrefixes returns stored target", () => {
+    saveRedirectTarget("/anything/at/all");
+    expect(consumeRedirectTarget("/fallback")).toBe("/anything/at/all");
+  });
+
+  it("matches bare /dashboard exactly", () => {
+    saveRedirectTarget("/dashboard");
+    expect(
+      consumeRedirectTarget("/teacher/dashboard", [
+        "/teacher/",
+        "/organization/",
+        "/dashboard",
+      ]),
+    ).toBe("/dashboard");
+  });
+
+  it("matches /dashboard sub-paths via bare prefix", () => {
+    saveRedirectTarget("/dashboard/teacher");
+    expect(
+      consumeRedirectTarget("/teacher/dashboard", [
+        "/teacher/",
+        "/organization/",
+        "/dashboard",
+      ]),
+    ).toBe("/dashboard/teacher");
+  });
+
+  it("bare prefix /dashboard does not over-match /dashboard-admin", () => {
+    saveRedirectTarget("/dashboard-admin/foo");
+    expect(
+      consumeRedirectTarget("/teacher/dashboard", [
+        "/teacher/",
+        "/organization/",
+        "/dashboard",
+      ]),
+    ).toBe("/teacher/dashboard");
+  });
+
+  it("does not match a different role despite shared substring", () => {
+    saveRedirectTarget("/teacher/students/100");
+    // "/student/" prefix should NOT match "/teacher/students/..."
+    expect(consumeRedirectTarget("/student/dashboard", ["/student/"])).toBe(
+      "/student/dashboard",
+    );
+  });
+
+  it("empty string in allowedPrefixes does not silently allow every path", () => {
+    saveRedirectTarget("/teacher/dashboard");
+    expect(consumeRedirectTarget("/student/dashboard", [""])).toBe(
+      "/student/dashboard",
+    );
+  });
+
+  it("bare '/' in allowedPrefixes does not silently allow every path", () => {
+    saveRedirectTarget("/teacher/dashboard");
+    expect(consumeRedirectTarget("/student/dashboard", ["/"])).toBe(
+      "/student/dashboard",
+    );
   });
 });

--- a/frontend/src/utils/redirectAfterLogin.ts
+++ b/frontend/src/utils/redirectAfterLogin.ts
@@ -1,6 +1,7 @@
 // sessionStorage-backed so the target survives multi-step flows, SSO round-trips, and 401 hard navigations.
 
-const STORAGE_KEY = "auth_redirect_after_login";
+/** @internal — exported only so tests can read raw storage; do not use directly. */
+export const REDIRECT_STORAGE_KEY = "auth_redirect_after_login";
 
 const LOGIN_PAGE_PREFIXES = [
   "/teacher/login",
@@ -36,19 +37,43 @@ export function saveRedirectTarget(path: unknown): void {
   if (!isSafeRedirectPath(path)) return;
   if (LOGIN_PAGE_PREFIXES.some((p) => path.startsWith(p))) return;
   try {
-    sessionStorage.setItem(STORAGE_KEY, path);
+    sessionStorage.setItem(REDIRECT_STORAGE_KEY, path);
   } catch {
     // sessionStorage may be unavailable (private mode, SSR); silently ignore.
   }
 }
 
-export function consumeRedirectTarget(fallback: string): string {
+/**
+ * Consume the saved redirect target. Role-sensitive callers MUST pass
+ * `allowedPrefixes` to prevent a path saved by a different role from being
+ * honored (e.g., a `/teacher/*` target hijacking a student login flow).
+ * Prefix matching: trailing-slash prefix matches any sub-path; bare prefix
+ * matches exact-or-sub-path (so `/dashboard` does not match `/dashboard-admin`).
+ */
+export function consumeRedirectTarget(
+  fallback: string,
+  allowedPrefixes?: string[],
+): string {
   let target: string | null = null;
   try {
-    target = sessionStorage.getItem(STORAGE_KEY);
-    sessionStorage.removeItem(STORAGE_KEY);
+    target = sessionStorage.getItem(REDIRECT_STORAGE_KEY);
+    sessionStorage.removeItem(REDIRECT_STORAGE_KEY);
   } catch {
     // ignore
   }
-  return isSafeRedirectPath(target) ? target : fallback;
+  if (!isSafeRedirectPath(target)) return fallback;
+  if (
+    allowedPrefixes &&
+    !allowedPrefixes.some((p) => matchesPrefix(target, p))
+  ) {
+    return fallback;
+  }
+  return target;
+}
+
+function matchesPrefix(target: string, prefix: string): boolean {
+  // Reject empty and bare "/" — both would silently allow every absolute path.
+  if (!prefix || prefix === "/") return false;
+  if (prefix.endsWith("/")) return target.startsWith(prefix);
+  return target === prefix || target.startsWith(prefix + "/");
 }


### PR DESCRIPTION
## Summary

Release PR from staging to main, including 3 commits: 1 frontend fix and 2 idempotent schema migrations.

## Included Changes

### Bug Fixes
- 隔離學生/教師 redirect-after-login 防止跨角色跳轉到 /teacher/login (Fixes #697) (#700)

### Migrations
- add ai_analysis_count column to student_item_progress (Phase 2 schema for #676) (#699)
- add show_option_images column to assignments (#631) (#698)

## Migration Safety

Both migrations follow the project's idempotent rule (CLAUDE.md):
- `ADD COLUMN IF NOT EXISTS` / DO $$ guards
- New columns are nullable or have DEFAULT
- No DROP / RENAME / ALTER TYPE
- Already executed successfully on staging

## Test plan

- [ ] Verify both migrations run idempotently on production DB (re-runnable, no errors)
- [ ] Smoke test cross-role redirect bug fix:
  - [ ] Visit /teacher/dashboard while logged out → redirected to /teacher/login
  - [ ] Navigate to /student/login and log in as student → should land on /student/dashboard (NOT /teacher/login)
- [ ] Verify PR #693 functionality not regressed:
  - [ ] Unauthenticated /student/assignment/N/activity link → student login → redirects back to original activity
  - [ ] Unauthenticated /teacher/programs/N → teacher login → redirects back to original page
- [ ] SSO (1Campus) login flow still works for both teacher and student paths
- [ ] Monitor error rates after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)