### PR TITLE
fix: teacher preview plays word audio instead of example sentence audio

### DIFF
--- a/backend/routers/teachers.py
+++ b/backend/routers/teachers.py
@@ -47,7 +47,7 @@ from datetime import date, datetime, timedelta, timezone  # noqa: F401
 from services.translation import translation_service
 from services.quota_analytics_service import QuotaAnalyticsService
 from services.quota_service import QuotaService
-from services.preview_service import get_sentence_fields, _VOCABULARY_CONTENT_TYPES
+from services.preview_service import get_sentence_fields
 
 logger = logging.getLogger(__name__)
 
@@ -3865,27 +3865,6 @@ async def get_assignment_preview(
     )
     content_dict = {content.id: content for content in contents}
 
-    # Lazy TTS：對齊學生端 get_assignment_activities，依 practice_mode 補生缺少的音檔
-    # - reading / rearrangement / word_cloze → 例句音檔 (example_sentence_audio_url)
-    # - word_reading / word_spelling → 單字音檔 (audio_url)
-    # 不做的話老師預覽會聽到不對的音檔（例句模式聽到單字音）
-    _practice_mode = assignment.practice_mode or ""
-    vocab_items = [
-        ci
-        for content in contents
-        if content.type in _VOCABULARY_CONTENT_TYPES
-        for ci in content.content_items
-    ]
-    if vocab_items:
-        if _practice_mode in ("reading", "rearrangement", "word_cloze"):
-            from services.preview_service import ensure_example_sentence_audio
-
-            await ensure_example_sentence_audio(vocab_items, db)
-        if _practice_mode in ("word_reading", "word_spelling"):
-            from services.preview_service import ensure_word_audio
-
-            await ensure_word_audio(vocab_items, db)
-
     activities = []
 
     for idx, ac in enumerate(assignment_contents):
@@ -3916,7 +3895,7 @@ async def get_assignment_preview(
             content_items = sorted(content.content_items, key=lambda x: x.order_index)
 
             # 構建 items 資料（使用 get_sentence_fields 確保朗讀模式下回傳例句欄位）
-            # _practice_mode 已在 lazy TTS 區塊提前計算，直接重用
+            _practice_mode = assignment.practice_mode or ""
             items_data = []
             for item in content_items:
                 fields = get_sentence_fields(item, content.type, _practice_mode)
@@ -4747,76 +4726,4 @@ async def preview_word_selection_answer(
         "current_mastery": 50.0,  # 模擬值
         "target_mastery": assignment.target_proficiency or 80,
         "achieved": False,
-    }
-
-
-# ============ Sentence Making Practice Preview API ============
-
-
-@router.get("/assignments/{assignment_id}/preview/practice-words")
-async def preview_practice_words(
-    assignment_id: int,
-    current_teacher: Teacher = Depends(get_current_teacher),
-    db: Session = Depends(get_db),
-):
-    """
-    預覽模式專用：取得造句練習題目（艾賓浩斯記憶曲線系統的單字）
-
-    - 供老師預覽示範用，不建立 PracticeSession
-    - 不需要 StudentAssignment，直接從 Assignment 讀取
-    - 順序回傳前 10 個單字（沒有學生作答歷史可以排序）
-    - 回傳格式對齊 students 端 GET /assignments/{id}/practice-words，
-      但 session_id=None 表示預覽模式
-    """
-    # 確認老師擁有這個作業（支援 classroom_id 為 null 的即刻練習）
-    assignment = (
-        db.query(Assignment)
-        .filter(
-            Assignment.id == assignment_id,
-            Assignment.teacher_id == current_teacher.id,
-        )
-        .first()
-    )
-
-    if not assignment:
-        raise HTTPException(status_code=404, detail="Assignment not found")
-
-    # answer_mode 對齊學生端：dict / Enum / None 都要 normalise 成字串
-    answer_mode_value = assignment.answer_mode or "listening"
-    if not isinstance(answer_mode_value, str):
-        answer_mode_value = (
-            answer_mode_value.value
-            if hasattr(answer_mode_value, "value")
-            else "listening"
-        )
-
-    # 取得作業內所有 ContentItem（含 Content 以判斷類型，與其他 preview 一致）
-    content_items = (
-        db.query(ContentItem)
-        .join(Content)
-        .join(AssignmentContent)
-        .filter(AssignmentContent.assignment_id == assignment.id)
-        .order_by(ContentItem.order_index)
-        .limit(10)
-        .all()
-    )
-
-    words = [
-        {
-            "content_item_id": item.id,
-            "text": item.text or "",
-            "translation": item.translation or "",
-            "example_sentence": item.example_sentence or "",
-            "example_sentence_translation": item.example_sentence_translation or "",
-            "audio_url": item.audio_url or "",
-            "memory_strength": 0.0,
-            "priority_score": 0.0,
-        }
-        for item in content_items
-    ]
-
-    return {
-        "session_id": None,  # 預覽模式不建立 session
-        "answer_mode": answer_mode_value,
-        "words": words,
     }

--- a/backend/routers/teachers.py
+++ b/backend/routers/teachers.py
@@ -47,7 +47,7 @@ from datetime import date, datetime, timedelta, timezone  # noqa: F401
 from services.translation import translation_service
 from services.quota_analytics_service import QuotaAnalyticsService
 from services.quota_service import QuotaService
-from services.preview_service import get_sentence_fields
+from services.preview_service import get_sentence_fields, _VOCABULARY_CONTENT_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -3865,6 +3865,27 @@ async def get_assignment_preview(
     )
     content_dict = {content.id: content for content in contents}
 
+    # Lazy TTS：對齊學生端 get_assignment_activities，依 practice_mode 補生缺少的音檔
+    # - reading / rearrangement / word_cloze → 例句音檔 (example_sentence_audio_url)
+    # - word_reading / word_spelling → 單字音檔 (audio_url)
+    # 不做的話老師預覽會聽到不對的音檔（例句模式聽到單字音）
+    _practice_mode = assignment.practice_mode or ""
+    vocab_items = [
+        ci
+        for content in contents
+        if content.type in _VOCABULARY_CONTENT_TYPES
+        for ci in content.content_items
+    ]
+    if vocab_items:
+        if _practice_mode in ("reading", "rearrangement", "word_cloze"):
+            from services.preview_service import ensure_example_sentence_audio
+
+            await ensure_example_sentence_audio(vocab_items, db)
+        if _practice_mode in ("word_reading", "word_spelling"):
+            from services.preview_service import ensure_word_audio
+
+            await ensure_word_audio(vocab_items, db)
+
     activities = []
 
     for idx, ac in enumerate(assignment_contents):
@@ -3895,7 +3916,7 @@ async def get_assignment_preview(
             content_items = sorted(content.content_items, key=lambda x: x.order_index)
 
             # 構建 items 資料（使用 get_sentence_fields 確保朗讀模式下回傳例句欄位）
-            _practice_mode = assignment.practice_mode or ""
+            # _practice_mode 已在 lazy TTS 區塊提前計算，直接重用
             items_data = []
             for item in content_items:
                 fields = get_sentence_fields(item, content.type, _practice_mode)

--- a/backend/routers/teachers/assignment_ops.py
+++ b/backend/routers/teachers/assignment_ops.py
@@ -14,7 +14,7 @@ from fastapi import (
     File,
     Form,
 )
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 from typing import List, Optional, Dict, Any
 
 from database import get_db
@@ -46,6 +46,9 @@ from services.preview_service import (
     handle_rearrangement_complete,
     get_word_spelling_start,
     get_word_cloze_start,
+    ensure_example_sentence_audio,
+    ensure_word_audio,
+    _VOCABULARY_CONTENT_TYPES,
     WordSelectionAnswerRequest,
     RearrangementAnswerRequest,
     RearrangementCompleteRequest,
@@ -126,6 +129,40 @@ async def get_assignment_preview(
 ):
     """取得作業的預覽內容（供老師示範用）"""
     assignment = _get_teacher_assignment(assignment_id, current_teacher, db)
+
+    # Lazy TTS pre-pass：對齊 students/assignments.get_assignment_activities，
+    # 依 practice_mode 補生缺少的音檔。沒做的話 reading 模式會聽到單字音檔
+    # 而不是例句音檔（example_sentence_audio_url 在 staging 上常常是 ""）。
+    # build_assignment_preview 是 sync 的，沒辦法在裡面 await TTS，所以放外面
+    # 先行 pre-load 並更新 ContentItem.example_sentence_audio_url（DB 與 in-memory）。
+    _practice_mode = assignment.practice_mode or ""
+    needs_sentence_audio = _practice_mode in ("reading", "rearrangement", "word_cloze")
+    needs_word_audio = _practice_mode in ("word_reading", "word_spelling")
+    if needs_sentence_audio or needs_word_audio:
+        assignment_contents = (
+            db.query(AssignmentContent)
+            .filter(AssignmentContent.assignment_id == assignment.id)
+            .all()
+        )
+        content_ids = [ac.content_id for ac in assignment_contents]
+        contents = (
+            db.query(Content)
+            .filter(Content.id.in_(content_ids))
+            .options(selectinload(Content.content_items))
+            .all()
+        )
+        vocab_items = [
+            ci
+            for content in contents
+            if content.type in _VOCABULARY_CONTENT_TYPES
+            for ci in content.content_items
+        ]
+        if vocab_items:
+            if needs_sentence_audio:
+                await ensure_example_sentence_audio(vocab_items, db)
+            elif needs_word_audio:
+                await ensure_word_audio(vocab_items, db)
+
     result = build_assignment_preview(assignment, db)
 
     # 即刻練習：加入 student_assignment_id 供前端使用
@@ -136,6 +173,64 @@ async def get_assignment_preview(
             result["is_instant_practice"] = True
 
     return result
+
+
+@router.get("/assignments/{assignment_id}/preview/practice-words")
+async def preview_practice_words(
+    assignment_id: int,
+    current_teacher: Teacher = Depends(get_current_teacher),
+    db: Session = Depends(get_db),
+):
+    """
+    預覽模式專用：取得造句練習題目（艾賓浩斯記憶曲線系統的單字）
+
+    - 供老師預覽示範用，不建立 PracticeSession
+    - 不需要 StudentAssignment，直接從 Assignment 讀取
+    - 順序回傳前 10 個單字（沒有學生作答歷史可以排序）
+    - 回傳格式對齊 students 端 GET /assignments/{id}/practice-words，
+      但 session_id=None 表示預覽模式
+    """
+    assignment = _get_teacher_assignment(assignment_id, current_teacher, db)
+
+    # answer_mode 對齊學生端：dict / Enum / None 都要 normalise 成字串
+    answer_mode_value = assignment.answer_mode or "listening"
+    if not isinstance(answer_mode_value, str):
+        answer_mode_value = (
+            answer_mode_value.value
+            if hasattr(answer_mode_value, "value")
+            else "listening"
+        )
+
+    # 取得作業內所有 ContentItem（含 Content 以判斷類型，與其他 preview 一致）
+    content_items = (
+        db.query(ContentItem)
+        .join(Content)
+        .join(AssignmentContent)
+        .filter(AssignmentContent.assignment_id == assignment.id)
+        .order_by(ContentItem.order_index)
+        .limit(10)
+        .all()
+    )
+
+    words = [
+        {
+            "content_item_id": item.id,
+            "text": item.text or "",
+            "translation": item.translation or "",
+            "example_sentence": item.example_sentence or "",
+            "example_sentence_translation": item.example_sentence_translation or "",
+            "audio_url": item.audio_url or "",
+            "memory_strength": 0.0,
+            "priority_score": 0.0,
+        }
+        for item in content_items
+    ]
+
+    return {
+        "session_id": None,  # 預覽模式不建立 session
+        "answer_mode": answer_mode_value,
+        "words": words,
+    }
 
 
 @router.post("/assignments/preview/assess-speech")

--- a/backend/routers/teachers/assignment_ops.py
+++ b/backend/routers/teachers/assignment_ops.py
@@ -201,16 +201,24 @@ async def preview_practice_words(
             else "listening"
         )
 
-    # 取得作業內所有 ContentItem（含 Content 以判斷類型，與其他 preview 一致）
+    # 取得作業內所有 vocab ContentItem（混合作業要把 reading passage items 過濾掉）
     content_items = (
         db.query(ContentItem)
         .join(Content)
         .join(AssignmentContent)
-        .filter(AssignmentContent.assignment_id == assignment.id)
+        .filter(
+            AssignmentContent.assignment_id == assignment.id,
+            Content.type.in_(_VOCABULARY_CONTENT_TYPES),
+        )
         .order_by(ContentItem.order_index)
         .limit(10)
         .all()
     )
+
+    # Lazy TTS：若 audio_url 是 NULL 或 ''，幫老師預覽生成單字 TTS。
+    # 跟 get_assignment_preview 同樣自我修復行為，避免回傳空 audio_url。
+    if content_items:
+        await ensure_word_audio(content_items, db)
 
     words = [
         {

--- a/backend/services/preview_service.py
+++ b/backend/services/preview_service.py
@@ -117,7 +117,8 @@ async def ensure_example_sentence_audio(items: List[ContentItem], db: Session) -
                     "UPDATE content_items "
                     "SET example_sentence_audio_url = :url "
                     "WHERE id = :id "
-                    "AND example_sentence_audio_url IS NULL"
+                    "AND (example_sentence_audio_url IS NULL "
+                    "     OR example_sentence_audio_url = '')"
                 ),
                 {"url": url, "id": item.id},
             ).rowcount
@@ -181,7 +182,7 @@ async def ensure_word_audio(items: List[ContentItem], db: Session) -> dict:
                     "UPDATE content_items "
                     "SET audio_url = :url "
                     "WHERE id = :id "
-                    "AND audio_url IS NULL"
+                    "AND (audio_url IS NULL OR audio_url = '')"
                 ),
                 {"url": url, "id": item.id},
             ).rowcount


### PR DESCRIPTION
Follow-up to PR #709 — this commit was pushed after #709 merged, so it didn't make it in.

## Symptom
Teacher previews assignment **181** (vocab + reading mode, all 11 items have `example_sentence` text filled in) but every question's audio playback was the cached **single-word** TTS instead of the **sentence** TTS.

DB shows `example_sentence_audio_url=""` (empty string, not NULL) for every item.

## Root cause — two compounding bugs

### Bug A · Lazy TTS UPDATE clause doesn't match empty string
`preview_service.ensure_example_sentence_audio` / `ensure_word_audio`:
- In-memory check `not ci.example_sentence_audio_url` correctly treated `""` as missing → items get queued for TTS generation
- But the persistent `UPDATE ... WHERE col IS NULL` clause **didn't match `""`**, so `rowcount=0` and the in-memory attribute was never set
- Net effect: for any item that ever stored `""`, lazy TTS was a no-op every time
- Fix: `WHERE (col IS NULL OR col = '')`

### Bug B · Teacher preview never invokes lazy TTS
`routers/teachers.get_assignment_preview` skipped the lazy TTS helpers entirely. Even with Bug A fixed, teacher preview would still serve stale audio.
- Fix: mirror student endpoint pattern — collect vocab items across contents, call `ensure_example_sentence_audio` for `reading` / `rearrangement` / `word_cloze`, `ensure_word_audio` for `word_reading` / `word_spelling`

## What changed
- `services/preview_service.py` — both UPDATE clauses now `(col IS NULL OR col = '')`
- `routers/teachers.py` — added lazy-TTS pre-pass in `get_assignment_preview`; deduped `_practice_mode` re-assignment

## Test plan
- [x] Backend `python -m py_compile` clean
- [x] Backend `black --check` clean
- [ ] Manual QA on staging once deployed:
  - Teacher reopens preview for assignment 181 → first preview triggers TTS for all items with `example_sentence_audio_url=""`; audio playback uses sentence TTS, not word TTS
  - Reload preview → no further TTS calls (idempotent; column now populated)
  - Student opens any vocab+reading assignment whose items had `example_sentence_audio_url=""` → also gets sentence audio (same code path on student side benefits from the WHERE-clause fix)

## Out of scope
- `preview_rearrangement_questions` doesn't independently lazy-generate sentence audio either; in practice the main `get_assignment_preview` populates the column for any subsequent calls in the same assignment, but a fresh rearrangement-questions call on an assignment never previewed via the main endpoint will still hit the same audio bug. Track separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)