### PR TITLE
feat(#715): WordCard component for spelling & cloze activities

### DIFF
--- a/backend/routers/students/assignments.py
+++ b/backend/routers/students/assignments.py
@@ -1979,9 +1979,16 @@ async def start_word_spelling_practice(
         )
         .all()
     )
-    from services.preview_service import ensure_word_audio
+    from services.preview_service import (
+        ensure_word_audio,
+        ensure_example_sentence_audio,
+    )
 
     item_audio_by_id = await ensure_word_audio(list(all_content_items), db)
+    sentence_audio_by_id = await ensure_example_sentence_audio(
+        list(all_content_items), db
+    )
+    item_by_id = {ci.id: ci for ci in all_content_items}
 
     # Ebbinghaus: pick 10 words student is least familiar with
     words_result = db.execute(
@@ -2014,13 +2021,21 @@ async def start_word_spelling_practice(
                 "audio_url": item_audio_by_id.get(ci.id) or ci.audio_url,
                 "image_url": ci.image_url,
                 "memory_strength": 0,
+                # Issue #715: 答對後翻面顯示完整單字卡所需欄位
+                "part_of_speech": ci.part_of_speech,
+                "example_sentence": ci.example_sentence,
+                "example_sentence_translation": ci.example_sentence_translation,
+                "example_sentence_audio_url": (
+                    sentence_audio_by_id.get(ci.id) or ci.example_sentence_audio_url
+                ),
             }
             for ci in content_items
         ]
     else:
         # Prefer freshly-backfilled audio over the function's cached value
-        words_data = [
-            {
+        def _build_spelling_word(row):
+            ci = item_by_id.get(row.content_item_id)
+            return {
                 "content_item_id": row.content_item_id,
                 "text": row.text,
                 "translation": row.translation or "",
@@ -2029,9 +2044,19 @@ async def start_word_spelling_practice(
                 "memory_strength": (
                     float(row.memory_strength) if row.memory_strength else 0
                 ),
+                # Issue #715: 答對後翻面顯示完整單字卡所需欄位
+                "part_of_speech": ci.part_of_speech if ci else None,
+                "example_sentence": ci.example_sentence if ci else None,
+                "example_sentence_translation": (
+                    ci.example_sentence_translation if ci else None
+                ),
+                "example_sentence_audio_url": sentence_audio_by_id.get(
+                    row.content_item_id,
+                    ci.example_sentence_audio_url if ci else None,
+                ),
             }
-            for row in words_result
-        ]
+
+        words_data = [_build_spelling_word(row) for row in words_result]
 
     if assignment and assignment.shuffle_questions:
         random.shuffle(words_data)
@@ -2687,6 +2712,11 @@ async def start_word_cloze_practice(
             continue
         blanked_sentence, correct_answer = cloze
         is_vocab_item = bool(ci.example_sentence)
+        sentence_audio_for_item = (
+            sentence_audio_by_id.get(ci.id) or ci.example_sentence_audio_url
+            if is_vocab_item
+            else ci.audio_url
+        )
         questions.append(
             {
                 "content_item_id": ci.id,
@@ -2699,13 +2729,19 @@ async def start_word_cloze_practice(
                     else (ci.translation or "")
                 )
                 or "",
-                "audio_url": (
-                    sentence_audio_by_id.get(ci.id) or ci.example_sentence_audio_url
-                    if is_vocab_item
-                    else ci.audio_url
-                ),
+                "audio_url": sentence_audio_for_item,
                 "correct_answer": correct_answer,
                 "correct_answer_length": len(correct_answer),
+                # Issue #715: 答對後翻面顯示完整單字卡所需欄位
+                "part_of_speech": ci.part_of_speech if is_vocab_item else None,
+                "example_sentence": ci.example_sentence if is_vocab_item else None,
+                "example_sentence_translation": (
+                    ci.example_sentence_translation if is_vocab_item else None
+                ),
+                "example_sentence_audio_url": (
+                    sentence_audio_for_item if is_vocab_item else None
+                ),
+                "word_audio_url": ci.audio_url if is_vocab_item else None,
             }
         )
 

--- a/backend/services/preview_service.py
+++ b/backend/services/preview_service.py
@@ -800,6 +800,7 @@ async def get_word_spelling_start(
 
     # Backfill missing single-word audio so 播放音檔 mode actually has audio.
     word_audio_by_id = await ensure_word_audio(list(content_items), db)
+    sentence_audio_by_id = await ensure_example_sentence_audio(list(content_items), db)
 
     total_words_in_assignment = len(content_items)
     exclude_id_set = _parse_exclude_ids(exclude_ids)
@@ -819,6 +820,13 @@ async def get_word_spelling_start(
             "audio_url": word_audio_by_id.get(ci.id) or ci.audio_url,
             "image_url": ci.image_url,
             "memory_strength": 0,
+            # Issue #715: 答對後翻面顯示完整單字卡所需欄位
+            "part_of_speech": ci.part_of_speech,
+            "example_sentence": ci.example_sentence,
+            "example_sentence_translation": ci.example_sentence_translation,
+            "example_sentence_audio_url": (
+                sentence_audio_by_id.get(ci.id) or ci.example_sentence_audio_url
+            ),
         }
         for ci in items_list
     ]
@@ -910,6 +918,11 @@ async def get_word_cloze_start(
             continue
         blanked_sentence, correct_answer = cloze
         is_vocab_item = bool(ci.example_sentence)
+        sentence_audio_for_item = (
+            sentence_audio_by_id.get(ci.id) or ci.example_sentence_audio_url
+            if is_vocab_item
+            else ci.audio_url
+        )
         questions.append(
             {
                 "content_item_id": ci.id,
@@ -927,13 +940,19 @@ async def get_word_cloze_start(
                 # own audio_url which IS the sentence audio.
                 # Use the helper's authoritative dict to dodge SQLAlchemy
                 # expire_on_commit edge cases.
-                "audio_url": (
-                    sentence_audio_by_id.get(ci.id) or ci.example_sentence_audio_url
-                    if is_vocab_item
-                    else ci.audio_url
-                ),
+                "audio_url": sentence_audio_for_item,
                 "correct_answer": correct_answer,
                 "correct_answer_length": len(correct_answer),
+                # Issue #715: 答對後翻面顯示完整單字卡所需欄位
+                "part_of_speech": ci.part_of_speech if is_vocab_item else None,
+                "example_sentence": ci.example_sentence if is_vocab_item else None,
+                "example_sentence_translation": (
+                    ci.example_sentence_translation if is_vocab_item else None
+                ),
+                "example_sentence_audio_url": (
+                    sentence_audio_for_item if is_vocab_item else None
+                ),
+                "word_audio_url": ci.audio_url if is_vocab_item else None,
             }
         )
 

--- a/backend/tests/unit/test_preview_service.py
+++ b/backend/tests/unit/test_preview_service.py
@@ -33,6 +33,7 @@ from services.preview_service import (
     check_rearrangement_answer,
     handle_rearrangement_retry,
     handle_rearrangement_complete,
+    get_word_cloze_start,
     _parse_exclude_ids,
     ALLOWED_AUDIO_FORMATS,
     MAX_AUDIO_FILE_SIZE,
@@ -510,3 +511,174 @@ class TestAssessSpeechPreview:
                 await assess_speech_preview(mock_file, "hello")
             # If we get 413 (too large), that means format check passed
             assert exc_info.value.status_code == 413
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_word_cloze_start (Issue #715)
+# ---------------------------------------------------------------------------
+
+
+def _make_word_cloze_assignment(
+    session,
+    classroom,
+    teacher,
+    lesson,
+    items,
+    **assignment_overrides,
+):
+    """Helper: build a VOCABULARY_SET assignment in word_cloze mode.
+
+    `items` is a list of dicts with keys: text, example_sentence (optional),
+    example_sentence_audio_url (optional), part_of_speech (optional),
+    example_sentence_translation (optional), audio_url (optional).
+    Pre-populating example_sentence_audio_url avoids triggering real TTS
+    calls inside ensure_example_sentence_audio.
+    """
+    defaults = dict(
+        title="Cloze Assignment",
+        classroom_id=classroom.id,
+        teacher_id=teacher.id,
+        due_date=datetime.utcnow() + timedelta(days=7),
+        practice_mode="word_cloze",
+    )
+    defaults.update(assignment_overrides)
+    assignment = Assignment(**defaults)
+    session.add(assignment)
+    session.flush()
+
+    content = Content(
+        lesson_id=lesson.id,
+        type=ContentType.VOCABULARY_SET,
+        title="Cloze Content",
+    )
+    session.add(content)
+    session.flush()
+
+    for idx, spec in enumerate(items):
+        item = ContentItem(
+            content_id=content.id,
+            order_index=idx,
+            text=spec["text"],
+            translation=spec.get("translation", ""),
+            audio_url=spec.get("audio_url"),
+            example_sentence=spec.get("example_sentence"),
+            example_sentence_translation=spec.get("example_sentence_translation"),
+            example_sentence_audio_url=spec.get("example_sentence_audio_url"),
+            part_of_speech=spec.get("part_of_speech"),
+        )
+        session.add(item)
+    session.flush()
+
+    session.add(
+        AssignmentContent(
+            assignment_id=assignment.id,
+            content_id=content.id,
+            order_index=0,
+        )
+    )
+    session.commit()
+    session.refresh(assignment)
+    return assignment
+
+
+class TestGetWordClozeStart:
+    @pytest.mark.asyncio
+    async def test_wrong_mode_raises(
+        self,
+        shared_test_session,
+        preview_teacher,
+        preview_classroom,
+        _program_and_lesson,
+    ):
+        assignment = _make_assignment(
+            shared_test_session,
+            preview_classroom,
+            preview_teacher,
+            _program_and_lesson,
+            practice_mode="word_reading",
+        )
+        with pytest.raises(Exception) as exc_info:
+            await get_word_cloze_start(assignment, shared_test_session)
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_returns_questions_with_715_fields(
+        self,
+        shared_test_session,
+        preview_teacher,
+        preview_classroom,
+        _program_and_lesson,
+    ):
+        assignment = _make_word_cloze_assignment(
+            shared_test_session,
+            preview_classroom,
+            preview_teacher,
+            _program_and_lesson,
+            items=[
+                {
+                    "text": "apple",
+                    "translation": "蘋果",
+                    "audio_url": "https://cdn.example.com/apple.mp3",
+                    "example_sentence": "I eat an apple every day.",
+                    "example_sentence_translation": "我每天吃一顆蘋果。",
+                    "example_sentence_audio_url": "https://cdn.example.com/apple_sent.mp3",
+                    "part_of_speech": "n.",
+                },
+            ],
+        )
+        result = await get_word_cloze_start(assignment, shared_test_session)
+
+        assert "questions" in result
+        assert len(result["questions"]) == 1
+        q = result["questions"][0]
+        # Five #715 fields must be present
+        assert q["part_of_speech"] == "n."
+        assert q["example_sentence"] == "I eat an apple every day."
+        assert q["example_sentence_translation"] == "我每天吃一顆蘋果。"
+        assert q["example_sentence_audio_url"] == "https://cdn.example.com/apple_sent.mp3"
+        assert q["word_audio_url"] == "https://cdn.example.com/apple.mp3"
+        # Sanity: cloze actually blanks out the target word
+        assert "_____" in q["blanked_sentence"]
+        assert q["correct_answer"].lower() == "apple"
+
+    @pytest.mark.asyncio
+    async def test_items_missing_example_sentence_are_skipped(
+        self,
+        shared_test_session,
+        preview_teacher,
+        preview_classroom,
+        _program_and_lesson,
+    ):
+        # Mix: 2 valid items + 1 with no example sentence and no multi-word text.
+        # The third item has no usable cloze source and must be silently skipped.
+        assignment = _make_word_cloze_assignment(
+            shared_test_session,
+            preview_classroom,
+            preview_teacher,
+            _program_and_lesson,
+            items=[
+                {
+                    "text": "apple",
+                    "example_sentence": "I eat an apple every day.",
+                    "example_sentence_audio_url": "https://x/apple.mp3",
+                },
+                {
+                    "text": "book",
+                    "example_sentence": "She reads a book.",
+                    "example_sentence_audio_url": "https://x/book.mp3",
+                },
+                {
+                    # No example_sentence and single-word text → unusable
+                    "text": "banana",
+                },
+            ],
+            shuffle_questions=False,
+        )
+        result = await get_word_cloze_start(assignment, shared_test_session)
+
+        # total_questions counts ALL items in the assignment (used by frontend
+        # progress display), while questions[] only contains usable cloze items.
+        assert result["total_questions"] == 3
+        assert len(result["questions"]) == 2
+        returned_words = {q["base_word"] for q in result["questions"]}
+        assert returned_words == {"apple", "book"}

--- a/backend/tests/unit/test_preview_service.py
+++ b/backend/tests/unit/test_preview_service.py
@@ -635,7 +635,9 @@ class TestGetWordClozeStart:
         assert q["part_of_speech"] == "n."
         assert q["example_sentence"] == "I eat an apple every day."
         assert q["example_sentence_translation"] == "我每天吃一顆蘋果。"
-        assert q["example_sentence_audio_url"] == "https://cdn.example.com/apple_sent.mp3"
+        assert (
+            q["example_sentence_audio_url"] == "https://cdn.example.com/apple_sent.mp3"
+        )
         assert q["word_audio_url"] == "https://cdn.example.com/apple.mp3"
         # Sanity: cloze actually blanks out the target word
         assert "_____" in q["blanked_sentence"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,6 +54,7 @@ import TestSubscription from "./pages/TestSubscription";
 import DemoAssignmentPage from "./pages/DemoAssignmentPage";
 import WordSpellingSample from "./pages/sample/WordSpellingSample";
 import WordClozeSample from "./pages/sample/WordClozeSample";
+import WordCardSample from "./pages/sample/WordCardSample";
 import TugOfWarSample from "./pages/sample/TugOfWarSample";
 import { Toaster } from "sonner";
 import { useCrossTabAuthSync } from "./hooks/useCrossTabAuthSync";
@@ -417,6 +418,10 @@ function App() {
           element={<WordClozeSample />}
         />
         <Route path="/sample/tug-of-war" element={<TugOfWarSample />} />
+        <Route
+          path="/sample/vocabulary-set/word-card"
+          element={<WordCardSample />}
+        />
 
         {/* Test Pages */}
         <Route

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -108,9 +108,8 @@ export default function WordClozeActivity({
   const [completing, setCompleting] = useState(false);
   const [scoreOverlayOpen, setScoreOverlayOpen] = useState(false);
   const nextQuestionCalledRef = useRef(false);
-  // Issue #715: 答對後翻面顯示完整單字卡，5 秒後自動切下一題（或手動點右箭頭）
+  // Issue #715: 答對後翻面顯示完整單字卡；學生用左右箭頭手動翻頁
   const [cardFace, setCardFace] = useState<"front" | "back">("back");
-  const autoAdvanceTimerRef = useRef<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [showTranslation, setShowTranslation] = useState(true);
@@ -453,11 +452,6 @@ export default function WordClozeActivity({
       nextQuestionCalledRef.current = false;
     }, 300);
 
-    if (autoAdvanceTimerRef.current !== null) {
-      window.clearTimeout(autoAdvanceTimerRef.current);
-      autoAdvanceTimerRef.current = null;
-    }
-
     setScoreOverlayOpen(false);
     setCardFace("back");
     setShowResult(false);
@@ -475,10 +469,6 @@ export default function WordClozeActivity({
   // Issue #715: 上一題（只在正面顯示時可用）
   const goToPrev = useCallback(() => {
     if (currentIndex === 0) return;
-    if (autoAdvanceTimerRef.current !== null) {
-      window.clearTimeout(autoAdvanceTimerRef.current);
-      autoAdvanceTimerRef.current = null;
-    }
     setScoreOverlayOpen(false);
     setCardFace("back");
     setShowResult(false);
@@ -488,26 +478,10 @@ export default function WordClozeActivity({
     setCurrentIndex(currentIndex - 1);
   }, [currentIndex, timeLimit]);
 
-  // ScoreOverlay 結束 → 啟動 5 秒倒數，5 秒後自動切下一題
+  // ScoreOverlay 結束 → 關閉動畫，等學生用左右箭頭手動翻頁
   const handleOverlayComplete = () => {
     setScoreOverlayOpen(false);
-    if (autoAdvanceTimerRef.current !== null) {
-      window.clearTimeout(autoAdvanceTimerRef.current);
-    }
-    autoAdvanceTimerRef.current = window.setTimeout(() => {
-      autoAdvanceTimerRef.current = null;
-      advanceToNext();
-    }, 5000);
   };
-
-  // 卸載時清掉 timer
-  useEffect(() => {
-    return () => {
-      if (autoAdvanceTimerRef.current !== null) {
-        window.clearTimeout(autoAdvanceTimerRef.current);
-      }
-    };
-  }, []);
 
   const handleRetry = () => {
     setShowResult(false);

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -43,6 +43,7 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/lib/api";
 import ScoreOverlay from "./shared/ScoreOverlay";
+import { WordCard } from "./shared/WordCard";
 import { aggregateTierCounts, weightedMastery } from "./wordFamiliarity";
 
 interface ClozeQuestion {
@@ -56,6 +57,12 @@ interface ClozeQuestion {
   // preview/demo mode (mirrors how word_selection exposes translation).
   correct_answer: string;
   correct_answer_length: number;
+  // Issue #715: 答對後翻面顯示完整單字卡所需欄位
+  part_of_speech?: string | null;
+  example_sentence?: string | null;
+  example_sentence_translation?: string | null;
+  example_sentence_audio_url?: string | null;
+  word_audio_url?: string | null;
 }
 
 interface ProficiencyStatus {
@@ -101,6 +108,9 @@ export default function WordClozeActivity({
   const [completing, setCompleting] = useState(false);
   const [scoreOverlayOpen, setScoreOverlayOpen] = useState(false);
   const nextQuestionCalledRef = useRef(false);
+  // Issue #715: 答對後翻面顯示完整單字卡，5 秒後自動切下一題（或手動點右箭頭）
+  const [cardFace, setCardFace] = useState<"front" | "back">("back");
+  const autoAdvanceTimerRef = useRef<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [showTranslation, setShowTranslation] = useState(true);
@@ -385,7 +395,8 @@ export default function WordClozeActivity({
       setShowResult(true);
       if (correct) {
         setCorrectCount((prev) => prev + 1);
-        setScoreOverlayOpen(true);
+        // Issue #715: 答對 → 翻面（不立刻顯示 ScoreOverlay）→ onFlipped 後才顯示
+        setCardFace("front");
       } else {
         setIncorrectAnswer(answer);
       }
@@ -411,7 +422,8 @@ export default function WordClozeActivity({
       setShowResult(true);
       if (correct) {
         setCorrectCount((prev) => prev + 1);
-        setScoreOverlayOpen(true);
+        // Issue #715: 答對 → 翻面（不立刻顯示 ScoreOverlay）→ onFlipped 後才顯示
+        setCardFace("front");
       } else {
         setIncorrectAnswer(answer);
       }
@@ -426,14 +438,28 @@ export default function WordClozeActivity({
     }
   };
 
-  const handleOverlayComplete = () => {
+  // Issue #715: 翻面動畫結束 → 顯示答對動畫
+  const handleCardFlipped = useCallback(() => {
+    if (cardFace === "front") {
+      setScoreOverlayOpen(true);
+    }
+  }, [cardFace]);
+
+  // Issue #715: 推進到下一題（共用：5 秒自動 / 右箭頭手動）
+  const advanceToNext = useCallback(() => {
     if (nextQuestionCalledRef.current) return;
     nextQuestionCalledRef.current = true;
     setTimeout(() => {
       nextQuestionCalledRef.current = false;
     }, 300);
 
+    if (autoAdvanceTimerRef.current !== null) {
+      window.clearTimeout(autoAdvanceTimerRef.current);
+      autoAdvanceTimerRef.current = null;
+    }
+
     setScoreOverlayOpen(false);
+    setCardFace("back");
     setShowResult(false);
     setTypedAnswer("");
     setIncorrectAnswer(null);
@@ -444,7 +470,44 @@ export default function WordClozeActivity({
     } else {
       setRoundCompleted(true);
     }
+  }, [currentIndex, questions.length, timeLimit]);
+
+  // Issue #715: 上一題（只在正面顯示時可用）
+  const goToPrev = useCallback(() => {
+    if (currentIndex === 0) return;
+    if (autoAdvanceTimerRef.current !== null) {
+      window.clearTimeout(autoAdvanceTimerRef.current);
+      autoAdvanceTimerRef.current = null;
+    }
+    setScoreOverlayOpen(false);
+    setCardFace("back");
+    setShowResult(false);
+    setTypedAnswer("");
+    setIncorrectAnswer(null);
+    if (timeLimit) setTimeRemaining(timeLimit);
+    setCurrentIndex(currentIndex - 1);
+  }, [currentIndex, timeLimit]);
+
+  // ScoreOverlay 結束 → 啟動 5 秒倒數，5 秒後自動切下一題
+  const handleOverlayComplete = () => {
+    setScoreOverlayOpen(false);
+    if (autoAdvanceTimerRef.current !== null) {
+      window.clearTimeout(autoAdvanceTimerRef.current);
+    }
+    autoAdvanceTimerRef.current = window.setTimeout(() => {
+      autoAdvanceTimerRef.current = null;
+      advanceToNext();
+    }, 5000);
   };
+
+  // 卸載時清掉 timer
+  useEffect(() => {
+    return () => {
+      if (autoAdvanceTimerRef.current !== null) {
+        window.clearTimeout(autoAdvanceTimerRef.current);
+      }
+    };
+  }, []);
 
   const handleRetry = () => {
     setShowResult(false);
@@ -698,147 +761,176 @@ export default function WordClozeActivity({
         />
       </div>
 
-      <div className="space-y-6">
-        {/* Translation hint (Chinese meaning only — never show base word) */}
-        {showTranslation && currentQ.translation && (
-          <div className="text-center">
-            <p className="text-sm text-gray-500 mb-1">
-              {t("wordCloze.translationHint") || "Translation"}
-            </p>
-            <h2 className="text-xl font-bold text-gray-800">
-              {currentQ.translation}
-            </h2>
-          </div>
-        )}
-
-        {currentQ.audio_url && (
-          <div className="flex flex-col items-center gap-2">
-            <Button
-              variant={audioOnlyMode ? "default" : "outline"}
-              size="lg"
-              onClick={playQuestionAudio}
-              className={cn(
-                "gap-2",
-                audioOnlyMode &&
-                  "h-16 px-8 text-lg bg-blue-600 hover:bg-blue-700 text-white shadow-lg",
-              )}
-            >
-              <Volume2 className={audioOnlyMode ? "h-7 w-7" : "h-5 w-5"} />
-              {t("wordCloze.playAudio") || "Play Audio"}
-            </Button>
-            {audioOnlyMode && (
-              <p className="text-xs text-gray-500">
-                {t("wordCloze.tapToReplay") || "點擊播放，可以重複聆聽"}
-              </p>
-            )}
-          </div>
-        )}
-
-        <div className="max-w-2xl mx-auto text-center">
-          <p className="text-xl leading-relaxed text-gray-800 font-medium px-4">
-            {currentQ.blanked_sentence}
-          </p>
-          {showTranslation && currentQ.sentence_translation && (
-            <p className="text-sm text-gray-500 mt-2">
-              {currentQ.sentence_translation}
-            </p>
-          )}
-        </div>
-
-        {timeLimit && timeRemaining !== null && (
-          <div className="flex justify-center">
-            <div
-              className={cn(
-                "flex items-center gap-2 px-4 py-2 rounded-full text-lg font-medium",
-                timeRemaining === 0
-                  ? "bg-red-100 text-red-700"
-                  : timeRemaining <= 5
-                    ? "bg-red-100 text-red-700"
-                    : timeRemaining <= 10
-                      ? "bg-yellow-100 text-yellow-700"
-                      : "bg-gray-100 text-gray-700",
-              )}
-            >
-              <Clock className="h-5 w-5" />
-              {timeRemaining === 0 ? (
-                <span>{t("wordCloze.timeUp") || "Time's up!"}</span>
-              ) : (
-                <>
-                  <span>{timeRemaining}</span>
-                  <span className="text-sm">
-                    {t("wordCloze.seconds") || "s"}
-                  </span>
-                </>
-              )}
-            </div>
-          </div>
-        )}
-
-        <div className="max-w-md mx-auto space-y-3">
-          <Input
-            ref={inputRef}
-            type="text"
-            value={typedAnswer}
-            onChange={(e) => setTypedAnswer(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={
-              t("wordCloze.inputPlaceholder") || "Fill in the blank..."
-            }
-            disabled={showResult || submitting}
-            className={cn(
-              "text-center text-xl h-14 rounded-xl border-2",
-              showResult && isCorrect && "border-green-500 bg-green-50",
-              showResult && !isCorrect && "border-red-500 bg-red-50",
-              !showResult && "border-gray-300 focus:border-indigo-500",
-            )}
-            autoComplete="off"
-            autoCapitalize="off"
-            autoCorrect="off"
-            spellCheck={false}
-          />
-
-          {showResult && !isCorrect && (
-            <div className="text-center space-y-2">
-              <div className="flex items-center justify-center gap-2 text-red-600">
-                <XCircle className="h-5 w-5" />
-                <span className="font-medium">
-                  {incorrectAnswer
-                    ? t("wordCloze.incorrectTryAgain") ||
-                      "Incorrect, try again!"
-                    : t("wordCloze.timeUpTryAgain") || "Time's up! Try again."}
-                </span>
+      <WordCard
+        viewMode="desktop"
+        face={cardFace}
+        onFlipped={handleCardFlipped}
+        word={currentQ.base_word || currentQ.correct_answer}
+        partOfSpeech={currentQ.part_of_speech ?? undefined}
+        translation={currentQ.translation || undefined}
+        audioUrl={currentQ.word_audio_url ?? undefined}
+        exampleSentence={currentQ.example_sentence ?? undefined}
+        exampleSentenceTranslation={
+          currentQ.example_sentence_translation ?? undefined
+        }
+        exampleSentenceAudioUrl={
+          currentQ.example_sentence_audio_url ?? undefined
+        }
+        hasPrev={cardFace === "front" && currentIndex > 0}
+        hasNext={cardFace === "front"}
+        onPrev={goToPrev}
+        onNext={advanceToNext}
+        back={
+          <div className="space-y-6">
+            {/* Translation hint (Chinese meaning only — never show base word) */}
+            {showTranslation && currentQ.translation && (
+              <div className="text-center">
+                <p className="text-sm text-gray-500 mb-1">
+                  {t("wordCloze.translationHint") || "Translation"}
+                </p>
+                <h2 className="text-xl font-bold text-gray-800">
+                  {currentQ.translation}
+                </h2>
               </div>
-              {showAnswerOnWrong && currentQ.correct_answer && (
-                <p className="text-sm text-gray-700">
-                  {t("wordCloze.correctAnswerLabel") || "正確答案"}:{" "}
-                  <span className="font-bold">{currentQ.correct_answer}</span>
+            )}
+
+            {currentQ.audio_url && (
+              <div className="flex flex-col items-center gap-2">
+                <Button
+                  variant={audioOnlyMode ? "default" : "outline"}
+                  size="lg"
+                  onClick={playQuestionAudio}
+                  className={cn(
+                    "gap-2",
+                    audioOnlyMode &&
+                      "h-16 px-8 text-lg bg-blue-600 hover:bg-blue-700 text-white shadow-lg",
+                  )}
+                >
+                  <Volume2 className={audioOnlyMode ? "h-7 w-7" : "h-5 w-5"} />
+                  {t("wordCloze.playAudio") || "Play Audio"}
+                </Button>
+                {audioOnlyMode && (
+                  <p className="text-xs text-gray-500">
+                    {t("wordCloze.tapToReplay") || "點擊播放，可以重複聆聽"}
+                  </p>
+                )}
+              </div>
+            )}
+
+            <div className="max-w-2xl mx-auto text-center">
+              <p className="text-xl leading-relaxed text-gray-800 font-medium px-4">
+                {currentQ.blanked_sentence}
+              </p>
+              {showTranslation && currentQ.sentence_translation && (
+                <p className="text-sm text-gray-500 mt-2">
+                  {currentQ.sentence_translation}
                 </p>
               )}
-              <Button onClick={handleRetry} variant="outline" className="gap-2">
-                <RotateCcw className="h-4 w-4" />
-                {t("wordCloze.retry") || "Retry"}
-              </Button>
             </div>
-          )}
 
-          {!showResult && (
-            <Button
-              onClick={() => handleSubmitAnswer()}
-              disabled={!typedAnswer.trim() || submitting}
-              className="w-full h-12 text-lg"
-            >
-              {submitting ? (
-                <Loader2 className="h-5 w-5 animate-spin" />
-              ) : (
-                <>
-                  <CheckCircle className="h-5 w-5 mr-2" />
-                  {t("wordCloze.checkAnswer") || "Check"}
-                </>
+            {timeLimit && timeRemaining !== null && (
+              <div className="flex justify-center">
+                <div
+                  className={cn(
+                    "flex items-center gap-2 px-4 py-2 rounded-full text-lg font-medium",
+                    timeRemaining === 0
+                      ? "bg-red-100 text-red-700"
+                      : timeRemaining <= 5
+                        ? "bg-red-100 text-red-700"
+                        : timeRemaining <= 10
+                          ? "bg-yellow-100 text-yellow-700"
+                          : "bg-gray-100 text-gray-700",
+                  )}
+                >
+                  <Clock className="h-5 w-5" />
+                  {timeRemaining === 0 ? (
+                    <span>{t("wordCloze.timeUp") || "Time's up!"}</span>
+                  ) : (
+                    <>
+                      <span>{timeRemaining}</span>
+                      <span className="text-sm">
+                        {t("wordCloze.seconds") || "s"}
+                      </span>
+                    </>
+                  )}
+                </div>
+              </div>
+            )}
+
+            <div className="max-w-md mx-auto space-y-3">
+              <Input
+                ref={inputRef}
+                type="text"
+                value={typedAnswer}
+                onChange={(e) => setTypedAnswer(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder={
+                  t("wordCloze.inputPlaceholder") || "Fill in the blank..."
+                }
+                disabled={showResult || submitting}
+                className={cn(
+                  "text-center text-xl h-14 rounded-xl border-2",
+                  showResult && isCorrect && "border-green-500 bg-green-50",
+                  showResult && !isCorrect && "border-red-500 bg-red-50",
+                  !showResult && "border-gray-300 focus:border-indigo-500",
+                )}
+                autoComplete="off"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+              />
+
+              {showResult && !isCorrect && (
+                <div className="text-center space-y-2">
+                  <div className="flex items-center justify-center gap-2 text-red-600">
+                    <XCircle className="h-5 w-5" />
+                    <span className="font-medium">
+                      {incorrectAnswer
+                        ? t("wordCloze.incorrectTryAgain") ||
+                          "Incorrect, try again!"
+                        : t("wordCloze.timeUpTryAgain") ||
+                          "Time's up! Try again."}
+                    </span>
+                  </div>
+                  {showAnswerOnWrong && currentQ.correct_answer && (
+                    <p className="text-sm text-gray-700">
+                      {t("wordCloze.correctAnswerLabel") || "正確答案"}:{" "}
+                      <span className="font-bold">
+                        {currentQ.correct_answer}
+                      </span>
+                    </p>
+                  )}
+                  <Button
+                    onClick={handleRetry}
+                    variant="outline"
+                    className="gap-2"
+                  >
+                    <RotateCcw className="h-4 w-4" />
+                    {t("wordCloze.retry") || "Retry"}
+                  </Button>
+                </div>
               )}
-            </Button>
-          )}
-        </div>
-      </div>
+
+              {!showResult && (
+                <Button
+                  onClick={() => handleSubmitAnswer()}
+                  disabled={!typedAnswer.trim() || submitting}
+                  className="w-full h-12 text-lg"
+                >
+                  {submitting ? (
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                  ) : (
+                    <>
+                      <CheckCircle className="h-5 w-5 mr-2" />
+                      {t("wordCloze.checkAnswer") || "Check"}
+                    </>
+                  )}
+                </Button>
+              )}
+            </div>
+          </div>
+        }
+      />
 
       <ScoreOverlay
         open={scoreOverlayOpen}

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -104,9 +104,8 @@ export default function WordSpellingActivity({
   const [completing, setCompleting] = useState(false);
   const [scoreOverlayOpen, setScoreOverlayOpen] = useState(false);
   const nextQuestionCalledRef = useRef(false);
-  // Issue #715: 答對後翻面顯示完整單字卡，5 秒後自動切下一題（或手動點右箭頭）
+  // Issue #715: 答對後翻面顯示完整單字卡；學生用左右箭頭手動翻頁
   const [cardFace, setCardFace] = useState<"front" | "back">("back");
-  const autoAdvanceTimerRef = useRef<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Settings
@@ -452,11 +451,6 @@ export default function WordSpellingActivity({
       nextQuestionCalledRef.current = false;
     }, 300);
 
-    if (autoAdvanceTimerRef.current !== null) {
-      window.clearTimeout(autoAdvanceTimerRef.current);
-      autoAdvanceTimerRef.current = null;
-    }
-
     setScoreOverlayOpen(false);
     setCardFace("back");
     setShowResult(false);
@@ -474,10 +468,6 @@ export default function WordSpellingActivity({
   // Issue #715: 上一題（只在正面顯示時可用）
   const goToPrev = useCallback(() => {
     if (currentIndex === 0) return;
-    if (autoAdvanceTimerRef.current !== null) {
-      window.clearTimeout(autoAdvanceTimerRef.current);
-      autoAdvanceTimerRef.current = null;
-    }
     setScoreOverlayOpen(false);
     setCardFace("back");
     setShowResult(false);
@@ -487,26 +477,10 @@ export default function WordSpellingActivity({
     setCurrentIndex(currentIndex - 1);
   }, [currentIndex, timeLimit]);
 
-  // ScoreOverlay 結束 → 啟動 5 秒倒數，5 秒後自動切下一題
+  // ScoreOverlay 結束 → 關閉動畫，等學生用左右箭頭手動翻頁
   const handleOverlayComplete = () => {
     setScoreOverlayOpen(false);
-    if (autoAdvanceTimerRef.current !== null) {
-      window.clearTimeout(autoAdvanceTimerRef.current);
-    }
-    autoAdvanceTimerRef.current = window.setTimeout(() => {
-      autoAdvanceTimerRef.current = null;
-      advanceToNext();
-    }, 5000);
   };
-
-  // 卸載時清掉 timer
-  useEffect(() => {
-    return () => {
-      if (autoAdvanceTimerRef.current !== null) {
-        window.clearTimeout(autoAdvanceTimerRef.current);
-      }
-    };
-  }, []);
 
   const handleRetry = () => {
     setShowResult(false);

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -43,6 +43,7 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/lib/api";
 import ScoreOverlay from "./shared/ScoreOverlay";
+import { WordCard } from "./shared/WordCard";
 import { aggregateTierCounts, weightedMastery } from "./wordFamiliarity";
 
 interface SpellingWord {
@@ -52,6 +53,11 @@ interface SpellingWord {
   audio_url?: string;
   image_url?: string;
   memory_strength: number;
+  // Issue #715: 答對後翻面顯示完整單字卡所需欄位
+  part_of_speech?: string | null;
+  example_sentence?: string | null;
+  example_sentence_translation?: string | null;
+  example_sentence_audio_url?: string | null;
 }
 
 interface ProficiencyStatus {
@@ -98,6 +104,9 @@ export default function WordSpellingActivity({
   const [completing, setCompleting] = useState(false);
   const [scoreOverlayOpen, setScoreOverlayOpen] = useState(false);
   const nextQuestionCalledRef = useRef(false);
+  // Issue #715: 答對後翻面顯示完整單字卡，5 秒後自動切下一題（或手動點右箭頭）
+  const [cardFace, setCardFace] = useState<"front" | "back">("back");
+  const autoAdvanceTimerRef = useRef<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Settings
@@ -394,7 +403,8 @@ export default function WordSpellingActivity({
 
     if (correct) {
       setCorrectCount((prev) => prev + 1);
-      setScoreOverlayOpen(true);
+      // Issue #715: 答對 → 翻面（不立刻顯示 ScoreOverlay）→ onFlipped 後才顯示
+      setCardFace("front");
     } else {
       setIncorrectAnswer(answer);
     }
@@ -427,15 +437,28 @@ export default function WordSpellingActivity({
     }
   };
 
-  // Correct overlay → next question; or retry on incorrect
-  const handleOverlayComplete = () => {
+  // Issue #715: 翻面動畫結束 → 顯示答對動畫
+  const handleCardFlipped = useCallback(() => {
+    if (cardFace === "front") {
+      setScoreOverlayOpen(true);
+    }
+  }, [cardFace]);
+
+  // Issue #715: 推進到下一題（共用：5 秒自動 / 右箭頭手動）
+  const advanceToNext = useCallback(() => {
     if (nextQuestionCalledRef.current) return;
     nextQuestionCalledRef.current = true;
     setTimeout(() => {
       nextQuestionCalledRef.current = false;
     }, 300);
 
+    if (autoAdvanceTimerRef.current !== null) {
+      window.clearTimeout(autoAdvanceTimerRef.current);
+      autoAdvanceTimerRef.current = null;
+    }
+
     setScoreOverlayOpen(false);
+    setCardFace("back");
     setShowResult(false);
     setTypedAnswer("");
     setIncorrectAnswer(null);
@@ -446,7 +469,44 @@ export default function WordSpellingActivity({
     } else {
       setRoundCompleted(true);
     }
+  }, [currentIndex, words.length, timeLimit]);
+
+  // Issue #715: 上一題（只在正面顯示時可用）
+  const goToPrev = useCallback(() => {
+    if (currentIndex === 0) return;
+    if (autoAdvanceTimerRef.current !== null) {
+      window.clearTimeout(autoAdvanceTimerRef.current);
+      autoAdvanceTimerRef.current = null;
+    }
+    setScoreOverlayOpen(false);
+    setCardFace("back");
+    setShowResult(false);
+    setTypedAnswer("");
+    setIncorrectAnswer(null);
+    if (timeLimit) setTimeRemaining(timeLimit);
+    setCurrentIndex(currentIndex - 1);
+  }, [currentIndex, timeLimit]);
+
+  // ScoreOverlay 結束 → 啟動 5 秒倒數，5 秒後自動切下一題
+  const handleOverlayComplete = () => {
+    setScoreOverlayOpen(false);
+    if (autoAdvanceTimerRef.current !== null) {
+      window.clearTimeout(autoAdvanceTimerRef.current);
+    }
+    autoAdvanceTimerRef.current = window.setTimeout(() => {
+      autoAdvanceTimerRef.current = null;
+      advanceToNext();
+    }, 5000);
   };
+
+  // 卸載時清掉 timer
+  useEffect(() => {
+    return () => {
+      if (autoAdvanceTimerRef.current !== null) {
+        window.clearTimeout(autoAdvanceTimerRef.current);
+      }
+    };
+  }, []);
 
   const handleRetry = () => {
     setShowResult(false);
@@ -708,140 +768,166 @@ export default function WordSpellingActivity({
         />
       </div>
 
-      <div className="space-y-6">
-        {showTranslation && currentWord.translation && (
-          <div className="text-center">
-            <p className="text-sm text-gray-500 mb-1">
-              {t("wordSpelling.translationHint") || "Translation"}
-            </p>
-            <h2 className="text-2xl font-bold text-gray-800">
-              {currentWord.translation}
-            </h2>
-          </div>
-        )}
-
-        {currentWord.audio_url && (
-          <div className="flex flex-col items-center gap-2">
-            <Button
-              variant={audioOnlyMode ? "default" : "outline"}
-              size="lg"
-              onClick={playWordAudio}
-              className={cn(
-                "gap-2",
-                audioOnlyMode &&
-                  "h-16 px-8 text-lg bg-blue-600 hover:bg-blue-700 text-white shadow-lg",
-              )}
-            >
-              <Volume2 className={audioOnlyMode ? "h-7 w-7" : "h-5 w-5"} />
-              {t("wordSpelling.playAudio") || "Play Audio"}
-            </Button>
-            {audioOnlyMode && (
-              <p className="text-xs text-gray-500">
-                {t("wordSpelling.tapToReplay") || "點擊播放，可以重複聆聽"}
-              </p>
-            )}
-          </div>
-        )}
-
-        <div className="text-center text-gray-600">
-          {t("wordSpelling.typeTheWord") || "Type the correct spelling:"}
-        </div>
-
-        {timeLimit && timeRemaining !== null && (
-          <div className="flex justify-center">
-            <div
-              className={cn(
-                "flex items-center gap-2 px-4 py-2 rounded-full text-lg font-medium",
-                timeRemaining === 0
-                  ? "bg-red-100 text-red-700"
-                  : timeRemaining <= 5
-                    ? "bg-red-100 text-red-700"
-                    : timeRemaining <= 10
-                      ? "bg-yellow-100 text-yellow-700"
-                      : "bg-gray-100 text-gray-700",
-              )}
-            >
-              <Clock className="h-5 w-5" />
-              {timeRemaining === 0 ? (
-                <span>{t("wordSpelling.timeUp") || "Time's up!"}</span>
-              ) : (
-                <>
-                  <span>{timeRemaining}</span>
-                  <span className="text-sm">
-                    {t("wordSpelling.seconds") || "s"}
-                  </span>
-                </>
-              )}
-            </div>
-          </div>
-        )}
-
-        <div className="max-w-md mx-auto space-y-3">
-          <Input
-            ref={inputRef}
-            type="text"
-            value={typedAnswer}
-            onChange={(e) => setTypedAnswer(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={
-              t("wordSpelling.inputPlaceholder") || "Type the word here..."
-            }
-            disabled={showResult || submitting}
-            className={cn(
-              "text-center text-xl h-14 rounded-xl border-2",
-              showResult && isCorrect && "border-green-500 bg-green-50",
-              showResult && !isCorrect && "border-red-500 bg-red-50",
-              !showResult && "border-gray-300 focus:border-indigo-500",
-            )}
-            autoComplete="off"
-            autoCapitalize="off"
-            autoCorrect="off"
-            spellCheck={false}
-          />
-
-          {showResult && !isCorrect && (
-            <div className="text-center space-y-2">
-              <div className="flex items-center justify-center gap-2 text-red-600">
-                <XCircle className="h-5 w-5" />
-                <span className="font-medium">
-                  {incorrectAnswer
-                    ? t("wordSpelling.incorrectTryAgain") ||
-                      "Incorrect, try again!"
-                    : t("wordSpelling.timeUpTryAgain") ||
-                      "Time's up! Try again."}
-                </span>
-              </div>
-              {showAnswerOnWrong && currentWord.text && (
-                <p className="text-sm text-gray-700">
-                  {t("wordSpelling.correctAnswerLabel") || "正確答案"}:{" "}
-                  <span className="font-bold">{currentWord.text}</span>
+      <WordCard
+        viewMode="desktop"
+        face={cardFace}
+        onFlipped={handleCardFlipped}
+        word={currentWord.text}
+        partOfSpeech={currentWord.part_of_speech ?? undefined}
+        translation={currentWord.translation || undefined}
+        audioUrl={currentWord.audio_url}
+        exampleSentence={currentWord.example_sentence ?? undefined}
+        exampleSentenceTranslation={
+          currentWord.example_sentence_translation ?? undefined
+        }
+        exampleSentenceAudioUrl={
+          currentWord.example_sentence_audio_url ?? undefined
+        }
+        hasPrev={cardFace === "front" && currentIndex > 0}
+        hasNext={cardFace === "front" && currentIndex < words.length - 1}
+        onPrev={goToPrev}
+        onNext={advanceToNext}
+        back={
+          <div className="space-y-6">
+            {showTranslation && currentWord.translation && (
+              <div className="text-center">
+                <p className="text-sm text-gray-500 mb-1">
+                  {t("wordSpelling.translationHint") || "Translation"}
                 </p>
-              )}
-              <Button onClick={handleRetry} variant="outline" className="gap-2">
-                <RotateCcw className="h-4 w-4" />
-                {t("wordSpelling.retry") || "Retry"}
-              </Button>
-            </div>
-          )}
+                <h2 className="text-2xl font-bold text-gray-800">
+                  {currentWord.translation}
+                </h2>
+              </div>
+            )}
 
-          {!showResult && (
-            <Button
-              onClick={() => handleSubmitAnswer()}
-              disabled={!typedAnswer.trim() || submitting}
-              className="w-full h-12 text-lg"
-            >
-              {submitting ? (
-                <Loader2 className="h-5 w-5 animate-spin" />
-              ) : (
-                <>
-                  <CheckCircle className="h-5 w-5 mr-2" />
-                  {t("wordSpelling.checkAnswer") || "Check"}
-                </>
+            {currentWord.audio_url && (
+              <div className="flex flex-col items-center gap-2">
+                <Button
+                  variant={audioOnlyMode ? "default" : "outline"}
+                  size="lg"
+                  onClick={playWordAudio}
+                  className={cn(
+                    "gap-2",
+                    audioOnlyMode &&
+                      "h-16 px-8 text-lg bg-blue-600 hover:bg-blue-700 text-white shadow-lg",
+                  )}
+                >
+                  <Volume2 className={audioOnlyMode ? "h-7 w-7" : "h-5 w-5"} />
+                  {t("wordSpelling.playAudio") || "Play Audio"}
+                </Button>
+                {audioOnlyMode && (
+                  <p className="text-xs text-gray-500">
+                    {t("wordSpelling.tapToReplay") || "點擊播放，可以重複聆聽"}
+                  </p>
+                )}
+              </div>
+            )}
+
+            <div className="text-center text-gray-600">
+              {t("wordSpelling.typeTheWord") || "Type the correct spelling:"}
+            </div>
+
+            {timeLimit && timeRemaining !== null && (
+              <div className="flex justify-center">
+                <div
+                  className={cn(
+                    "flex items-center gap-2 px-4 py-2 rounded-full text-lg font-medium",
+                    timeRemaining === 0
+                      ? "bg-red-100 text-red-700"
+                      : timeRemaining <= 5
+                        ? "bg-red-100 text-red-700"
+                        : timeRemaining <= 10
+                          ? "bg-yellow-100 text-yellow-700"
+                          : "bg-gray-100 text-gray-700",
+                  )}
+                >
+                  <Clock className="h-5 w-5" />
+                  {timeRemaining === 0 ? (
+                    <span>{t("wordSpelling.timeUp") || "Time's up!"}</span>
+                  ) : (
+                    <>
+                      <span>{timeRemaining}</span>
+                      <span className="text-sm">
+                        {t("wordSpelling.seconds") || "s"}
+                      </span>
+                    </>
+                  )}
+                </div>
+              </div>
+            )}
+
+            <div className="max-w-md mx-auto space-y-3">
+              <Input
+                ref={inputRef}
+                type="text"
+                value={typedAnswer}
+                onChange={(e) => setTypedAnswer(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder={
+                  t("wordSpelling.inputPlaceholder") || "Type the word here..."
+                }
+                disabled={showResult || submitting}
+                className={cn(
+                  "text-center text-xl h-14 rounded-xl border-2",
+                  showResult && isCorrect && "border-green-500 bg-green-50",
+                  showResult && !isCorrect && "border-red-500 bg-red-50",
+                  !showResult && "border-gray-300 focus:border-indigo-500",
+                )}
+                autoComplete="off"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+              />
+
+              {showResult && !isCorrect && (
+                <div className="text-center space-y-2">
+                  <div className="flex items-center justify-center gap-2 text-red-600">
+                    <XCircle className="h-5 w-5" />
+                    <span className="font-medium">
+                      {incorrectAnswer
+                        ? t("wordSpelling.incorrectTryAgain") ||
+                          "Incorrect, try again!"
+                        : t("wordSpelling.timeUpTryAgain") ||
+                          "Time's up! Try again."}
+                    </span>
+                  </div>
+                  {showAnswerOnWrong && currentWord.text && (
+                    <p className="text-sm text-gray-700">
+                      {t("wordSpelling.correctAnswerLabel") || "正確答案"}:{" "}
+                      <span className="font-bold">{currentWord.text}</span>
+                    </p>
+                  )}
+                  <Button
+                    onClick={handleRetry}
+                    variant="outline"
+                    className="gap-2"
+                  >
+                    <RotateCcw className="h-4 w-4" />
+                    {t("wordSpelling.retry") || "Retry"}
+                  </Button>
+                </div>
               )}
-            </Button>
-          )}
-        </div>
-      </div>
+
+              {!showResult && (
+                <Button
+                  onClick={() => handleSubmitAnswer()}
+                  disabled={!typedAnswer.trim() || submitting}
+                  className="w-full h-12 text-lg"
+                >
+                  {submitting ? (
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                  ) : (
+                    <>
+                      <CheckCircle className="h-5 w-5 mr-2" />
+                      {t("wordSpelling.checkAnswer") || "Check"}
+                    </>
+                  )}
+                </Button>
+              )}
+            </div>
+          </div>
+        }
+      />
 
       <ScoreOverlay
         open={scoreOverlayOpen}

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -784,7 +784,7 @@ export default function WordSpellingActivity({
           currentWord.example_sentence_audio_url ?? undefined
         }
         hasPrev={cardFace === "front" && currentIndex > 0}
-        hasNext={cardFace === "front" && currentIndex < words.length - 1}
+        hasNext={cardFace === "front"}
         onPrev={goToPrev}
         onNext={advanceToNext}
         back={

--- a/frontend/src/components/activities/shared/WordCard.tsx
+++ b/frontend/src/components/activities/shared/WordCard.tsx
@@ -118,12 +118,13 @@ export function WordCard({
         {showNext && <NavArrow direction="next" onClick={onNext!} />}
         <div
           className={cn(
-            "relative w-full",
+            "relative w-full grid",
             animateFlip && "transition-transform duration-[600ms] ease-in-out",
           )}
           style={{
             transformStyle: "preserve-3d",
             transform: isBack ? "rotateY(180deg)" : "rotateY(0deg)",
+            gridTemplateAreas: '"stack"',
           }}
         >
           <CardFace>
@@ -140,7 +141,11 @@ export function WordCard({
             />
           </CardFace>
 
-          <CardFace rotated>{back}</CardFace>
+          <CardFace rotated>
+            <Card className="overflow-hidden">
+              <CardContent className="p-6">{back}</CardContent>
+            </Card>
+          </CardFace>
         </div>
       </div>
 
@@ -189,8 +194,8 @@ function CardFace({
 }) {
   return (
     <div
-      className={cn(rotated && "absolute inset-0")}
       style={{
+        gridArea: "stack",
         backfaceVisibility: "hidden",
         WebkitBackfaceVisibility: "hidden",
         transform: rotated ? "rotateY(180deg)" : undefined,

--- a/frontend/src/components/activities/shared/WordCard.tsx
+++ b/frontend/src/components/activities/shared/WordCard.tsx
@@ -332,11 +332,11 @@ function WordCardFront({
         {/* 分隔線 */}
         {hasExample && <div className="my-5 border-t border-gray-200" />}
 
-        {/* 例句區 */}
+        {/* 例句區（區塊置中、文字左對齊以利閱讀） */}
         {hasExample && (
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2 max-w-md w-full mx-auto">
             <div className="flex items-start gap-3">
-              <p className="flex-1 text-base md:text-lg leading-relaxed text-gray-900">
+              <p className="flex-1 text-base md:text-lg leading-relaxed text-gray-900 text-left">
                 <HighlightedSentence
                   sentence={exampleSentence!}
                   target={word}
@@ -349,7 +349,7 @@ function WordCardFront({
               />
             </div>
             {exampleSentenceTranslation && (
-              <p className="text-sm md:text-base text-gray-600 leading-relaxed">
+              <p className="text-sm md:text-base text-gray-600 leading-relaxed text-left">
                 {exampleSentenceTranslation}
               </p>
             )}

--- a/frontend/src/components/activities/shared/WordCard.tsx
+++ b/frontend/src/components/activities/shared/WordCard.tsx
@@ -99,6 +99,7 @@ export function WordCard({
   // front → back（切換到下一題）瞬間 snap，避免閃現正面。
   const lastFaceRef = useRef(face);
   const [animateFlip, setAnimateFlip] = useState(false);
+  const flipPlaybackRef = useRef<HTMLAudioElement | null>(null);
   useEffect(() => {
     if (lastFaceRef.current === face) return;
     const goingToFront = face === "front";
@@ -107,9 +108,18 @@ export function WordCard({
     if (!goingToFront) return;
     const timer = window.setTimeout(() => {
       onFlipped?.();
+      // Issue #715: 翻到正面後自動播放一次單字音檔（不播例句）
+      if (audioUrl) {
+        try {
+          flipPlaybackRef.current = new Audio(audioUrl);
+          void flipPlaybackRef.current.play();
+        } catch {
+          /* ignore play errors (e.g. autoplay blocked) */
+        }
+      }
     }, 600);
     return () => window.clearTimeout(timer);
-  }, [face, onFlipped]);
+  }, [face, onFlipped, audioUrl]);
 
   return (
     <div className="w-full">
@@ -233,11 +243,11 @@ function PlayAudioButton({
       disabled={!audioUrl}
       aria-label={ariaLabel}
       className={cn(
-        "inline-flex items-center justify-center rounded-full transition-colors shrink-0",
+        "inline-flex items-center justify-center transition-colors shrink-0 bg-transparent",
         dim,
         audioUrl
-          ? "bg-blue-500 text-white hover:bg-blue-600"
-          : "bg-gray-200 text-gray-400 cursor-not-allowed",
+          ? "text-blue-500 hover:text-blue-600"
+          : "text-gray-300 cursor-not-allowed",
       )}
     >
       <Volume2 className={icon} />

--- a/frontend/src/components/activities/shared/WordCard.tsx
+++ b/frontend/src/components/activities/shared/WordCard.tsx
@@ -301,17 +301,23 @@ function WordCardFront({
           viewMode === "desktop" && showImage && "p-8",
         )}
       >
-        {/* 單字區 */}
-        <div className="flex flex-col items-center text-center gap-2.5">
-          <div className="flex items-center gap-3">
-            <h2 className="text-3xl md:text-4xl font-bold text-gray-900 break-all">
+        {/* 單字區（區塊置中、內容左對齊） */}
+        <div className="flex flex-col gap-2 max-w-md w-full mx-auto text-left">
+          {/* 第一行：播放鈕 + 單字 */}
+          <div className="flex items-center gap-2">
+            <PlayAudioButton
+              audioUrl={audioUrl}
+              size="sm"
+              ariaLabel="播放單字音檔"
+            />
+            <h2 className="text-lg font-bold text-gray-900 break-all">
               {word}
             </h2>
-            <PlayAudioButton audioUrl={audioUrl} ariaLabel="播放單字音檔" />
           </div>
 
+          {/* 第二行：詞性 + 翻譯 */}
           {(partOfSpeech || translation) && (
-            <div className="flex items-center justify-center gap-2 flex-wrap">
+            <div className="flex items-center gap-2 flex-wrap">
               {partOfSpeech && (
                 <Badge
                   variant="secondary"
@@ -321,7 +327,7 @@ function WordCardFront({
                 </Badge>
               )}
               {translation && (
-                <p className="text-base md:text-lg text-gray-700">
+                <p className="text-sm md:text-base text-gray-700">
                   {translation}
                 </p>
               )}
@@ -330,26 +336,28 @@ function WordCardFront({
         </div>
 
         {/* 分隔線 */}
-        {hasExample && <div className="my-5 border-t border-gray-200" />}
-
-        {/* 例句區（區塊置中、文字左對齊以利閱讀） */}
         {hasExample && (
-          <div className="flex flex-col gap-2 max-w-md w-full mx-auto">
-            <div className="flex items-start gap-3">
-              <p className="flex-1 text-base md:text-lg leading-relaxed text-gray-900 text-left">
-                <HighlightedSentence
-                  sentence={exampleSentence!}
-                  target={word}
-                />
-              </p>
+          <div className="my-5 border-t border-gray-200 max-w-md w-full mx-auto" />
+        )}
+
+        {/* 例句區（區塊置中、內容左對齊） */}
+        {hasExample && (
+          <div className="flex flex-col gap-2 max-w-md w-full mx-auto text-left">
+            <div className="flex items-start gap-2">
               <PlayAudioButton
                 audioUrl={exampleSentenceAudioUrl}
                 size="sm"
                 ariaLabel="播放例句音檔"
               />
+              <p className="flex-1 text-base leading-relaxed text-gray-900">
+                <HighlightedSentence
+                  sentence={exampleSentence!}
+                  target={word}
+                />
+              </p>
             </div>
             {exampleSentenceTranslation && (
-              <p className="text-sm md:text-base text-gray-600 leading-relaxed text-left">
+              <p className="text-sm text-gray-600 leading-relaxed pl-10">
                 {exampleSentenceTranslation}
               </p>
             )}

--- a/frontend/src/components/activities/shared/WordCard.tsx
+++ b/frontend/src/components/activities/shared/WordCard.tsx
@@ -118,7 +118,7 @@ export function WordCard({
         {showNext && <NavArrow direction="next" onClick={onNext!} />}
         <div
           className={cn(
-            "relative w-full grid min-h-[480px]",
+            "relative w-full grid",
             animateFlip && "transition-transform duration-[600ms] ease-in-out",
           )}
           style={{

--- a/frontend/src/components/activities/shared/WordCard.tsx
+++ b/frontend/src/components/activities/shared/WordCard.tsx
@@ -111,6 +111,8 @@ export function WordCard({
       // Issue #715: 翻到正面後自動播放一次單字音檔（不播例句）
       if (audioUrl) {
         try {
+          // 先暫停上一張卡的播放，避免快速切換時音檔疊播
+          flipPlaybackRef.current?.pause();
           flipPlaybackRef.current = new Audio(audioUrl);
           void flipPlaybackRef.current.play();
         } catch {

--- a/frontend/src/components/activities/shared/WordCard.tsx
+++ b/frontend/src/components/activities/shared/WordCard.tsx
@@ -142,8 +142,8 @@ export function WordCard({
           </CardFace>
 
           <CardFace rotated>
-            <Card className="overflow-hidden h-full">
-              <CardContent className="p-6 h-full flex flex-col justify-center">
+            <Card className="overflow-hidden h-full flex flex-col">
+              <CardContent className="flex-1 p-6 flex flex-col justify-center">
                 {back}
               </CardContent>
             </Card>
@@ -272,8 +272,8 @@ function WordCardFront({
   return (
     <Card
       className={cn(
-        "overflow-hidden h-full",
-        viewMode === "desktop" && showImage && "flex flex-row",
+        "overflow-hidden h-full flex",
+        viewMode === "desktop" && showImage ? "flex-row" : "flex-col",
       )}
     >
       {showImage && (

--- a/frontend/src/components/activities/shared/WordCard.tsx
+++ b/frontend/src/components/activities/shared/WordCard.tsx
@@ -1,0 +1,383 @@
+/**
+ * WordCard - 單字卡（共用元件）
+ *
+ * 用途：作為單字拼寫 / 克漏字活動「答對後」的正解揭示卡（正面 = 完整單字資訊）。
+ *
+ * === 結構 ===
+ * 兩面卡片（CSS 3D rotateY 翻面）
+ * ├── 正面（front）= WordCard 元件本身渲染
+ * │   ├── 圖片（可選）
+ * │   ├── 單字（大字） + 單字音檔播放按鈕
+ * │   ├── 詞性 Badge（灰色膠囊，可選）
+ * │   ├── 中譯
+ * │   ├── 例句（高亮目標單字） + 例句音檔播放按鈕
+ * │   └── 例句翻譯
+ * └── 背面（back）= 由父層透過 `back` prop 傳入（通常是答題 UI，例如 WordActivityCard）
+ *
+ * === 翻卡互動 ===
+ * - 受控（controlled）：父層用 `face` 控制顯示哪一面
+ * - 答題流程：face="back"（顯示答題 UI）→ 學生答對 → 父層改為 face="front" → 自動翻面
+ * - 翻面動畫 600ms（Y 軸），動畫結束觸發 onFlipped 回呼（給父層接 ScoreOverlay）
+ * - 只有 back → front 走動畫；front → back（切換上/下一張）瞬間 snap，避免閃現正面（=答案）
+ *
+ * === 左右導覽（上一張 / 下一張單字卡）===
+ * - 卡片左右兩側顯示箭頭按鈕（ChevronLeft / ChevronRight）
+ * - hasPrev=false 不顯示上一張箭頭；hasNext=false 不顯示下一張箭頭
+ *
+ * === 響應式 ===
+ * - viewMode="mobile"：直式（圖片在上、文字在下），寬度撐滿；箭頭貼卡片內側
+ * - viewMode="desktop"：橫式（圖片左 30%、文字在右）；箭頭外側懸浮
+ *
+ * === 設計規範對齊 ===
+ * 樣式對齊 WordActivityCard.tsx（同 Card 元件、同圓角/陰影/padding/字級）
+ */
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ChevronLeft, ChevronRight, Volume2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface WordCardProps {
+  // Layout
+  viewMode: "mobile" | "desktop";
+
+  // 翻面控制（受控）
+  face: "front" | "back";
+  /** 翻面動畫結束時觸發 */
+  onFlipped?: () => void;
+
+  // 圖片（可選）
+  imageUrl?: string;
+
+  // 單字資訊（正面）
+  word: string;
+  partOfSpeech?: string;
+  translation?: string;
+  audioUrl?: string;
+  exampleSentence?: string;
+  exampleSentenceTranslation?: string;
+  exampleSentenceAudioUrl?: string;
+
+  // 背面內容 — 由父層提供（通常是答題 UI）
+  back?: ReactNode;
+
+  // 左右導覽（上一張 / 下一張單字卡）— has*=false 則不顯示對應箭頭
+  hasPrev?: boolean;
+  hasNext?: boolean;
+  onPrev?: () => void;
+  onNext?: () => void;
+
+  // 額外覆蓋區（如答對動畫提示）— 渲染在卡片下方
+  footer?: ReactNode;
+}
+
+export function WordCard({
+  viewMode,
+  face,
+  onFlipped,
+  imageUrl,
+  word,
+  partOfSpeech,
+  translation,
+  audioUrl,
+  exampleSentence,
+  exampleSentenceTranslation,
+  exampleSentenceAudioUrl,
+  back,
+  hasPrev,
+  hasNext,
+  onPrev,
+  onNext,
+  footer,
+}: WordCardProps) {
+  const isBack = face === "back";
+  const showPrev = Boolean(hasPrev && onPrev);
+  const showNext = Boolean(hasNext && onNext);
+
+  // 只有 back → front（答對揭示）走 600ms 翻面動畫；
+  // front → back（切換到下一題）瞬間 snap，避免閃現正面。
+  const lastFaceRef = useRef(face);
+  const [animateFlip, setAnimateFlip] = useState(false);
+  useEffect(() => {
+    if (lastFaceRef.current === face) return;
+    const goingToFront = face === "front";
+    lastFaceRef.current = face;
+    setAnimateFlip(goingToFront);
+    if (!goingToFront) return;
+    const timer = window.setTimeout(() => {
+      onFlipped?.();
+    }, 600);
+    return () => window.clearTimeout(timer);
+  }, [face, onFlipped]);
+
+  return (
+    <div className="w-full">
+      <div className="relative w-full" style={{ perspective: "1200px" }}>
+        {showPrev && <NavArrow direction="prev" onClick={onPrev!} />}
+        {showNext && <NavArrow direction="next" onClick={onNext!} />}
+        <div
+          className={cn(
+            "relative w-full",
+            animateFlip && "transition-transform duration-[600ms] ease-in-out",
+          )}
+          style={{
+            transformStyle: "preserve-3d",
+            transform: isBack ? "rotateY(180deg)" : "rotateY(0deg)",
+          }}
+        >
+          <CardFace>
+            <WordCardFront
+              viewMode={viewMode}
+              imageUrl={imageUrl}
+              word={word}
+              partOfSpeech={partOfSpeech}
+              translation={translation}
+              audioUrl={audioUrl}
+              exampleSentence={exampleSentence}
+              exampleSentenceTranslation={exampleSentenceTranslation}
+              exampleSentenceAudioUrl={exampleSentenceAudioUrl}
+            />
+          </CardFace>
+
+          <CardFace rotated>{back}</CardFace>
+        </div>
+      </div>
+
+      {footer && <div className="mt-4">{footer}</div>}
+    </div>
+  );
+}
+
+function NavArrow({
+  direction,
+  onClick,
+}: {
+  direction: "prev" | "next";
+  onClick: () => void;
+}) {
+  const isPrev = direction === "prev";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={isPrev ? "上一張" : "下一張"}
+      className={cn(
+        "absolute top-1/2 -translate-y-1/2 z-10",
+        "flex items-center justify-center",
+        "h-10 w-10 md:h-12 md:w-12 rounded-full",
+        "bg-white/90 hover:bg-white border border-gray-200 shadow-md",
+        "text-gray-600 hover:text-gray-900 transition-colors",
+        isPrev ? "left-2 md:-left-6" : "right-2 md:-right-6",
+      )}
+    >
+      {isPrev ? (
+        <ChevronLeft className="h-5 w-5 md:h-6 md:w-6" />
+      ) : (
+        <ChevronRight className="h-5 w-5 md:h-6 md:w-6" />
+      )}
+    </button>
+  );
+}
+
+function CardFace({
+  rotated = false,
+  children,
+}: {
+  rotated?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(rotated && "absolute inset-0")}
+      style={{
+        backfaceVisibility: "hidden",
+        WebkitBackfaceVisibility: "hidden",
+        transform: rotated ? "rotateY(180deg)" : undefined,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function PlayAudioButton({
+  audioUrl,
+  size = "md",
+  ariaLabel,
+}: {
+  audioUrl?: string;
+  size?: "sm" | "md";
+  ariaLabel: string;
+}) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const handleClick = () => {
+    if (!audioUrl) return;
+    if (!audioRef.current) audioRef.current = new Audio(audioUrl);
+    audioRef.current.currentTime = 0;
+    void audioRef.current.play();
+  };
+  const dim = size === "sm" ? "h-8 w-8" : "h-10 w-10";
+  const icon = size === "sm" ? "h-4 w-4" : "h-5 w-5";
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={!audioUrl}
+      aria-label={ariaLabel}
+      className={cn(
+        "inline-flex items-center justify-center rounded-full transition-colors shrink-0",
+        dim,
+        audioUrl
+          ? "bg-blue-500 text-white hover:bg-blue-600"
+          : "bg-gray-200 text-gray-400 cursor-not-allowed",
+      )}
+    >
+      <Volume2 className={icon} />
+    </button>
+  );
+}
+
+function WordCardFront({
+  viewMode,
+  imageUrl,
+  word,
+  partOfSpeech,
+  translation,
+  audioUrl,
+  exampleSentence,
+  exampleSentenceTranslation,
+  exampleSentenceAudioUrl,
+}: {
+  viewMode: "mobile" | "desktop";
+  imageUrl?: string;
+  word: string;
+  partOfSpeech?: string;
+  translation?: string;
+  audioUrl?: string;
+  exampleSentence?: string;
+  exampleSentenceTranslation?: string;
+  exampleSentenceAudioUrl?: string;
+}) {
+  const showImage = Boolean(imageUrl);
+  const hasExample = Boolean(exampleSentence);
+
+  return (
+    <Card
+      className={cn(
+        "overflow-hidden",
+        viewMode === "desktop" && showImage && "flex flex-row",
+      )}
+    >
+      {showImage && (
+        <div
+          className={cn(
+            "flex items-center justify-center bg-gray-100 select-none pointer-events-none",
+            viewMode === "mobile"
+              ? "h-48 w-full"
+              : "w-[30%] min-w-64 min-h-[200px]",
+          )}
+        >
+          <img
+            src={imageUrl}
+            alt=""
+            title=""
+            draggable={false}
+            className="max-h-full max-w-full object-contain"
+          />
+        </div>
+      )}
+
+      <CardContent
+        className={cn(
+          "flex-1 p-6 select-none",
+          viewMode === "desktop" && showImage && "p-8",
+        )}
+      >
+        {/* 單字區 */}
+        <div className="flex flex-col items-center text-center gap-2.5">
+          <div className="flex items-center gap-3">
+            <h2 className="text-3xl md:text-4xl font-bold text-gray-900 break-all">
+              {word}
+            </h2>
+            <PlayAudioButton audioUrl={audioUrl} ariaLabel="播放單字音檔" />
+          </div>
+
+          {(partOfSpeech || translation) && (
+            <div className="flex items-center justify-center gap-2 flex-wrap">
+              {partOfSpeech && (
+                <Badge
+                  variant="secondary"
+                  className="bg-gray-200 text-gray-700 hover:bg-gray-200 font-normal"
+                >
+                  {partOfSpeech}
+                </Badge>
+              )}
+              {translation && (
+                <p className="text-base md:text-lg text-gray-700">
+                  {translation}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* 分隔線 */}
+        {hasExample && <div className="my-5 border-t border-gray-200" />}
+
+        {/* 例句區 */}
+        {hasExample && (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-start gap-3">
+              <p className="flex-1 text-base md:text-lg leading-relaxed text-gray-900">
+                <HighlightedSentence
+                  sentence={exampleSentence!}
+                  target={word}
+                />
+              </p>
+              <PlayAudioButton
+                audioUrl={exampleSentenceAudioUrl}
+                size="sm"
+                ariaLabel="播放例句音檔"
+              />
+            </div>
+            {exampleSentenceTranslation && (
+              <p className="text-sm md:text-base text-gray-600 leading-relaxed">
+                {exampleSentenceTranslation}
+              </p>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * 把例句中所有目標單字（不分大小寫，整詞 word boundary）標成藍色粗體。
+ */
+function HighlightedSentence({
+  sentence,
+  target,
+}: {
+  sentence: string;
+  target: string;
+}) {
+  if (!target.trim()) return <>{sentence}</>;
+  const escaped = target.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const parts = sentence.split(new RegExp(`\\b(${escaped})\\b`, "gi"));
+  const targetLower = target.toLowerCase();
+  return (
+    <>
+      {parts.map((part, i) =>
+        part.toLowerCase() === targetLower ? (
+          <span key={i} className="text-blue-600 font-bold">
+            {part}
+          </span>
+        ) : (
+          <span key={i}>{part}</span>
+        ),
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/activities/shared/WordCard.tsx
+++ b/frontend/src/components/activities/shared/WordCard.tsx
@@ -230,6 +230,12 @@ function PlayAudioButton({
   ariaLabel: string;
 }) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  // 父層常複用同一個 WordCard instance 切換不同單字，audioUrl 變更時
+  // 必須清掉舊的 Audio，否則點擊會播到上一張卡的音檔。
+  useEffect(() => {
+    audioRef.current?.pause();
+    audioRef.current = null;
+  }, [audioUrl]);
   const handleClick = () => {
     if (!audioUrl) return;
     if (!audioRef.current) audioRef.current = new Audio(audioUrl);

--- a/frontend/src/components/activities/shared/WordCard.tsx
+++ b/frontend/src/components/activities/shared/WordCard.tsx
@@ -118,7 +118,7 @@ export function WordCard({
         {showNext && <NavArrow direction="next" onClick={onNext!} />}
         <div
           className={cn(
-            "relative w-full grid",
+            "relative w-full grid min-h-[480px]",
             animateFlip && "transition-transform duration-[600ms] ease-in-out",
           )}
           style={{
@@ -142,8 +142,10 @@ export function WordCard({
           </CardFace>
 
           <CardFace rotated>
-            <Card className="overflow-hidden">
-              <CardContent className="p-6">{back}</CardContent>
+            <Card className="overflow-hidden h-full">
+              <CardContent className="p-6 h-full flex flex-col justify-center">
+                {back}
+              </CardContent>
             </Card>
           </CardFace>
         </div>
@@ -270,7 +272,7 @@ function WordCardFront({
   return (
     <Card
       className={cn(
-        "overflow-hidden",
+        "overflow-hidden h-full",
         viewMode === "desktop" && showImage && "flex flex-row",
       )}
     >
@@ -295,7 +297,7 @@ function WordCardFront({
 
       <CardContent
         className={cn(
-          "flex-1 p-6 select-none",
+          "flex-1 p-6 select-none flex flex-col justify-center",
           viewMode === "desktop" && showImage && "p-8",
         )}
       >

--- a/frontend/src/pages/sample/WordCardSample.tsx
+++ b/frontend/src/pages/sample/WordCardSample.tsx
@@ -1,0 +1,226 @@
+/**
+ * WordCardSample - 單字卡 Sample 頁面（純前端設計稿）
+ *
+ * 用途：展示 WordCard 元件在各種狀態下的呈現，供工程師對照實作。
+ *
+ * === 卡片模型 ===
+ * - 背面（back）= 答題 UI（學生作答畫面）
+ * - 正面（front）= 完整單字資訊（單字 + 詞性 + 中譯 + 例句 + 例句翻譯 + 兩個音檔播放鈕）
+ *
+ * === 互動流程 ===
+ * 1. 預設 face="back"，學生在背面作答
+ * 2. 答對 → 父層改 face="front" → 自動翻面（600ms）
+ * 3. onFlipped 觸發 → 顯示 ScoreOverlay 答對動畫
+ * 4. 動畫結束 → 顯示完整單字卡正面，學生用左右箭頭切換上一張/下一張
+ *
+ * === 參考 Issue ===
+ * #715 - 單字拼寫 / 克漏字拼寫 新增單字卡元件（翻卡形式）
+ */
+
+import { useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { CheckCircle } from "lucide-react";
+import { WordCard } from "@/components/activities/shared/WordCard";
+import ScoreOverlay from "@/components/activities/shared/ScoreOverlay";
+
+const SAMPLE_WORD = {
+  word: "apple",
+  partOfSpeech: "n.",
+  translation: "蘋果",
+  audioUrl: undefined as string | undefined,
+  exampleSentence: "I eat an apple every morning for breakfast.",
+  exampleSentenceTranslation: "我每天早上吃一顆蘋果當早餐。",
+  exampleSentenceAudioUrl: undefined as string | undefined,
+};
+
+const DECK = [
+  SAMPLE_WORD,
+  {
+    word: "banana",
+    partOfSpeech: "n.",
+    translation: "香蕉",
+    audioUrl: undefined,
+    exampleSentence: "The monkey loves to eat banana.",
+    exampleSentenceTranslation: "猴子喜歡吃香蕉。",
+    exampleSentenceAudioUrl: undefined,
+  },
+  {
+    word: "celebrate",
+    partOfSpeech: "v.",
+    translation: "慶祝",
+    audioUrl: undefined,
+    exampleSentence: "We celebrate the new year with fireworks.",
+    exampleSentenceTranslation: "我們用煙火慶祝新年。",
+    exampleSentenceAudioUrl: undefined,
+  },
+];
+
+const NO_POS_WORD = {
+  ...SAMPLE_WORD,
+  word: "running",
+  partOfSpeech: undefined as string | undefined,
+  translation: "跑步",
+  exampleSentence: "She is running to catch the bus.",
+  exampleSentenceTranslation: "她正在跑去趕公車。",
+};
+
+const NO_EXAMPLE_WORD = {
+  ...SAMPLE_WORD,
+  word: "ephemeral",
+  partOfSpeech: "adj.",
+  translation: "短暫的",
+  exampleSentence: undefined as string | undefined,
+  exampleSentenceTranslation: undefined as string | undefined,
+};
+
+export default function WordCardSample() {
+  return (
+    <div className="min-h-screen bg-gray-50 py-8 px-4">
+      <div className="max-w-5xl mx-auto space-y-12">
+        <header>
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">
+            單字卡（WordCard）Sample
+          </h1>
+          <p className="text-sm text-gray-600">
+            背面 = 答題 UI；正面 = 完整單字資訊。點「模擬答對」觀察翻面流程。
+          </p>
+        </header>
+
+        <Section title="互動範例：背面答題 → 答對自動翻面 → 動畫 → 左右切換上/下一張">
+          <FlipFlowDemo />
+        </Section>
+
+        <Section title="Desktop 正面（完整單字資訊一張）">
+          <div className="max-w-2xl">
+            <WordCard viewMode="desktop" face="front" {...SAMPLE_WORD} />
+          </div>
+        </Section>
+
+        <Section title="Mobile 正面">
+          <div className="max-w-sm">
+            <WordCard viewMode="mobile" face="front" {...SAMPLE_WORD} />
+          </div>
+        </Section>
+
+        <Section title="邊界：無詞性">
+          <div className="max-w-2xl">
+            <WordCard viewMode="desktop" face="front" {...NO_POS_WORD} />
+          </div>
+        </Section>
+
+        <Section title="邊界：無例句（只顯示單字 + 詞性 + 翻譯）">
+          <div className="max-w-2xl">
+            <WordCard viewMode="desktop" face="front" {...NO_EXAMPLE_WORD} />
+          </div>
+        </Section>
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <h2 className="text-lg font-semibold text-gray-800 mb-4">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+/**
+ * 模擬 Mock 答題 UI（背面）— 真正整合時會替換成 WordActivityCard
+ */
+function MockAnswerUI({
+  word,
+  onCorrect,
+}: {
+  word: string;
+  onCorrect: () => void;
+}) {
+  return (
+    <Card className="overflow-hidden">
+      <CardContent className="p-8 text-center">
+        <p className="text-sm text-gray-500 mb-4">（這裡是答題 UI 的位置）</p>
+        <p className="text-base text-gray-700 mb-6">
+          請拼出 <span className="font-semibold">{word}</span>
+        </p>
+        <Button onClick={onCorrect} className="bg-green-500 hover:bg-green-600">
+          <CheckCircle className="h-4 w-4 mr-2" />
+          模擬答對
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function FlipFlowDemo() {
+  const [index, setIndex] = useState(0);
+  const [face, setFace] = useState<"front" | "back">("back");
+  const [showScore, setShowScore] = useState(false);
+
+  const current = DECK[index];
+
+  const handleCorrect = () => {
+    setFace("front");
+  };
+
+  const handleFlipped = () => {
+    if (face !== "front") return;
+    setShowScore(true);
+  };
+
+  const handleScoreEnd = () => {
+    setShowScore(false);
+  };
+
+  const goPrev = () => {
+    if (index === 0) return;
+    setShowScore(false);
+    setFace("back");
+    setIndex((i) => i - 1);
+  };
+
+  const goNext = () => {
+    if (index === DECK.length - 1) return;
+    setShowScore(false);
+    setFace("back");
+    setIndex((i) => i + 1);
+  };
+
+  return (
+    <div className="max-w-2xl">
+      <WordCard
+        viewMode="desktop"
+        face={face}
+        onFlipped={handleFlipped}
+        {...current}
+        back={<MockAnswerUI word={current.word} onCorrect={handleCorrect} />}
+        hasPrev={face === "front" && index > 0}
+        hasNext={face === "front" && index < DECK.length - 1}
+        onPrev={goPrev}
+        onNext={goNext}
+        footer={
+          face === "front" ? (
+            <div className="text-center text-sm text-gray-500">
+              第 {index + 1} / {DECK.length} 張 — 用左右箭頭切換
+            </div>
+          ) : null
+        }
+      />
+
+      <ScoreOverlay
+        open={showScore}
+        score={100}
+        isError={false}
+        onComplete={handleScoreEnd}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 新增 `WordCard` 翻卡元件（前/後面、音檔、例句、圖片）作為克漏字與單字拼寫的單字顯示
- 整合 `WordCard` 至 `WordSpellingActivity` 與 `WordClozeActivity`
- Backend 在 spelling/cloze API（含 preview / demo）暴露單字卡所需欄位

Closes #715

## Test plan
- [ ] 單字拼寫題正確顯示翻卡，翻面後自動播放單字音檔
- [ ] 克漏字題正確顯示翻卡，例句置中
- [ ] 教師預覽 / Demo API 回傳完整 word card 欄位
- [ ] 最後一題仍保留 next 按鈕、不會自動跳題
- [ ] 卡片大小穩定（不會因短內容塌陷）

🤖 Generated with [Claude Code](https://claude.com/claude-code)