### PR TITLE
feat(#732): hide spelling/cloze + show_option_images toggle behind feature flags

### DIFF
--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -949,35 +949,35 @@ export function AssignmentDetailSheet({
                     {/* 顯示選項圖片 (word_selection only) Issue #631 */}
                     {FEATURE_FLAGS.SHOW_OPTION_IMAGES &&
                       assignment.practice_mode === "word_selection" && (
-                      <div className="space-y-1.5">
-                        <Label className="text-xs text-gray-600 dark:text-gray-400">
-                          {t(
-                            "dialogs.assignmentDialog.practiceMode.showOptionImages",
-                          )}
-                        </Label>
-                        <div className="flex items-center h-9">
-                          <input
-                            type="checkbox"
-                            checked={editAdvanced.show_option_images}
-                            onChange={(e) =>
-                              setEditAdvanced((prev) => ({
-                                ...prev,
-                                show_option_images: e.target.checked,
-                                show_image: e.target.checked
-                                  ? false
-                                  : prev.show_image,
-                              }))
-                            }
-                            className="h-4 w-4 rounded border-gray-300"
-                          />
-                          <span className="ml-2 text-sm text-gray-600 dark:text-gray-400">
+                        <div className="space-y-1.5">
+                          <Label className="text-xs text-gray-600 dark:text-gray-400">
                             {t(
-                              "dialogs.assignmentDialog.practiceMode.showOptionImagesDesc",
+                              "dialogs.assignmentDialog.practiceMode.showOptionImages",
                             )}
-                          </span>
+                          </Label>
+                          <div className="flex items-center h-9">
+                            <input
+                              type="checkbox"
+                              checked={editAdvanced.show_option_images}
+                              onChange={(e) =>
+                                setEditAdvanced((prev) => ({
+                                  ...prev,
+                                  show_option_images: e.target.checked,
+                                  show_image: e.target.checked
+                                    ? false
+                                    : prev.show_image,
+                                }))
+                              }
+                              className="h-4 w-4 rounded border-gray-300"
+                            />
+                            <span className="ml-2 text-sm text-gray-600 dark:text-gray-400">
+                              {t(
+                                "dialogs.assignmentDialog.practiceMode.showOptionImagesDesc",
+                              )}
+                            </span>
+                          </div>
                         </div>
-                      </div>
-                    )}
+                      )}
                   </div>
                 </div>
               </div>

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -38,6 +38,7 @@ import StudentStatusPanel, {
   StudentProgress,
 } from "@/components/StudentStatusPanel";
 import { useSidebar } from "@/contexts/SidebarContext";
+import { FEATURE_FLAGS } from "@/config/featureFlags";
 
 interface AssignmentContent {
   id: number;
@@ -946,7 +947,8 @@ export function AssignmentDetailSheet({
                     )}
 
                     {/* 顯示選項圖片 (word_selection only) Issue #631 */}
-                    {assignment.practice_mode === "word_selection" && (
+                    {FEATURE_FLAGS.SHOW_OPTION_IMAGES &&
+                      assignment.practice_mode === "word_selection" && (
                       <div className="space-y-1.5">
                         <Label className="text-xs text-gray-600 dark:text-gray-400">
                           {t(

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -63,6 +63,7 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import { useWorkspaceSafe } from "@/contexts/WorkspaceContext";
+import { FEATURE_FLAGS } from "@/config/featureFlags";
 
 interface Student {
   id: number;
@@ -2823,82 +2824,86 @@ export function AssignmentDialog({
                     </button>
 
                     {/* 單字拼寫 */}
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          practice_mode: "word_spelling",
-                          time_limit_per_question: 0,
-                          // 預設：顯示翻譯、不播音檔、不顯示答案、達標 80%
-                          show_translation: true,
-                          play_audio: false,
-                          show_answer: false,
-                          target_proficiency: 80,
-                          shuffle_questions: false,
-                        }))
-                      }
-                      className={`p-6 rounded-xl border-2 transition-all ${
-                        formData.practice_mode === "word_spelling"
-                          ? "border-blue-500 bg-blue-50 shadow-md"
-                          : "border-gray-200 hover:border-gray-300 hover:shadow-sm"
-                      }`}
-                    >
-                      <div className="flex flex-col items-center gap-3">
-                        <span className="text-4xl">✏️</span>
-                        <div className="text-center">
-                          <div className="font-semibold text-lg">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.wordSpelling",
-                            ) || "單字拼寫"}
-                          </div>
-                          <div className="text-sm text-gray-500 mt-1">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.wordSpellingDesc",
-                            ) || "看翻譯或聽音檔，拼寫正確的單字"}
+                    {FEATURE_FLAGS.WORD_SPELLING_CLOZE && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setFormData((prev) => ({
+                            ...prev,
+                            practice_mode: "word_spelling",
+                            time_limit_per_question: 0,
+                            // 預設：顯示翻譯、不播音檔、不顯示答案、達標 80%
+                            show_translation: true,
+                            play_audio: false,
+                            show_answer: false,
+                            target_proficiency: 80,
+                            shuffle_questions: false,
+                          }))
+                        }
+                        className={`p-6 rounded-xl border-2 transition-all ${
+                          formData.practice_mode === "word_spelling"
+                            ? "border-blue-500 bg-blue-50 shadow-md"
+                            : "border-gray-200 hover:border-gray-300 hover:shadow-sm"
+                        }`}
+                      >
+                        <div className="flex flex-col items-center gap-3">
+                          <span className="text-4xl">✏️</span>
+                          <div className="text-center">
+                            <div className="font-semibold text-lg">
+                              {t(
+                                "dialogs.assignmentDialog.practiceMode.wordSpelling",
+                              ) || "單字拼寫"}
+                            </div>
+                            <div className="text-sm text-gray-500 mt-1">
+                              {t(
+                                "dialogs.assignmentDialog.practiceMode.wordSpellingDesc",
+                              ) || "看翻譯或聽音檔，拼寫正確的單字"}
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    </button>
+                      </button>
+                    )}
 
                     {/* 克漏字 */}
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          practice_mode: "word_cloze",
-                          time_limit_per_question: 0,
-                          // 預設：顯示翻譯、不播音檔、不顯示答案、達標 80%
-                          show_translation: true,
-                          play_audio: false,
-                          show_answer: false,
-                          target_proficiency: 80,
-                          shuffle_questions: false,
-                        }))
-                      }
-                      className={`p-6 rounded-xl border-2 transition-all ${
-                        formData.practice_mode === "word_cloze"
-                          ? "border-blue-500 bg-blue-50 shadow-md"
-                          : "border-gray-200 hover:border-gray-300 hover:shadow-sm"
-                      }`}
-                    >
-                      <div className="flex flex-col items-center gap-3">
-                        <span className="text-4xl">📝</span>
-                        <div className="text-center">
-                          <div className="font-semibold text-lg">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.wordCloze",
-                            ) || "克漏字"}
-                          </div>
-                          <div className="text-sm text-gray-500 mt-1">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.wordClozeDesc",
-                            ) || "看例句填空，輸入正確的單字變形"}
+                    {FEATURE_FLAGS.WORD_SPELLING_CLOZE && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setFormData((prev) => ({
+                            ...prev,
+                            practice_mode: "word_cloze",
+                            time_limit_per_question: 0,
+                            // 預設：顯示翻譯、不播音檔、不顯示答案、達標 80%
+                            show_translation: true,
+                            play_audio: false,
+                            show_answer: false,
+                            target_proficiency: 80,
+                            shuffle_questions: false,
+                          }))
+                        }
+                        className={`p-6 rounded-xl border-2 transition-all ${
+                          formData.practice_mode === "word_cloze"
+                            ? "border-blue-500 bg-blue-50 shadow-md"
+                            : "border-gray-200 hover:border-gray-300 hover:shadow-sm"
+                        }`}
+                      >
+                        <div className="flex flex-col items-center gap-3">
+                          <span className="text-4xl">📝</span>
+                          <div className="text-center">
+                            <div className="font-semibold text-lg">
+                              {t(
+                                "dialogs.assignmentDialog.practiceMode.wordCloze",
+                              ) || "克漏字"}
+                            </div>
+                            <div className="text-sm text-gray-500 mt-1">
+                              {t(
+                                "dialogs.assignmentDialog.practiceMode.wordClozeDesc",
+                              ) || "看例句填空，輸入正確的單字變形"}
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    </button>
+                      </button>
+                    )}
                   </div>
 
                   {/* ===== 例句集細節設定 (reading / rearrangement) ===== */}
@@ -3437,7 +3442,8 @@ export function AssignmentDialog({
                         </div>
 
                         {/* 顯示選項圖片（單字選擇專用，與顯示題目圖片互斥）Issue #631 */}
-                        {formData.practice_mode === "word_selection" &&
+                        {FEATURE_FLAGS.SHOW_OPTION_IMAGES &&
+                          formData.practice_mode === "word_selection" &&
                           (() => {
                             const hasMissingImage = cartItems.some(
                               (i) => i.hasMissingImage,

--- a/frontend/src/config/featureFlags.ts
+++ b/frontend/src/config/featureFlags.ts
@@ -7,4 +7,8 @@ export const FEATURE_FLAGS = {
   ASSIGNMENTS: true,
   /** 1Campus SSO 登入按鈕 */
   ONE_CAMPUS_LOGIN: true,
+  /** 出作業時的「單字拼寫 / 克漏字」作答模式選項（Issue #641 / #262）。Issue #732: prod 上線前暫時隱藏 */
+  WORD_SPELLING_CLOZE: false,
+  /** 出作業進階設定的「顯示選項圖片」toggle（Issue #631）。Issue #732: prod 上線前暫時隱藏 */
+  SHOW_OPTION_IMAGES: false,
 } as const;


### PR DESCRIPTION
## Summary

Fixes #732 (partial — see Revert plan).

準備將 staging merge 到 main（production）。但 #641（單字拼寫 / 克漏字）與 #631（show_option_images toggle）仍有後續問題待解，不能對 prod 用戶開放。

本 PR 在前端用 feature flag 把這些入口隱藏起來，**底層型別、預設值、條件分支、批改頁、學生作答頁、後端、API 完全不動**——已建立的 word_spelling / word_cloze / show_option_images=true 作業仍可正常使用。

## Changes

新增 2 個 feature flag（沿用既有 `frontend/src/config/featureFlags.ts` 慣例）：

\`\`\`ts
FEATURE_FLAGS = {
  // ...existing...
  WORD_SPELLING_CLOZE: false,  // #641 / #262 — prod 上線前隱藏
  SHOW_OPTION_IMAGES: false,   // #631 — prod 上線前隱藏
}
\`\`\`

包裹 4 個 JSX 入口：

| File | Site | Flag |
|---|---|---|
| AssignmentDialog.tsx | 「單字拼寫」practice-mode 卡片 | `WORD_SPELLING_CLOZE` |
| AssignmentDialog.tsx | 「克漏字」practice-mode 卡片 | `WORD_SPELLING_CLOZE` |
| AssignmentDialog.tsx | 出作業進階設定「顯示選項圖片」toggle | `SHOW_OPTION_IMAGES` |
| AssignmentDetailSheet.tsx | 作業詳情編輯「顯示選項圖片」toggle | `SHOW_OPTION_IMAGES` |

## What's intentionally NOT changed

- ❌ Type union（\`word_spelling\` / \`word_cloze\` 仍在 union type 中）
- ❌ formData 預設值（\`show_option_images: false\` 不變）
- ❌ \`practice_mode === "word_spelling" / "word_cloze"\` 的條件分支設定區塊（變為走不到的程式碼，但保留完整）
- ❌ 後端、API、批改頁、學生作答頁、i18n 字串

→ 既有作業資料完全不受影響，學生端答題正常。

## Revert plan (上 prod 後馬上做)

部署到 production 後，在 staging 分支執行：

\`\`\`bash
git revert <this-merge-commit>
\`\`\`

或者更精細：把 \`featureFlags.ts\` 的兩個 key 從 \`false\` 改回 \`true\`（單行修改）。
等 #641 / #631 後續修正完成後，再開正式啟用 PR。

## Test plan

- [x] \`npm run typecheck\` — pass
- [x] \`npm run build\` — pass
- [x] \`npm run lint\` — 0 new warnings（94 baseline 與 staging 相同）
- [ ] Dev server 手動驗證：
  - [ ] 出作業 Step 1 看不到「單字拼寫」「克漏字」卡片
  - [ ] 選「單字選擇」後進階設定看不到「顯示選項圖片」toggle
  - [ ] 作業詳情編輯模式看不到「顯示選項圖片」toggle
  - [ ] 既有 word_spelling / word_cloze 作業仍可正常開啟、批改、檢視
  - [ ] 既有 \`show_option_images=true\` 作業學生端仍正常顯示選項圖片

🤖 Generated with [Claude Code](https://claude.com/claude-code)