### PR TITLE
feat: add 1Campus OAuth 2.0 SSO login flow (Fixes #634)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -410,7 +410,10 @@ jobs:
         ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_ID=${{ secrets.ONE_CAMPUS_OAUTH_CLIENT_ID }}"
         ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_SECRET=${{ secrets.ONE_CAMPUS_OAUTH_CLIENT_SECRET }}"
         ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_REDIRECT_URI=${{ steps.db_env.outputs.FRONTEND_URL }}/auth/1campus/callback"
-        # 1Campus Data API (Jasmine) credentials — same client, used for client_credentials flow.
+        # 1Campus Data API (Jasmine) — client_credentials grant for the Jasmine API.
+        # Currently the same registered Duotopia client as ONE_CAMPUS_OAUTH_*,
+        # but stored as separate secrets so they can be rotated independently
+        # (or split into different clients in the future) without code changes.
         ENV_VARS="$ENV_VARS,ONE_CAMPUS_CLIENT_ID=${{ secrets.ONE_CAMPUS_CLIENT_ID }}"
         ENV_VARS="$ENV_VARS,ONE_CAMPUS_CLIENT_SECRET=${{ secrets.ONE_CAMPUS_CLIENT_SECRET }}"
 

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -410,6 +410,9 @@ jobs:
         ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_ID=${{ secrets.ONE_CAMPUS_OAUTH_CLIENT_ID }}"
         ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_SECRET=${{ secrets.ONE_CAMPUS_OAUTH_CLIENT_SECRET }}"
         ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_REDIRECT_URI=${{ steps.db_env.outputs.FRONTEND_URL }}/auth/1campus/callback"
+        # 1Campus Data API (Jasmine) credentials — same client, used for client_credentials flow.
+        ENV_VARS="$ENV_VARS,ONE_CAMPUS_CLIENT_ID=${{ secrets.ONE_CAMPUS_CLIENT_ID }}"
+        ENV_VARS="$ENV_VARS,ONE_CAMPUS_CLIENT_SECRET=${{ secrets.ONE_CAMPUS_CLIENT_SECRET }}"
 
         # Environment-specific configuration
         if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -406,6 +406,11 @@ jobs:
         ENV_VARS="$ENV_VARS,TAPPAY_PRODUCTION_PARTNER_KEY=${{ secrets.TAPPAY_PRODUCTION_PARTNER_KEY }}"
         ENV_VARS="$ENV_VARS,TAPPAY_PRODUCTION_MERCHANT_ID=${{ secrets.TAPPAY_PRODUCTION_MERCHANT_ID }}"
 
+        # 1Campus OAuth (registered Duotopia client; redirect URI regex covers all envs)
+        ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_ID=${{ secrets.ONE_CAMPUS_OAUTH_CLIENT_ID }}"
+        ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_SECRET=${{ secrets.ONE_CAMPUS_OAUTH_CLIENT_SECRET }}"
+        ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_REDIRECT_URI=${{ steps.db_env.outputs.FRONTEND_URL }}/auth/1campus/callback"
+
         # Environment-specific configuration
         if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
           ENV_VARS="$ENV_VARS,TAPPAY_ENV=production"

--- a/.github/workflows/deploy-per-issue.yml
+++ b/.github/workflows/deploy-per-issue.yml
@@ -143,10 +143,10 @@ jobs:
           ENV_VARS="$ENV_VARS,TAPPAY_PRODUCTION_APP_KEY=${{ secrets.TAPPAY_PRODUCTION_APP_KEY }}"
           ENV_VARS="$ENV_VARS,TAPPAY_PRODUCTION_PARTNER_KEY=${{ secrets.TAPPAY_PRODUCTION_PARTNER_KEY }}"
           ENV_VARS="$ENV_VARS,TAPPAY_PRODUCTION_MERCHANT_ID=${{ secrets.TAPPAY_PRODUCTION_MERCHANT_ID }}"
-          # 1Campus OAuth (test credentials from public quickstart docs).
+          # 1Campus OAuth credentials from GitHub Secrets.
           # REDIRECT_URI is a placeholder; updated to the real frontend URL in update-backend-frontend-url.
-          ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_ID=edf96e2da7a4f156f1df52f07ab3490f"
-          ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_SECRET=84aff4ae1841be51b6dcdd41546e3ad1eaf9b2d05e8240050753ac5fdddf3940"
+          ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_ID=${{ secrets.ONE_CAMPUS_OAUTH_CLIENT_ID }}"
+          ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_SECRET=${{ secrets.ONE_CAMPUS_OAUTH_CLIENT_SECRET }}"
           ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_REDIRECT_URI=https://placeholder-will-be-updated.run.app/auth/1campus/callback"
 
           echo "🔍 DEBUG: Deploying to Cloud Run (without output capture)"

--- a/.github/workflows/deploy-per-issue.yml
+++ b/.github/workflows/deploy-per-issue.yml
@@ -148,7 +148,10 @@ jobs:
           ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_ID=${{ secrets.ONE_CAMPUS_OAUTH_CLIENT_ID }}"
           ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_SECRET=${{ secrets.ONE_CAMPUS_OAUTH_CLIENT_SECRET }}"
           ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_REDIRECT_URI=https://placeholder-will-be-updated.run.app/auth/1campus/callback"
-          # 1Campus Data API (Jasmine) credentials — same client, used for client_credentials flow.
+          # 1Campus Data API (Jasmine) — client_credentials grant for the Jasmine API.
+          # Currently the same registered Duotopia client as ONE_CAMPUS_OAUTH_*,
+          # but stored as separate secrets so they can be rotated independently
+          # (or split into different clients in the future) without code changes.
           ENV_VARS="$ENV_VARS,ONE_CAMPUS_CLIENT_ID=${{ secrets.ONE_CAMPUS_CLIENT_ID }}"
           ENV_VARS="$ENV_VARS,ONE_CAMPUS_CLIENT_SECRET=${{ secrets.ONE_CAMPUS_CLIENT_SECRET }}"
 

--- a/.github/workflows/deploy-per-issue.yml
+++ b/.github/workflows/deploy-per-issue.yml
@@ -144,7 +144,10 @@ jobs:
           ENV_VARS="$ENV_VARS,TAPPAY_PRODUCTION_PARTNER_KEY=${{ secrets.TAPPAY_PRODUCTION_PARTNER_KEY }}"
           ENV_VARS="$ENV_VARS,TAPPAY_PRODUCTION_MERCHANT_ID=${{ secrets.TAPPAY_PRODUCTION_MERCHANT_ID }}"
           # 1Campus OAuth credentials from GitHub Secrets.
-          # REDIRECT_URI is a placeholder; updated to the real frontend URL in update-backend-frontend-url.
+          # The redirect URI is intentionally a placeholder here because the
+          # frontend Cloud Run URL hasn't been generated yet at this step.
+          # The `update-backend-frontend-url` job (see below) replaces it with
+          # the real frontend URL after frontend deploy completes.
           ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_ID=${{ secrets.ONE_CAMPUS_OAUTH_CLIENT_ID }}"
           ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_SECRET=${{ secrets.ONE_CAMPUS_OAUTH_CLIENT_SECRET }}"
           ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_REDIRECT_URI=https://placeholder-will-be-updated.run.app/auth/1campus/callback"

--- a/.github/workflows/deploy-per-issue.yml
+++ b/.github/workflows/deploy-per-issue.yml
@@ -148,6 +148,9 @@ jobs:
           ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_ID=${{ secrets.ONE_CAMPUS_OAUTH_CLIENT_ID }}"
           ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_SECRET=${{ secrets.ONE_CAMPUS_OAUTH_CLIENT_SECRET }}"
           ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_REDIRECT_URI=https://placeholder-will-be-updated.run.app/auth/1campus/callback"
+          # 1Campus Data API (Jasmine) credentials — same client, used for client_credentials flow.
+          ENV_VARS="$ENV_VARS,ONE_CAMPUS_CLIENT_ID=${{ secrets.ONE_CAMPUS_CLIENT_ID }}"
+          ENV_VARS="$ENV_VARS,ONE_CAMPUS_CLIENT_SECRET=${{ secrets.ONE_CAMPUS_CLIENT_SECRET }}"
 
           echo "🔍 DEBUG: Deploying to Cloud Run (without output capture)"
           gcloud run deploy "${SERVICE}" \

--- a/.github/workflows/deploy-per-issue.yml
+++ b/.github/workflows/deploy-per-issue.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'frontend/**'
       - 'backend/**'
+      - '.github/workflows/deploy-per-issue.yml'
       - '!**/*.md'
 
 permissions:
@@ -142,6 +143,11 @@ jobs:
           ENV_VARS="$ENV_VARS,TAPPAY_PRODUCTION_APP_KEY=${{ secrets.TAPPAY_PRODUCTION_APP_KEY }}"
           ENV_VARS="$ENV_VARS,TAPPAY_PRODUCTION_PARTNER_KEY=${{ secrets.TAPPAY_PRODUCTION_PARTNER_KEY }}"
           ENV_VARS="$ENV_VARS,TAPPAY_PRODUCTION_MERCHANT_ID=${{ secrets.TAPPAY_PRODUCTION_MERCHANT_ID }}"
+          # 1Campus OAuth (test credentials from public quickstart docs).
+          # REDIRECT_URI is a placeholder; updated to the real frontend URL in update-backend-frontend-url.
+          ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_ID=edf96e2da7a4f156f1df52f07ab3490f"
+          ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_CLIENT_SECRET=84aff4ae1841be51b6dcdd41546e3ad1eaf9b2d05e8240050753ac5fdddf3940"
+          ENV_VARS="$ENV_VARS,ONE_CAMPUS_OAUTH_REDIRECT_URI=https://placeholder-will-be-updated.run.app/auth/1campus/callback"
 
           echo "🔍 DEBUG: Deploying to Cloud Run (without output capture)"
           gcloud run deploy "${SERVICE}" \
@@ -312,17 +318,20 @@ jobs:
           ISSUE=${{ needs.extract.outputs.issue_number }}
           SERVICE="duotopia-preview-issue-${ISSUE}-backend"
           FRONTEND_URL="${{ needs.deploy-frontend.outputs.url }}"
+          ONE_CAMPUS_REDIRECT_URI="${FRONTEND_URL}/auth/1campus/callback"
 
           echo "📝 Frontend URL: ${FRONTEND_URL}"
+          echo "📝 1Campus OAuth Redirect URI: ${ONE_CAMPUS_REDIRECT_URI}"
 
-          # Update FRONTEND_URL and DEMO_ALLOWED_ORIGINS environment variables
+          # Update FRONTEND_URL, DEMO_ALLOWED_ORIGINS, and 1Campus OAuth redirect URI
           gcloud run services update "${SERVICE}" \
             --platform managed \
             --region ${{ env.REGION }} \
-            --update-env-vars "FRONTEND_URL=${FRONTEND_URL},DEMO_ALLOWED_ORIGINS=${FRONTEND_URL}"
+            --update-env-vars "FRONTEND_URL=${FRONTEND_URL},DEMO_ALLOWED_ORIGINS=${FRONTEND_URL},ONE_CAMPUS_OAUTH_REDIRECT_URI=${ONE_CAMPUS_REDIRECT_URI}"
 
           echo "✅ Backend FRONTEND_URL updated to: ${FRONTEND_URL}"
           echo "✅ Backend DEMO_ALLOWED_ORIGINS updated to: ${FRONTEND_URL}"
+          echo "✅ Backend ONE_CAMPUS_OAUTH_REDIRECT_URI updated to: ${ONE_CAMPUS_REDIRECT_URI}"
 
   cleanup-images:
     runs-on: ubuntu-latest

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -65,9 +65,7 @@ class Settings:
     )
 
     # 1Campus OAuth (auth.ischool.com.tw)
-    ONE_CAMPUS_OAUTH_CLIENT_ID: Optional[str] = os.getenv(
-        "ONE_CAMPUS_OAUTH_CLIENT_ID"
-    )
+    ONE_CAMPUS_OAUTH_CLIENT_ID: Optional[str] = os.getenv("ONE_CAMPUS_OAUTH_CLIENT_ID")
     ONE_CAMPUS_OAUTH_CLIENT_SECRET: Optional[str] = os.getenv(
         "ONE_CAMPUS_OAUTH_CLIENT_SECRET"
     )

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -64,6 +64,17 @@ class Settings:
         "ONE_CAMPUS_API_BASE_URL", "https://devapi.1campus.net"
     )
 
+    # 1Campus OAuth (auth.ischool.com.tw)
+    ONE_CAMPUS_OAUTH_CLIENT_ID: Optional[str] = os.getenv(
+        "ONE_CAMPUS_OAUTH_CLIENT_ID"
+    )
+    ONE_CAMPUS_OAUTH_CLIENT_SECRET: Optional[str] = os.getenv(
+        "ONE_CAMPUS_OAUTH_CLIENT_SECRET"
+    )
+    ONE_CAMPUS_OAUTH_REDIRECT_URI: Optional[str] = os.getenv(
+        "ONE_CAMPUS_OAUTH_REDIRECT_URI"
+    )
+
     # OpenAI (optional)
     OPENAI_API_KEY: Optional[str] = os.getenv("OPENAI_API_KEY")
 

--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -250,9 +250,7 @@ async def _handle_identity_code_flow(
     """Handle the Identity Code flow (from 1Campus platform)."""
     # Step 1: Exchange identity code
     try:
-        identity_data = await OneCampusService.exchange_identity_code(
-            school_dsns, code
-        )
+        identity_data = await OneCampusService.exchange_identity_code(school_dsns, code)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except OneCampusCodeNotFoundError:
@@ -462,20 +460,23 @@ async def _handle_oauth_flow(
     # Step 4: Match or create account
     display_name = f"{last_name}{first_name}".strip()
 
-    identity, user, detected_role, action = (
-        OneCampusAccountService.find_or_create_by_oauth(
-            db=db,
-            uuid=uuid,
-            mail=mail,
-            first_name=first_name,
-            last_name=last_name,
-            role_type=role_type,
-            one_campus_student_id=one_campus_student_id,
-            student_name=student_name,
-            student_number=student_number,
-            teacher_name=teacher_name,
-            national_id_hash=national_id_hash,
-        )
+    (
+        identity,
+        user,
+        detected_role,
+        action,
+    ) = OneCampusAccountService.find_or_create_by_oauth(
+        db=db,
+        uuid=uuid,
+        mail=mail,
+        first_name=first_name,
+        last_name=last_name,
+        role_type=role_type,
+        one_campus_student_id=one_campus_student_id,
+        student_name=student_name,
+        student_number=student_number,
+        teacher_name=teacher_name,
+        national_id_hash=national_id_hash,
     )
 
     # Step 5: Build response

--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -133,6 +133,11 @@ def _create_oauth_state() -> str:
     Format: base64(json({"nonce": ..., "exp": ...})).signature
     Verified on the OAuth callback to defend against forged state values.
     Stateless (no DB/session needed); per-issue and stateless deploys friendly.
+
+    Note on replay: this token is reusable within its 10-minute TTL, but the
+    OAuth authorization code (issued by 1Campus and tied to this state) is
+    single-use, so a captured state alone cannot complete a login flow. The
+    `.` separator is safe because base64url uses only [A-Za-z0-9_-] (no dots).
     """
     payload_dict = {
         "nonce": secrets.token_urlsafe(16),
@@ -488,23 +493,25 @@ async def _handle_oauth_flow(
     try:
         user_role_data = await OneCampusService.get_user_role(account=mail)
         for school in user_role_data.get("school", []):
-            # Extract national_id_hash
-            for role_key in ("studentRole", "teacherRole"):
-                role_data = school.get(role_key)
-                if role_data and role_data.get("idNumberHash"):
-                    national_id_hash = role_data["idNumberHash"]
-                    break
-
-            # Determine role
+            # Determine role and extract hash from the SAME role to keep them
+            # in sync. A user may have both teacherRole and studentRole in one
+            # school; if we extracted hash from one and role from the other,
+            # the teacher account would be linked to the student's national ID
+            # hash (and vice versa).
             if school.get("teacherRole"):
                 role_type = "teacher"
-                teacher_name = school["teacherRole"].get("teacherName")
+                tr = school["teacherRole"]
+                teacher_name = tr.get("teacherName")
+                if tr.get("idNumberHash"):
+                    national_id_hash = tr["idNumberHash"]
             elif school.get("studentRole"):
                 role_type = "student"
                 sr = school["studentRole"]
                 one_campus_student_id = str(sr.get("studentID", ""))
                 student_name = sr.get("studentName")
                 student_number = sr.get("studentNumber")
+                if sr.get("idNumberHash"):
+                    national_id_hash = sr["idNumberHash"]
 
             if role_type:
                 break
@@ -714,15 +721,18 @@ async def bind_account(
 ):
     """Request to bind a 1Campus SSO account to a Duotopia email.
 
-    The caller must be logged in via 1Campus SSO (has an Identity with
-    one_campus_student_id or one_campus_account but no verified email).
+    The caller must be logged in via 1Campus SSO. The Identity is resolved
+    from the authenticated user's `identity_id` (NOT from a request parameter),
+    so a logged-in user can only bind their own identity — there is no path
+    to operate on another user's identity_id even if it were guessed.
     Sends a verification email to the provided address.
     After verification, the Identity merge happens in verify-email endpoint.
     """
     user_type = current_user.get("type")
     user_id = int(current_user.get("sub"))
 
-    # Resolve the Identity for the current user
+    # Resolve the Identity for the current user (from the JWT subject, never
+    # from request body) — this guards against impersonation attempts.
     if user_type == "student":
         user = db.query(Student).filter(Student.id == user_id).first()
         if not user:
@@ -759,10 +769,13 @@ async def bind_account(
 
     target_email = body.email.strip().lower()
 
-    # Block only if the identity is already bound to this exact email (would be a no-op).
-    # Allow rebind to a different email — the OAuth-created identity stores the
-    # 1Campus mail as "verified", but the user may want to link an existing
-    # Duotopia account with a different email address.
+    # Block only when the identity is already bound to this exact email (no-op).
+    # Allowing rebind to a *different* email is intentional: when OAuth creates
+    # a new Identity for a 1Campus user, we set email=<1campus mail>,
+    # email_verified=True (1Campus is the IdP and verifies institutional mails).
+    # If we rejected on email_verified alone, the user could never link the
+    # SSO identity to their existing Duotopia email. The verification email
+    # sent below ensures the user actually owns the target_email before merge.
     if (
         identity.email_verified
         and identity.email

--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -14,10 +14,12 @@ import hashlib
 import hmac
 import json
 import logging
+import secrets
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, EmailStr
 from sqlalchemy import func
@@ -41,6 +43,9 @@ from services.one_campus_account_service import OneCampusAccountService
 
 # Merge token validity: 10 minutes
 MERGE_TOKEN_TTL = 600
+
+# OAuth state token validity: 10 minutes
+OAUTH_STATE_TTL = 600
 
 logger = logging.getLogger(__name__)
 
@@ -120,6 +125,44 @@ def _verify_merge_token(token: str) -> dict:
         "one_campus_student_id": payload_dict["sid"],
         "one_campus_account": payload_dict["acc"],
     }
+
+
+def _create_oauth_state() -> str:
+    """Create a stateless HMAC-signed OAuth state token for CSRF protection.
+
+    Format: base64(json({"nonce": ..., "exp": ...})).signature
+    Verified on the OAuth callback to defend against forged state values.
+    Stateless (no DB/session needed); per-issue and stateless deploys friendly.
+    """
+    payload_dict = {
+        "nonce": secrets.token_urlsafe(16),
+        "exp": int(time.time()) + OAUTH_STATE_TTL,
+    }
+    payload_b64 = base64.urlsafe_b64encode(json.dumps(payload_dict).encode()).decode()
+    sig = hmac.HMAC(
+        settings.JWT_SECRET.encode(), payload_b64.encode(), hashlib.sha256
+    ).hexdigest()
+    return f"{payload_b64}.{sig}"
+
+
+def _verify_oauth_state(state: Optional[str]) -> bool:
+    """Verify an OAuth state token. Returns True if valid, False otherwise."""
+    if not state:
+        return False
+    parts = state.split(".", 1)
+    if len(parts) != 2:
+        return False
+    payload_b64, sig = parts
+    expected_sig = hmac.HMAC(
+        settings.JWT_SECRET.encode(), payload_b64.encode(), hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(sig, expected_sig):
+        return False
+    try:
+        payload_dict = json.loads(base64.urlsafe_b64decode(payload_b64))
+    except (json.JSONDecodeError, UnicodeDecodeError, binascii.Error):
+        return False
+    return payload_dict.get("exp", 0) >= int(time.time())
 
 
 def _build_student_response(db: Session, student: Student) -> dict:
@@ -208,13 +251,16 @@ def _build_teacher_response(db: Session, teacher: Teacher) -> dict:
 
 
 @router.get("/login-url")
-async def get_login_url():
-    """Return the 1Campus OAuth authorize URL.
+@limiter.limit("30/minute")
+async def get_login_url(request: Request):
+    """Return the 1Campus OAuth authorize URL with a CSRF state token.
 
     The frontend redirects users to this URL to initiate SSO login.
+    The state is verified on the callback to defend against forged callbacks.
     """
     try:
-        url = OneCampusService.get_oauth_authorize_url()
+        state = _create_oauth_state()
+        url = OneCampusService.get_oauth_authorize_url(state=state)
     except RuntimeError as e:
         raise HTTPException(status_code=500, detail=str(e))
     return {"url": url}
@@ -228,16 +274,24 @@ async def one_campus_callback(
     schoolDsns: Optional[str] = Query(
         None, description="School DSNS (present for Identity Code flow only)"
     ),
+    state: Optional[str] = Query(
+        None, description="CSRF state token (required for OAuth flow)"
+    ),
     db: Session = Depends(get_db),
 ):
     """Handle 1Campus SSO callback.
 
     Two flows are supported, detected by the presence of schoolDsns:
     - With schoolDsns: Identity Code flow (user comes from 1Campus platform)
-    - Without schoolDsns: OAuth 2.0 flow (user clicks login on Duotopia)
+    - Without schoolDsns: OAuth 2.0 flow (user clicks login on Duotopia) — state required
     """
     if schoolDsns:
         return await _handle_identity_code_flow(request, code, schoolDsns, db)
+    if not _verify_oauth_state(state):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid or expired OAuth state. Please try logging in again.",
+        )
     return await _handle_oauth_flow(request, code, db)
 
 
@@ -390,7 +444,7 @@ async def _handle_oauth_flow(
         token_data = await OneCampusService.exchange_oauth_code(code)
     except RuntimeError as e:
         raise HTTPException(status_code=500, detail=str(e))
-    except Exception as e:
+    except httpx.HTTPError as e:
         logger.error("1Campus OAuth code exchange failed: %s", e)
         raise HTTPException(
             status_code=502,
@@ -406,7 +460,7 @@ async def _handle_oauth_flow(
     # Step 2: Get user info
     try:
         user_info = await OneCampusService.get_oauth_user_info(oauth_access_token)
-    except Exception as e:
+    except httpx.HTTPError as e:
         logger.error("1Campus OAuth user info fetch failed: %s", e)
         raise HTTPException(
             status_code=502,
@@ -454,12 +508,19 @@ async def _handle_oauth_flow(
 
             if role_type:
                 break
-    except Exception as e:
+    except httpx.HTTPError as e:
         logger.warning("1Campus getUserRole after OAuth failed (non-fatal): %s", e)
 
-    # Step 4: Match or create account
-    display_name = f"{last_name}{first_name}".strip()
+    if role_type is None:
+        logger.warning(
+            "1Campus OAuth: could not determine role for uuid=%s mail=%s — "
+            "defaulting to teacher. This typically means getUserRole returned "
+            "no schools or the school has not authorized our app.",
+            uuid,
+            mail,
+        )
 
+    # Step 4: Match or create account
     (
         identity,
         user,
@@ -505,6 +566,7 @@ async def _handle_oauth_flow(
             },
             expires_delta=timedelta(hours=24),
         )
+        # Note: Teacher model has no last_login field (unlike Student); nothing to update.
         return OneCampusCallbackResponse(
             access_token=access_token,
             role_type="teacher",
@@ -695,14 +757,21 @@ async def bind_account(
             detail="This account is not linked to 1Campus SSO.",
         )
 
-    # Must not already have a verified email
-    if identity.email_verified and identity.email:
+    target_email = body.email.strip().lower()
+
+    # Block only if the identity is already bound to this exact email (would be a no-op).
+    # Allow rebind to a different email — the OAuth-created identity stores the
+    # 1Campus mail as "verified", but the user may want to link an existing
+    # Duotopia account with a different email address.
+    if (
+        identity.email_verified
+        and identity.email
+        and identity.email.lower() == target_email
+    ):
         raise HTTPException(
             status_code=400,
-            detail="This account already has a verified email.",
+            detail="This account is already bound to this email.",
         )
-
-    target_email = body.email.strip().lower()
 
     if user_type == "student":
         from services.email_service import email_service

--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -137,7 +137,8 @@ def _create_oauth_state() -> str:
     Note on replay: this token is reusable within its 10-minute TTL, but the
     OAuth authorization code (issued by 1Campus and tied to this state) is
     single-use, so a captured state alone cannot complete a login flow. The
-    `.` separator is safe because base64url uses only [A-Za-z0-9_-] (no dots).
+    `.` separator is safe because base64url uses [A-Za-z0-9_-=] and a hex
+    HMAC digest uses only [0-9a-f] — neither contains a dot.
     """
     payload_dict = {
         "nonce": secrets.token_urlsafe(16),
@@ -721,12 +722,18 @@ async def bind_account(
 ):
     """Request to bind a 1Campus SSO account to a Duotopia email.
 
-    The caller must be logged in via 1Campus SSO. The Identity is resolved
-    from the authenticated user's `identity_id` (NOT from a request parameter),
-    so a logged-in user can only bind their own identity — there is no path
-    to operate on another user's identity_id even if it were guessed.
-    Sends a verification email to the provided address.
-    After verification, the Identity merge happens in verify-email endpoint.
+    The caller must be logged in via 1Campus SSO (the Identity has
+    `one_campus_account` set). The Identity is resolved from the
+    authenticated user's `identity_id` (NOT from a request parameter), so a
+    logged-in user can only bind their own identity — there is no path to
+    operate on another user's identity_id even if it were guessed.
+
+    Identities created by the OAuth flow have `email_verified=True` with the
+    1Campus mail. Users may still want to link an existing Duotopia account
+    that uses a different email — we allow that here, then verify ownership
+    by sending a verification email to the target_email. Merge happens in
+    `verify-teacher-bind` (teachers) / verify-email endpoint (students)
+    after the user clicks the verification link.
     """
     user_type = current_user.get("type")
     user_id = int(current_user.get("sub"))

--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -1,7 +1,10 @@
 """1Campus SSO authentication endpoints.
 
 Provides:
+- GET /api/auth/1campus/login-url — return OAuth authorize URL
 - GET /api/auth/1campus/callback — handle code exchange + account matching
+  - With schoolDsns: Identity Code flow (from 1Campus platform)
+  - Without schoolDsns: OAuth 2.0 flow (from Duotopia login page)
 - POST /api/auth/1campus/merge-confirm — confirm account merge (requires signed token)
 """
 
@@ -204,24 +207,52 @@ def _build_teacher_response(db: Session, teacher: Teacher) -> dict:
 # --- Endpoints ---
 
 
+@router.get("/login-url")
+async def get_login_url():
+    """Return the 1Campus OAuth authorize URL.
+
+    The frontend redirects users to this URL to initiate SSO login.
+    """
+    try:
+        url = OneCampusService.get_oauth_authorize_url()
+    except RuntimeError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return {"url": url}
+
+
 @router.get("/callback")
 @limiter.limit("10/minute")
 async def one_campus_callback(
     request: Request,
-    code: str = Query(..., description="1Campus one-time identity code"),
-    schoolDsns: str = Query(..., description="School DSNS identifier"),
+    code: str = Query(..., description="Authorization code or identity code"),
+    schoolDsns: Optional[str] = Query(
+        None, description="School DSNS (present for Identity Code flow only)"
+    ),
     db: Session = Depends(get_db),
 ):
     """Handle 1Campus SSO callback.
 
-    1. Exchange code for identity info
-    2. Fetch extended data (idNumberHash) via Data API
-    3. Match or create account
-    4. Return JWT token
+    Two flows are supported, detected by the presence of schoolDsns:
+    - With schoolDsns: Identity Code flow (user comes from 1Campus platform)
+    - Without schoolDsns: OAuth 2.0 flow (user clicks login on Duotopia)
     """
+    if schoolDsns:
+        return await _handle_identity_code_flow(request, code, schoolDsns, db)
+    return await _handle_oauth_flow(request, code, db)
+
+
+async def _handle_identity_code_flow(
+    request: Request,
+    code: str,
+    school_dsns: str,
+    db: Session,
+) -> OneCampusCallbackResponse:
+    """Handle the Identity Code flow (from 1Campus platform)."""
     # Step 1: Exchange identity code
     try:
-        identity_data = await OneCampusService.exchange_identity_code(schoolDsns, code)
+        identity_data = await OneCampusService.exchange_identity_code(
+            school_dsns, code
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except OneCampusCodeNotFoundError:
@@ -249,7 +280,6 @@ async def one_campus_callback(
     try:
         user_role_data = await OneCampusService.get_user_role(account=account)
         for school in user_role_data.get("school", []):
-            # Try student role first, then teacher role
             for role_key in ("studentRole", "teacherRole"):
                 role_data = school.get(role_key)
                 if role_data and role_data.get("idNumberHash"):
@@ -270,7 +300,7 @@ async def one_campus_callback(
             one_campus_account=account,
             teacher_name=teacher_name,
             national_id_hash=national_id_hash,
-            school_dsns=schoolDsns,
+            school_dsns=school_dsns,
         )
 
         teacher_response = _build_teacher_response(db, teacher)
@@ -305,7 +335,6 @@ async def one_campus_callback(
     student_name = student_data.get("studentName", "")
     student_number = student_data.get("studentNumber")
 
-    # Step 3: Match or create account
     identity, student, action = OneCampusAccountService.find_or_create_student(
         db=db,
         one_campus_student_id=one_campus_student_id,
@@ -313,10 +342,9 @@ async def one_campus_callback(
         student_name=student_name,
         student_number=student_number,
         national_id_hash=national_id_hash,
-        school_dsns=schoolDsns,
+        school_dsns=school_dsns,
     )
 
-    # Step 4: Handle result
     if action == "merge_prompt":
         merge_token = _create_merge_token(
             existing_identity_id=identity.id,
@@ -351,6 +379,137 @@ async def one_campus_callback(
         student=_build_student_response(db, student),
         action=action,
     )
+
+
+async def _handle_oauth_flow(
+    request: Request,
+    code: str,
+    db: Session,
+) -> OneCampusCallbackResponse:
+    """Handle the OAuth 2.0 Authorization Code flow (from Duotopia login page)."""
+    # Step 1: Exchange authorization code for access token
+    try:
+        token_data = await OneCampusService.exchange_oauth_code(code)
+    except RuntimeError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    except Exception as e:
+        logger.error("1Campus OAuth code exchange failed: %s", e)
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to communicate with 1Campus. Please try again.",
+        )
+
+    oauth_access_token = token_data.get("access_token")
+    if not oauth_access_token:
+        raise HTTPException(
+            status_code=502, detail="1Campus did not return an access token."
+        )
+
+    # Step 2: Get user info
+    try:
+        user_info = await OneCampusService.get_oauth_user_info(oauth_access_token)
+    except Exception as e:
+        logger.error("1Campus OAuth user info fetch failed: %s", e)
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to fetch user info from 1Campus.",
+        )
+
+    uuid = user_info.get("uuid", "")
+    first_name = user_info.get("firstName", "")
+    last_name = user_info.get("lastName", "")
+    mail = user_info.get("mail", "")
+
+    if not uuid:
+        raise HTTPException(
+            status_code=502, detail="1Campus did not return a user UUID."
+        )
+
+    # Step 3: Try getUserRole to determine teacher/student role
+    role_type = None
+    national_id_hash = None
+    one_campus_student_id = None
+    student_name = None
+    student_number = None
+    teacher_name = None
+
+    try:
+        user_role_data = await OneCampusService.get_user_role(account=mail)
+        for school in user_role_data.get("school", []):
+            # Extract national_id_hash
+            for role_key in ("studentRole", "teacherRole"):
+                role_data = school.get(role_key)
+                if role_data and role_data.get("idNumberHash"):
+                    national_id_hash = role_data["idNumberHash"]
+                    break
+
+            # Determine role
+            if school.get("teacherRole"):
+                role_type = "teacher"
+                teacher_name = school["teacherRole"].get("teacherName")
+            elif school.get("studentRole"):
+                role_type = "student"
+                sr = school["studentRole"]
+                one_campus_student_id = str(sr.get("studentID", ""))
+                student_name = sr.get("studentName")
+                student_number = sr.get("studentNumber")
+
+            if role_type:
+                break
+    except Exception as e:
+        logger.warning("1Campus getUserRole after OAuth failed (non-fatal): %s", e)
+
+    # Step 4: Match or create account
+    display_name = f"{last_name}{first_name}".strip()
+
+    identity, user, detected_role, action = (
+        OneCampusAccountService.find_or_create_by_oauth(
+            db=db,
+            uuid=uuid,
+            mail=mail,
+            first_name=first_name,
+            last_name=last_name,
+            role_type=role_type,
+            one_campus_student_id=one_campus_student_id,
+            student_name=student_name,
+            student_number=student_number,
+            teacher_name=teacher_name,
+            national_id_hash=national_id_hash,
+        )
+    )
+
+    # Step 5: Build response
+    if detected_role == "student":
+        access_token = create_access_token(
+            data={"sub": str(user.id), "type": "student"},
+            expires_delta=timedelta(hours=24),
+        )
+        user.last_login = datetime.now(timezone.utc)
+        db.commit()
+        return OneCampusCallbackResponse(
+            access_token=access_token,
+            role_type="student",
+            student=_build_student_response(db, user),
+            action=action,
+        )
+    else:
+        teacher_response = _build_teacher_response(db, user)
+        access_token = create_access_token(
+            data={
+                "sub": str(user.id),
+                "email": user.email,
+                "type": "teacher",
+                "name": user.name,
+                "role": teacher_response["role"],
+            },
+            expires_delta=timedelta(hours=24),
+        )
+        return OneCampusCallbackResponse(
+            access_token=access_token,
+            role_type="teacher",
+            user=teacher_response,
+            action=action,
+        )
 
 
 @router.post("/merge-confirm")

--- a/backend/services/one_campus_account_service.py
+++ b/backend/services/one_campus_account_service.py
@@ -11,6 +11,7 @@ Handles:
 import logging
 from typing import Optional
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from models.user import Identity, Student, Teacher
@@ -135,7 +136,7 @@ class OneCampusAccountService:
             email_identity = (
                 db.query(Identity)
                 .filter(
-                    Identity.email == one_campus_account,
+                    func.lower(Identity.email) == one_campus_account.lower(),
                     Identity.email_verified.is_(True),
                     Identity.is_active.is_(True),
                 )
@@ -322,7 +323,7 @@ class OneCampusAccountService:
             email_identity = (
                 db.query(Identity)
                 .filter(
-                    Identity.email == one_campus_account,
+                    func.lower(Identity.email) == one_campus_account.lower(),
                     Identity.email_verified.is_(True),
                     Identity.is_active.is_(True),
                 )
@@ -354,11 +355,13 @@ class OneCampusAccountService:
 
         # Step 3: Create new Identity + Teacher
         # Use the real 1Campus account email instead of a placeholder,
-        # but only if no other Identity/Teacher already uses this email.
+        # but only if no other Identity/Teacher already uses this email
+        # (case-insensitive to align with the LOWER(email) unique indexes).
+        account_lower = one_campus_account.lower()
         identity_email_taken = (
             db.query(Identity)
             .filter(
-                Identity.email == one_campus_account,
+                func.lower(Identity.email) == account_lower,
                 Identity.is_active.is_(True),
             )
             .first()
@@ -367,7 +370,7 @@ class OneCampusAccountService:
         teacher_email_taken = (
             db.query(Teacher)
             .filter(
-                Teacher.email == one_campus_account,
+                func.lower(Teacher.email) == account_lower,
                 Teacher.is_active.is_(True),
             )
             .first()
@@ -440,8 +443,6 @@ class OneCampusAccountService:
         Returns: (identity, user, role_type, action)
         where action is "existing", "created"
         """
-        display_name = f"{last_name}{first_name}".strip() or mail
-
         # Step 1: Match by uuid
         identity = OneCampusAccountService.find_by_uuid(db, uuid)
         if identity:
@@ -487,12 +488,27 @@ class OneCampusAccountService:
                 )
                 return identity, teacher, "teacher", "existing"
 
-        # Step 2: Match by verified email
-        if mail:
+            # Identity exists by uuid but has no active student or teacher.
+            # Don't fall through to email match — that would create a second
+            # identity for the same uuid (orphaning this one). Reuse it instead.
+            logger.warning(
+                "1Campus OAuth: identity_id=%s matched by uuid has no active "
+                "user. Will create a new student/teacher under this identity.",
+                identity.id,
+            )
+            existing_identity_for_uuid = identity
+        else:
+            existing_identity_for_uuid = None
+
+        # Step 2: Match by verified email (case-insensitive)
+        # Skip if we already found an Identity by uuid above — reuse that one
+        # rather than creating a parallel email-matched identity.
+        if mail and existing_identity_for_uuid is None:
+            mail_lower = mail.lower()
             email_identity = (
                 db.query(Identity)
                 .filter(
-                    Identity.email == mail,
+                    func.lower(Identity.email) == mail_lower,
                     Identity.email_verified.is_(True),
                     Identity.is_active.is_(True),
                 )
@@ -544,33 +560,43 @@ class OneCampusAccountService:
                     )
                     return email_identity, teacher, "teacher", "existing"
 
-        # Step 3: Create new account
+        # Step 3: Create new account (or attach to identity matched by uuid above)
         # Determine role: use getUserRole result, default to teacher
         effective_role = role_type or "teacher"
+        display_name = f"{last_name}{first_name}".strip() or mail
 
-        # Check email uniqueness for Identity
-        identity_email_taken = (
-            (
-                db.query(Identity)
-                .filter(Identity.email == mail, Identity.is_active.is_(True))
-                .first()
+        if existing_identity_for_uuid is not None:
+            # Reuse the identity already matched by uuid; just create the missing user.
+            identity = existing_identity_for_uuid
+        else:
+            # Check email uniqueness for Identity (case-insensitive)
+            identity_email_taken = (
+                (
+                    db.query(Identity)
+                    .filter(
+                        func.lower(Identity.email) == mail.lower(),
+                        Identity.is_active.is_(True),
+                    )
+                    .first()
+                )
+                is not None
+                if mail
+                else False
             )
-            is not None
-            if mail
-            else False
-        )
 
-        identity = Identity(
-            email=mail if not identity_email_taken else None,
-            one_campus_uuid=uuid,
-            one_campus_account=mail,
-            one_campus_student_id=one_campus_student_id,
-            national_id_hash=national_id_hash,
-            email_verified=bool(mail),
-            is_active=True,
-        )
-        db.add(identity)
-        db.flush()
+            identity = Identity(
+                email=mail if not identity_email_taken else None,
+                one_campus_uuid=uuid,
+                one_campus_account=mail,
+                one_campus_student_id=one_campus_student_id,
+                national_id_hash=national_id_hash,
+                # 1Campus is the IdP and verifies institutional emails on its side,
+                # so we trust the returned mail as already verified.
+                email_verified=bool(mail),
+                is_active=True,
+            )
+            db.add(identity)
+            db.flush()
 
         if effective_role == "student":
             name = student_name or display_name
@@ -595,11 +621,14 @@ class OneCampusAccountService:
             return identity, student, "student", "created"
         else:
             name = teacher_name or display_name
-            # Check teacher email uniqueness
+            # Check teacher email uniqueness (case-insensitive)
             teacher_email_taken = (
                 (
                     db.query(Teacher)
-                    .filter(Teacher.email == mail, Teacher.is_active.is_(True))
+                    .filter(
+                        func.lower(Teacher.email) == mail.lower(),
+                        Teacher.is_active.is_(True),
+                    )
                     .first()
                 )
                 is not None

--- a/backend/services/one_campus_account_service.py
+++ b/backend/services/one_campus_account_service.py
@@ -2,8 +2,9 @@
 1Campus account matching and creation service.
 
 Handles:
-- Finding existing Identity by one_campus_student_id or national_id_hash
-- Creating new Identity + Student for first-time SSO users
+- Finding existing Identity by one_campus_uuid, one_campus_student_id, or national_id_hash
+- OAuth-based account matching (uuid + email fallback)
+- Creating new Identity + Student/Teacher for first-time SSO users
 - Detecting duplicate accounts for merge prompt
 """
 
@@ -19,6 +20,18 @@ logger = logging.getLogger(__name__)
 
 class OneCampusAccountService:
     """Account matching and creation for 1Campus SSO."""
+
+    @staticmethod
+    def find_by_uuid(db: Session, uuid: str) -> Optional[Identity]:
+        """Find Identity by 1Campus OAuth uuid (exact match)."""
+        return (
+            db.query(Identity)
+            .filter(
+                Identity.one_campus_uuid == uuid,
+                Identity.is_active.is_(True),
+            )
+            .first()
+        )
 
     @staticmethod
     def find_by_one_campus_id(
@@ -399,3 +412,215 @@ class OneCampusAccountService:
             one_campus_account,
         )
         return identity, teacher, "created"
+
+    @staticmethod
+    def find_or_create_by_oauth(
+        db: Session,
+        uuid: str,
+        mail: str,
+        first_name: str,
+        last_name: str,
+        role_type: Optional[str] = None,
+        one_campus_student_id: Optional[str] = None,
+        student_name: Optional[str] = None,
+        student_number: Optional[str] = None,
+        teacher_name: Optional[str] = None,
+        national_id_hash: Optional[str] = None,
+    ) -> tuple:
+        """Find or create account from OAuth user info.
+
+        Matching priority:
+        1. Exact match by one_campus_uuid
+        2. Match by verified email
+        3. Create new account
+
+        When role_type is provided (from getUserRole), creates the
+        appropriate student or teacher. Otherwise defaults to teacher.
+
+        Returns: (identity, user, role_type, action)
+        where action is "existing", "created"
+        """
+        display_name = f"{last_name}{first_name}".strip() or mail
+
+        # Step 1: Match by uuid
+        identity = OneCampusAccountService.find_by_uuid(db, uuid)
+        if identity:
+            # Update email if changed
+            if mail and identity.email != mail:
+                identity.email = mail
+            identity.one_campus_account = mail
+            db.commit()
+
+            # Try student first, then teacher
+            student = (
+                db.query(Student)
+                .filter(
+                    Student.identity_id == identity.id,
+                    Student.is_active.is_(True),
+                )
+                .order_by(Student.is_primary_account.desc().nulls_last())
+                .first()
+            )
+            if student:
+                logger.info(
+                    "1Campus OAuth: existing student by uuid, "
+                    "student_id=%s, identity_id=%s",
+                    student.id,
+                    identity.id,
+                )
+                return identity, student, "student", "existing"
+
+            teacher = (
+                db.query(Teacher)
+                .filter(
+                    Teacher.identity_id == identity.id,
+                    Teacher.is_active.is_(True),
+                )
+                .first()
+            )
+            if teacher:
+                logger.info(
+                    "1Campus OAuth: existing teacher by uuid, "
+                    "teacher_id=%s, identity_id=%s",
+                    teacher.id,
+                    identity.id,
+                )
+                return identity, teacher, "teacher", "existing"
+
+        # Step 2: Match by verified email
+        if mail:
+            email_identity = (
+                db.query(Identity)
+                .filter(
+                    Identity.email == mail,
+                    Identity.email_verified.is_(True),
+                    Identity.is_active.is_(True),
+                )
+                .first()
+            )
+            if email_identity:
+                # Link uuid to existing identity
+                email_identity.one_campus_uuid = uuid
+                email_identity.one_campus_account = mail
+                if national_id_hash:
+                    email_identity.national_id_hash = national_id_hash
+                db.commit()
+
+                # Try student first, then teacher
+                student = (
+                    db.query(Student)
+                    .filter(
+                        Student.identity_id == email_identity.id,
+                        Student.is_active.is_(True),
+                    )
+                    .order_by(Student.is_primary_account.desc().nulls_last())
+                    .first()
+                )
+                if student:
+                    logger.info(
+                        "1Campus OAuth: matched student by email, "
+                        "student_id=%s, identity_id=%s, email=%s",
+                        student.id,
+                        email_identity.id,
+                        mail,
+                    )
+                    return email_identity, student, "student", "existing"
+
+                teacher = (
+                    db.query(Teacher)
+                    .filter(
+                        Teacher.identity_id == email_identity.id,
+                        Teacher.is_active.is_(True),
+                    )
+                    .first()
+                )
+                if teacher:
+                    logger.info(
+                        "1Campus OAuth: matched teacher by email, "
+                        "teacher_id=%s, identity_id=%s, email=%s",
+                        teacher.id,
+                        email_identity.id,
+                        mail,
+                    )
+                    return email_identity, teacher, "teacher", "existing"
+
+        # Step 3: Create new account
+        # Determine role: use getUserRole result, default to teacher
+        effective_role = role_type or "teacher"
+
+        # Check email uniqueness for Identity
+        identity_email_taken = (
+            db.query(Identity)
+            .filter(Identity.email == mail, Identity.is_active.is_(True))
+            .first()
+        ) is not None if mail else False
+
+        identity = Identity(
+            email=mail if not identity_email_taken else None,
+            one_campus_uuid=uuid,
+            one_campus_account=mail,
+            one_campus_student_id=one_campus_student_id,
+            national_id_hash=national_id_hash,
+            email_verified=bool(mail),
+            is_active=True,
+        )
+        db.add(identity)
+        db.flush()
+
+        if effective_role == "student":
+            name = student_name or display_name
+            student = Student(
+                name=name,
+                student_number=student_number,
+                password_hash=None,
+                identity_id=identity.id,
+                is_primary_account=True,
+                is_active=True,
+            )
+            db.add(student)
+            db.commit()
+            db.refresh(identity)
+            db.refresh(student)
+            logger.info(
+                "1Campus OAuth: created student_id=%s, identity_id=%s, uuid=%s",
+                student.id,
+                identity.id,
+                uuid,
+            )
+            return identity, student, "student", "created"
+        else:
+            name = teacher_name or display_name
+            # Check teacher email uniqueness
+            teacher_email_taken = (
+                db.query(Teacher)
+                .filter(Teacher.email == mail, Teacher.is_active.is_(True))
+                .first()
+            ) is not None if mail else False
+
+            if mail and not teacher_email_taken:
+                teacher_email = mail
+            elif mail:
+                safe = mail.replace("@", "_at_")
+                teacher_email = f"1campus_{safe}@sso.duotopia.com"
+            else:
+                teacher_email = f"1campus_{uuid}@sso.duotopia.com"
+
+            teacher = Teacher(
+                name=name,
+                email=teacher_email,
+                password_hash=None,
+                has_password=False,
+                identity_id=identity.id,
+                is_active=True,
+            )
+            db.add(teacher)
+            db.commit()
+            db.refresh(identity)
+            db.refresh(teacher)
+            logger.info(
+                "1Campus OAuth: created teacher_id=%s, identity_id=%s, uuid=%s",
+                teacher.id,
+                identity.id,
+                uuid,
+            )
+            return identity, teacher, "teacher", "created"

--- a/backend/services/one_campus_account_service.py
+++ b/backend/services/one_campus_account_service.py
@@ -550,10 +550,15 @@ class OneCampusAccountService:
 
         # Check email uniqueness for Identity
         identity_email_taken = (
-            db.query(Identity)
-            .filter(Identity.email == mail, Identity.is_active.is_(True))
-            .first()
-        ) is not None if mail else False
+            (
+                db.query(Identity)
+                .filter(Identity.email == mail, Identity.is_active.is_(True))
+                .first()
+            )
+            is not None
+            if mail
+            else False
+        )
 
         identity = Identity(
             email=mail if not identity_email_taken else None,
@@ -592,10 +597,15 @@ class OneCampusAccountService:
             name = teacher_name or display_name
             # Check teacher email uniqueness
             teacher_email_taken = (
-                db.query(Teacher)
-                .filter(Teacher.email == mail, Teacher.is_active.is_(True))
-                .first()
-            ) is not None if mail else False
+                (
+                    db.query(Teacher)
+                    .filter(Teacher.email == mail, Teacher.is_active.is_(True))
+                    .first()
+                )
+                is not None
+                if mail
+                else False
+            )
 
             if mail and not teacher_email_taken:
                 teacher_email = mail

--- a/backend/services/one_campus_service.py
+++ b/backend/services/one_campus_service.py
@@ -39,9 +39,7 @@ ONE_CAMPUS_OAUTH_CLIENT_ID = getattr(settings, "ONE_CAMPUS_OAUTH_CLIENT_ID", Non
 ONE_CAMPUS_OAUTH_CLIENT_SECRET = getattr(
     settings, "ONE_CAMPUS_OAUTH_CLIENT_SECRET", None
 )
-ONE_CAMPUS_OAUTH_REDIRECT_URI = getattr(
-    settings, "ONE_CAMPUS_OAUTH_REDIRECT_URI", None
-)
+ONE_CAMPUS_OAUTH_REDIRECT_URI = getattr(settings, "ONE_CAMPUS_OAUTH_REDIRECT_URI", None)
 
 # Token cache (module-level singleton) with asyncio.Lock to prevent race conditions
 _token_cache: dict = {"access_token": None, "expires_at": 0}

--- a/backend/services/one_campus_service.py
+++ b/backend/services/one_campus_service.py
@@ -13,8 +13,7 @@ import logging
 import re
 import time
 from typing import Optional
-
-import httpx
+from urllib.parse import urlencode
 
 from utils.http_client import get_http_client
 from core.config import settings
@@ -93,22 +92,27 @@ class OneCampusService:
     """1Campus API client."""
 
     @staticmethod
-    def get_oauth_authorize_url() -> str:
+    def get_oauth_authorize_url(state: str) -> str:
         """Build the OAuth authorize URL for 1Campus SSO.
 
-        The frontend redirects the user to this URL to initiate login.
+        Caller must pass a CSRF state token (verified on the callback).
+        All query parameters are URL-encoded to handle special characters
+        in redirect_uri or client_id safely.
         """
         if not ONE_CAMPUS_OAUTH_CLIENT_ID or not ONE_CAMPUS_OAUTH_REDIRECT_URI:
             raise RuntimeError(
                 "ONE_CAMPUS_OAUTH_CLIENT_ID and ONE_CAMPUS_OAUTH_REDIRECT_URI must be set"
             )
-        return (
-            f"{ONE_CAMPUS_OAUTH_BASE}/oauth/authorize.php"
-            f"?client_id={ONE_CAMPUS_OAUTH_CLIENT_ID}"
-            f"&response_type=code"
-            f"&redirect_uri={ONE_CAMPUS_OAUTH_REDIRECT_URI}"
-            f"&scope=User.Mail,User.BasicInfo"
+        params = urlencode(
+            {
+                "client_id": ONE_CAMPUS_OAUTH_CLIENT_ID,
+                "response_type": "code",
+                "redirect_uri": ONE_CAMPUS_OAUTH_REDIRECT_URI,
+                "scope": "User.Mail,User.BasicInfo",
+                "state": state,
+            }
         )
+        return f"{ONE_CAMPUS_OAUTH_BASE}/oauth/authorize.php?{params}"
 
     @staticmethod
     async def exchange_oauth_code(code: str) -> dict:
@@ -143,14 +147,15 @@ class OneCampusService:
     async def get_oauth_user_info(access_token: str) -> dict:
         """Get user info from 1Campus OAuth.
 
-        GET https://auth.ischool.com.tw/services/me.php?access_token=xxx
+        Token is passed via Authorization header (not query string) to
+        avoid leaking via server logs, browser history, or Referer headers.
 
         Returns dict with keys: uuid, firstName, lastName, language, mail.
         """
         client = get_http_client()
         resp = await client.get(
             f"{ONE_CAMPUS_OAUTH_BASE}/services/me.php",
-            params={"access_token": access_token},
+            headers={"Authorization": f"Bearer {access_token}"},
         )
         resp.raise_for_status()
         return resp.json()

--- a/backend/services/one_campus_service.py
+++ b/backend/services/one_campus_service.py
@@ -3,6 +3,7 @@
 
 Handles:
 - OAuth client_credentials token management with caching
+- OAuth 2.0 Authorization Code flow (auth.ischool.com.tw)
 - Identity code exchange (SSO login)
 - getUserRole for cross-school identity data (idNumberHash)
 """
@@ -31,6 +32,16 @@ ONE_CAMPUS_API_BASE = (
 
 ONE_CAMPUS_CLIENT_ID = getattr(settings, "ONE_CAMPUS_CLIENT_ID", None)
 ONE_CAMPUS_CLIENT_SECRET = getattr(settings, "ONE_CAMPUS_CLIENT_SECRET", None)
+
+# 1Campus OAuth (auth.ischool.com.tw)
+ONE_CAMPUS_OAUTH_BASE = "https://auth.ischool.com.tw"
+ONE_CAMPUS_OAUTH_CLIENT_ID = getattr(settings, "ONE_CAMPUS_OAUTH_CLIENT_ID", None)
+ONE_CAMPUS_OAUTH_CLIENT_SECRET = getattr(
+    settings, "ONE_CAMPUS_OAUTH_CLIENT_SECRET", None
+)
+ONE_CAMPUS_OAUTH_REDIRECT_URI = getattr(
+    settings, "ONE_CAMPUS_OAUTH_REDIRECT_URI", None
+)
 
 # Token cache (module-level singleton) with asyncio.Lock to prevent race conditions
 _token_cache: dict = {"access_token": None, "expires_at": 0}
@@ -82,6 +93,69 @@ async def _get_access_token() -> str:
 
 class OneCampusService:
     """1Campus API client."""
+
+    @staticmethod
+    def get_oauth_authorize_url() -> str:
+        """Build the OAuth authorize URL for 1Campus SSO.
+
+        The frontend redirects the user to this URL to initiate login.
+        """
+        if not ONE_CAMPUS_OAUTH_CLIENT_ID or not ONE_CAMPUS_OAUTH_REDIRECT_URI:
+            raise RuntimeError(
+                "ONE_CAMPUS_OAUTH_CLIENT_ID and ONE_CAMPUS_OAUTH_REDIRECT_URI must be set"
+            )
+        return (
+            f"{ONE_CAMPUS_OAUTH_BASE}/oauth/authorize.php"
+            f"?client_id={ONE_CAMPUS_OAUTH_CLIENT_ID}"
+            f"&response_type=code"
+            f"&redirect_uri={ONE_CAMPUS_OAUTH_REDIRECT_URI}"
+            f"&scope=User.Mail,User.BasicInfo"
+        )
+
+    @staticmethod
+    async def exchange_oauth_code(code: str) -> dict:
+        """Exchange an OAuth authorization code for an access token.
+
+        POST https://auth.ischool.com.tw/oauth/token.php
+
+        Returns dict with keys: access_token, expires_in, token_type, scope, refresh_token.
+        """
+        if not ONE_CAMPUS_OAUTH_CLIENT_ID or not ONE_CAMPUS_OAUTH_CLIENT_SECRET:
+            raise RuntimeError(
+                "ONE_CAMPUS_OAUTH_CLIENT_ID and ONE_CAMPUS_OAUTH_CLIENT_SECRET must be set"
+            )
+        if not ONE_CAMPUS_OAUTH_REDIRECT_URI:
+            raise RuntimeError("ONE_CAMPUS_OAUTH_REDIRECT_URI must be set")
+
+        client = get_http_client()
+        resp = await client.post(
+            f"{ONE_CAMPUS_OAUTH_BASE}/oauth/token.php",
+            data={
+                "client_id": ONE_CAMPUS_OAUTH_CLIENT_ID,
+                "client_secret": ONE_CAMPUS_OAUTH_CLIENT_SECRET,
+                "redirect_uri": ONE_CAMPUS_OAUTH_REDIRECT_URI,
+                "code": code,
+                "grant_type": "authorization_code",
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    @staticmethod
+    async def get_oauth_user_info(access_token: str) -> dict:
+        """Get user info from 1Campus OAuth.
+
+        GET https://auth.ischool.com.tw/services/me.php?access_token=xxx
+
+        Returns dict with keys: uuid, firstName, lastName, language, mail.
+        """
+        client = get_http_client()
+        resp = await client.get(
+            f"{ONE_CAMPUS_OAUTH_BASE}/services/me.php",
+            params={"access_token": access_token},
+        )
+        resp.raise_for_status()
+        return resp.json()
 
     @staticmethod
     async def exchange_identity_code(school_dsns: str, code: str) -> dict:

--- a/frontend/src/components/TeacherLoginSheet.tsx
+++ b/frontend/src/components/TeacherLoginSheet.tsx
@@ -15,6 +15,7 @@ import { Loader2, User, Lock, ArrowLeft, Zap, Eye, EyeOff } from "lucide-react";
 import { apiClient } from "@/lib/api";
 import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
 import { useTranslation } from "react-i18next";
+import { FEATURE_FLAGS } from "@/config/featureFlags";
 
 interface TeacherLoginSheetProps {
   isOpen: boolean;
@@ -222,6 +223,49 @@ export default function TeacherLoginSheet({
               </Link>
             </div>
           </form>
+
+          {/* 1Campus SSO Login */}
+          {FEATURE_FLAGS.ONE_CAMPUS_LOGIN && (
+            <>
+              <div className="relative my-6">
+                <div className="absolute inset-0 flex items-center">
+                  <div className="w-full border-t border-gray-200" />
+                </div>
+                <div className="relative flex justify-center text-sm">
+                  <span className="px-2 bg-white text-gray-500">
+                    {t("teacherLogin.oneCampus.separator", "or")}
+                  </span>
+                </div>
+              </div>
+
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full py-4 bg-gradient-to-r from-green-50 to-emerald-50 hover:from-green-100 hover:to-emerald-100 border-green-200 text-green-700 font-medium"
+                onClick={async () => {
+                  try {
+                    const res = await apiClient.get<{ url: string }>(
+                      "/api/auth/1campus/login-url",
+                    );
+                    window.location.href = res.url;
+                  } catch {
+                    setError(
+                      t(
+                        "teacherLogin.oneCampus.error",
+                        "Failed to connect to 1Campus. Please try again.",
+                      ),
+                    );
+                  }
+                }}
+              >
+                🏫{" "}
+                {t(
+                  "teacherLogin.oneCampus.button",
+                  "Log in with School Account (1Campus)",
+                )}
+              </Button>
+            </>
+          )}
 
           {/* Quick Login Section - Only show in non-production */}
           {showDemoSection && (

--- a/frontend/src/components/TeacherLoginSheet.tsx
+++ b/frontend/src/components/TeacherLoginSheet.tsx
@@ -245,6 +245,7 @@ export default function TeacherLoginSheet({
                 disabled={isOneCampusLoading}
                 className="w-full py-4 bg-gradient-to-r from-green-50 to-emerald-50 hover:from-green-100 hover:to-emerald-100 border-green-200 text-green-700 font-medium"
                 onClick={async () => {
+                  setError("");
                   setIsOneCampusLoading(true);
                   try {
                     const res = await apiClient.get<{ url: string }>(

--- a/frontend/src/components/TeacherLoginSheet.tsx
+++ b/frontend/src/components/TeacherLoginSheet.tsx
@@ -29,6 +29,7 @@ export default function TeacherLoginSheet({
   const navigate = useNavigate();
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
+  const [isOneCampusLoading, setIsOneCampusLoading] = useState(false);
   const [error, setError] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [formData, setFormData] = useState({
@@ -241,13 +242,16 @@ export default function TeacherLoginSheet({
               <Button
                 type="button"
                 variant="outline"
+                disabled={isOneCampusLoading}
                 className="w-full py-4 bg-gradient-to-r from-green-50 to-emerald-50 hover:from-green-100 hover:to-emerald-100 border-green-200 text-green-700 font-medium"
                 onClick={async () => {
+                  setIsOneCampusLoading(true);
                   try {
                     const res = await apiClient.get<{ url: string }>(
                       "/api/auth/1campus/login-url",
                     );
                     window.location.href = res.url;
+                    // Don't reset loading on success — page will navigate away.
                   } catch {
                     setError(
                       t(
@@ -255,13 +259,26 @@ export default function TeacherLoginSheet({
                         "Failed to connect to 1Campus. Please try again.",
                       ),
                     );
+                    setIsOneCampusLoading(false);
                   }
                 }}
               >
-                🏫{" "}
-                {t(
-                  "teacherLogin.oneCampus.button",
-                  "Log in with School Account (1Campus)",
+                {isOneCampusLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    {t(
+                      "teacherLogin.oneCampus.loading",
+                      "Redirecting to 1Campus...",
+                    )}
+                  </>
+                ) : (
+                  <>
+                    🏫{" "}
+                    {t(
+                      "teacherLogin.oneCampus.button",
+                      "Log in with School Account (1Campus)",
+                    )}
+                  </>
                 )}
               </Button>
             </>

--- a/frontend/src/config/featureFlags.ts
+++ b/frontend/src/config/featureFlags.ts
@@ -6,5 +6,5 @@ export const FEATURE_FLAGS = {
   /** 左側選單「作業管理」 */
   ASSIGNMENTS: true,
   /** 1Campus SSO 登入按鈕 */
-  ONE_CAMPUS_LOGIN: false,
+  ONE_CAMPUS_LOGIN: true,
 } as const;

--- a/frontend/src/pages/OneCampusCallback.tsx
+++ b/frontend/src/pages/OneCampusCallback.tsx
@@ -54,7 +54,7 @@ export default function OneCampusCallback() {
     const schoolDsns =
       searchParams.get("schoolDsns") || searchParams.get("dsns");
 
-    if (!code || !schoolDsns) {
+    if (!code) {
       setStatus("error");
       setErrorMessage(
         t(
@@ -65,14 +65,19 @@ export default function OneCampusCallback() {
       return;
     }
 
-    handleCallback(code, schoolDsns);
+    // With schoolDsns → Identity Code flow; without → OAuth flow
+    handleCallback(code, schoolDsns || undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
 
-  async function handleCallback(code: string, schoolDsns: string) {
+  async function handleCallback(code: string, schoolDsns?: string) {
     try {
+      const params: Record<string, string> = { code };
+      if (schoolDsns) {
+        params.schoolDsns = schoolDsns;
+      }
       const response = await api.get("/api/auth/1campus/callback", {
-        params: { code, schoolDsns },
+        params,
       });
       const data = response.data;
 

--- a/frontend/src/pages/OneCampusCallback.tsx
+++ b/frontend/src/pages/OneCampusCallback.tsx
@@ -53,6 +53,7 @@ export default function OneCampusCallback() {
     const code = searchParams.get("code");
     const schoolDsns =
       searchParams.get("schoolDsns") || searchParams.get("dsns");
+    const state = searchParams.get("state");
 
     if (!code) {
       setStatus("error");
@@ -65,16 +66,27 @@ export default function OneCampusCallback() {
       return;
     }
 
-    // With schoolDsns → Identity Code flow; without → OAuth flow
-    handleCallback(code, schoolDsns || undefined);
+    // With schoolDsns → Identity Code flow; without → OAuth flow (state required)
+    handleCallback(
+      code,
+      schoolDsns || undefined,
+      state || undefined,
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
 
-  async function handleCallback(code: string, schoolDsns?: string) {
+  async function handleCallback(
+    code: string,
+    schoolDsns?: string,
+    state?: string,
+  ) {
     try {
       const params: Record<string, string> = { code };
       if (schoolDsns) {
         params.schoolDsns = schoolDsns;
+      }
+      if (state) {
+        params.state = state;
       }
       const response = await api.get("/api/auth/1campus/callback", {
         params,

--- a/frontend/src/pages/OneCampusCallback.tsx
+++ b/frontend/src/pages/OneCampusCallback.tsx
@@ -67,11 +67,7 @@ export default function OneCampusCallback() {
     }
 
     // With schoolDsns → Identity Code flow; without → OAuth flow (state required)
-    handleCallback(
-      code,
-      schoolDsns || undefined,
-      state || undefined,
-    );
+    handleCallback(code, schoolDsns || undefined, state || undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
 

--- a/frontend/src/pages/StudentLogin.tsx
+++ b/frontend/src/pages/StudentLogin.tsx
@@ -3,7 +3,15 @@ import { useNavigate, Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { ArrowLeft, ChevronRight, Home, Mail, Eye, EyeOff } from "lucide-react";
+import {
+  ArrowLeft,
+  ChevronRight,
+  Home,
+  Mail,
+  Eye,
+  EyeOff,
+  Loader2,
+} from "lucide-react";
 import { useStudentAuthStore, StudentUser } from "@/stores/studentAuthStore";
 import { authService } from "@/services/authService";
 import { teacherService } from "@/services/teacherService";
@@ -59,6 +67,7 @@ export default function StudentLogin() {
 
   // Login mode: "teacher" (original 4-step) or "email" (direct email login)
   const [loginMode, setLoginMode] = useState<"teacher" | "email">("teacher");
+  const [isOneCampusLoading, setIsOneCampusLoading] = useState(false);
 
   // Multi-step form state
   const [step, setStep] = useState(1);
@@ -498,13 +507,17 @@ export default function StudentLogin() {
                 {FEATURE_FLAGS.ONE_CAMPUS_LOGIN && (
                   <Button
                     variant="outline"
+                    disabled={isOneCampusLoading}
                     className="w-full py-4 bg-gradient-to-r from-green-50 to-emerald-50 hover:from-green-100 hover:to-emerald-100 border-green-200 text-green-700 font-medium"
                     onClick={async () => {
+                      setError("");
+                      setIsOneCampusLoading(true);
                       try {
                         const res = await apiClient.get<{ url: string }>(
                           "/api/auth/1campus/login-url",
                         );
                         window.location.href = res.url;
+                        // Don't reset loading on success — page navigates away.
                       } catch {
                         setError(
                           t(
@@ -512,13 +525,26 @@ export default function StudentLogin() {
                             "Failed to connect to 1Campus. Please try again.",
                           ),
                         );
+                        setIsOneCampusLoading(false);
                       }
                     }}
                   >
-                    🏫{" "}
-                    {t(
-                      "studentLogin.oneCampus.button",
-                      "Log in with School Account (1Campus)",
+                    {isOneCampusLoading ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        {t(
+                          "studentLogin.oneCampus.loading",
+                          "Redirecting to 1Campus...",
+                        )}
+                      </>
+                    ) : (
+                      <>
+                        🏫{" "}
+                        {t(
+                          "studentLogin.oneCampus.button",
+                          "Log in with School Account (1Campus)",
+                        )}
+                      </>
                     )}
                   </Button>
                 )}

--- a/frontend/src/pages/StudentLogin.tsx
+++ b/frontend/src/pages/StudentLogin.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, ChevronRight, Home, Mail, Eye, EyeOff } from "lucide-react";
 import { useStudentAuthStore, StudentUser } from "@/stores/studentAuthStore";
 import { authService } from "@/services/authService";
 import { teacherService } from "@/services/teacherService";
+import { apiClient } from "@/lib/api";
 import { useTranslation } from "react-i18next";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { FEATURE_FLAGS } from "@/config/featureFlags";
@@ -498,8 +499,20 @@ export default function StudentLogin() {
                   <Button
                     variant="outline"
                     className="w-full py-4 bg-gradient-to-r from-green-50 to-emerald-50 hover:from-green-100 hover:to-emerald-100 border-green-200 text-green-700 font-medium"
-                    onClick={() => {
-                      window.location.href = "https://1campus.net";
+                    onClick={async () => {
+                      try {
+                        const res = await apiClient.get<{ url: string }>(
+                          "/api/auth/1campus/login-url",
+                        );
+                        window.location.href = res.url;
+                      } catch {
+                        setError(
+                          t(
+                            "studentLogin.oneCampus.error",
+                            "Failed to connect to 1Campus. Please try again.",
+                          ),
+                        );
+                      }
                     }}
                   >
                     🏫{" "}

--- a/frontend/src/pages/TeacherLogin.tsx
+++ b/frontend/src/pages/TeacherLogin.tsx
@@ -268,8 +268,20 @@ export default function TeacherLogin() {
                   type="button"
                   variant="outline"
                   className="w-full py-4 bg-gradient-to-r from-green-50 to-emerald-50 hover:from-green-100 hover:to-emerald-100 border-green-200 text-green-700 font-medium"
-                  onClick={() => {
-                    window.location.href = "https://1campus.net";
+                  onClick={async () => {
+                    try {
+                      const res = await apiClient.get<{ url: string }>(
+                        "/api/auth/1campus/login-url",
+                      );
+                      window.location.href = res.url;
+                    } catch {
+                      setError(
+                        t(
+                          "teacherLogin.oneCampus.error",
+                          "Failed to connect to 1Campus. Please try again.",
+                        ),
+                      );
+                    }
                   }}
                 >
                   🏫{" "}

--- a/frontend/src/pages/TeacherLogin.tsx
+++ b/frontend/src/pages/TeacherLogin.tsx
@@ -31,6 +31,7 @@ export default function TeacherLogin() {
   const isAuthenticated = useTeacherAuthStore((state) => state.isAuthenticated);
   const user = useTeacherAuthStore((state) => state.user);
   const [isLoading, setIsLoading] = useState(false);
+  const [isOneCampusLoading, setIsOneCampusLoading] = useState(false);
   const [error, setError] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [formData, setFormData] = useState({
@@ -267,13 +268,17 @@ export default function TeacherLogin() {
                 <Button
                   type="button"
                   variant="outline"
+                  disabled={isOneCampusLoading}
                   className="w-full py-4 bg-gradient-to-r from-green-50 to-emerald-50 hover:from-green-100 hover:to-emerald-100 border-green-200 text-green-700 font-medium"
                   onClick={async () => {
+                    setError("");
+                    setIsOneCampusLoading(true);
                     try {
                       const res = await apiClient.get<{ url: string }>(
                         "/api/auth/1campus/login-url",
                       );
                       window.location.href = res.url;
+                      // Don't reset loading on success — page navigates away.
                     } catch {
                       setError(
                         t(
@@ -281,13 +286,26 @@ export default function TeacherLogin() {
                           "Failed to connect to 1Campus. Please try again.",
                         ),
                       );
+                      setIsOneCampusLoading(false);
                     }
                   }}
                 >
-                  🏫{" "}
-                  {t(
-                    "teacherLogin.oneCampus.button",
-                    "Log in with School Account (1Campus)",
+                  {isOneCampusLoading ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      {t(
+                        "teacherLogin.oneCampus.loading",
+                        "Redirecting to 1Campus...",
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      🏫{" "}
+                      {t(
+                        "teacherLogin.oneCampus.button",
+                        "Log in with School Account (1Campus)",
+                      )}
+                    </>
                   )}
                 </Button>
               </>


### PR DESCRIPTION
## Summary
- 將 Duotopia 站內 1Campus 登入按鈕改用 **OAuth 2.0 Authorization Code** 流程（`auth.ischool.com.tw`）
- 保留原本的 **Identity Code** 流程（從 1Campus 平台進入時走原邏輯）
- Callback 端點統一：依 `schoolDsns` 是否存在自動分流
- 啟用 `ONE_CAMPUS_LOGIN` feature flag
- **Per-issue deploy workflow 自動帶入 OAuth env vars**（用測試憑證）

## 流程對照

| 來源 | 流程 | Callback 參數 |
|------|------|--------------|
| 1Campus 平台內開啟 Duotopia | Identity Code（原有，未變動） | `?code=xxx&schoolDsns=xxx` |
| Duotopia 站內點 1Campus 按鈕 | **OAuth 2.0**（新增） | `?code=xxx` |

## Per-Issue 測試環境

部署完成後 frontend URL 會貼在 issue #634 留言區。

OAuth 環境變數**已由 workflow 自動帶入**：
- `ONE_CAMPUS_OAUTH_CLIENT_ID` — 測試憑證 `edf96e2da7a4f156f1df52f07ab3490f`
- `ONE_CAMPUS_OAUTH_CLIENT_SECRET` — 測試憑證
- `ONE_CAMPUS_OAUTH_REDIRECT_URI` — 動態填入 `<frontend-url>/auth/1campus/callback`

> ⚠️ 測試憑證來自 1Campus 公開的 quickstart docs，**僅適用於 per-issue 預覽環境**。正式 staging/production 部署前必須換成正式憑證並到 `https://auth.ischool.com.tw/1campus/manage/` 註冊 redirect URI。

## 變更內容

### Backend
- `config.py` — 新增 OAuth 相關環境變數
- `one_campus_service.py` — 新增 `get_oauth_authorize_url()`、`exchange_oauth_code()`、`get_oauth_user_info()`
- `one_campus_account_service.py` — 新增 `find_by_uuid()` + `find_or_create_by_oauth()`（uuid → email → 建新帳號的多層比對）
- `auth_one_campus.py` — 新增 `GET /api/auth/1campus/login-url`；callback 重構為統一入口

### Frontend
- `OneCampusCallback.tsx` — 移除 `schoolDsns` 必填限制
- `TeacherLogin.tsx` — 1Campus 按鈕改呼叫 backend 取得 OAuth URL
- `StudentLogin.tsx` — 同上
- `featureFlags.ts` — `ONE_CAMPUS_LOGIN: true`

### CI/CD
- `deploy-per-issue.yml` — 自動 inject OAuth 測試憑證 + 動態填入 redirect URI

> 註：`one_campus_uuid` migration 已先以 #639 merge 進 staging

## Test plan
- [ ] 從 Duotopia teacher login 點 1Campus 按鈕 → 跳轉 OAuth → 成功登入並建立/匹配帳號
- [ ] 從 Duotopia student login 點 1Campus 按鈕 → 同上
- [ ] 確認 `getUserRole` 在 OAuth 登入後能取得角色資訊（決定建立 teacher 或 student）
- [ ] 從 1Campus 平台內進入 Duotopia（Identity Code 流程）仍然正常運作
- [ ] 第二次 OAuth 登入時透過 `one_campus_uuid` 直接登入

🤖 Generated with [Claude Code](https://claude.com/claude-code)