### PR TITLE
feat(#703): add recording_duration_seconds column (Phase A migration)

### DIFF
--- a/backend/alembic/versions/20260429_1200_add_recording_duration_seconds_to_student_item_progress.py
+++ b/backend/alembic/versions/20260429_1200_add_recording_duration_seconds_to_student_item_progress.py
@@ -1,0 +1,44 @@
+"""add_recording_duration_seconds_to_student_item_progress
+
+Revision ID: 20260429_1200
+Revises: 20260428_1000
+Create Date: 2026-04-29 12:00:00.000000
+
+Issue #703: 學生錄音檔問題 (Phase A - migration only)
+Add recording_duration_seconds column to student_item_progress table.
+This allows the playback UI to display the recorded duration without relying on
+<audio>.duration, which is broken on iOS Safari fMP4 streams.
+Phase B will read/write this column from the upload endpoint and playback UI.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260429_1200"
+down_revision: Union[str, None] = "20260428_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'student_item_progress'
+                  AND column_name = 'recording_duration_seconds'
+            ) THEN
+                ALTER TABLE student_item_progress
+                    ADD COLUMN recording_duration_seconds INTEGER;
+            END IF;
+        END $$;
+    """
+    )
+
+
+def downgrade() -> None:
+    # No destructive operations per CLAUDE.md database migration rules.
+    pass

--- a/backend/alembic/versions/20260429_1200_add_recording_duration_seconds_to_student_item_progress.py
+++ b/backend/alembic/versions/20260429_1200_add_recording_duration_seconds_to_student_item_progress.py
@@ -1,7 +1,7 @@
 """add_recording_duration_seconds_to_student_item_progress
 
 Revision ID: 20260429_1200
-Revises: 20260428_1000
+Revises: 20260428_1100
 Create Date: 2026-04-29 12:00:00.000000
 
 Issue #703: 學生錄音檔問題 (Phase A - migration only)
@@ -17,7 +17,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260429_1200"
-down_revision: Union[str, None] = "20260428_1000"
+down_revision: Union[str, None] = "20260428_1100"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/models/progress.py
+++ b/backend/models/progress.py
@@ -106,6 +106,9 @@ class StudentItemProgress(Base):
 
     # Recording data
     recording_url = Column(Text)
+    recording_duration_seconds = Column(
+        Integer, nullable=True
+    )  # client-reported duration
     answer_text = Column(Text)
     transcription = Column(Text)  # AI 轉錄文字（與 DB 一致）
     submitted_at = Column(DateTime(timezone=True))

--- a/backend/tests/integration/api/test_issue_703_migration.py
+++ b/backend/tests/integration/api/test_issue_703_migration.py
@@ -1,0 +1,25 @@
+"""
+Issue #703 - Phase A: DB column exists smoke test.
+
+Verifies that StudentItemProgress has the recording_duration_seconds column
+declared in the SQLAlchemy model. No DB connection required — this is a
+model-level introspection test.
+"""
+import sys
+import os
+
+# Ensure backend package root is importable without a running app
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../"))
+
+
+def test_student_item_progress_has_recording_duration_seconds():
+    """recording_duration_seconds column must exist on StudentItemProgress model."""
+    from models.progress import StudentItemProgress  # noqa: PLC0415
+
+    assert hasattr(
+        StudentItemProgress, "recording_duration_seconds"
+    ), "StudentItemProgress is missing the 'recording_duration_seconds' column"
+
+    col = StudentItemProgress.__table__.c.get("recording_duration_seconds")
+    assert col is not None, "Column not found in __table__"
+    assert col.nullable, "Column should be nullable (existing rows must not break)"


### PR DESCRIPTION
## Summary

This is **Phase A** of issue #703 (學生錄音檔問題) — migration only, no behavior changes.

A single nullable `INTEGER` column `recording_duration_seconds` is added to the `student_item_progress` table. This allows the playback UI (Phase B) to display the recorded duration without relying on `<audio>.duration`, which is broken on iOS Safari fMP4 streams.

**Phase B** (a separate PR) will read and write this column from the audio upload endpoint and the playback UI component.

## Changes

- `backend/alembic/versions/20260429_1200_add_recording_duration_seconds_to_student_item_progress.py` — idempotent migration (`DO $$ IF NOT EXISTS $$`)
- `backend/models/progress.py` — `recording_duration_seconds = Column(Integer, nullable=True)` added to `StudentItemProgress`
- `backend/tests/integration/api/test_issue_703_migration.py` — smoke test asserting the column exists on the model

## Migration details

- **Idempotent**: uses PL/pgSQL `IF NOT EXISTS` guard; safe to re-run on any environment
- **Non-destructive**: nullable column, no default required, existing rows stay NULL
- **downgrade**: no-op (`pass`) per CLAUDE.md rules

## Related

Closes part of #703 (Phase A only — do NOT auto-close the issue; use Phase B PR for that)