### PR TITLE
revert(#732): restore spelling/cloze + show_option_images visibility on staging

### DIFF
--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -38,7 +38,6 @@ import StudentStatusPanel, {
   StudentProgress,
 } from "@/components/StudentStatusPanel";
 import { useSidebar } from "@/contexts/SidebarContext";
-import { FEATURE_FLAGS } from "@/config/featureFlags";
 
 interface AssignmentContent {
   id: number;
@@ -947,37 +946,36 @@ export function AssignmentDetailSheet({
                     )}
 
                     {/* 顯示選項圖片 (word_selection only) Issue #631 */}
-                    {FEATURE_FLAGS.SHOW_OPTION_IMAGES &&
-                      assignment.practice_mode === "word_selection" && (
-                        <div className="space-y-1.5">
-                          <Label className="text-xs text-gray-600 dark:text-gray-400">
+                    {assignment.practice_mode === "word_selection" && (
+                      <div className="space-y-1.5">
+                        <Label className="text-xs text-gray-600 dark:text-gray-400">
+                          {t(
+                            "dialogs.assignmentDialog.practiceMode.showOptionImages",
+                          )}
+                        </Label>
+                        <div className="flex items-center h-9">
+                          <input
+                            type="checkbox"
+                            checked={editAdvanced.show_option_images}
+                            onChange={(e) =>
+                              setEditAdvanced((prev) => ({
+                                ...prev,
+                                show_option_images: e.target.checked,
+                                show_image: e.target.checked
+                                  ? false
+                                  : prev.show_image,
+                              }))
+                            }
+                            className="h-4 w-4 rounded border-gray-300"
+                          />
+                          <span className="ml-2 text-sm text-gray-600 dark:text-gray-400">
                             {t(
-                              "dialogs.assignmentDialog.practiceMode.showOptionImages",
+                              "dialogs.assignmentDialog.practiceMode.showOptionImagesDesc",
                             )}
-                          </Label>
-                          <div className="flex items-center h-9">
-                            <input
-                              type="checkbox"
-                              checked={editAdvanced.show_option_images}
-                              onChange={(e) =>
-                                setEditAdvanced((prev) => ({
-                                  ...prev,
-                                  show_option_images: e.target.checked,
-                                  show_image: e.target.checked
-                                    ? false
-                                    : prev.show_image,
-                                }))
-                              }
-                              className="h-4 w-4 rounded border-gray-300"
-                            />
-                            <span className="ml-2 text-sm text-gray-600 dark:text-gray-400">
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.showOptionImagesDesc",
-                              )}
-                            </span>
-                          </div>
+                          </span>
                         </div>
-                      )}
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -63,7 +63,6 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import { useWorkspaceSafe } from "@/contexts/WorkspaceContext";
-import { FEATURE_FLAGS } from "@/config/featureFlags";
 
 interface Student {
   id: number;
@@ -2824,86 +2823,82 @@ export function AssignmentDialog({
                     </button>
 
                     {/* 單字拼寫 */}
-                    {FEATURE_FLAGS.WORD_SPELLING_CLOZE && (
-                      <button
-                        type="button"
-                        onClick={() =>
-                          setFormData((prev) => ({
-                            ...prev,
-                            practice_mode: "word_spelling",
-                            time_limit_per_question: 0,
-                            // 預設：顯示翻譯、不播音檔、不顯示答案、達標 80%
-                            show_translation: true,
-                            play_audio: false,
-                            show_answer: false,
-                            target_proficiency: 80,
-                            shuffle_questions: false,
-                          }))
-                        }
-                        className={`p-6 rounded-xl border-2 transition-all ${
-                          formData.practice_mode === "word_spelling"
-                            ? "border-blue-500 bg-blue-50 shadow-md"
-                            : "border-gray-200 hover:border-gray-300 hover:shadow-sm"
-                        }`}
-                      >
-                        <div className="flex flex-col items-center gap-3">
-                          <span className="text-4xl">✏️</span>
-                          <div className="text-center">
-                            <div className="font-semibold text-lg">
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.wordSpelling",
-                              ) || "單字拼寫"}
-                            </div>
-                            <div className="text-sm text-gray-500 mt-1">
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.wordSpellingDesc",
-                              ) || "看翻譯或聽音檔，拼寫正確的單字"}
-                            </div>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          practice_mode: "word_spelling",
+                          time_limit_per_question: 0,
+                          // 預設：顯示翻譯、不播音檔、不顯示答案、達標 80%
+                          show_translation: true,
+                          play_audio: false,
+                          show_answer: false,
+                          target_proficiency: 80,
+                          shuffle_questions: false,
+                        }))
+                      }
+                      className={`p-6 rounded-xl border-2 transition-all ${
+                        formData.practice_mode === "word_spelling"
+                          ? "border-blue-500 bg-blue-50 shadow-md"
+                          : "border-gray-200 hover:border-gray-300 hover:shadow-sm"
+                      }`}
+                    >
+                      <div className="flex flex-col items-center gap-3">
+                        <span className="text-4xl">✏️</span>
+                        <div className="text-center">
+                          <div className="font-semibold text-lg">
+                            {t(
+                              "dialogs.assignmentDialog.practiceMode.wordSpelling",
+                            ) || "單字拼寫"}
+                          </div>
+                          <div className="text-sm text-gray-500 mt-1">
+                            {t(
+                              "dialogs.assignmentDialog.practiceMode.wordSpellingDesc",
+                            ) || "看翻譯或聽音檔，拼寫正確的單字"}
                           </div>
                         </div>
-                      </button>
-                    )}
+                      </div>
+                    </button>
 
                     {/* 克漏字 */}
-                    {FEATURE_FLAGS.WORD_SPELLING_CLOZE && (
-                      <button
-                        type="button"
-                        onClick={() =>
-                          setFormData((prev) => ({
-                            ...prev,
-                            practice_mode: "word_cloze",
-                            time_limit_per_question: 0,
-                            // 預設：顯示翻譯、不播音檔、不顯示答案、達標 80%
-                            show_translation: true,
-                            play_audio: false,
-                            show_answer: false,
-                            target_proficiency: 80,
-                            shuffle_questions: false,
-                          }))
-                        }
-                        className={`p-6 rounded-xl border-2 transition-all ${
-                          formData.practice_mode === "word_cloze"
-                            ? "border-blue-500 bg-blue-50 shadow-md"
-                            : "border-gray-200 hover:border-gray-300 hover:shadow-sm"
-                        }`}
-                      >
-                        <div className="flex flex-col items-center gap-3">
-                          <span className="text-4xl">📝</span>
-                          <div className="text-center">
-                            <div className="font-semibold text-lg">
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.wordCloze",
-                              ) || "克漏字"}
-                            </div>
-                            <div className="text-sm text-gray-500 mt-1">
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.wordClozeDesc",
-                              ) || "看例句填空，輸入正確的單字變形"}
-                            </div>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          practice_mode: "word_cloze",
+                          time_limit_per_question: 0,
+                          // 預設：顯示翻譯、不播音檔、不顯示答案、達標 80%
+                          show_translation: true,
+                          play_audio: false,
+                          show_answer: false,
+                          target_proficiency: 80,
+                          shuffle_questions: false,
+                        }))
+                      }
+                      className={`p-6 rounded-xl border-2 transition-all ${
+                        formData.practice_mode === "word_cloze"
+                          ? "border-blue-500 bg-blue-50 shadow-md"
+                          : "border-gray-200 hover:border-gray-300 hover:shadow-sm"
+                      }`}
+                    >
+                      <div className="flex flex-col items-center gap-3">
+                        <span className="text-4xl">📝</span>
+                        <div className="text-center">
+                          <div className="font-semibold text-lg">
+                            {t(
+                              "dialogs.assignmentDialog.practiceMode.wordCloze",
+                            ) || "克漏字"}
+                          </div>
+                          <div className="text-sm text-gray-500 mt-1">
+                            {t(
+                              "dialogs.assignmentDialog.practiceMode.wordClozeDesc",
+                            ) || "看例句填空，輸入正確的單字變形"}
                           </div>
                         </div>
-                      </button>
-                    )}
+                      </div>
+                    </button>
                   </div>
 
                   {/* ===== 例句集細節設定 (reading / rearrangement) ===== */}
@@ -3442,8 +3437,7 @@ export function AssignmentDialog({
                         </div>
 
                         {/* 顯示選項圖片（單字選擇專用，與顯示題目圖片互斥）Issue #631 */}
-                        {FEATURE_FLAGS.SHOW_OPTION_IMAGES &&
-                          formData.practice_mode === "word_selection" &&
+                        {formData.practice_mode === "word_selection" &&
                           (() => {
                             const hasMissingImage = cartItems.some(
                               (i) => i.hasMissingImage,

--- a/frontend/src/config/featureFlags.ts
+++ b/frontend/src/config/featureFlags.ts
@@ -7,8 +7,4 @@ export const FEATURE_FLAGS = {
   ASSIGNMENTS: true,
   /** 1Campus SSO 登入按鈕 */
   ONE_CAMPUS_LOGIN: true,
-  /** 出作業時的「單字拼寫 / 克漏字」作答模式選項（Issue #641 / #262）。Issue #732: prod 上線前暫時隱藏 */
-  WORD_SPELLING_CLOZE: false,
-  /** 出作業進階設定的「顯示選項圖片」toggle（Issue #631）。Issue #732: prod 上線前暫時隱藏 */
-  SHOW_OPTION_IMAGES: false,
 } as const;


### PR DESCRIPTION
## Summary

Reverts #736 now that the staging→main release (#737) has shipped to production. This restores visibility of the temporarily-hidden features on staging/develop so dev/QA can continue working on them:

- 「單字拼寫」/「克漏字」作答模式（#641 / #262）
- 進階設定「顯示選項圖片」toggle（#631 / #707）

Per the original plan documented in #736.

## What this reverts

- Removes \`WORD_SPELLING_CLOZE\` and \`SHOW_OPTION_IMAGES\` keys from \`FEATURE_FLAGS\` in \`frontend/src/config/featureFlags.ts\`
- Unwraps the 4 JSX sites (2 mode-picker cards in AssignmentDialog + 1 toggle in AssignmentDialog + 1 toggle in AssignmentDetailSheet)
- Removes the now-unused \`FEATURE_FLAGS\` import from \`AssignmentDialog.tsx\` and \`AssignmentDetailSheet.tsx\`

Pure inverse of #736 (\`git revert 42e9b383\`) — no other changes.

## Impact

- **Production (main)**: 🚫 not affected — this PR targets staging, not main
- **Staging**: Returns to pre-#736 state. Old hidden features re-appear in the assignment dialog
- **Existing assignments / backend / API / grading flow**: zero behavioral change in any environment

## Test plan

- [x] \`git revert\` clean (no conflicts)
- [ ] CI green (typecheck / lint / build / Test Frontend)
- [ ] On per-issue env: 「單字拼寫」「克漏字」cards visible in assignment creation
- [ ] On per-issue env: 「顯示選項圖片」toggle visible for single-word-selection mode

## Closes

Closes #732 (the temporary-hide issue — purpose fulfilled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)