### PR TITLE
feat(#719): 1Campus bind/merge marker (Phase 1, no data migration)

### DIFF
--- a/backend/alembic/versions/20260508_1000_add_identity_merge_marker.py
+++ b/backend/alembic/versions/20260508_1000_add_identity_merge_marker.py
@@ -1,0 +1,87 @@
+"""Add merge marker fields to identities table
+
+Revision ID: 20260508_1000
+Revises: 20260429_1200
+Create Date: 2026-05-08 10:00:00.000000
+
+Adds merged_into_identity_id and merged_at to Identity for tracking bind/merge
+of 1Campus SSO accounts with existing Duotopia accounts (Phase 1 of #719).
+
+These fields allow:
+1. Marking source Identities as merged (so we can find them for future migration)
+2. Re-login redirect: when a uuid points to a deactivated merged Identity,
+   we follow merged_into_identity_id to return the surviving user.
+
+Related: #719
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260508_1000"
+down_revision = "20260429_1200"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add merged_into_identity_id column (FK to identities.id)
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'identities'
+                AND column_name = 'merged_into_identity_id'
+            ) THEN
+                ALTER TABLE identities
+                ADD COLUMN merged_into_identity_id INTEGER;
+            END IF;
+        END $$;
+        """
+    )
+
+    # Add index on merged_into_identity_id for forward lookup
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_identities_merged_into_identity_id "
+        "ON identities (merged_into_identity_id) WHERE merged_into_identity_id IS NOT NULL"
+    )
+
+    # Add FK constraint (checked first to ensure idempotency)
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'fk_identities_merged_into_identity_id'
+            ) THEN
+                ALTER TABLE identities
+                ADD CONSTRAINT fk_identities_merged_into_identity_id
+                FOREIGN KEY (merged_into_identity_id)
+                REFERENCES identities(id)
+                ON DELETE SET NULL;
+            END IF;
+        END $$;
+        """
+    )
+
+    # Add merged_at column
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'identities'
+                AND column_name = 'merged_at'
+            ) THEN
+                ALTER TABLE identities
+                ADD COLUMN merged_at TIMESTAMP WITH TIME ZONE;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Intentionally a no-op: do not drop columns to preserve data.
+    pass

--- a/backend/alembic/versions/20260508_1200_add_identity_merge_marker.py
+++ b/backend/alembic/versions/20260508_1200_add_identity_merge_marker.py
@@ -1,8 +1,8 @@
 """Add merge marker fields to identities table
 
-Revision ID: 20260508_1000
-Revises: 20260429_1200
-Create Date: 2026-05-08 10:00:00.000000
+Revision ID: 20260508_1200
+Revises: 20260508_1100
+Create Date: 2026-05-08 12:00:00.000000
 
 Adds merged_into_identity_id and merged_at to Identity for tracking bind/merge
 of 1Campus SSO accounts with existing Duotopia accounts (Phase 1 of #719).
@@ -18,8 +18,8 @@ Related: #719
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "20260508_1000"
-down_revision = "20260429_1200"
+revision = "20260508_1200"
+down_revision = "20260508_1100"
 branch_labels = None
 depends_on = None
 

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -57,6 +57,17 @@ class Identity(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
+    # Merge marker fields (Phase 1: no data migration, just identity tracking)
+    # When an Identity is merged into another, we mark the source as inactive
+    # and record which identity it was merged into so future logins can redirect.
+    merged_into_identity_id = Column(
+        Integer,
+        ForeignKey("identities.id"),
+        nullable=True,
+        index=True,
+    )
+    merged_at = Column(DateTime(timezone=True), nullable=True)
+
     # Relationships
     linked_students = relationship(
         "Student",

--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -540,11 +540,7 @@ async def _handle_oauth_merge_flow_from_state(
         )
 
     # Step 6: Find Identity B by uuid (including deactivated/merged)
-    identity_b = (
-        db.query(Identity)
-        .filter(Identity.one_campus_uuid == uuid)
-        .first()
-    )
+    identity_b = db.query(Identity).filter(Identity.one_campus_uuid == uuid).first()
 
     if identity_b is None:
         # Pure bind: uuid not seen before, write 1Campus fields directly to A
@@ -567,7 +563,9 @@ async def _handle_oauth_merge_flow_from_state(
         # Merge: B is a different identity → mark B merged into A
         from services.one_campus_account_service import OneCampusAccountService
 
-        OneCampusAccountService.mark_identity_merged(db, identity_b.id, target_identity_id)
+        OneCampusAccountService.mark_identity_merged(
+            db, identity_b.id, target_identity_id
+        )
         db.commit()
         logger.info(
             "1Campus merge flow: merged identity_b_id=%s into identity_a_id=%s",

--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -48,9 +48,6 @@ MERGE_TOKEN_TTL = 600
 # OAuth state token validity: 10 minutes
 OAUTH_STATE_TTL = 600
 
-# Prefix for OAuth merge state (different from plain OAuth state to avoid confusion)
-OAUTH_MERGE_STATE_PREFIX = "merge"
-
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/auth/1campus", tags=["auth-1campus"])
@@ -383,6 +380,19 @@ async def get_login_url_for_merge(
             detail="No identity found. Please ensure your account is set up correctly.",
         )
 
+    # Enforce email_verified=True upfront so users can't bypass the frontend
+    # gate, complete OAuth, then get rejected at the callback. Mirrors the
+    # check inside _handle_oauth_merge_flow_from_state.
+    identity = db.get(Identity, user.identity_id)
+    if not identity or not identity.email_verified:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "EMAIL_NOT_VERIFIED",
+                "message": "Please verify your email before binding a 1Campus account.",
+            },
+        )
+
     try:
         merge_state = _create_oauth_merge_state(user.identity_id, user_type)
         url = OneCampusService.get_oauth_authorize_url(state=merge_state)
@@ -561,8 +571,6 @@ async def _handle_oauth_merge_flow_from_state(
         )
     else:
         # Merge: B is a different identity → mark B merged into A
-        from services.one_campus_account_service import OneCampusAccountService
-
         OneCampusAccountService.mark_identity_merged(
             db, identity_b.id, target_identity_id
         )
@@ -1305,6 +1313,7 @@ async def get_binding_status(
     email = identity.email if identity else user.email
 
     return {
+        "user_id": user.id,
         "has_1campus_binding": one_campus_account is not None,
         "one_campus_account": one_campus_account,
         "email": email,

--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -393,6 +393,18 @@ async def get_login_url_for_merge(
             },
         )
 
+    # Reject if the identity is already bound to a 1Campus account. Without
+    # this guard, a stale tab could complete OAuth and silently overwrite the
+    # existing binding via the pure-bind path in the callback handler.
+    if identity.one_campus_uuid:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "ALREADY_BOUND",
+                "message": "This account is already linked to a 1Campus account.",
+            },
+        )
+
     try:
         merge_state = _create_oauth_merge_state(user.identity_id, user_type)
         url = OneCampusService.get_oauth_authorize_url(state=merge_state)
@@ -553,7 +565,24 @@ async def _handle_oauth_merge_flow_from_state(
     identity_b = db.query(Identity).filter(Identity.one_campus_uuid == uuid).first()
 
     if identity_b is None:
-        # Pure bind: uuid not seen before, write 1Campus fields directly to A
+        # Pure bind: uuid not seen before, write 1Campus fields directly to A.
+        # Guard against overwriting an existing binding — login-url-for-merge
+        # already rejects this case, but defend in depth in case the state
+        # token was issued before the binding was set.
+        if target_identity.one_campus_uuid:
+            logger.info(
+                "1Campus merge flow: pure-bind no-op, target identity_id=%s "
+                "already bound to uuid=%s",
+                target_identity_id,
+                target_identity.one_campus_uuid,
+            )
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "ALREADY_BOUND",
+                    "message": "This account is already linked to a 1Campus account.",
+                },
+            )
         target_identity.one_campus_uuid = uuid
         target_identity.one_campus_account = mail
         db.commit()
@@ -570,10 +599,28 @@ async def _handle_oauth_merge_flow_from_state(
             target_identity_id,
         )
     else:
-        # Merge: B is a different identity → mark B merged into A
-        OneCampusAccountService.mark_identity_merged(
-            db, identity_b.id, target_identity_id
-        )
+        # Merge: B is a different identity → mark B merged into A.
+        # mark_identity_merged raises ValueError if B is already merged
+        # elsewhere or inactive (cycle / re-merge guard) — surface as 409.
+        try:
+            OneCampusAccountService.mark_identity_merged(
+                db, identity_b.id, target_identity_id
+            )
+        except ValueError as e:
+            logger.warning(
+                "1Campus merge flow: refused to merge identity_b_id=%s "
+                "into identity_a_id=%s: %s",
+                identity_b.id,
+                target_identity_id,
+                e,
+            )
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "SOURCE_ALREADY_MERGED",
+                    "message": "This 1Campus account is already linked to another Duotopia account.",
+                },
+            )
         db.commit()
         logger.info(
             "1Campus merge flow: merged identity_b_id=%s into identity_a_id=%s",
@@ -581,7 +628,9 @@ async def _handle_oauth_merge_flow_from_state(
             target_identity_id,
         )
 
-    # Step 7: Return access_token for A's user
+    # Step 7: Return access_token for A's user.
+    # Note: Teacher model has no last_login field (unlike Student); only the
+    # student branch updates it.
     if target_user_type == "teacher":
         teacher_response = _build_teacher_response(db, target_user)
         access_token = create_access_token(

--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -48,6 +48,9 @@ MERGE_TOKEN_TTL = 600
 # OAuth state token validity: 10 minutes
 OAUTH_STATE_TTL = 600
 
+# Prefix for OAuth merge state (different from plain OAuth state to avoid confusion)
+OAUTH_MERGE_STATE_PREFIX = "merge"
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/auth/1campus", tags=["auth-1campus"])
@@ -186,6 +189,53 @@ def _verify_oauth_state(state: Optional[str]) -> Optional[dict]:
     return payload_dict
 
 
+def _create_oauth_merge_state(identity_id: int, user_type: str) -> str:
+    """Create an HMAC-signed OAuth state token for the merge flow.
+
+    Encodes the logged-in user's identity_id and user_type so the callback
+    knows to run the merge flow instead of the regular login flow.
+
+    Format: base64(json({"nonce": ..., "merge_for_identity_id": ...,
+                         "merge_for_user_type": ..., "exp": ...})).signature
+    """
+    payload_dict = {
+        "nonce": secrets.token_urlsafe(16),
+        "merge_for_identity_id": identity_id,
+        "merge_for_user_type": user_type,
+        "exp": int(time.time()) + OAUTH_STATE_TTL,
+    }
+    payload_b64 = base64.urlsafe_b64encode(json.dumps(payload_dict).encode()).decode()
+    sig = hmac.HMAC(
+        settings.JWT_SECRET.encode(), payload_b64.encode(), hashlib.sha256
+    ).hexdigest()
+    return f"{payload_b64}.{sig}"
+
+
+def _verify_oauth_merge_state(state: Optional[str]) -> Optional[dict]:
+    """Verify an OAuth merge state token. Returns payload dict or None on failure."""
+    if not state:
+        return None
+    parts = state.split(".", 1)
+    if len(parts) != 2:
+        return None
+    payload_b64, sig = parts
+    expected_sig = hmac.HMAC(
+        settings.JWT_SECRET.encode(), payload_b64.encode(), hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(sig, expected_sig):
+        return None
+    try:
+        payload_dict = json.loads(base64.urlsafe_b64decode(payload_b64))
+    except (json.JSONDecodeError, UnicodeDecodeError, binascii.Error):
+        return None
+    if payload_dict.get("exp", 0) < int(time.time()):
+        return None
+    # Must contain merge fields to distinguish from plain oauth state
+    if "merge_for_identity_id" not in payload_dict:
+        return None
+    return payload_dict
+
+
 def _build_student_response(db: Session, student: Student) -> dict:
     """Build the student login response payload (same shape as email login)."""
     classrooms_list = _get_aggregated_classrooms(db, student)
@@ -298,6 +348,50 @@ async def get_login_url(
     return {"url": url}
 
 
+@router.get("/login-url-for-merge")
+@limiter.limit("10/minute")
+async def get_login_url_for_merge(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    """Return a 1Campus OAuth URL with a merge state token.
+
+    The merge state token encodes the logged-in user's identity_id and user_type
+    so the callback knows to run Flow 2 (merge logged-in user A with 1Campus user B)
+    instead of the regular login flow.
+
+    Requires authentication. Used from the settings page.
+    """
+    user_type = current_user.get("type")
+    user_id = int(current_user.get("sub"))
+
+    # Resolve identity_id for current user
+    if user_type == "student":
+        user = db.query(Student).filter(Student.id == user_id).first()
+    elif user_type == "teacher":
+        user = db.query(Teacher).filter(Teacher.id == user_id).first()
+    else:
+        raise HTTPException(status_code=400, detail="Unsupported user type")
+
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if not user.identity_id:
+        raise HTTPException(
+            status_code=400,
+            detail="No identity found. Please ensure your account is set up correctly.",
+        )
+
+    try:
+        merge_state = _create_oauth_merge_state(user.identity_id, user_type)
+        url = OneCampusService.get_oauth_authorize_url(state=merge_state)
+    except RuntimeError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return {"url": url}
+
+
 @router.get("/callback")
 @limiter.limit("10/minute")
 async def one_campus_callback(
@@ -319,6 +413,13 @@ async def one_campus_callback(
     """
     if schoolDsns:
         return await _handle_identity_code_flow(request, code, schoolDsns, db)
+
+    # Check if state is a merge state token (Flow 2). Must come before the
+    # regular state check because merge state has a different payload shape.
+    merge_payload = _verify_oauth_merge_state(state)
+    if merge_payload is not None:
+        return await _handle_oauth_merge_flow_from_state(request, code, state, db)
+
     state_payload = _verify_oauth_state(state)
     if state_payload is None:
         raise HTTPException(
@@ -327,6 +428,185 @@ async def one_campus_callback(
         )
     role_hint = state_payload.get("role") if isinstance(state_payload, dict) else None
     return await _handle_oauth_flow(request, code, db, role_hint=role_hint)
+
+
+async def _handle_oauth_merge_flow_from_state(
+    request: Request,
+    code: str,
+    merge_state: str,
+    db: Session,
+) -> OneCampusCallbackResponse:
+    """Handle Flow 2: logged-in user A merges with 1Campus account B.
+
+    The merge_state token encodes target_identity_id (A) and user_type.
+    Steps:
+    1. Verify merge state token
+    2. Exchange code for 1Campus user info → get uuid
+    3. Verify target A has email_verified=True
+    4. Find Identity_B by uuid
+    5a. B doesn't exist → pure bind (write 1Campus fields to A)
+    5b. B == A → no-op (already bound)
+    5c. B exists and B != A → mark B merged into A, commit
+    6. Return access_token for A's user
+    """
+    merge_payload = _verify_oauth_merge_state(merge_state)
+    if not merge_payload:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid or expired merge state. Please try again from settings.",
+        )
+
+    target_identity_id = merge_payload["merge_for_identity_id"]
+    target_user_type = merge_payload["merge_for_user_type"]
+
+    # Step 1: Exchange code for 1Campus access token
+    try:
+        token_data = await OneCampusService.exchange_oauth_code(code)
+    except RuntimeError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    except httpx.HTTPError as e:
+        logger.error("1Campus OAuth code exchange failed during merge: %s", e)
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to communicate with 1Campus. Please try again.",
+        )
+
+    oauth_access_token = token_data.get("access_token")
+    if not oauth_access_token:
+        raise HTTPException(
+            status_code=502, detail="1Campus did not return an access token."
+        )
+
+    # Step 2: Get user info
+    try:
+        user_info = await OneCampusService.get_oauth_user_info(oauth_access_token)
+    except httpx.HTTPError as e:
+        logger.error("1Campus user info fetch failed during merge: %s", e)
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to fetch user info from 1Campus.",
+        )
+
+    uuid = user_info.get("uuid", "")
+    mail = user_info.get("mail", "")
+
+    if not uuid:
+        raise HTTPException(
+            status_code=502, detail="1Campus did not return a user UUID."
+        )
+
+    # Step 3: Load target Identity A
+    target_identity = db.get(Identity, target_identity_id)
+    if not target_identity or not target_identity.is_active:
+        raise HTTPException(status_code=404, detail="Target identity not found.")
+
+    # Step 4: A must have email_verified=True
+    if not target_identity.email_verified:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "TARGET_NOT_VERIFIED",
+                "message": (
+                    "Please verify your Duotopia email address before binding "
+                    "a 1Campus account."
+                ),
+            },
+        )
+
+    # Step 5: Find target user (Teacher or Student) under A
+    if target_user_type == "teacher":
+        target_user = (
+            db.query(Teacher)
+            .filter(
+                Teacher.identity_id == target_identity_id,
+                Teacher.is_active.is_(True),
+            )
+            .first()
+        )
+    else:
+        target_user = (
+            db.query(Student)
+            .filter(
+                Student.identity_id == target_identity_id,
+                Student.is_active.is_(True),
+            )
+            .order_by(Student.is_primary_account.desc().nulls_last())
+            .first()
+        )
+
+    if not target_user:
+        raise HTTPException(
+            status_code=404, detail="No active user found under target identity."
+        )
+
+    # Step 6: Find Identity B by uuid (including deactivated/merged)
+    identity_b = (
+        db.query(Identity)
+        .filter(Identity.one_campus_uuid == uuid)
+        .first()
+    )
+
+    if identity_b is None:
+        # Pure bind: uuid not seen before, write 1Campus fields directly to A
+        target_identity.one_campus_uuid = uuid
+        target_identity.one_campus_account = mail
+        db.commit()
+        logger.info(
+            "1Campus merge flow: pure bind, uuid=%s written to identity_id=%s",
+            uuid,
+            target_identity_id,
+        )
+    elif identity_b.id == target_identity_id:
+        # No-op: A is already bound to this uuid
+        logger.info(
+            "1Campus merge flow: no-op, uuid=%s already bound to identity_id=%s",
+            uuid,
+            target_identity_id,
+        )
+    else:
+        # Merge: B is a different identity → mark B merged into A
+        from services.one_campus_account_service import OneCampusAccountService
+
+        OneCampusAccountService.mark_identity_merged(db, identity_b.id, target_identity_id)
+        db.commit()
+        logger.info(
+            "1Campus merge flow: merged identity_b_id=%s into identity_a_id=%s",
+            identity_b.id,
+            target_identity_id,
+        )
+
+    # Step 7: Return access_token for A's user
+    if target_user_type == "teacher":
+        teacher_response = _build_teacher_response(db, target_user)
+        access_token = create_access_token(
+            data={
+                "sub": str(target_user.id),
+                "email": target_user.email,
+                "type": "teacher",
+                "name": target_user.name,
+                "role": teacher_response["role"],
+            },
+            expires_delta=timedelta(hours=24),
+        )
+        return OneCampusCallbackResponse(
+            access_token=access_token,
+            role_type="teacher",
+            user=teacher_response,
+            action="merge_complete",
+        )
+    else:
+        access_token = create_access_token(
+            data={"sub": str(target_user.id), "type": "student"},
+            expires_delta=timedelta(hours=24),
+        )
+        target_user.last_login = datetime.now(timezone.utc)
+        db.commit()
+        return OneCampusCallbackResponse(
+            access_token=access_token,
+            role_type="student",
+            student=_build_student_response(db, target_user),
+            action="merge_complete",
+        )
 
 
 async def _handle_identity_code_flow(
@@ -901,6 +1181,29 @@ async def bind_account(
             detail="This account is already bound to this email.",
         )
 
+    # Scenario 4: target email exists but email_verified=False → reject with
+    # structured error so the frontend can offer "Resend verification email".
+    existing_target_identity = (
+        db.query(Identity)
+        .filter(
+            func.lower(Identity.email) == target_email,
+            Identity.is_active.is_(True),
+        )
+        .first()
+    )
+    if existing_target_identity and not existing_target_identity.email_verified:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "TARGET_EMAIL_NOT_VERIFIED",
+                "message": (
+                    f"Your Duotopia account ({target_email}) has not completed email "
+                    "verification yet. Please verify first."
+                ),
+                "target_email": target_email,
+            },
+        )
+
     if user_type == "student":
         from services.email_service import email_service
 
@@ -968,3 +1271,45 @@ async def bind_account(
             "email": target_email,
             "action": "verification_sent",
         }
+
+
+@router.get("/binding-status")
+@limiter.limit("30/minute")
+async def get_binding_status(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    """Return current user's 1Campus binding and email verification status.
+
+    Used by the settings page to show binding status and available actions.
+    Requires authentication.
+    """
+    user_type = current_user.get("type")
+    user_id = int(current_user.get("sub"))
+
+    if user_type == "student":
+        user = db.query(Student).filter(Student.id == user_id).first()
+    elif user_type == "teacher":
+        user = db.query(Teacher).filter(Teacher.id == user_id).first()
+    else:
+        raise HTTPException(status_code=400, detail="Unsupported user type")
+
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    identity = None
+    if user.identity_id:
+        identity = db.get(Identity, user.identity_id)
+
+    one_campus_account = identity.one_campus_account if identity else None
+    email_verified = identity.email_verified if identity else user.email_verified
+    email = identity.email if identity else user.email
+
+    return {
+        "has_1campus_binding": one_campus_account is not None,
+        "one_campus_account": one_campus_account,
+        "email": email,
+        "email_verified": email_verified,
+        "user_type": user_type,
+    }

--- a/backend/routers/auth_one_campus.py
+++ b/backend/routers/auth_one_campus.py
@@ -1309,8 +1309,12 @@ async def get_binding_status(
         identity = db.get(Identity, user.identity_id)
 
     one_campus_account = identity.one_campus_account if identity else None
-    email_verified = identity.email_verified if identity else user.email_verified
-    email = identity.email if identity else user.email
+    # email_verified lives on Identity; fall back safely if the user has no
+    # identity_id and the user model doesn't expose the attribute directly.
+    email_verified = (
+        identity.email_verified if identity else getattr(user, "email_verified", False)
+    )
+    email = identity.email if identity else getattr(user, "email", None)
 
     return {
         "user_id": user.id,

--- a/backend/routers/students/profile.py
+++ b/backend/routers/students/profile.py
@@ -104,6 +104,13 @@ async def get_current_student_info(
             classroom_name = classroom.name
             classroom_id = classroom.id
 
+    # Get 1Campus binding status from Identity
+    one_campus_account = None
+    if student.identity_id:
+        identity = db.query(Identity).filter(Identity.id == student.identity_id).first()
+        if identity:
+            one_campus_account = identity.one_campus_account
+
     return {
         "id": student.id,
         "name": student.name,
@@ -114,6 +121,9 @@ async def get_current_student_info(
         "classroom_name": classroom_name,
         "target_wpm": student.target_wpm,
         "target_accuracy": student.target_accuracy,
+        # 1Campus binding status
+        "one_campus_account": one_campus_account,
+        "has_1campus_binding": one_campus_account is not None,
     }
 
 

--- a/backend/services/one_campus_account_service.py
+++ b/backend/services/one_campus_account_service.py
@@ -44,11 +44,7 @@ class OneCampusAccountService:
         Used during re-login to detect when a uuid points to a merged identity
         so we can redirect to the surviving target identity.
         """
-        return (
-            db.query(Identity)
-            .filter(Identity.one_campus_uuid == uuid)
-            .first()
-        )
+        return db.query(Identity).filter(Identity.one_campus_uuid == uuid).first()
 
     @staticmethod
     def mark_identity_merged(

--- a/backend/services/one_campus_account_service.py
+++ b/backend/services/one_campus_account_service.py
@@ -84,20 +84,36 @@ class OneCampusAccountService:
             )
             return
 
+        # Cycle / re-merge guard: refuse to merge a source that is already
+        # merged elsewhere or has been deactivated. This prevents A→B→A cycles
+        # (find_by_uuid follows only one merged_into hop, so a cycle would
+        # silently land on an inactive identity and fall through to "create
+        # new").
+        if source.merged_into_identity_id is not None or not source.is_active:
+            raise ValueError(
+                f"Source identity_id={source_identity_id} is already merged or inactive "
+                f"(merged_into={source.merged_into_identity_id}, "
+                f"is_active={source.is_active})"
+            )
+
         # Transfer 1Campus fields to target if target doesn't have them.
-        # Clear from source first (unique constraint on one_campus_uuid) before
-        # setting on target, then flush to release the unique index slot.
+        # Each field is cleared from source before assignment to target (and
+        # flushed for unique fields) so the source row never ends up duplicating
+        # identifying data with the surviving target.
         if not target.one_campus_uuid and source.one_campus_uuid:
             transferred_uuid = source.one_campus_uuid
             source.one_campus_uuid = None
-            db.flush()
+            db.flush()  # release UNIQUE index slot before reassigning
             target.one_campus_uuid = transferred_uuid
         if not target.one_campus_account and source.one_campus_account:
             target.one_campus_account = source.one_campus_account
+            source.one_campus_account = None
         if not target.one_campus_student_id and source.one_campus_student_id:
             target.one_campus_student_id = source.one_campus_student_id
+            source.one_campus_student_id = None
         if not target.national_id_hash and source.national_id_hash:
             target.national_id_hash = source.national_id_hash
+            source.national_id_hash = None
 
         # Mark source as merged and deactivate
         source.merged_into_identity_id = target_identity_id

--- a/backend/services/one_campus_account_service.py
+++ b/backend/services/one_campus_account_service.py
@@ -6,9 +6,12 @@ Handles:
 - OAuth-based account matching (uuid + email fallback)
 - Creating new Identity + Student/Teacher for first-time SSO users
 - Detecting duplicate accounts for merge prompt
+- Marking identities as merged (Phase 1 bind/merge for #719)
+- Re-login redirect: when uuid points to a merged identity, resolve to target
 """
 
 import logging
+from datetime import datetime, timezone
 from typing import Optional
 
 from sqlalchemy import func
@@ -24,7 +27,7 @@ class OneCampusAccountService:
 
     @staticmethod
     def find_by_uuid(db: Session, uuid: str) -> Optional[Identity]:
-        """Find Identity by 1Campus OAuth uuid (exact match)."""
+        """Find Identity by 1Campus OAuth uuid (active only)."""
         return (
             db.query(Identity)
             .filter(
@@ -32,6 +35,109 @@ class OneCampusAccountService:
                 Identity.is_active.is_(True),
             )
             .first()
+        )
+
+    @staticmethod
+    def find_by_uuid_including_merged(db: Session, uuid: str) -> Optional[Identity]:
+        """Find Identity by 1Campus OAuth uuid, including deactivated/merged ones.
+
+        Used during re-login to detect when a uuid points to a merged identity
+        so we can redirect to the surviving target identity.
+        """
+        return (
+            db.query(Identity)
+            .filter(Identity.one_campus_uuid == uuid)
+            .first()
+        )
+
+    @staticmethod
+    def mark_identity_merged(
+        db: Session,
+        source_identity_id: int,
+        target_identity_id: int,
+    ) -> None:
+        """Mark source Identity as merged into target Identity.
+
+        Sets:
+        - source.merged_into_identity_id = target.id
+        - source.merged_at = now() (only if not already set — idempotent)
+        - source.is_active = False
+        - Transfers 1Campus fields from source to target (if target has none)
+        - Deactivates Teacher/Student under source
+
+        Does NOT commit — the caller is responsible for commit.
+        Idempotent: calling twice is a safe no-op.
+        """
+        source = db.get(Identity, source_identity_id)
+        target = db.get(Identity, target_identity_id)
+
+        if not source or not target:
+            raise ValueError(
+                f"Identity not found: source={source_identity_id}, target={target_identity_id}"
+            )
+
+        # Idempotency: if already marked as merged into this target, skip
+        if (
+            source.merged_into_identity_id == target_identity_id
+            and source.merged_at is not None
+        ):
+            logger.info(
+                "1Campus merge: source identity_id=%s already merged into %s, skipping",
+                source_identity_id,
+                target_identity_id,
+            )
+            return
+
+        # Transfer 1Campus fields to target if target doesn't have them.
+        # Clear from source first (unique constraint on one_campus_uuid) before
+        # setting on target, then flush to release the unique index slot.
+        if not target.one_campus_uuid and source.one_campus_uuid:
+            transferred_uuid = source.one_campus_uuid
+            source.one_campus_uuid = None
+            db.flush()
+            target.one_campus_uuid = transferred_uuid
+        if not target.one_campus_account and source.one_campus_account:
+            target.one_campus_account = source.one_campus_account
+        if not target.one_campus_student_id and source.one_campus_student_id:
+            target.one_campus_student_id = source.one_campus_student_id
+        if not target.national_id_hash and source.national_id_hash:
+            target.national_id_hash = source.national_id_hash
+
+        # Mark source as merged and deactivate
+        source.merged_into_identity_id = target_identity_id
+        source.merged_at = datetime.now(timezone.utc)
+        source.is_active = False
+
+        # Deactivate all Teachers under source
+        for teacher in (
+            db.query(Teacher)
+            .filter(Teacher.identity_id == source.id, Teacher.is_active.is_(True))
+            .all()
+        ):
+            teacher.is_active = False
+            logger.info(
+                "1Campus merge: deactivated teacher_id=%s under source identity_id=%s",
+                teacher.id,
+                source.id,
+            )
+
+        # Deactivate all Students under source
+        for student in (
+            db.query(Student)
+            .filter(Student.identity_id == source.id, Student.is_active.is_(True))
+            .all()
+        ):
+            student.is_active = False
+            logger.info(
+                "1Campus merge: deactivated student_id=%s under source identity_id=%s",
+                student.id,
+                source.id,
+            )
+
+        logger.info(
+            "1Campus merge: marked identity_id=%s as merged into identity_id=%s",
+            source_identity_id,
+            target_identity_id,
         )
 
     @staticmethod
@@ -443,60 +549,112 @@ class OneCampusAccountService:
         Returns: (identity, user, role_type, action)
         where action is "existing", "created"
         """
-        # Step 1: Match by uuid
-        identity = OneCampusAccountService.find_by_uuid(db, uuid)
+        # Step 1: Match by uuid — check both active and merged identities
+        identity = OneCampusAccountService.find_by_uuid_including_merged(db, uuid)
         if identity:
-            # Update email if changed
-            if mail and identity.email != mail:
-                identity.email = mail
-            identity.one_campus_account = mail
-            db.commit()
+            # Re-login redirect: if this identity was merged into another, resolve to target
+            if identity.merged_into_identity_id is not None:
+                target_identity = db.get(Identity, identity.merged_into_identity_id)
+                if target_identity and target_identity.is_active:
+                    logger.info(
+                        "1Campus OAuth: uuid=%s points to merged identity_id=%s, "
+                        "redirecting to target identity_id=%s",
+                        uuid,
+                        identity.id,
+                        target_identity.id,
+                    )
+                    # Find student or teacher under target
+                    student = (
+                        db.query(Student)
+                        .filter(
+                            Student.identity_id == target_identity.id,
+                            Student.is_active.is_(True),
+                        )
+                        .order_by(Student.is_primary_account.desc().nulls_last())
+                        .first()
+                    )
+                    if student:
+                        return target_identity, student, "student", "merge_redirect"
 
-            # Try student first, then teacher
-            student = (
-                db.query(Student)
-                .filter(
-                    Student.identity_id == identity.id,
-                    Student.is_active.is_(True),
+                    teacher = (
+                        db.query(Teacher)
+                        .filter(
+                            Teacher.identity_id == target_identity.id,
+                            Teacher.is_active.is_(True),
+                        )
+                        .first()
+                    )
+                    if teacher:
+                        return target_identity, teacher, "teacher", "merge_redirect"
+
+                # Target not found or inactive — fall through to create new
+                logger.warning(
+                    "1Campus OAuth: uuid=%s merged identity target_id=%s is invalid/inactive",
+                    uuid,
+                    identity.merged_into_identity_id,
                 )
-                .order_by(Student.is_primary_account.desc().nulls_last())
-                .first()
-            )
-            if student:
-                logger.info(
-                    "1Campus OAuth: existing student by uuid, "
-                    "student_id=%s, identity_id=%s",
-                    student.id,
+                existing_identity_for_uuid = None
+            elif not identity.is_active:
+                # Deactivated but not merged — treat as not found
+                logger.warning(
+                    "1Campus OAuth: uuid=%s points to inactive non-merged identity_id=%s",
+                    uuid,
                     identity.id,
                 )
-                return identity, student, "student", "existing"
+                existing_identity_for_uuid = None
+            else:
+                # Active, non-merged identity — normal login
+                # Update email if changed
+                if mail and identity.email != mail:
+                    identity.email = mail
+                identity.one_campus_account = mail
+                db.commit()
 
-            teacher = (
-                db.query(Teacher)
-                .filter(
-                    Teacher.identity_id == identity.id,
-                    Teacher.is_active.is_(True),
+                # Try student first, then teacher
+                student = (
+                    db.query(Student)
+                    .filter(
+                        Student.identity_id == identity.id,
+                        Student.is_active.is_(True),
+                    )
+                    .order_by(Student.is_primary_account.desc().nulls_last())
+                    .first()
                 )
-                .first()
-            )
-            if teacher:
-                logger.info(
-                    "1Campus OAuth: existing teacher by uuid, "
-                    "teacher_id=%s, identity_id=%s",
-                    teacher.id,
+                if student:
+                    logger.info(
+                        "1Campus OAuth: existing student by uuid, "
+                        "student_id=%s, identity_id=%s",
+                        student.id,
+                        identity.id,
+                    )
+                    return identity, student, "student", "existing"
+
+                teacher = (
+                    db.query(Teacher)
+                    .filter(
+                        Teacher.identity_id == identity.id,
+                        Teacher.is_active.is_(True),
+                    )
+                    .first()
+                )
+                if teacher:
+                    logger.info(
+                        "1Campus OAuth: existing teacher by uuid, "
+                        "teacher_id=%s, identity_id=%s",
+                        teacher.id,
+                        identity.id,
+                    )
+                    return identity, teacher, "teacher", "existing"
+
+                # Identity exists by uuid but has no active student or teacher.
+                # Don't fall through to email match — that would create a second
+                # identity for the same uuid (orphaning this one). Reuse it instead.
+                logger.warning(
+                    "1Campus OAuth: identity_id=%s matched by uuid has no active "
+                    "user. Will create a new student/teacher under this identity.",
                     identity.id,
                 )
-                return identity, teacher, "teacher", "existing"
-
-            # Identity exists by uuid but has no active student or teacher.
-            # Don't fall through to email match — that would create a second
-            # identity for the same uuid (orphaning this one). Reuse it instead.
-            logger.warning(
-                "1Campus OAuth: identity_id=%s matched by uuid has no active "
-                "user. Will create a new student/teacher under this identity.",
-                identity.id,
-            )
-            existing_identity_for_uuid = identity
+                existing_identity_for_uuid = identity
         else:
             existing_identity_for_uuid = None
 

--- a/backend/tests/unit/test_identity_merge_marker.py
+++ b/backend/tests/unit/test_identity_merge_marker.py
@@ -54,7 +54,9 @@ class TestMarkIdentityMerged:
 
         assert source.is_active is False
 
-    def test_transfers_one_campus_fields_from_source_to_target(self, shared_test_session):
+    def test_transfers_one_campus_fields_from_source_to_target(
+        self, shared_test_session
+    ):
         """mark_identity_merged moves 1Campus fields to target when target has none."""
         db = shared_test_session
 
@@ -81,7 +83,9 @@ class TestMarkIdentityMerged:
         assert target.one_campus_student_id == "S003"
         assert target.national_id_hash == "a" * 64
 
-    def test_does_not_overwrite_existing_one_campus_fields_on_target(self, shared_test_session):
+    def test_does_not_overwrite_existing_one_campus_fields_on_target(
+        self, shared_test_session
+    ):
         """Target with existing 1Campus fields retains them (not overwritten)."""
         db = shared_test_session
 

--- a/backend/tests/unit/test_identity_merge_marker.py
+++ b/backend/tests/unit/test_identity_merge_marker.py
@@ -1,0 +1,186 @@
+"""
+Tests for Identity merge marker functionality.
+
+Covers:
+- mark_identity_merged sets merged_into_identity_id, merged_at, is_active=False
+- Transfers 1Campus fields from source to target
+- Deactivates Teacher/Student under source
+- Idempotency (calling twice is a no-op)
+- Target with existing 1Campus fields is not overwritten
+"""
+
+import pytest
+from datetime import datetime, timezone
+
+from models.user import Identity, Student, Teacher
+from services.one_campus_account_service import OneCampusAccountService
+from auth import get_password_hash
+
+
+class TestMarkIdentityMerged:
+    """OneCampusAccountService.mark_identity_merged behavior."""
+
+    def test_sets_merged_into_identity_id(self, shared_test_session):
+        """mark_identity_merged sets merged_into_identity_id on source."""
+        db = shared_test_session
+
+        source = Identity(email="source@test.com", email_verified=True, is_active=True)
+        target = Identity(email="target@test.com", email_verified=True, is_active=True)
+        db.add(source)
+        db.add(target)
+        db.flush()
+
+        OneCampusAccountService.mark_identity_merged(db, source.id, target.id)
+        db.commit()
+        db.refresh(source)
+
+        assert source.merged_into_identity_id == target.id
+        assert source.merged_at is not None
+        assert isinstance(source.merged_at, datetime)
+
+    def test_sets_source_inactive(self, shared_test_session):
+        """mark_identity_merged deactivates source Identity."""
+        db = shared_test_session
+
+        source = Identity(email="src2@test.com", email_verified=True, is_active=True)
+        target = Identity(email="tgt2@test.com", email_verified=True, is_active=True)
+        db.add(source)
+        db.add(target)
+        db.flush()
+
+        OneCampusAccountService.mark_identity_merged(db, source.id, target.id)
+        db.commit()
+        db.refresh(source)
+
+        assert source.is_active is False
+
+    def test_transfers_one_campus_fields_from_source_to_target(self, shared_test_session):
+        """mark_identity_merged moves 1Campus fields to target when target has none."""
+        db = shared_test_session
+
+        source = Identity(
+            email="src3@test.com",
+            email_verified=True,
+            is_active=True,
+            one_campus_uuid="uuid-src3",
+            one_campus_account="src3@1campus.net",
+            one_campus_student_id="S003",
+            national_id_hash="a" * 64,
+        )
+        target = Identity(email="tgt3@test.com", email_verified=True, is_active=True)
+        db.add(source)
+        db.add(target)
+        db.flush()
+
+        OneCampusAccountService.mark_identity_merged(db, source.id, target.id)
+        db.commit()
+        db.refresh(target)
+
+        assert target.one_campus_uuid == "uuid-src3"
+        assert target.one_campus_account == "src3@1campus.net"
+        assert target.one_campus_student_id == "S003"
+        assert target.national_id_hash == "a" * 64
+
+    def test_does_not_overwrite_existing_one_campus_fields_on_target(self, shared_test_session):
+        """Target with existing 1Campus fields retains them (not overwritten)."""
+        db = shared_test_session
+
+        source = Identity(
+            email="src4@test.com",
+            email_verified=True,
+            is_active=True,
+            one_campus_uuid="uuid-src4",
+            one_campus_account="src4@1campus.net",
+        )
+        target = Identity(
+            email="tgt4@test.com",
+            email_verified=True,
+            is_active=True,
+            one_campus_uuid="uuid-tgt4-existing",
+            one_campus_account="tgt4@1campus.net",
+        )
+        db.add(source)
+        db.add(target)
+        db.flush()
+
+        OneCampusAccountService.mark_identity_merged(db, source.id, target.id)
+        db.commit()
+        db.refresh(target)
+
+        # Target keeps its own 1Campus fields
+        assert target.one_campus_uuid == "uuid-tgt4-existing"
+        assert target.one_campus_account == "tgt4@1campus.net"
+
+    def test_deactivates_teacher_under_source(self, shared_test_session):
+        """mark_identity_merged sets is_active=False on Teacher(s) under source."""
+        db = shared_test_session
+
+        source = Identity(email="src5@test.com", email_verified=True, is_active=True)
+        target = Identity(email="tgt5@test.com", email_verified=True, is_active=True)
+        db.add(source)
+        db.add(target)
+        db.flush()
+
+        teacher = Teacher(
+            name="Source Teacher",
+            email="src5@test.com",
+            password_hash=get_password_hash("pass"),
+            identity_id=source.id,
+            is_active=True,
+        )
+        db.add(teacher)
+        db.commit()
+
+        OneCampusAccountService.mark_identity_merged(db, source.id, target.id)
+        db.commit()
+        db.refresh(teacher)
+
+        assert teacher.is_active is False
+
+    def test_deactivates_student_under_source(self, shared_test_session):
+        """mark_identity_merged sets is_active=False on Student(s) under source."""
+        db = shared_test_session
+
+        source = Identity(email="src6@test.com", email_verified=True, is_active=True)
+        target = Identity(email="tgt6@test.com", email_verified=True, is_active=True)
+        db.add(source)
+        db.add(target)
+        db.flush()
+
+        student = Student(
+            name="Source Student",
+            identity_id=source.id,
+            is_active=True,
+            is_primary_account=True,
+        )
+        db.add(student)
+        db.commit()
+
+        OneCampusAccountService.mark_identity_merged(db, source.id, target.id)
+        db.commit()
+        db.refresh(student)
+
+        assert student.is_active is False
+
+    def test_idempotent_calling_twice_is_noop(self, shared_test_session):
+        """Calling mark_identity_merged twice does not raise and result is same."""
+        db = shared_test_session
+
+        source = Identity(email="src7@test.com", email_verified=True, is_active=True)
+        target = Identity(email="tgt7@test.com", email_verified=True, is_active=True)
+        db.add(source)
+        db.add(target)
+        db.flush()
+
+        OneCampusAccountService.mark_identity_merged(db, source.id, target.id)
+        db.commit()
+        first_merged_at = db.get(Identity, source.id).merged_at
+
+        # Call again — should be a no-op without error
+        OneCampusAccountService.mark_identity_merged(db, source.id, target.id)
+        db.commit()
+        second_merged_at = db.get(Identity, source.id).merged_at
+
+        # merged_at should remain the same (not updated on repeated call)
+        assert db.get(Identity, source.id).merged_into_identity_id == target.id
+        assert second_merged_at == first_merged_at

--- a/backend/tests/unit/test_one_campus_bind_scenario4.py
+++ b/backend/tests/unit/test_one_campus_bind_scenario4.py
@@ -1,0 +1,270 @@
+"""
+Tests for /bind-account Scenario 4:
+When target email exists but email_verified=False → reject with structured error.
+
+These tests call the router function directly (not via TestClient) to avoid
+Casbin permission system startup issues in the unit test environment.
+
+Covers:
+- 400 with code=TARGET_EMAIL_NOT_VERIFIED when target Identity is unverified
+- Existing behavior preserved for verified target Identity
+- Existing behavior preserved when target email not in system
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from models.user import Identity, Student, Teacher
+from auth import get_password_hash
+
+
+async def _call_bind_account(db, current_user: dict, email: str):
+    """Call bind_account router function directly, bypassing HTTP layer."""
+    from routers.auth_one_campus import bind_account, BindAccountRequest
+
+    class MockRequest:
+        pass
+
+    req_body = BindAccountRequest(email=email)
+    return await bind_account(
+        request=MockRequest(),
+        body=req_body,
+        db=db,
+        current_user=current_user,
+    )
+
+
+class TestBindAccountScenario4:
+    """Scenario 4: target email exists but email_verified=False → 400 with structured error."""
+
+    def test_student_bind_to_unverified_target_returns_400_with_code(
+        self, shared_test_session
+    ):
+        """Student bind-account: target email has unverified Identity → HTTPException 400."""
+        import asyncio
+        db = shared_test_session
+
+        # 1Campus SSO student identity (already logged in via OAuth)
+        sso_identity = Identity(
+            email="sc4_sso_student1@1campus.net",
+            email_verified=True,
+            one_campus_account="sc4_sso_student1@1campus.net",
+            one_campus_uuid="sc4-uuid-sso-st1",
+            is_active=True,
+        )
+        db.add(sso_identity)
+        db.flush()
+
+        sso_student = Student(
+            name="SC4 SSO Student 1",
+            identity_id=sso_identity.id,
+            is_active=True,
+            is_primary_account=True,
+        )
+        db.add(sso_student)
+        db.flush()
+
+        # Target: existing Duotopia account with UNVERIFIED email
+        target_identity = Identity(
+            email="sc4_target_unverified1@school.edu.tw",
+            email_verified=False,
+            is_active=True,
+        )
+        db.add(target_identity)
+        db.flush()
+
+        target_student = Student(
+            name="SC4 Target Unverified Student",
+            email="sc4_target_unverified1@school.edu.tw",
+            identity_id=target_identity.id,
+            is_active=True,
+        )
+        db.add(target_student)
+        db.commit()
+
+        current_user = {"sub": str(sso_student.id), "type": "student"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.get_event_loop().run_until_complete(
+                _call_bind_account(
+                    db=db,
+                    current_user=current_user,
+                    email="sc4_target_unverified1@school.edu.tw",
+                )
+            )
+
+        assert exc_info.value.status_code == 400
+        detail = exc_info.value.detail
+        if isinstance(detail, dict):
+            assert detail.get("code") == "TARGET_EMAIL_NOT_VERIFIED"
+            assert detail.get("target_email") == "sc4_target_unverified1@school.edu.tw"
+        else:
+            assert "TARGET_EMAIL_NOT_VERIFIED" in str(detail)
+
+    def test_teacher_bind_to_unverified_target_returns_400_with_code(
+        self, shared_test_session
+    ):
+        """Teacher bind-account: target email has unverified Identity → HTTPException 400."""
+        import asyncio
+        db = shared_test_session
+
+        sso_identity = Identity(
+            email="sc4_sso_teacher1@1campus.net",
+            email_verified=True,
+            one_campus_account="sc4_sso_teacher1@1campus.net",
+            one_campus_uuid="sc4-uuid-sso-tc1",
+            is_active=True,
+        )
+        db.add(sso_identity)
+        db.flush()
+
+        sso_teacher = Teacher(
+            name="SC4 SSO Teacher 1",
+            email="sc4_sso_teacher1@1campus.net",
+            identity_id=sso_identity.id,
+            is_active=True,
+        )
+        db.add(sso_teacher)
+        db.flush()
+
+        target_identity = Identity(
+            email="sc4_target_unverified_tc1@school.edu.tw",
+            email_verified=False,
+            is_active=True,
+        )
+        db.add(target_identity)
+        db.commit()
+
+        current_user = {"sub": str(sso_teacher.id), "type": "teacher"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.get_event_loop().run_until_complete(
+                _call_bind_account(
+                    db=db,
+                    current_user=current_user,
+                    email="sc4_target_unverified_tc1@school.edu.tw",
+                )
+            )
+
+        assert exc_info.value.status_code == 400
+        detail = exc_info.value.detail
+        if isinstance(detail, dict):
+            assert detail.get("code") == "TARGET_EMAIL_NOT_VERIFIED"
+        else:
+            assert "TARGET_EMAIL_NOT_VERIFIED" in str(detail)
+
+    def test_bind_to_verified_target_does_not_raise_scenario4_error(
+        self, shared_test_session
+    ):
+        """Bind to verified target Identity → does NOT raise scenario 4 error.
+
+        The scenario 4 check happens before any email service call, so we can
+        verify it doesn't trigger even if later steps may fail for other reasons.
+        """
+        import asyncio
+        from sqlalchemy.exc import IntegrityError as SQLAIntegrityError
+        db = shared_test_session
+
+        sso_identity = Identity(
+            email="sc4_sso_student2@1campus.net",
+            email_verified=True,
+            one_campus_account="sc4_sso_student2@1campus.net",
+            one_campus_uuid="sc4-uuid-sso-st2",
+            is_active=True,
+        )
+        db.add(sso_identity)
+        db.flush()
+
+        sso_student = Student(
+            name="SC4 SSO Student 2",
+            identity_id=sso_identity.id,
+            is_active=True,
+            is_primary_account=True,
+        )
+        db.add(sso_student)
+        db.flush()
+
+        # Target: VERIFIED Identity with a DIFFERENT email than the sso_identity
+        target_identity = Identity(
+            email="sc4_target_verified2@school.edu.tw",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(target_identity)
+        db.flush()
+
+        target_student = Student(
+            name="SC4 Target Verified Student",
+            email="sc4_target_verified2@school.edu.tw",
+            email_verified=True,
+            identity_id=target_identity.id,
+            is_active=True,
+        )
+        db.add(target_student)
+        db.commit()
+
+        current_user = {"sub": str(sso_student.id), "type": "student"}
+
+        # Should NOT raise the scenario 4 error.
+        # Any other exception (DB constraint, email service) is acceptable;
+        # we only care that scenario 4 is not what's raised.
+        raised_scenario4 = False
+        try:
+            asyncio.get_event_loop().run_until_complete(
+                _call_bind_account(
+                    db=db,
+                    current_user=current_user,
+                    email="sc4_target_verified2@school.edu.tw",
+                )
+            )
+        except HTTPException as e:
+            detail = e.detail
+            if isinstance(detail, dict) and detail.get("code") == "TARGET_EMAIL_NOT_VERIFIED":
+                raised_scenario4 = True
+        except Exception:
+            # Other failures (DB errors, email service mock missing, etc.) are OK
+            pass
+
+        assert not raised_scenario4, "Should NOT raise TARGET_EMAIL_NOT_VERIFIED for verified target"
+
+    def test_bind_to_nonexistent_email_does_not_raise_scenario4_error(
+        self, shared_test_session
+    ):
+        """Bind to email not in system → not rejected by scenario 4 check."""
+        import asyncio
+        db = shared_test_session
+
+        sso_identity = Identity(
+            email="sc4_sso_student3@1campus.net",
+            email_verified=True,
+            one_campus_account="sc4_sso_student3@1campus.net",
+            one_campus_uuid="sc4-uuid-sso-st3",
+            is_active=True,
+        )
+        db.add(sso_identity)
+        db.flush()
+
+        sso_student = Student(
+            name="SC4 SSO Student 3",
+            identity_id=sso_identity.id,
+            is_active=True,
+            is_primary_account=True,
+        )
+        db.add(sso_student)
+        db.commit()
+
+        current_user = {"sub": str(sso_student.id), "type": "student"}
+
+        try:
+            asyncio.get_event_loop().run_until_complete(
+                _call_bind_account(
+                    db=db,
+                    current_user=current_user,
+                    email="sc4_totally_new_email@nowhere.com",
+                )
+            )
+        except HTTPException as e:
+            if isinstance(e.detail, dict):
+                assert e.detail.get("code") != "TARGET_EMAIL_NOT_VERIFIED"
+            else:
+                assert "TARGET_EMAIL_NOT_VERIFIED" not in str(e.detail)

--- a/backend/tests/unit/test_one_campus_bind_scenario4.py
+++ b/backend/tests/unit/test_one_campus_bind_scenario4.py
@@ -42,6 +42,7 @@ class TestBindAccountScenario4:
     ):
         """Student bind-account: target email has unverified Identity → HTTPException 400."""
         import asyncio
+
         db = shared_test_session
 
         # 1Campus SSO student identity (already logged in via OAuth)
@@ -106,6 +107,7 @@ class TestBindAccountScenario4:
     ):
         """Teacher bind-account: target email has unverified Identity → HTTPException 400."""
         import asyncio
+
         db = shared_test_session
 
         sso_identity = Identity(
@@ -163,6 +165,7 @@ class TestBindAccountScenario4:
         """
         import asyncio
         from sqlalchemy.exc import IntegrityError as SQLAIntegrityError
+
         db = shared_test_session
 
         sso_identity = Identity(
@@ -219,19 +222,25 @@ class TestBindAccountScenario4:
             )
         except HTTPException as e:
             detail = e.detail
-            if isinstance(detail, dict) and detail.get("code") == "TARGET_EMAIL_NOT_VERIFIED":
+            if (
+                isinstance(detail, dict)
+                and detail.get("code") == "TARGET_EMAIL_NOT_VERIFIED"
+            ):
                 raised_scenario4 = True
         except Exception:
             # Other failures (DB errors, email service mock missing, etc.) are OK
             pass
 
-        assert not raised_scenario4, "Should NOT raise TARGET_EMAIL_NOT_VERIFIED for verified target"
+        assert (
+            not raised_scenario4
+        ), "Should NOT raise TARGET_EMAIL_NOT_VERIFIED for verified target"
 
     def test_bind_to_nonexistent_email_does_not_raise_scenario4_error(
         self, shared_test_session
     ):
         """Bind to email not in system → not rejected by scenario 4 check."""
         import asyncio
+
         db = shared_test_session
 
         sso_identity = Identity(

--- a/backend/tests/unit/test_one_campus_oauth_merge_flow.py
+++ b/backend/tests/unit/test_one_campus_oauth_merge_flow.py
@@ -1,0 +1,390 @@
+"""
+Tests for Flow 2: A triggers 1Campus OAuth merge from settings.
+
+These tests call router/service functions directly to avoid Casbin startup issues.
+
+Covers:
+- login-url-for-merge requires auth, returns URL with merge state
+- _handle_oauth_merge_flow: uuid matches B → B merged into A, returns A's token
+- _handle_oauth_merge_flow: A.email_verified=False → HTTPException 400
+- _handle_oauth_merge_flow: uuid not in system → pure bind (writes fields to A)
+- _handle_oauth_merge_flow: uuid == A's identity → no-op (already bound)
+"""
+
+import pytest
+import time
+import base64
+import json
+import hmac
+import hashlib
+from datetime import timedelta, datetime, timezone
+from unittest.mock import AsyncMock, patch
+from fastapi import HTTPException
+
+from models.user import Identity, Student, Teacher
+from auth import create_access_token
+
+
+def _make_merge_state_token(identity_id: int, user_type: str) -> str:
+    """Create a valid OAuth merge state token using same logic as router."""
+    from core.config import settings
+
+    payload_dict = {
+        "nonce": "testmerge",
+        "merge_for_identity_id": identity_id,
+        "merge_for_user_type": user_type,
+        "exp": int(time.time()) + 600,
+    }
+    payload_b64 = base64.urlsafe_b64encode(
+        json.dumps(payload_dict).encode()
+    ).decode()
+    sig = hmac.HMAC(
+        settings.JWT_SECRET.encode(), payload_b64.encode(), hashlib.sha256
+    ).hexdigest()
+    return f"{payload_b64}.{sig}"
+
+
+async def _call_login_url_for_merge(db, current_user: dict):
+    """Call login_url_for_merge router function directly."""
+    from routers.auth_one_campus import get_login_url_for_merge
+
+    class MockRequest:
+        pass
+
+    return await get_login_url_for_merge(
+        request=MockRequest(),
+        db=db,
+        current_user=current_user,
+    )
+
+
+async def _call_handle_oauth_merge_flow(db, code: str, merge_state_token: str):
+    """Call _handle_oauth_merge_flow through the callback handler."""
+    from routers.auth_one_campus import _handle_oauth_merge_flow_from_state
+
+    class MockRequest:
+        pass
+
+    return await _handle_oauth_merge_flow_from_state(
+        request=MockRequest(),
+        code=code,
+        merge_state=merge_state_token,
+        db=db,
+    )
+
+
+class TestLoginUrlForMerge:
+    """GET /api/auth/1campus/login-url-for-merge"""
+
+    def test_teacher_gets_url_with_merge_state(self, shared_test_session):
+        """Authenticated teacher → returns url containing merge state."""
+        import asyncio
+        db = shared_test_session
+
+        identity = Identity(
+            email="mergeurl_teacher@test.com",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(identity)
+        db.flush()
+
+        teacher = Teacher(
+            name="Merge URL Teacher",
+            email="mergeurl_teacher@test.com",
+            identity_id=identity.id,
+            is_active=True,
+        )
+        db.add(teacher)
+        db.commit()
+
+        current_user = {"sub": str(teacher.id), "type": "teacher"}
+
+        with patch(
+            "services.one_campus_service.OneCampusService.get_oauth_authorize_url",
+            return_value="https://auth.ischool.com.tw/oauth?state=MERGE_STATE",
+        ):
+            result = asyncio.get_event_loop().run_until_complete(
+                _call_login_url_for_merge(db=db, current_user=current_user)
+            )
+
+        assert "url" in result
+        assert "https://" in result["url"]
+
+    def test_student_gets_url_with_merge_state(self, shared_test_session):
+        """Authenticated student → returns url."""
+        import asyncio
+        db = shared_test_session
+
+        identity = Identity(
+            email="mergeurl_student@test.com",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(identity)
+        db.flush()
+
+        student = Student(
+            name="Merge URL Student",
+            email="mergeurl_student@test.com",
+            identity_id=identity.id,
+            is_active=True,
+        )
+        db.add(student)
+        db.commit()
+
+        current_user = {"sub": str(student.id), "type": "student"}
+
+        with patch(
+            "services.one_campus_service.OneCampusService.get_oauth_authorize_url",
+            return_value="https://auth.ischool.com.tw/oauth?state=MERGE_STATE_S",
+        ):
+            result = asyncio.get_event_loop().run_until_complete(
+                _call_login_url_for_merge(db=db, current_user=current_user)
+            )
+
+        assert "url" in result
+
+
+class TestCallbackWithMergeState:
+    """OAuth callback with merge state token triggers merge flow."""
+
+    def test_uuid_matches_b_marks_b_merged_into_a(self, shared_test_session):
+        """UUID matches B → B merged into A, returns A's token."""
+        import asyncio
+        db = shared_test_session
+
+        # Target identity A (email-logged-in user requesting merge)
+        identity_a = Identity(
+            email="mf_target_a@test.com",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(identity_a)
+        db.flush()
+
+        teacher_a = Teacher(
+            name="MF Teacher A",
+            email="mf_target_a@test.com",
+            identity_id=identity_a.id,
+            is_active=True,
+        )
+        db.add(teacher_a)
+        db.flush()
+
+        # Source identity B (1Campus SSO account, found by uuid)
+        identity_b = Identity(
+            email="mf_source_b@1campus.net",
+            one_campus_uuid="mf-uuid-source-b",
+            one_campus_account="mf_source_b@1campus.net",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(identity_b)
+        db.flush()
+
+        teacher_b = Teacher(
+            name="MF Teacher B",
+            email="mf_source_b@1campus.net",
+            identity_id=identity_b.id,
+            is_active=True,
+        )
+        db.add(teacher_b)
+        db.commit()
+
+        merge_state = _make_merge_state_token(identity_a.id, "teacher")
+
+        mock_token = {"access_token": "1campus_token_xyz"}
+        mock_user_info = {
+            "uuid": "mf-uuid-source-b",
+            "firstName": "B",
+            "lastName": "Teacher",
+            "mail": "mf_source_b@1campus.net",
+        }
+
+        with patch(
+            "services.one_campus_service.OneCampusService.exchange_oauth_code",
+            new=AsyncMock(return_value=mock_token),
+        ), patch(
+            "services.one_campus_service.OneCampusService.get_oauth_user_info",
+            new=AsyncMock(return_value=mock_user_info),
+        ), patch(
+            "services.one_campus_service.OneCampusService.get_user_role",
+            new=AsyncMock(return_value={"school": []}),
+        ):
+            result = asyncio.get_event_loop().run_until_complete(
+                _call_handle_oauth_merge_flow(
+                    db=db, code="test_code", merge_state_token=merge_state
+                )
+            )
+
+        # Should return access_token for target user A
+        assert result.access_token is not None
+
+        db.refresh(identity_b)
+        # B should be marked as merged into A
+        assert identity_b.merged_into_identity_id == identity_a.id
+        assert identity_b.merged_at is not None
+        assert identity_b.is_active is False
+
+    def test_target_unverified_raises_400(self, shared_test_session):
+        """If A.email_verified=False → HTTPException 400."""
+        import asyncio
+        db = shared_test_session
+
+        identity_a_unverified = Identity(
+            email="mf_unverified_a@test.com",
+            email_verified=False,
+            is_active=True,
+        )
+        db.add(identity_a_unverified)
+        db.flush()
+
+        teacher_a = Teacher(
+            name="MF Unverified A",
+            email="mf_unverified_a@test.com",
+            identity_id=identity_a_unverified.id,
+            is_active=True,
+        )
+        db.add(teacher_a)
+        db.commit()
+
+        merge_state = _make_merge_state_token(identity_a_unverified.id, "teacher")
+
+        mock_token = {"access_token": "1campus_token_xyz"}
+        mock_user_info = {
+            "uuid": "mf-uuid-unverified-test",
+            "firstName": "X",
+            "lastName": "Y",
+            "mail": "mf_x@1campus.net",
+        }
+
+        with patch(
+            "services.one_campus_service.OneCampusService.exchange_oauth_code",
+            new=AsyncMock(return_value=mock_token),
+        ), patch(
+            "services.one_campus_service.OneCampusService.get_oauth_user_info",
+            new=AsyncMock(return_value=mock_user_info),
+        ), patch(
+            "services.one_campus_service.OneCampusService.get_user_role",
+            new=AsyncMock(return_value={"school": []}),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.get_event_loop().run_until_complete(
+                    _call_handle_oauth_merge_flow(
+                        db=db, code="test_code", merge_state_token=merge_state
+                    )
+                )
+
+        assert exc_info.value.status_code == 400
+
+    def test_uuid_not_in_system_pure_bind(self, shared_test_session):
+        """UUID not in system → pure bind: write 1Campus fields to target (A)."""
+        import asyncio
+        db = shared_test_session
+
+        identity_a = Identity(
+            email="mf_purebind_a@test.com",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(identity_a)
+        db.flush()
+
+        teacher_a = Teacher(
+            name="MF Pure Bind Teacher",
+            email="mf_purebind_a@test.com",
+            identity_id=identity_a.id,
+            is_active=True,
+        )
+        db.add(teacher_a)
+        db.commit()
+
+        merge_state = _make_merge_state_token(identity_a.id, "teacher")
+
+        mock_token = {"access_token": "1campus_token_xyz"}
+        mock_user_info = {
+            "uuid": "mf-uuid-brand-new-never-seen",
+            "firstName": "New",
+            "lastName": "User",
+            "mail": "mf_newuser@1campus.net",
+        }
+
+        with patch(
+            "services.one_campus_service.OneCampusService.exchange_oauth_code",
+            new=AsyncMock(return_value=mock_token),
+        ), patch(
+            "services.one_campus_service.OneCampusService.get_oauth_user_info",
+            new=AsyncMock(return_value=mock_user_info),
+        ), patch(
+            "services.one_campus_service.OneCampusService.get_user_role",
+            new=AsyncMock(return_value={"school": []}),
+        ):
+            result = asyncio.get_event_loop().run_until_complete(
+                _call_handle_oauth_merge_flow(
+                    db=db, code="test_code", merge_state_token=merge_state
+                )
+            )
+
+        assert result.access_token is not None
+
+        db.refresh(identity_a)
+        # 1Campus fields written to A
+        assert identity_a.one_campus_uuid == "mf-uuid-brand-new-never-seen"
+
+    def test_uuid_matches_target_noop(self, shared_test_session):
+        """UUID == A's identity → no-op (already bound), returns A's token."""
+        import asyncio
+        db = shared_test_session
+
+        identity_a = Identity(
+            email="mf_already_bound@test.com",
+            email_verified=True,
+            one_campus_uuid="mf-uuid-already-bound",
+            one_campus_account="mf_already_bound@1campus.net",
+            is_active=True,
+        )
+        db.add(identity_a)
+        db.flush()
+
+        teacher_a = Teacher(
+            name="MF Already Bound Teacher",
+            email="mf_already_bound@test.com",
+            identity_id=identity_a.id,
+            is_active=True,
+        )
+        db.add(teacher_a)
+        db.commit()
+
+        merge_state = _make_merge_state_token(identity_a.id, "teacher")
+
+        mock_token = {"access_token": "1campus_token_xyz"}
+        mock_user_info = {
+            "uuid": "mf-uuid-already-bound",
+            "firstName": "Already",
+            "lastName": "Bound",
+            "mail": "mf_already_bound@1campus.net",
+        }
+
+        with patch(
+            "services.one_campus_service.OneCampusService.exchange_oauth_code",
+            new=AsyncMock(return_value=mock_token),
+        ), patch(
+            "services.one_campus_service.OneCampusService.get_oauth_user_info",
+            new=AsyncMock(return_value=mock_user_info),
+        ), patch(
+            "services.one_campus_service.OneCampusService.get_user_role",
+            new=AsyncMock(return_value={"school": []}),
+        ):
+            result = asyncio.get_event_loop().run_until_complete(
+                _call_handle_oauth_merge_flow(
+                    db=db, code="test_code", merge_state_token=merge_state
+                )
+            )
+
+        assert result.access_token is not None
+
+        # A should still be active and not marked as merged
+        db.refresh(identity_a)
+        assert identity_a.is_active is True
+        assert identity_a.merged_into_identity_id is None

--- a/backend/tests/unit/test_one_campus_oauth_merge_flow.py
+++ b/backend/tests/unit/test_one_campus_oauth_merge_flow.py
@@ -35,9 +35,7 @@ def _make_merge_state_token(identity_id: int, user_type: str) -> str:
         "merge_for_user_type": user_type,
         "exp": int(time.time()) + 600,
     }
-    payload_b64 = base64.urlsafe_b64encode(
-        json.dumps(payload_dict).encode()
-    ).decode()
+    payload_b64 = base64.urlsafe_b64encode(json.dumps(payload_dict).encode()).decode()
     sig = hmac.HMAC(
         settings.JWT_SECRET.encode(), payload_b64.encode(), hashlib.sha256
     ).hexdigest()
@@ -79,6 +77,7 @@ class TestLoginUrlForMerge:
     def test_teacher_gets_url_with_merge_state(self, shared_test_session):
         """Authenticated teacher → returns url containing merge state."""
         import asyncio
+
         db = shared_test_session
 
         identity = Identity(
@@ -114,6 +113,7 @@ class TestLoginUrlForMerge:
     def test_student_gets_url_with_merge_state(self, shared_test_session):
         """Authenticated student → returns url."""
         import asyncio
+
         db = shared_test_session
 
         identity = Identity(
@@ -152,6 +152,7 @@ class TestCallbackWithMergeState:
     def test_uuid_matches_b_marks_b_merged_into_a(self, shared_test_session):
         """UUID matches B → B merged into A, returns A's token."""
         import asyncio
+
         db = shared_test_session
 
         # Target identity A (email-logged-in user requesting merge)
@@ -230,6 +231,7 @@ class TestCallbackWithMergeState:
     def test_target_unverified_raises_400(self, shared_test_session):
         """If A.email_verified=False → HTTPException 400."""
         import asyncio
+
         db = shared_test_session
 
         identity_a_unverified = Identity(
@@ -281,6 +283,7 @@ class TestCallbackWithMergeState:
     def test_uuid_not_in_system_pure_bind(self, shared_test_session):
         """UUID not in system → pure bind: write 1Campus fields to target (A)."""
         import asyncio
+
         db = shared_test_session
 
         identity_a = Identity(
@@ -335,6 +338,7 @@ class TestCallbackWithMergeState:
     def test_uuid_matches_target_noop(self, shared_test_session):
         """UUID == A's identity → no-op (already bound), returns A's token."""
         import asyncio
+
         db = shared_test_session
 
         identity_a = Identity(

--- a/backend/tests/unit/test_one_campus_relogin_after_merge.py
+++ b/backend/tests/unit/test_one_campus_relogin_after_merge.py
@@ -78,7 +78,7 @@ class TestReloginAfterMerge:
         # Should return target A's identity and teacher
         assert identity.id == identity_a.id
         assert user.id == teacher_a.id
-        assert action in ("existing", "merge_redirect")
+        assert action == "merge_redirect"
 
     def test_find_by_uuid_resolves_merged_student_identity_to_target(
         self, shared_test_session

--- a/backend/tests/unit/test_one_campus_relogin_after_merge.py
+++ b/backend/tests/unit/test_one_campus_relogin_after_merge.py
@@ -1,0 +1,218 @@
+"""
+Tests for re-login redirect after merge.
+
+When 1Campus uuid points to a merged Identity (merged_into_identity_id IS NOT NULL),
+the login should resolve to the target Identity and return that user's token.
+
+Covers:
+- Login via 1Campus with uuid pointing to merged Identity → resolves to target
+- Audit log line emitted for redirection
+"""
+
+import pytest
+import logging
+from datetime import datetime, timezone
+
+from models.user import Identity, Student, Teacher
+from services.one_campus_account_service import OneCampusAccountService
+
+
+class TestReloginAfterMerge:
+    """find_or_create_by_oauth with merged uuid should resolve to target's user."""
+
+    def test_find_by_uuid_resolves_merged_teacher_identity_to_target(
+        self, shared_test_session
+    ):
+        """UUID pointing to merged deactivated Identity → returns target teacher."""
+        db = shared_test_session
+
+        # Target identity A (the surviving one)
+        identity_a = Identity(
+            email="rl_survivor_a@test.com",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(identity_a)
+        db.flush()
+
+        teacher_a = Teacher(
+            name="RL Survivor Teacher A",
+            email="rl_survivor_a@test.com",
+            identity_id=identity_a.id,
+            is_active=True,
+        )
+        db.add(teacher_a)
+        db.flush()
+
+        # Merged (deactivated) identity B with uuid — no email to avoid unique conflict
+        identity_b = Identity(
+            one_campus_uuid="rl-uuid-merged-b-teacher",
+            one_campus_account="rl_merged_b@1campus.net",
+            email_verified=False,
+            is_active=False,  # deactivated by merge
+        )
+        db.add(identity_b)
+        db.flush()
+
+        # Set merge marker: B → A
+        identity_b.merged_into_identity_id = identity_a.id
+        identity_b.merged_at = datetime.now(timezone.utc)
+        db.commit()
+
+        # Simulate find_or_create_by_oauth with uuid that points to merged B
+        identity, user, role_type, action = OneCampusAccountService.find_or_create_by_oauth(
+            db=db,
+            uuid="rl-uuid-merged-b-teacher",
+            mail="rl_merged_b@1campus.net",
+            first_name="Merged",
+            last_name="B",
+            role_type="teacher",
+            teacher_name="Teacher B",
+        )
+
+        # Should return target A's identity and teacher
+        assert identity.id == identity_a.id
+        assert user.id == teacher_a.id
+        assert action in ("existing", "merge_redirect")
+
+    def test_find_by_uuid_resolves_merged_student_identity_to_target(
+        self, shared_test_session
+    ):
+        """Merged student uuid → resolves to target student."""
+        db = shared_test_session
+
+        identity_a = Identity(
+            email="rl_survivor_student_a@test.com",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(identity_a)
+        db.flush()
+
+        student_a = Student(
+            name="RL Survivor Student A",
+            email="rl_survivor_student_a@test.com",
+            identity_id=identity_a.id,
+            is_active=True,
+            is_primary_account=True,
+        )
+        db.add(student_a)
+        db.flush()
+
+        identity_b = Identity(
+            one_campus_uuid="rl-uuid-merged-student-b",
+            one_campus_account="rl_merged_student_b@1campus.net",
+            email_verified=False,
+            is_active=False,
+        )
+        db.add(identity_b)
+        db.flush()
+
+        identity_b.merged_into_identity_id = identity_a.id
+        identity_b.merged_at = datetime.now(timezone.utc)
+        db.commit()
+
+        identity, user, role_type, action = OneCampusAccountService.find_or_create_by_oauth(
+            db=db,
+            uuid="rl-uuid-merged-student-b",
+            mail="rl_merged_student_b@1campus.net",
+            first_name="Student",
+            last_name="B",
+            role_type="student",
+            student_name="Student B",
+        )
+
+        assert identity.id == identity_a.id
+        assert user.id == student_a.id
+        assert role_type == "student"
+
+    def test_audit_log_emitted_for_merge_redirect(
+        self, shared_test_session, caplog
+    ):
+        """Redirect from merged Identity logs a clear audit message."""
+        db = shared_test_session
+
+        identity_a = Identity(
+            email="rl_auditlog_a@test.com",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(identity_a)
+        db.flush()
+
+        teacher_a = Teacher(
+            name="RL Audit Teacher A",
+            email="rl_auditlog_a@test.com",
+            identity_id=identity_a.id,
+            is_active=True,
+        )
+        db.add(teacher_a)
+        db.flush()
+
+        identity_b = Identity(
+            one_campus_uuid="rl-uuid-auditlog-b",
+            one_campus_account="rl_auditlog_b@1campus.net",
+            email_verified=False,
+            is_active=False,
+        )
+        db.add(identity_b)
+        db.flush()
+
+        identity_b.merged_into_identity_id = identity_a.id
+        identity_b.merged_at = datetime.now(timezone.utc)
+        db.commit()
+
+        with caplog.at_level(logging.INFO, logger="services.one_campus_account_service"):
+            OneCampusAccountService.find_or_create_by_oauth(
+                db=db,
+                uuid="rl-uuid-auditlog-b",
+                mail="rl_auditlog_b@1campus.net",
+                first_name="B",
+                last_name="Audit",
+                role_type="teacher",
+                teacher_name="RL Audit Teacher B",
+            )
+
+        # At least one log line should mention the redirect / merge
+        log_text = " ".join(caplog.messages)
+        assert any(
+            keyword in log_text.lower()
+            for keyword in ["merge", "redirect", "merged", "resolv"]
+        )
+
+    def test_non_merged_uuid_not_affected(self, shared_test_session):
+        """UUID pointing to active non-merged identity works as before."""
+        db = shared_test_session
+
+        identity_normal = Identity(
+            email="rl_normal@test.com",
+            one_campus_uuid="rl-uuid-normal-active",
+            one_campus_account="rl_normal@1campus.net",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(identity_normal)
+        db.flush()
+
+        teacher_normal = Teacher(
+            name="RL Normal Teacher",
+            email="rl_normal@test.com",
+            identity_id=identity_normal.id,
+            is_active=True,
+        )
+        db.add(teacher_normal)
+        db.commit()
+
+        identity, user, role_type, action = OneCampusAccountService.find_or_create_by_oauth(
+            db=db,
+            uuid="rl-uuid-normal-active",
+            mail="rl_normal@1campus.net",
+            first_name="Normal",
+            last_name="Teacher",
+            role_type="teacher",
+        )
+
+        # Should return the same identity and teacher (not redirected)
+        assert identity.id == identity_normal.id
+        assert user.id == teacher_normal.id
+        assert action == "existing"

--- a/backend/tests/unit/test_one_campus_relogin_after_merge.py
+++ b/backend/tests/unit/test_one_campus_relogin_after_merge.py
@@ -60,7 +60,12 @@ class TestReloginAfterMerge:
         db.commit()
 
         # Simulate find_or_create_by_oauth with uuid that points to merged B
-        identity, user, role_type, action = OneCampusAccountService.find_or_create_by_oauth(
+        (
+            identity,
+            user,
+            role_type,
+            action,
+        ) = OneCampusAccountService.find_or_create_by_oauth(
             db=db,
             uuid="rl-uuid-merged-b-teacher",
             mail="rl_merged_b@1campus.net",
@@ -112,7 +117,12 @@ class TestReloginAfterMerge:
         identity_b.merged_at = datetime.now(timezone.utc)
         db.commit()
 
-        identity, user, role_type, action = OneCampusAccountService.find_or_create_by_oauth(
+        (
+            identity,
+            user,
+            role_type,
+            action,
+        ) = OneCampusAccountService.find_or_create_by_oauth(
             db=db,
             uuid="rl-uuid-merged-student-b",
             mail="rl_merged_student_b@1campus.net",
@@ -126,9 +136,7 @@ class TestReloginAfterMerge:
         assert user.id == student_a.id
         assert role_type == "student"
 
-    def test_audit_log_emitted_for_merge_redirect(
-        self, shared_test_session, caplog
-    ):
+    def test_audit_log_emitted_for_merge_redirect(self, shared_test_session, caplog):
         """Redirect from merged Identity logs a clear audit message."""
         db = shared_test_session
 
@@ -162,7 +170,9 @@ class TestReloginAfterMerge:
         identity_b.merged_at = datetime.now(timezone.utc)
         db.commit()
 
-        with caplog.at_level(logging.INFO, logger="services.one_campus_account_service"):
+        with caplog.at_level(
+            logging.INFO, logger="services.one_campus_account_service"
+        ):
             OneCampusAccountService.find_or_create_by_oauth(
                 db=db,
                 uuid="rl-uuid-auditlog-b",
@@ -203,7 +213,12 @@ class TestReloginAfterMerge:
         db.add(teacher_normal)
         db.commit()
 
-        identity, user, role_type, action = OneCampusAccountService.find_or_create_by_oauth(
+        (
+            identity,
+            user,
+            role_type,
+            action,
+        ) = OneCampusAccountService.find_or_create_by_oauth(
             db=db,
             uuid="rl-uuid-normal-active",
             mail="rl_normal@1campus.net",

--- a/frontend/src/components/settings/OneCampusBindSection.tsx
+++ b/frontend/src/components/settings/OneCampusBindSection.tsx
@@ -24,6 +24,7 @@ import {
 import api from "@/services/api";
 
 interface BindingStatus {
+  user_id: number;
   has_1campus_binding: boolean;
   one_campus_account: string | null;
   email: string | null;
@@ -42,10 +43,6 @@ export interface OneCampusBindSectionProps {
    */
   onMergeFlowStart?: (url: string) => void;
   /**
-   * Called after bind-account (email flow) succeeds.
-   */
-  onBindEmailSent?: (email: string) => void;
-  /**
    * userType override — if not provided, fetched from API.
    */
   userType?: "teacher" | "student";
@@ -53,7 +50,6 @@ export interface OneCampusBindSectionProps {
 
 export default function OneCampusBindSection({
   onMergeFlowStart,
-  onBindEmailSent: _onBindEmailSent,
   userType,
 }: OneCampusBindSectionProps) {
   const [status, setStatus] = useState<BindingStatus | null>(null);
@@ -109,11 +105,10 @@ export default function OneCampusBindSection({
           { email: status.email },
         );
       } else {
-        // Student resend — uses student-specific endpoint
-        // This triggers a new verification email
+        // Student resend — dedicated endpoint that re-sends the existing
+        // pending verification (does NOT change the email or reset state).
         await api.post<ResendVerificationResponse>(
-          "/api/students/update-email",
-          { email: status.email },
+          `/api/students/${status.user_id}/email/resend-verification`,
         );
       }
       toast.success("Verification email sent. Please check your inbox.");
@@ -140,7 +135,6 @@ export default function OneCampusBindSection({
   const isBound = status.has_1campus_binding;
   const emailVerified = status.email_verified;
   const hasEmail = !!status.email;
-  const isLoggedInVia1Campus = isBound;
 
   // Determine what action to show
   // - If not bound and email verified → show "Bind 1Campus account" (merge flow)
@@ -207,7 +201,7 @@ export default function OneCampusBindSection({
         {/* Action area */}
         <div className="pt-2 space-y-2">
           {/* Show bind button only if: not already bound, email verified */}
-          {!isLoggedInVia1Campus && !isBound && emailVerified && (
+          {!isBound && emailVerified && (
             <Button
               size="sm"
               variant="secondary"
@@ -225,7 +219,7 @@ export default function OneCampusBindSection({
           )}
 
           {/* Show disabled bind button + resend if email not verified */}
-          {!isLoggedInVia1Campus && !isBound && hasEmail && !emailVerified && (
+          {!isBound && hasEmail && !emailVerified && (
             <div className="space-y-2">
               <Button
                 size="sm"

--- a/frontend/src/components/settings/OneCampusBindSection.tsx
+++ b/frontend/src/components/settings/OneCampusBindSection.tsx
@@ -1,0 +1,261 @@
+/**
+ * OneCampusBindSection
+ *
+ * Displays 1Campus binding status and Duotopia email verification status,
+ * with action buttons for bind / resend verification.
+ *
+ * Shared between TeacherProfile and StudentProfile settings pages.
+ *
+ * Scope: Issue #719 Phase 1 — bind/merge marker (no data migration).
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { toast } from "sonner";
+import { Link2, CheckCircle, AlertCircle, Loader2, RefreshCw } from "lucide-react";
+import api from "@/services/api";
+
+interface BindingStatus {
+  has_1campus_binding: boolean;
+  one_campus_account: string | null;
+  email: string | null;
+  email_verified: boolean;
+  user_type: string;
+}
+
+interface ResendVerificationResponse {
+  message: string;
+}
+
+export interface OneCampusBindSectionProps {
+  /**
+   * Called after a successful OAuth redirect is initiated (merge flow).
+   * Parent should navigate to the 1Campus OAuth URL.
+   */
+  onMergeFlowStart?: (url: string) => void;
+  /**
+   * Called after bind-account (email flow) succeeds.
+   */
+  onBindEmailSent?: (email: string) => void;
+  /**
+   * userType override — if not provided, fetched from API.
+   */
+  userType?: "teacher" | "student";
+}
+
+export default function OneCampusBindSection({
+  onMergeFlowStart,
+  onBindEmailSent: _onBindEmailSent,
+  userType,
+}: OneCampusBindSectionProps) {
+  const [status, setStatus] = useState<BindingStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [mergeLoading, setMergeLoading] = useState(false);
+  const [resendLoading, setResendLoading] = useState(false);
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const resp = await api.get<BindingStatus>(
+        "/api/auth/1campus/binding-status"
+      );
+      setStatus(resp.data);
+    } catch (err) {
+      console.error("Failed to load 1Campus binding status:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadStatus();
+  }, [loadStatus]);
+
+  async function handleBind1Campus() {
+    setMergeLoading(true);
+    try {
+      const resp = await api.get<{ url: string }>(
+        "/api/auth/1campus/login-url-for-merge"
+      );
+      const url = resp.data.url;
+      if (onMergeFlowStart) {
+        onMergeFlowStart(url);
+      } else {
+        // Default: redirect in same window
+        window.location.href = url;
+      }
+    } catch (err: unknown) {
+      console.error("Failed to get 1Campus merge URL:", err);
+      toast.error("Failed to initiate 1Campus binding. Please try again.");
+    } finally {
+      setMergeLoading(false);
+    }
+  }
+
+  async function handleResendVerification() {
+    if (!status?.email) return;
+    setResendLoading(true);
+    try {
+      if (userType === "teacher" || status.user_type === "teacher") {
+        await api.post<ResendVerificationResponse>(
+          "/api/auth/resend-verification",
+          { email: status.email }
+        );
+      } else {
+        // Student resend — uses student-specific endpoint
+        // This triggers a new verification email
+        await api.post<ResendVerificationResponse>(
+          "/api/students/update-email",
+          { email: status.email }
+        );
+      }
+      toast.success("Verification email sent. Please check your inbox.");
+    } catch (err: unknown) {
+      console.error("Failed to resend verification email:", err);
+      toast.error("Failed to send verification email. Please try again later.");
+    } finally {
+      setResendLoading(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <Card className="mb-6">
+        <CardContent className="p-6 text-center">
+          <Loader2 className="h-5 w-5 animate-spin mx-auto text-gray-400" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!status) return null;
+
+  const isBound = status.has_1campus_binding;
+  const emailVerified = status.email_verified;
+  const hasEmail = !!status.email;
+  const isLoggedInVia1Campus = isBound;
+
+  // Determine what action to show
+  // - If not bound and email verified → show "Bind 1Campus account" (merge flow)
+  // - If not bound and email NOT verified → show disabled button + resend verification
+  // - If bound → show bound status, no action needed
+
+  return (
+    <Card className="mb-6 border-l-4 border-l-green-400 overflow-hidden">
+      <CardHeader className="bg-gradient-to-r from-green-50 to-emerald-50">
+        <CardTitle className="flex items-center gap-2">
+          <Link2 className="h-5 w-5 text-green-600" />
+          1Campus Account Binding
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 pt-4">
+        {/* 1Campus status */}
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm text-gray-500">1Campus Account</p>
+            {isBound ? (
+              <div className="flex items-center gap-2 mt-1">
+                <p className="font-medium">{status.one_campus_account}</p>
+                <Badge className="bg-green-100 text-green-700 flex items-center gap-1">
+                  <CheckCircle className="h-3 w-3" />
+                  Bound
+                </Badge>
+              </div>
+            ) : (
+              <p className="font-medium text-gray-400">Not bound</p>
+            )}
+          </div>
+        </div>
+
+        {/* Duotopia email status */}
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm text-gray-500">Duotopia Email</p>
+            <div className="flex items-center gap-2 mt-1">
+              <p className="font-medium">
+                {hasEmail ? status.email : "Not set"}
+              </p>
+              {hasEmail && (
+                <div>
+                  {emailVerified ? (
+                    <Badge className="bg-green-100 text-green-700 flex items-center gap-1">
+                      <CheckCircle className="h-3 w-3" />
+                      Verified
+                    </Badge>
+                  ) : (
+                    <Badge
+                      variant="outline"
+                      className="text-orange-600 border-orange-300 flex items-center gap-1"
+                    >
+                      <AlertCircle className="h-3 w-3" />
+                      Unverified
+                    </Badge>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Action area */}
+        <div className="pt-2 space-y-2">
+          {/* Show bind button only if: not already bound, email verified */}
+          {!isLoggedInVia1Campus && !isBound && emailVerified && (
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={handleBind1Campus}
+              disabled={mergeLoading}
+              className="hover:bg-gray-200 transition-colors"
+            >
+              {mergeLoading ? (
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+              ) : (
+                <Link2 className="h-4 w-4 mr-2" />
+              )}
+              Bind 1Campus Account
+            </Button>
+          )}
+
+          {/* Show disabled bind button + resend if email not verified */}
+          {!isLoggedInVia1Campus && !isBound && hasEmail && !emailVerified && (
+            <div className="space-y-2">
+              <Button
+                size="sm"
+                variant="secondary"
+                disabled
+                className="cursor-not-allowed opacity-60"
+                title="Please verify your email first before binding a 1Campus account"
+              >
+                <Link2 className="h-4 w-4 mr-2" />
+                Bind 1Campus Account (verify email first)
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleResendVerification}
+                disabled={resendLoading}
+                className="hover:bg-blue-50 text-blue-600 border-blue-300"
+              >
+                {resendLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                ) : (
+                  <RefreshCw className="h-4 w-4 mr-2" />
+                )}
+                Resend Verification Email
+              </Button>
+            </div>
+          )}
+
+          {/* Already bound — no action needed */}
+          {isBound && (
+            <p className="text-sm text-gray-500">
+              Your account is linked to a 1Campus school account.
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/settings/OneCampusBindSection.tsx
+++ b/frontend/src/components/settings/OneCampusBindSection.tsx
@@ -89,7 +89,27 @@ export default function OneCampusBindSection({
       }
     } catch (err: unknown) {
       console.error("Failed to get 1Campus merge URL:", err);
-      toast.error("Failed to initiate 1Campus binding. Please try again.");
+      // Parse the structured backend response to surface actionable messages.
+      const detail = (
+        err as {
+          response?: {
+            data?: { detail?: { code?: string; message?: string } };
+          };
+        }
+      )?.response?.data?.detail;
+      if (detail?.code === "EMAIL_NOT_VERIFIED") {
+        toast.error(
+          detail.message ||
+            "Please verify your email before binding a 1Campus account.",
+        );
+      } else if (detail?.code === "ALREADY_BOUND") {
+        toast.error(
+          detail.message ||
+            "This account is already linked to a 1Campus account.",
+        );
+      } else {
+        toast.error("Failed to initiate 1Campus binding. Please try again.");
+      }
     } finally {
       setMergeLoading(false);
     }

--- a/frontend/src/components/settings/OneCampusBindSection.tsx
+++ b/frontend/src/components/settings/OneCampusBindSection.tsx
@@ -14,7 +14,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
-import { Link2, CheckCircle, AlertCircle, Loader2, RefreshCw } from "lucide-react";
+import {
+  Link2,
+  CheckCircle,
+  AlertCircle,
+  Loader2,
+  RefreshCw,
+} from "lucide-react";
 import api from "@/services/api";
 
 interface BindingStatus {
@@ -58,7 +64,7 @@ export default function OneCampusBindSection({
   const loadStatus = useCallback(async () => {
     try {
       const resp = await api.get<BindingStatus>(
-        "/api/auth/1campus/binding-status"
+        "/api/auth/1campus/binding-status",
       );
       setStatus(resp.data);
     } catch (err) {
@@ -76,7 +82,7 @@ export default function OneCampusBindSection({
     setMergeLoading(true);
     try {
       const resp = await api.get<{ url: string }>(
-        "/api/auth/1campus/login-url-for-merge"
+        "/api/auth/1campus/login-url-for-merge",
       );
       const url = resp.data.url;
       if (onMergeFlowStart) {
@@ -100,14 +106,14 @@ export default function OneCampusBindSection({
       if (userType === "teacher" || status.user_type === "teacher") {
         await api.post<ResendVerificationResponse>(
           "/api/auth/resend-verification",
-          { email: status.email }
+          { email: status.email },
         );
       } else {
         // Student resend — uses student-specific endpoint
         // This triggers a new verification email
         await api.post<ResendVerificationResponse>(
           "/api/students/update-email",
-          { email: status.email }
+          { email: status.email },
         );
       }
       toast.success("Verification email sent. Please check your inbox.");

--- a/frontend/src/pages/OneCampusCallback.tsx
+++ b/frontend/src/pages/OneCampusCallback.tsx
@@ -32,7 +32,12 @@ export default function OneCampusCallback() {
   const { login: teacherLogin } = useTeacherAuthStore();
 
   const [status, setStatus] = useState<
-    "loading" | "error" | "merge_prompt" | "bind_prompt" | "bind_sent"
+    | "loading"
+    | "error"
+    | "merge_prompt"
+    | "bind_prompt"
+    | "bind_sent"
+    | "merge_complete"
   >("loading");
   const [errorMessage, setErrorMessage] = useState("");
   const [mergeInfo, setMergeInfo] = useState<{
@@ -92,6 +97,45 @@ export default function OneCampusCallback() {
       if (data.action === "merge_prompt") {
         setMergeInfo(data.merge_info);
         setStatus("merge_prompt");
+        return;
+      }
+
+      // Flow 2 merge complete — stay logged in as target user, show success
+      if (data.action === "merge_complete") {
+        if (data.access_token) {
+          if (data.role_type === "teacher" && data.user) {
+            teacherLogin(data.access_token, {
+              id: data.user.id,
+              name: data.user.name,
+              email: data.user.email,
+              role: data.user.role,
+              organization_id: data.user.organization_id,
+              school_id: data.user.school_id,
+              is_demo: data.user.is_demo,
+              is_admin: data.user.is_admin,
+            });
+            setBindRoleType("teacher");
+          } else if (data.student) {
+            studentLogin(data.access_token, {
+              id: data.student.id,
+              name: data.student.name,
+              email: data.student.email || "",
+              student_number: data.student.student_number || "",
+              classroom_id: data.student.classroom_id,
+              classroom_name: data.student.classroom_name,
+              school_id: data.student.school_id,
+              school_name: data.student.school_name,
+              organization_id: data.student.organization_id,
+              organization_name: data.student.organization_name,
+              has_linked_accounts: data.student.has_linked_accounts,
+              linked_accounts_count: data.student.linked_accounts_count,
+              classrooms: data.student.classrooms,
+              classrooms_count: data.student.classrooms_count,
+            });
+            setBindRoleType("student");
+          }
+        }
+        setStatus("merge_complete");
         return;
       }
 
@@ -379,6 +423,38 @@ export default function OneCampusCallback() {
           <CardContent className="text-center">
             <Button onClick={handleBindSkip} className="w-full">
               {t("oneCampus.bind.continue", "Continue to Dashboard")}
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {status === "merge_complete" && (
+        <Card className="max-w-md w-full">
+          <CardHeader className="text-center">
+            <Link2 className="h-12 w-12 text-green-500 mx-auto mb-2" />
+            <CardTitle>
+              {t("oneCampus.mergeComplete.title", "1Campus Account Linked")}
+            </CardTitle>
+            <CardDescription>
+              {t(
+                "oneCampus.mergeComplete.description",
+                "Your 1Campus account has been successfully linked. You can now log in with either account.",
+              )}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-center">
+            <Button
+              onClick={() => {
+                // Navigate back to the appropriate settings page based on bindRoleType
+                if (bindRoleType === "teacher") {
+                  navigate("/teacher/profile", { replace: true });
+                } else {
+                  navigate("/student/profile", { replace: true });
+                }
+              }}
+              className="w-full"
+            >
+              {t("oneCampus.mergeComplete.continue", "Return to Settings")}
             </Button>
           </CardContent>
         </Card>

--- a/frontend/src/pages/OneCampusCallback.tsx
+++ b/frontend/src/pages/OneCampusCallback.tsx
@@ -102,6 +102,7 @@ export default function OneCampusCallback() {
 
       // Flow 2 merge complete — stay logged in as target user, show success
       if (data.action === "merge_complete") {
+        let loggedIn = false;
         if (data.access_token) {
           if (data.role_type === "teacher" && data.user) {
             teacherLogin(data.access_token, {
@@ -115,6 +116,7 @@ export default function OneCampusCallback() {
               is_admin: data.user.is_admin,
             });
             setBindRoleType("teacher");
+            loggedIn = true;
           } else if (data.student) {
             studentLogin(data.access_token, {
               id: data.student.id,
@@ -133,9 +135,18 @@ export default function OneCampusCallback() {
               classrooms_count: data.student.classrooms_count,
             });
             setBindRoleType("student");
+            loggedIn = true;
           }
         }
-        setStatus("merge_complete");
+        if (loggedIn) {
+          setStatus("merge_complete");
+        } else {
+          // No usable login payload — surface as error instead of pretending success
+          setErrorMessage(
+            "Merge completed but the server did not return login credentials. Please try logging in again.",
+          );
+          setStatus("error");
+        }
         return;
       }
 

--- a/frontend/src/pages/student/StudentProfile.tsx
+++ b/frontend/src/pages/student/StudentProfile.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { useStudentAuthStore } from "@/stores/studentAuthStore";
+import OneCampusBindSection from "@/components/settings/OneCampusBindSection";
 import { toast } from "sonner";
 import {
   User,
@@ -556,6 +557,9 @@ export default function StudentProfile() {
             )}
           </CardContent>
         </Card>
+
+        {/* 1Campus Binding Section */}
+        <OneCampusBindSection userType="student" />
 
         {/* Password Settings Card */}
         <Card className="mb-6 border-l-4 border-l-amber-400 overflow-hidden">

--- a/frontend/src/pages/teacher/TeacherProfile.tsx
+++ b/frontend/src/pages/teacher/TeacherProfile.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { apiClient } from "@/lib/api";
 import { toast } from "sonner";
+import OneCampusBindSection from "@/components/settings/OneCampusBindSection";
 import {
   User,
   Mail,
@@ -460,6 +461,9 @@ export default function TeacherProfile() {
           </div>
         </CardContent>
       </Card>
+
+      {/* 1Campus Binding Card */}
+      <OneCampusBindSection userType="teacher" />
 
       {/* Quota Info Card */}
       <QuotaCard />


### PR DESCRIPTION
## Summary

Phase 1 of #719 — adds the minimum to support 1Campus ↔ Duotopia account binding **without** doing any cross-Identity data migration. Source Identities are marked (`merged_into_identity_id`) so a future migration script (separate issue) can find and migrate them.

## Two flows enabled

**Flow 1 (B → A)**: 1Campus user wants to bind to existing email account
- If target email's Identity is unverified → 400 with `code=TARGET_EMAIL_NOT_VERIFIED` so the UI offers a "resend verification" button.

**Flow 2 (A → B)**: User logged in as A (email/password, verified) clicks "Bind 1Campus" on the settings page
- New endpoint `GET /api/auth/1campus/login-url-for-merge` returns a OAuth URL with a signed merge state.
- Callback transfers 1Campus fields (`one_campus_uuid`, `one_campus_account`, `national_id_hash`) from B to A, marks `B.merged_into_identity_id = A.id`, sets `B.is_active = False`.
- Requires `A.email_verified=True`.

**Re-login UX**: when 1Campus uuid lands on a merged (deactivated) Identity, `find_by_uuid` now follows `merged_into_identity_id` and returns the surviving Identity, so the user still logs in as A seamlessly.

## Schema changes

- `identities.merged_into_identity_id` — nullable FK to `identities.id`, indexed (partial index where not null)
- `identities.merged_at` — nullable timestamp
- Migration `20260508_1200_add_identity_merge_marker.py` — idempotent per CLAUDE.md rules (`DO \$\$` + `IF NOT EXISTS`)

## Out of scope (intentionally — separate issue to follow)

- ❌ Cross-Identity **data migration**: classrooms, programs, assignments, teacher_organizations, teacher_schools, subscription_*, point_usage_logs, card_*, classroom_students, assignment_students, recordings, student_item_progress, student_assignment. Admin handles manually for now.
- ❌ UI 1 (login-page bind entry)
- ❌ Scenarios 5-13 (subscription conflict, demo protection, session invalidation, unbind, multi-1Campus per identity)

## Test plan

- [x] 21 new backend unit tests, all passing:
  - `test_identity_merge_marker.py` — mark_identity_merged sets fields, transfers 1Campus fields, deactivates source user, idempotent
  - `test_one_campus_bind_scenario4.py` — bind to unverified target returns 400 + structured code
  - `test_one_campus_oauth_merge_flow.py` — login-url-for-merge + callback merge flow + uuid-not-found pure bind + uuid-equals-target no-op
  - `test_one_campus_relogin_after_merge.py` — find_by_uuid follows merged_into pointer
- [x] Frontend typecheck: 0 errors
- [x] Frontend build: success
- [x] Frontend lint: same warning count as staging baseline (94, no new ones)
- [ ] Manual UI check on per-issue env: settings page shows binding section for both teacher and student
- [ ] Manual flow check: trigger Flow 1 + Flow 2 against staging Supabase

## Files

**Backend** (8): `models/user.py`, alembic migration, `services/one_campus_account_service.py`, `routers/auth_one_campus.py`, `routers/students/profile.py`, 4 test files

**Frontend** (4): new `components/settings/OneCampusBindSection.tsx`, modified `pages/teacher/TeacherProfile.tsx`, `pages/student/StudentProfile.tsx`, `pages/OneCampusCallback.tsx`

Related to #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)