### PR TITLE
Release: [Feature]: {單字拼寫/單字克漏字拼寫}作答畫面調整 (Fixes #716)

### DIFF
--- a/backend/routers/students/assignments.py
+++ b/backend/routers/students/assignments.py
@@ -2167,8 +2167,8 @@ async def submit_word_spelling_answer(
 
     correct_answer = content_item.text or ""
 
-    # Case-insensitive comparison, trim whitespace
-    is_correct = request.typed_answer.strip().lower() == correct_answer.strip().lower()
+    # Issue #716: case-sensitive comparison (trim only)
+    is_correct = request.typed_answer.strip() == correct_answer.strip()
 
     # Update memory strength via SM-2 function
     result = db.execute(
@@ -2861,7 +2861,8 @@ async def submit_word_cloze_answer(
         )
     _blanked, correct_answer = cloze
 
-    is_correct = request.typed_answer.strip().lower() == correct_answer.strip().lower()
+    # Issue #716: case-sensitive comparison (trim only)
+    is_correct = request.typed_answer.strip() == correct_answer.strip()
 
     result = db.execute(
         text(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50,6 +50,7 @@
         "react-i18next": "^16.2.1",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.18.0",
+        "react-simple-keyboard": "^3.8.205",
         "recharts": "^3.8.0",
         "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
@@ -9421,6 +9422,16 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-simple-keyboard": {
+      "version": "3.8.205",
+      "resolved": "https://registry.npmjs.org/react-simple-keyboard/-/react-simple-keyboard-3.8.205.tgz",
+      "integrity": "sha512-EeglFADIuUSOeLkbx9XdMTeA0PH+QkTrkYXf7N8sLqz1GipNkWgYLzdAsk06y6XVlefMvwXLk2WT/Wt4qfGWfw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-style-singleton": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,6 +72,7 @@
     "react-i18next": "^16.2.1",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.18.0",
+    "react-simple-keyboard": "^3.8.205",
     "recharts": "^3.8.0",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",

--- a/frontend/src/components/AssignmentDetailSheet.tsx
+++ b/frontend/src/components/AssignmentDetailSheet.tsx
@@ -775,7 +775,9 @@ export function AssignmentDetailSheet({
                       >
                         {(assignment.practice_mode === "rearrangement" ||
                           assignment.practice_mode === "word_reading" ||
-                          assignment.practice_mode === "word_selection") && (
+                          assignment.practice_mode === "word_selection" ||
+                          assignment.practice_mode === "word_spelling" ||
+                          assignment.practice_mode === "word_cloze") && (
                           <option value={0}>
                             {t(
                               "dialogs.assignmentDialog.practiceMode.unlimited",

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2829,7 +2829,7 @@ export function AssignmentDialog({
                         setFormData((prev) => ({
                           ...prev,
                           practice_mode: "word_spelling",
-                          time_limit_per_question: 0,
+                          time_limit_per_question: 30,
                           // 預設：顯示翻譯、不播音檔、不顯示答案、達標 80%
                           show_translation: true,
                           play_audio: false,
@@ -2868,7 +2868,7 @@ export function AssignmentDialog({
                         setFormData((prev) => ({
                           ...prev,
                           practice_mode: "word_cloze",
-                          time_limit_per_question: 0,
+                          time_limit_per_question: 30,
                           // 預設：顯示翻譯、不播音檔、不顯示答案、達標 80%
                           show_translation: true,
                           play_audio: false,

--- a/frontend/src/components/activities/RearrangementActivity.tsx
+++ b/frontend/src/components/activities/RearrangementActivity.tsx
@@ -16,10 +16,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
-import { Loader2, Volume2, Clock, RotateCcw } from "lucide-react";
+import { Loader2, Volume2, RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import ScoreOverlay from "./shared/ScoreOverlay";
+import CountdownRing from "./shared/CountdownRing";
 
 export interface RearrangementQuestion {
   content_item_id: number;
@@ -877,12 +878,6 @@ const RearrangementActivity: React.FC<RearrangementActivityProps> = ({
     [playAudioAsync],
   );
 
-  const formatTime = (seconds: number) => {
-    const mins = Math.floor(seconds / 60);
-    const secs = seconds % 60;
-    return `${mins}:${secs.toString().padStart(2, "0")}`;
-  };
-
   // Loading 狀態
   if (loading) {
     return (
@@ -910,7 +905,6 @@ const RearrangementActivity: React.FC<RearrangementActivityProps> = ({
   }
 
   const isUnlimited = currentQuestion.time_limit === 0;
-  const isLowTime = !isUnlimited && currentState.timeRemaining <= 10;
   const progressPercent =
     ((currentQuestionIndex + (currentState.completed ? 1 : 0)) /
       questions.length) *
@@ -991,22 +985,18 @@ const RearrangementActivity: React.FC<RearrangementActivityProps> = ({
               })}
             </CardTitle>
             <div className="flex items-center gap-3">
-              {/* 計時器 - 不限時模式顯示 "不限時"，有限時模式顯示倒數 */}
-              <div
-                className={cn(
-                  "flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium",
-                  isUnlimited
-                    ? "bg-green-100 text-green-700"
-                    : isLowTime
-                      ? "bg-red-100 text-red-700 animate-pulse"
-                      : "bg-gray-100 text-gray-700",
-                )}
-              >
-                <Clock className="h-4 w-4" />
-                {isUnlimited
-                  ? t("rearrangement.unlimited")
-                  : formatTime(currentState.timeRemaining)}
-              </div>
+              {/* Issue #716: 限時用環狀倒數；不限時顯示綠色 badge */}
+              {isUnlimited ? (
+                <div className="flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-700">
+                  {t("rearrangement.unlimited")}
+                </div>
+              ) : (
+                <CountdownRing
+                  key={currentQuestionIndex}
+                  seconds={currentState.timeRemaining}
+                  total={currentQuestion.time_limit}
+                />
+              )}
 
               {/* 音檔按鈕與語速選單 - 已完成的題目不能播放 */}
               {currentQuestion.play_audio && currentQuestion.audio_url && (

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -725,7 +725,7 @@ export default function WordClozeActivity({
   const currentQ = questions[currentIndex];
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-3">
       {isPracticeMode && (
         <div className="flex items-center gap-2 text-sm text-blue-600 bg-blue-50 rounded-lg px-4 py-2">
           <BookOpen className="h-4 w-4" />
@@ -822,7 +822,7 @@ export default function WordClozeActivity({
                   </Badge>
                 </div>
               )}
-              <p className="text-xl md:text-2xl leading-relaxed text-gray-800 font-semibold px-4 tracking-wide">
+              <p className="text-lg md:text-xl leading-relaxed text-gray-800 font-semibold px-4 tracking-wide">
                 {currentQ.blanked_sentence}
               </p>
               {showTranslation && currentQ.sentence_translation && (

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -500,47 +500,22 @@ export default function WordClozeActivity({
     setTypedAnswer((prev) => prev.slice(0, -1));
   }, [showResult, isCorrect]);
   const vkEnter = useCallback(() => {
-    if (cardFace === "front") {
-      advanceToNext();
-    } else if (!showResult && !submitting && typedAnswer.trim()) {
+    // Issue #716: 虛擬鍵盤 Enter 只負責送出；看正面時改用右箭頭手動切下一題。
+    if (
+      cardFace === "back" &&
+      !showResult &&
+      !submitting &&
+      typedAnswer.trim()
+    ) {
       handleSubmitAnswer();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cardFace, showResult, submitting, typedAnswer, advanceToNext]);
+  }, [cardFace, showResult, submitting, typedAnswer]);
 
   // ScoreOverlay 結束 → 關閉動畫，等學生用左右箭頭手動翻頁
   const handleOverlayComplete = () => {
     setScoreOverlayOpen(false);
   };
-
-  // Issue #716: 桌機 Enter — 作答時送出、看卡時切下一題。
-  useEffect(() => {
-    if (deviceMode !== "desktop" || roundCompleted || loading) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key !== "Enter") return;
-      // Issue #716: 過濾 auto-repeat，避免「送出 → 翻面 → 立刻下一題」。
-      if (e.repeat) return;
-      if (cardFace === "front") {
-        e.preventDefault();
-        advanceToNext();
-      } else if (!showResult && !submitting && typedAnswer.trim()) {
-        e.preventDefault();
-        handleSubmitAnswer();
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    deviceMode,
-    cardFace,
-    showResult,
-    submitting,
-    typedAnswer,
-    roundCompleted,
-    loading,
-    advanceToNext,
-  ]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !showResult && !submitting && typedAnswer.trim()) {

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -781,9 +781,14 @@ export default function WordClozeActivity({
 
             <div className="max-w-2xl mx-auto text-center py-2 space-y-2">
               {currentQ.part_of_speech && (
-                <p className="text-sm italic text-gray-500">
-                  {currentQ.part_of_speech}
-                </p>
+                <div className="flex justify-center">
+                  <Badge
+                    variant="secondary"
+                    className="bg-gray-200 text-gray-700 hover:bg-gray-200 font-normal"
+                  >
+                    {currentQ.part_of_speech}
+                  </Badge>
+                </div>
               )}
               <p className="text-xl md:text-2xl leading-relaxed text-gray-800 font-semibold px-4 tracking-wide">
                 {currentQ.blanked_sentence}

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -779,12 +779,12 @@ export default function WordClozeActivity({
               </div>
             )}
 
-            <div className="max-w-2xl mx-auto text-center">
-              <p className="text-xl leading-relaxed text-gray-800 font-medium px-4">
+            <div className="max-w-2xl mx-auto text-center py-2 space-y-3">
+              <p className="text-2xl md:text-3xl leading-relaxed text-gray-800 font-semibold px-4 tracking-wide">
                 {currentQ.blanked_sentence}
               </p>
               {showTranslation && currentQ.sentence_translation && (
-                <p className="text-sm text-gray-500 mt-2">
+                <p className="text-base text-gray-500">
                   {currentQ.sentence_translation}
                 </p>
               )}
@@ -841,10 +841,15 @@ export default function WordClozeActivity({
                 }
                 disabled={(showResult && isCorrect) || submitting}
                 className={cn(
-                  "text-center text-xl h-14 rounded-xl border-2",
-                  showResult && isCorrect && "border-green-500 bg-green-50",
-                  showResult && !isCorrect && "border-red-500 bg-red-50",
-                  !showResult && "border-gray-300 focus:border-indigo-500",
+                  "text-center text-2xl h-14 px-0 bg-transparent shadow-none rounded-none border-0 border-b-2 transition-colors",
+                  "focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
+                  showResult && isCorrect && "border-green-500 text-green-700",
+                  showResult &&
+                    !isCorrect &&
+                    "border-red-500 text-red-600 placeholder:text-red-400",
+                  !(showResult && !isCorrect) &&
+                    !(showResult && isCorrect) &&
+                    "border-gray-300 focus:border-indigo-500",
                 )}
                 autoComplete="off"
                 autoCapitalize="off"

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -46,8 +46,8 @@ import { WordCard } from "./shared/WordCard";
 import { useInputDeviceMode } from "@/hooks/useInputDeviceMode";
 import { aggregateTierCounts, weightedMastery } from "./wordFamiliarity";
 
-// Issue #716: 答案僅允許英文字母與連字號；過濾掉建議選字、注音、Emoji。
-const ALLOWED_CHAR = /[a-zA-Z-]/;
+// Issue #716: 答案允許英文字母、連字號、空格；過濾掉建議選字、注音、Emoji。
+const ALLOWED_CHAR = /[a-zA-Z\- ]/;
 const sanitizeAnswer = (raw: string) =>
   Array.from(raw)
     .filter((c) => ALLOWED_CHAR.test(c))

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -797,6 +797,20 @@ export default function WordClozeActivity({
             )}
             {/* Issue #716: cloze Display Translation 僅顯示例句翻譯，不顯示單字翻譯 → 移除單字翻譯 hint */}
 
+            {/* Issue #716: Play Audio 模式音檔鈕置中於例句上方，避免 inline 對齊問題 */}
+            {audioOnlyMode && currentQ.audio_url && (
+              <div className="flex justify-center">
+                <button
+                  type="button"
+                  onClick={playQuestionAudio}
+                  aria-label={t("wordCloze.playAudio") || "Play Audio"}
+                  className="inline-flex items-center justify-center transition-colors shrink-0 bg-transparent h-12 w-12 text-blue-500 hover:text-blue-600"
+                >
+                  <Volume2 className="h-7 w-7" />
+                </button>
+              </div>
+            )}
+
             <div className="max-w-2xl mx-auto text-center py-2 space-y-2">
               {currentQ.part_of_speech && (
                 <div className="flex justify-center">
@@ -808,22 +822,9 @@ export default function WordClozeActivity({
                   </Badge>
                 </div>
               )}
-              {/* Issue #716: Play Audio 模式音檔鈕緊接例句左側，採 WordCard 風格 */}
-              <div className="flex items-start justify-center gap-2 px-4">
-                {audioOnlyMode && currentQ.audio_url && (
-                  <button
-                    type="button"
-                    onClick={playQuestionAudio}
-                    aria-label={t("wordCloze.playAudio") || "Play Audio"}
-                    className="inline-flex items-center justify-center transition-colors shrink-0 bg-transparent h-10 w-10 text-blue-500 hover:text-blue-600 mt-1"
-                  >
-                    <Volume2 className="h-5 w-5" />
-                  </button>
-                )}
-                <p className="text-xl md:text-2xl leading-relaxed text-gray-800 font-semibold tracking-wide">
-                  {currentQ.blanked_sentence}
-                </p>
-              </div>
+              <p className="text-xl md:text-2xl leading-relaxed text-gray-800 font-semibold px-4 tracking-wide">
+                {currentQ.blanked_sentence}
+              </p>
               {showTranslation && currentQ.sentence_translation && (
                 <p className="text-sm text-gray-500">
                   {currentQ.sentence_translation}

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -721,7 +721,7 @@ export default function WordClozeActivity({
   const currentQ = questions[currentIndex];
 
   return (
-    <div className={cn("space-y-6", deviceMode === "mobile" && "pb-72")}>
+    <div className="space-y-6">
       {isPracticeMode && (
         <div className="flex items-center gap-2 text-sm text-blue-600 bg-blue-50 rounded-lg px-4 py-2">
           <BookOpen className="h-4 w-4" />
@@ -900,8 +900,12 @@ export default function WordClozeActivity({
         }
       />
         </div>
-        {deviceMode === "tablet" && (
-          <div className="flex-[4] min-w-0">
+        {useVirtualKeyboard && (
+          <div
+            className={cn(
+              deviceMode === "tablet" ? "flex-[4] min-w-0" : "mt-3",
+            )}
+          >
             <VirtualKeyboard
               onKey={vkAppend}
               onBackspace={vkBackspace}
@@ -910,15 +914,6 @@ export default function WordClozeActivity({
           </div>
         )}
       </div>
-
-      {deviceMode === "mobile" && (
-        <VirtualKeyboard
-          onKey={vkAppend}
-          onBackspace={vkBackspace}
-          onEnter={vkEnter}
-          className="fixed bottom-0 left-0 right-0 z-50 border-t shadow-2xl"
-        />
-      )}
 
       <ScoreOverlay
         open={scoreOverlayOpen}

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -759,7 +759,7 @@ export default function WordClozeActivity({
 
       <div
         className={cn(
-          deviceMode === "tablet" && "flex items-start gap-4",
+          deviceMode === "tablet" && "flex items-stretch gap-4",
         )}
       >
         <div className={cn("min-w-0", deviceMode === "tablet" && "flex-[6]")}>
@@ -903,7 +903,9 @@ export default function WordClozeActivity({
         {useVirtualKeyboard && (
           <div
             className={cn(
-              deviceMode === "tablet" ? "flex-[4] min-w-0" : "mt-3",
+              deviceMode === "tablet"
+                ? "flex-[4] min-w-0 flex flex-col justify-center"
+                : "mt-3",
             )}
           >
             <VirtualKeyboard

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -31,7 +31,6 @@ import {
   XCircle,
   Clock,
   Send,
-  RotateCcw,
   FileText,
   Trophy,
   RefreshCw,
@@ -495,14 +494,6 @@ export default function WordClozeActivity({
     setScoreOverlayOpen(false);
   };
 
-  const handleRetry = () => {
-    setShowResult(false);
-    setTypedAnswer("");
-    setIncorrectAnswer(null);
-    if (timeLimit) setTimeRemaining(timeLimit);
-    inputRef.current?.focus();
-  };
-
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !showResult && !submitting && typedAnswer.trim()) {
       handleSubmitAnswer();
@@ -833,7 +824,11 @@ export default function WordClozeActivity({
                 ref={inputRef}
                 type="text"
                 value={typedAnswer}
-                onChange={(e) => setTypedAnswer(e.target.value)}
+                onChange={(e) => {
+                  setTypedAnswer(e.target.value);
+                  // Issue #716: 一打字立刻清除錯誤提示，不必按 Retry
+                  if (showResult && !isCorrect) setShowResult(false);
+                }}
                 onKeyDown={handleKeyDown}
                 onPaste={(e) => e.preventDefault()}
                 onDrop={(e) => e.preventDefault()}
@@ -844,7 +839,7 @@ export default function WordClozeActivity({
                     ? currentQ.correct_answer
                     : t("wordCloze.inputPlaceholder") || "Fill in the blank..."
                 }
-                disabled={showResult || submitting}
+                disabled={(showResult && isCorrect) || submitting}
                 className={cn(
                   "text-center text-xl h-14 rounded-xl border-2",
                   showResult && isCorrect && "border-green-500 bg-green-50",
@@ -858,29 +853,19 @@ export default function WordClozeActivity({
               />
 
               {showResult && !isCorrect && (
-                <div className="text-center space-y-2">
-                  <div className="flex items-center justify-center gap-2 text-red-600">
-                    <XCircle className="h-5 w-5" />
-                    <span className="font-medium">
-                      {incorrectAnswer
-                        ? t("wordCloze.incorrectTryAgain") ||
-                          "Incorrect, try again!"
-                        : t("wordCloze.timeUpTryAgain") ||
-                          "Time's up! Try again."}
-                    </span>
-                  </div>
-                  <Button
-                    onClick={handleRetry}
-                    variant="outline"
-                    className="gap-2"
-                  >
-                    <RotateCcw className="h-4 w-4" />
-                    {t("wordCloze.retry") || "Retry"}
-                  </Button>
+                <div className="flex items-center justify-center gap-2 text-red-600">
+                  <XCircle className="h-5 w-5" />
+                  <span className="font-medium">
+                    {incorrectAnswer
+                      ? t("wordCloze.incorrectTryAgain") ||
+                        "Incorrect, try again!"
+                      : t("wordCloze.timeUpTryAgain") ||
+                        "Time's up! Try again."}
+                  </span>
                 </div>
               )}
 
-              {!showResult && (
+              {!(showResult && isCorrect) && (
                 <Button
                   onClick={() => handleSubmitAnswer()}
                   disabled={!typedAnswer.trim() || submitting}

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -513,6 +513,33 @@ export default function WordClozeActivity({
     setScoreOverlayOpen(false);
   };
 
+  // Issue #716: 桌機 Enter — 作答時送出、看卡時切下一題。
+  useEffect(() => {
+    if (deviceMode !== "desktop" || roundCompleted || loading) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Enter") return;
+      if (cardFace === "front") {
+        e.preventDefault();
+        advanceToNext();
+      } else if (!showResult && !submitting && typedAnswer.trim()) {
+        e.preventDefault();
+        handleSubmitAnswer();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    deviceMode,
+    cardFace,
+    showResult,
+    submitting,
+    typedAnswer,
+    roundCompleted,
+    loading,
+    advanceToNext,
+  ]);
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !showResult && !submitting && typedAnswer.trim()) {
       handleSubmitAnswer();

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -750,17 +750,13 @@ export default function WordClozeActivity({
         word={currentQ.base_word || currentQ.correct_answer}
         partOfSpeech={currentQ.part_of_speech ?? undefined}
         translation={currentQ.translation || undefined}
-        audioUrl={
-          audioOnlyMode ? (currentQ.word_audio_url ?? undefined) : undefined
-        }
+        audioUrl={currentQ.word_audio_url ?? undefined}
         exampleSentence={currentQ.example_sentence ?? undefined}
         exampleSentenceTranslation={
           currentQ.example_sentence_translation ?? undefined
         }
         exampleSentenceAudioUrl={
-          audioOnlyMode
-            ? (currentQ.example_sentence_audio_url ?? undefined)
-            : undefined
+          currentQ.example_sentence_audio_url ?? undefined
         }
         hasPrev={cardFace === "front" && currentIndex > 0}
         hasNext={cardFace === "front"}

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -115,6 +115,8 @@ export default function WordClozeActivity({
   const [showTranslation, setShowTranslation] = useState(true);
   const [audioOnlyMode, setAudioOnlyMode] = useState(false);
   const [showAnswerOnWrong, setShowAnswerOnWrong] = useState(false);
+  // Issue #716: 答錯後改用 placeholder 顯示正解，需要記錄上一次是否答錯
+  const [lastAttemptWrong, setLastAttemptWrong] = useState(false);
 
   const [proficiency, setProficiency] = useState<ProficiencyStatus>({
     current_mastery: 0,
@@ -324,9 +326,11 @@ export default function WordClozeActivity({
     }
   }, [questions, currentIndex]);
 
-  // Auto-play sentence audio on each new question
+  // Auto-play sentence audio on each new question.
+  // Issue #716: 僅 Play Audio (audioOnlyMode) 子模式播放；Display Translation 不播。
   useEffect(() => {
     if (
+      audioOnlyMode &&
       questions[currentIndex]?.audio_url &&
       !showResult &&
       !roundCompleted &&
@@ -335,7 +339,7 @@ export default function WordClozeActivity({
       playQuestionAudio();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentIndex, questions.length, roundCompleted, loading]);
+  }, [currentIndex, questions.length, roundCompleted, loading, audioOnlyMode]);
 
   // Timer
   useEffect(() => {
@@ -385,19 +389,19 @@ export default function WordClozeActivity({
     setSubmitting(true);
 
     if (isPreviewMode || isDemoMode) {
-      // Local compare against the backend-supplied correct answer
-      // (case-insensitive, trimmed) — same pattern as spelling.
-      const expected = (currentQ.correct_answer || "").trim().toLowerCase();
-      const correct =
-        !isTimeout && expected.length > 0 && answer.toLowerCase() === expected;
+      // Issue #716: case-sensitive comparison (trim only) — match backend.
+      const expected = (currentQ.correct_answer || "").trim();
+      const correct = !isTimeout && expected.length > 0 && answer === expected;
       setIsCorrect(correct);
       setShowResult(true);
       if (correct) {
         setCorrectCount((prev) => prev + 1);
+        setLastAttemptWrong(false);
         // Issue #715: 答對 → 翻面（不立刻顯示 ScoreOverlay）→ onFlipped 後才顯示
         setCardFace("front");
       } else {
         setIncorrectAnswer(answer);
+        setLastAttemptWrong(true);
       }
       recordPreviewAnswer(currentQ.content_item_id, correct);
       setSubmitting(false);
@@ -421,10 +425,12 @@ export default function WordClozeActivity({
       setShowResult(true);
       if (correct) {
         setCorrectCount((prev) => prev + 1);
+        setLastAttemptWrong(false);
         // Issue #715: 答對 → 翻面（不立刻顯示 ScoreOverlay）→ onFlipped 後才顯示
         setCardFace("front");
       } else {
         setIncorrectAnswer(answer);
+        setLastAttemptWrong(true);
       }
       await fetchProficiency();
     } catch (error) {
@@ -457,6 +463,7 @@ export default function WordClozeActivity({
     setShowResult(false);
     setTypedAnswer("");
     setIncorrectAnswer(null);
+    setLastAttemptWrong(false);
     if (timeLimit) setTimeRemaining(timeLimit);
 
     if (currentIndex < questions.length - 1) {
@@ -474,6 +481,7 @@ export default function WordClozeActivity({
     setShowResult(false);
     setTypedAnswer("");
     setIncorrectAnswer(null);
+    setLastAttemptWrong(false);
     if (timeLimit) setTimeRemaining(timeLimit);
     setCurrentIndex(currentIndex - 1);
   }, [currentIndex, timeLimit]);
@@ -742,13 +750,17 @@ export default function WordClozeActivity({
         word={currentQ.base_word || currentQ.correct_answer}
         partOfSpeech={currentQ.part_of_speech ?? undefined}
         translation={currentQ.translation || undefined}
-        audioUrl={currentQ.word_audio_url ?? undefined}
+        audioUrl={
+          audioOnlyMode ? (currentQ.word_audio_url ?? undefined) : undefined
+        }
         exampleSentence={currentQ.example_sentence ?? undefined}
         exampleSentenceTranslation={
           currentQ.example_sentence_translation ?? undefined
         }
         exampleSentenceAudioUrl={
-          currentQ.example_sentence_audio_url ?? undefined
+          audioOnlyMode
+            ? (currentQ.example_sentence_audio_url ?? undefined)
+            : undefined
         }
         hasPrev={cardFace === "front" && currentIndex > 0}
         hasNext={cardFace === "front"}
@@ -756,38 +768,23 @@ export default function WordClozeActivity({
         onNext={advanceToNext}
         back={
           <div className="space-y-6">
-            {/* Translation hint (Chinese meaning only — never show base word) */}
-            {showTranslation && currentQ.translation && (
-              <div className="text-center">
-                <p className="text-sm text-gray-500 mb-1">
-                  {t("wordCloze.translationHint") || "Translation"}
-                </p>
-                <h2 className="text-xl font-bold text-gray-800">
-                  {currentQ.translation}
-                </h2>
-              </div>
-            )}
+            {/* Issue #716: cloze Display Translation 僅顯示例句翻譯，不顯示單字翻譯 → 移除單字翻譯 hint */}
 
-            {currentQ.audio_url && (
+            {/* Issue #716: 音檔功能僅在 Play Audio 模式出現 */}
+            {audioOnlyMode && currentQ.audio_url && (
               <div className="flex flex-col items-center gap-2">
                 <Button
-                  variant={audioOnlyMode ? "default" : "outline"}
+                  variant="default"
                   size="lg"
                   onClick={playQuestionAudio}
-                  className={cn(
-                    "gap-2",
-                    audioOnlyMode &&
-                      "h-16 px-8 text-lg bg-blue-600 hover:bg-blue-700 text-white shadow-lg",
-                  )}
+                  className="gap-2 h-16 px-8 text-lg bg-blue-600 hover:bg-blue-700 text-white shadow-lg"
                 >
-                  <Volume2 className={audioOnlyMode ? "h-7 w-7" : "h-5 w-5"} />
+                  <Volume2 className="h-7 w-7" />
                   {t("wordCloze.playAudio") || "Play Audio"}
                 </Button>
-                {audioOnlyMode && (
-                  <p className="text-xs text-gray-500">
-                    {t("wordCloze.tapToReplay") || "點擊播放，可以重複聆聽"}
-                  </p>
-                )}
+                <p className="text-xs text-gray-500">
+                  {t("wordCloze.tapToReplay") || "點擊播放，可以重複聆聽"}
+                </p>
               </div>
             )}
 
@@ -838,8 +835,14 @@ export default function WordClozeActivity({
                 value={typedAnswer}
                 onChange={(e) => setTypedAnswer(e.target.value)}
                 onKeyDown={handleKeyDown}
+                onPaste={(e) => e.preventDefault()}
+                onDrop={(e) => e.preventDefault()}
                 placeholder={
-                  t("wordCloze.inputPlaceholder") || "Fill in the blank..."
+                  showAnswerOnWrong &&
+                  lastAttemptWrong &&
+                  currentQ.correct_answer
+                    ? currentQ.correct_answer
+                    : t("wordCloze.inputPlaceholder") || "Fill in the blank..."
                 }
                 disabled={showResult || submitting}
                 className={cn(
@@ -866,14 +869,6 @@ export default function WordClozeActivity({
                           "Time's up! Try again."}
                     </span>
                   </div>
-                  {showAnswerOnWrong && currentQ.correct_answer && (
-                    <p className="text-sm text-gray-700">
-                      {t("wordCloze.correctAnswerLabel") || "正確答案"}:{" "}
-                      <span className="font-bold">
-                        {currentQ.correct_answer}
-                      </span>
-                    </p>
-                  )}
                   <Button
                     onClick={handleRetry}
                     variant="outline"

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -797,24 +797,6 @@ export default function WordClozeActivity({
             )}
             {/* Issue #716: cloze Display Translation 僅顯示例句翻譯，不顯示單字翻譯 → 移除單字翻譯 hint */}
 
-            {/* Issue #716: 音檔功能僅在 Play Audio 模式出現 */}
-            {audioOnlyMode && currentQ.audio_url && (
-              <div className="flex flex-col items-center gap-2">
-                <Button
-                  variant="default"
-                  size="lg"
-                  onClick={playQuestionAudio}
-                  className="gap-2 h-16 px-8 text-lg bg-blue-600 hover:bg-blue-700 text-white shadow-lg"
-                >
-                  <Volume2 className="h-7 w-7" />
-                  {t("wordCloze.playAudio") || "Play Audio"}
-                </Button>
-                <p className="text-xs text-gray-500">
-                  {t("wordCloze.tapToReplay") || "點擊播放，可以重複聆聽"}
-                </p>
-              </div>
-            )}
-
             <div className="max-w-2xl mx-auto text-center py-2 space-y-2">
               {currentQ.part_of_speech && (
                 <div className="flex justify-center">
@@ -826,9 +808,22 @@ export default function WordClozeActivity({
                   </Badge>
                 </div>
               )}
-              <p className="text-xl md:text-2xl leading-relaxed text-gray-800 font-semibold px-4 tracking-wide">
-                {currentQ.blanked_sentence}
-              </p>
+              {/* Issue #716: Play Audio 模式音檔鈕緊接例句左側，採 WordCard 風格 */}
+              <div className="flex items-start justify-center gap-2 px-4">
+                {audioOnlyMode && currentQ.audio_url && (
+                  <button
+                    type="button"
+                    onClick={playQuestionAudio}
+                    aria-label={t("wordCloze.playAudio") || "Play Audio"}
+                    className="inline-flex items-center justify-center transition-colors shrink-0 bg-transparent h-10 w-10 text-blue-500 hover:text-blue-600 mt-1"
+                  >
+                    <Volume2 className="h-5 w-5" />
+                  </button>
+                )}
+                <p className="text-xl md:text-2xl leading-relaxed text-gray-800 font-semibold tracking-wide">
+                  {currentQ.blanked_sentence}
+                </p>
+              </div>
               {showTranslation && currentQ.sentence_translation && (
                 <p className="text-sm text-gray-500">
                   {currentQ.sentence_translation}

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -402,6 +402,8 @@ export default function WordClozeActivity({
       } else {
         setIncorrectAnswer(answer);
         setLastAttemptWrong(true);
+        // Issue #716: 清空 input 讓正解 placeholder 露出來
+        setTypedAnswer("");
       }
       recordPreviewAnswer(currentQ.content_item_id, correct);
       setSubmitting(false);
@@ -431,6 +433,8 @@ export default function WordClozeActivity({
       } else {
         setIncorrectAnswer(answer);
         setLastAttemptWrong(true);
+        // Issue #716: 清空 input 讓正解 placeholder 露出來
+        setTypedAnswer("");
       }
       await fetchProficiency();
     } catch (error) {

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -866,7 +866,7 @@ export default function WordClozeActivity({
                 disabled={(showResult && isCorrect) || submitting}
                 className={cn(
                   "text-center text-2xl h-14 pl-10 pr-10 bg-transparent shadow-none rounded-none border-0 border-b-2 transition-colors",
-                  "placeholder:text-base focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
+                  "focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
                   showResult && isCorrect && "border-green-500 text-green-700",
                   showResult &&
                     !isCorrect &&

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -41,8 +41,17 @@ import { cn } from "@/lib/utils";
 import { apiClient } from "@/lib/api";
 import ScoreOverlay from "./shared/ScoreOverlay";
 import CountdownRing from "./shared/CountdownRing";
+import VirtualKeyboard from "./shared/VirtualKeyboard";
 import { WordCard } from "./shared/WordCard";
+import { useInputDeviceMode } from "@/hooks/useInputDeviceMode";
 import { aggregateTierCounts, weightedMastery } from "./wordFamiliarity";
+
+// Issue #716: 答案僅允許英文字母與連字號；過濾掉建議選字、注音、Emoji。
+const ALLOWED_CHAR = /[a-zA-Z-]/;
+const sanitizeAnswer = (raw: string) =>
+  Array.from(raw)
+    .filter((c) => ALLOWED_CHAR.test(c))
+    .join("");
 
 interface ClozeQuestion {
   content_item_id: number;
@@ -94,6 +103,9 @@ export default function WordClozeActivity({
   onComplete,
 }: WordClozeActivityProps) {
   const { t } = useTranslation();
+  // Issue #716: 觸控裝置改用 VirtualKeyboard，避免系統建議選字。
+  const deviceMode = useInputDeviceMode();
+  const useVirtualKeyboard = deviceMode !== "desktop";
 
   const [loading, setLoading] = useState(true);
   const [questions, setQuestions] = useState<ClozeQuestion[]>([]);
@@ -471,17 +483,30 @@ export default function WordClozeActivity({
     }
   }, [currentIndex, questions.length, timeLimit]);
 
-  // Issue #715: 上一題（只在正面顯示時可用）
-  const goToPrev = useCallback(() => {
-    if (currentIndex === 0) return;
-    setScoreOverlayOpen(false);
-    setCardFace("back");
-    setShowResult(false);
-    setTypedAnswer("");
-    setLastAttemptWrong(false);
-    if (timeLimit) setTimeRemaining(timeLimit);
-    setCurrentIndex(currentIndex - 1);
-  }, [currentIndex, timeLimit]);
+  // Issue #716: 移除「上一題」— 艾賓浩斯算法鼓勵把 10 題跑完。
+
+  // Issue #716: VirtualKeyboard 輸入回調
+  const vkAppend = useCallback(
+    (ch: string) => {
+      const sanitized = sanitizeAnswer(ch);
+      if (!sanitized) return;
+      if (showResult && !isCorrect) setShowResult(false);
+      setTypedAnswer((prev) => prev + sanitized);
+    },
+    [showResult, isCorrect],
+  );
+  const vkBackspace = useCallback(() => {
+    if (showResult && !isCorrect) setShowResult(false);
+    setTypedAnswer((prev) => prev.slice(0, -1));
+  }, [showResult, isCorrect]);
+  const vkEnter = useCallback(() => {
+    if (cardFace === "front") {
+      advanceToNext();
+    } else if (!showResult && !submitting && typedAnswer.trim()) {
+      handleSubmitAnswer();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cardFace, showResult, submitting, typedAnswer, advanceToNext]);
 
   // ScoreOverlay 結束 → 關閉動畫，等學生用左右箭頭手動翻頁
   const handleOverlayComplete = () => {
@@ -696,7 +721,7 @@ export default function WordClozeActivity({
   const currentQ = questions[currentIndex];
 
   return (
-    <div className="space-y-6">
+    <div className={cn("space-y-6", deviceMode === "mobile" && "pb-72")}>
       {isPracticeMode && (
         <div className="flex items-center gap-2 text-sm text-blue-600 bg-blue-50 rounded-lg px-4 py-2">
           <BookOpen className="h-4 w-4" />
@@ -732,8 +757,14 @@ export default function WordClozeActivity({
         />
       </div>
 
+      <div
+        className={cn(
+          deviceMode === "tablet" && "flex items-start gap-4",
+        )}
+      >
+        <div className={cn("min-w-0", deviceMode === "tablet" && "flex-[6]")}>
       <WordCard
-        viewMode="desktop"
+        viewMode={deviceMode === "mobile" ? "mobile" : "desktop"}
         face={cardFace}
         onFlipped={handleCardFlipped}
         word={currentQ.base_word || currentQ.correct_answer}
@@ -747,9 +778,8 @@ export default function WordClozeActivity({
         exampleSentenceAudioUrl={
           currentQ.example_sentence_audio_url ?? undefined
         }
-        hasPrev={cardFace === "front" && currentIndex > 0}
+        hasPrev={false}
         hasNext={cardFace === "front"}
-        onPrev={goToPrev}
         onNext={advanceToNext}
         back={
           <div className="relative space-y-6">
@@ -808,10 +838,16 @@ export default function WordClozeActivity({
                 ref={inputRef}
                 type="text"
                 value={typedAnswer}
+                inputMode={useVirtualKeyboard ? "none" : "text"}
                 onChange={(e) => {
-                  setTypedAnswer(e.target.value);
-                  // Issue #716: 一打字立刻清除錯誤提示，不必按 Retry
+                  setTypedAnswer(sanitizeAnswer(e.target.value));
                   if (showResult && !isCorrect) setShowResult(false);
+                }}
+                onBeforeInput={(e) => {
+                  const ev = e.nativeEvent as InputEvent;
+                  if (ev.inputType === "insertReplacementText") {
+                    e.preventDefault();
+                  }
                 }}
                 onKeyDown={handleKeyDown}
                 onPaste={(e) => e.preventDefault()}
@@ -863,6 +899,26 @@ export default function WordClozeActivity({
           </div>
         }
       />
+        </div>
+        {deviceMode === "tablet" && (
+          <div className="flex-[4] min-w-0">
+            <VirtualKeyboard
+              onKey={vkAppend}
+              onBackspace={vkBackspace}
+              onEnter={vkEnter}
+            />
+          </div>
+        )}
+      </div>
+
+      {deviceMode === "mobile" && (
+        <VirtualKeyboard
+          onKey={vkAppend}
+          onBackspace={vkBackspace}
+          onEnter={vkEnter}
+          className="fixed bottom-0 left-0 right-0 z-50 border-t shadow-2xl"
+        />
+      )}
 
       <ScoreOverlay
         open={scoreOverlayOpen}

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -862,7 +862,7 @@ export default function WordClozeActivity({
                 disabled={(showResult && isCorrect) || submitting}
                 className={cn(
                   "text-center text-2xl h-14 pl-10 pr-10 bg-transparent shadow-none rounded-none border-0 border-b-2 transition-colors",
-                  "focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
+                  "placeholder:text-base focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
                   showResult && isCorrect && "border-green-500 text-green-700",
                   showResult &&
                     !isCorrect &&

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -752,7 +752,15 @@ export default function WordClozeActivity({
         onPrev={goToPrev}
         onNext={advanceToNext}
         back={
-          <div className="space-y-6">
+          <div className="relative space-y-6">
+            {timeLimit && timeRemaining !== null && (
+              <CountdownRing
+                key={currentIndex}
+                seconds={timeRemaining}
+                total={timeLimit}
+                className="absolute top-0 right-0 z-10"
+              />
+            )}
             {/* Issue #716: cloze Display Translation 僅顯示例句翻譯，不顯示單字翻譯 → 移除單字翻譯 hint */}
 
             {/* Issue #716: 音檔功能僅在 Play Audio 模式出現 */}
@@ -794,13 +802,8 @@ export default function WordClozeActivity({
               )}
             </div>
 
-            {timeLimit && timeRemaining !== null && (
-              <div className="flex justify-center">
-                <CountdownRing seconds={timeRemaining} total={timeLimit} />
-              </div>
-            )}
 
-            <div className="max-w-md mx-auto space-y-3">
+            <div className="max-w-md mx-auto relative">
               <Input
                 ref={inputRef}
                 type="text"
@@ -822,7 +825,7 @@ export default function WordClozeActivity({
                 }
                 disabled={(showResult && isCorrect) || submitting}
                 className={cn(
-                  "text-center text-2xl h-14 px-0 bg-transparent shadow-none rounded-none border-0 border-b-2 transition-colors",
+                  "text-center text-2xl h-14 pl-10 pr-10 bg-transparent shadow-none rounded-none border-0 border-b-2 transition-colors",
                   "focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
                   showResult && isCorrect && "border-green-500 text-green-700",
                   showResult &&
@@ -837,22 +840,24 @@ export default function WordClozeActivity({
                 autoCorrect="off"
                 spellCheck={false}
               />
-
               {!(showResult && isCorrect) && (
-                <Button
+                <button
+                  type="button"
                   onClick={() => handleSubmitAnswer()}
                   disabled={!typedAnswer.trim() || submitting}
-                  className="w-full h-12 text-lg"
+                  aria-label={t("wordCloze.checkAnswer") || "Check"}
+                  className={cn(
+                    "absolute right-0 top-1/2 -translate-y-1/2 p-2 rounded-full transition-colors",
+                    "text-indigo-600 hover:bg-indigo-50",
+                    "disabled:text-gray-300 disabled:hover:bg-transparent disabled:cursor-not-allowed",
+                  )}
                 >
                   {submitting ? (
                     <Loader2 className="h-5 w-5 animate-spin" />
                   ) : (
-                    <>
-                      <CheckCircle className="h-5 w-5 mr-2" />
-                      {t("wordCloze.checkAnswer") || "Check"}
-                    </>
+                    <Send className="h-5 w-5" />
                   )}
-                </Button>
+                </button>
               )}
             </div>
           </div>

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -762,143 +762,143 @@ export default function WordClozeActivity({
       </div>
 
       <div
-        className={cn(
-          deviceMode === "tablet" && "flex items-stretch gap-4",
-        )}
+        className={cn(deviceMode === "tablet" && "flex items-stretch gap-4")}
       >
         <div className={cn("min-w-0", deviceMode === "tablet" && "flex-[6]")}>
-      <WordCard
-        viewMode={deviceMode === "mobile" ? "mobile" : "desktop"}
-        face={cardFace}
-        onFlipped={handleCardFlipped}
-        word={currentQ.base_word || currentQ.correct_answer}
-        partOfSpeech={currentQ.part_of_speech ?? undefined}
-        translation={currentQ.translation || undefined}
-        audioUrl={currentQ.word_audio_url ?? undefined}
-        exampleSentence={currentQ.example_sentence ?? undefined}
-        exampleSentenceTranslation={
-          currentQ.example_sentence_translation ?? undefined
-        }
-        exampleSentenceAudioUrl={
-          currentQ.example_sentence_audio_url ?? undefined
-        }
-        hasPrev={false}
-        hasNext={cardFace === "front"}
-        onNext={advanceToNext}
-        back={
-          <div className="relative space-y-6">
-            {timeLimit && timeRemaining !== null && (
-              <CountdownRing
-                key={currentIndex}
-                seconds={timeRemaining}
-                total={timeLimit}
-                className="absolute top-0 right-0 z-10"
-              />
-            )}
-            {/* Issue #716: cloze Display Translation 僅顯示例句翻譯，不顯示單字翻譯 → 移除單字翻譯 hint */}
-
-            {/* Issue #716: Play Audio 模式音檔鈕置中於例句上方，避免 inline 對齊問題 */}
-            {audioOnlyMode && currentQ.audio_url && (
-              <div className="flex justify-center">
-                <button
-                  type="button"
-                  onClick={playQuestionAudio}
-                  aria-label={t("wordCloze.playAudio") || "Play Audio"}
-                  className="inline-flex items-center justify-center transition-colors shrink-0 bg-transparent h-12 w-12 text-blue-500 hover:text-blue-600"
-                >
-                  <Volume2 className="h-7 w-7" />
-                </button>
-              </div>
-            )}
-
-            <div className="max-w-2xl mx-auto text-center py-2 space-y-2">
-              {currentQ.part_of_speech && (
-                <div className="flex justify-center">
-                  <Badge
-                    variant="secondary"
-                    className="bg-gray-200 text-gray-700 hover:bg-gray-200 font-normal"
-                  >
-                    {currentQ.part_of_speech}
-                  </Badge>
-                </div>
-              )}
-              <p className="text-lg md:text-xl leading-relaxed text-gray-800 font-semibold px-4 tracking-wide">
-                {currentQ.blanked_sentence}
-              </p>
-              {showTranslation && currentQ.sentence_translation && (
-                <p className="text-sm text-gray-500">
-                  {currentQ.sentence_translation}
-                </p>
-              )}
-            </div>
-
-
-            <div className="max-w-md mx-auto relative">
-              <Input
-                ref={inputRef}
-                type="text"
-                value={typedAnswer}
-                inputMode={useVirtualKeyboard ? "none" : "text"}
-                onChange={(e) => {
-                  setTypedAnswer(sanitizeAnswer(e.target.value));
-                  if (showResult && !isCorrect) setShowResult(false);
-                }}
-                onBeforeInput={(e) => {
-                  const ev = e.nativeEvent as InputEvent;
-                  if (ev.inputType === "insertReplacementText") {
-                    e.preventDefault();
-                  }
-                }}
-                onKeyDown={handleKeyDown}
-                onPaste={(e) => e.preventDefault()}
-                onDrop={(e) => e.preventDefault()}
-                placeholder={
-                  showAnswerOnWrong &&
-                  lastAttemptWrong &&
-                  currentQ.correct_answer
-                    ? currentQ.correct_answer
-                    : t("wordCloze.inputPlaceholder") || "Fill in the blank..."
-                }
-                disabled={(showResult && isCorrect) || submitting}
-                className={cn(
-                  "text-center text-2xl h-14 pl-10 pr-10 bg-transparent shadow-none rounded-none border-0 border-b-2 transition-colors",
-                  "focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
-                  showResult && isCorrect && "border-green-500 text-green-700",
-                  showResult &&
-                    !isCorrect &&
-                    "border-red-500 text-red-600 placeholder:text-red-400",
-                  !(showResult && !isCorrect) &&
-                    !(showResult && isCorrect) &&
-                    "border-gray-300 focus:border-indigo-500",
+          <WordCard
+            viewMode={deviceMode === "mobile" ? "mobile" : "desktop"}
+            face={cardFace}
+            onFlipped={handleCardFlipped}
+            word={currentQ.base_word || currentQ.correct_answer}
+            partOfSpeech={currentQ.part_of_speech ?? undefined}
+            translation={currentQ.translation || undefined}
+            audioUrl={currentQ.word_audio_url ?? undefined}
+            exampleSentence={currentQ.example_sentence ?? undefined}
+            exampleSentenceTranslation={
+              currentQ.example_sentence_translation ?? undefined
+            }
+            exampleSentenceAudioUrl={
+              currentQ.example_sentence_audio_url ?? undefined
+            }
+            hasPrev={false}
+            hasNext={cardFace === "front"}
+            onNext={advanceToNext}
+            back={
+              <div className="relative space-y-6">
+                {timeLimit && timeRemaining !== null && (
+                  <CountdownRing
+                    key={currentIndex}
+                    seconds={timeRemaining}
+                    total={timeLimit}
+                    className="absolute top-0 right-0 z-10"
+                  />
                 )}
-                autoComplete="off"
-                autoCapitalize="off"
-                autoCorrect="off"
-                spellCheck={false}
-              />
-              {!(showResult && isCorrect) && (
-                <button
-                  type="button"
-                  onClick={() => handleSubmitAnswer()}
-                  disabled={!typedAnswer.trim() || submitting}
-                  aria-label={t("wordCloze.checkAnswer") || "Check"}
-                  className={cn(
-                    "absolute right-0 top-1/2 -translate-y-1/2 p-2 rounded-full transition-colors",
-                    "text-indigo-600 hover:bg-indigo-50",
-                    "disabled:text-gray-300 disabled:hover:bg-transparent disabled:cursor-not-allowed",
+                {/* Issue #716: cloze Display Translation 僅顯示例句翻譯，不顯示單字翻譯 → 移除單字翻譯 hint */}
+
+                {/* Issue #716: Play Audio 模式音檔鈕置中於例句上方，避免 inline 對齊問題 */}
+                {audioOnlyMode && currentQ.audio_url && (
+                  <div className="flex justify-center">
+                    <button
+                      type="button"
+                      onClick={playQuestionAudio}
+                      aria-label={t("wordCloze.playAudio") || "Play Audio"}
+                      className="inline-flex items-center justify-center transition-colors shrink-0 bg-transparent h-12 w-12 text-blue-500 hover:text-blue-600"
+                    >
+                      <Volume2 className="h-7 w-7" />
+                    </button>
+                  </div>
+                )}
+
+                <div className="max-w-2xl mx-auto text-center py-2 space-y-2">
+                  {currentQ.part_of_speech && (
+                    <div className="flex justify-center">
+                      <Badge
+                        variant="secondary"
+                        className="bg-gray-200 text-gray-700 hover:bg-gray-200 font-normal"
+                      >
+                        {currentQ.part_of_speech}
+                      </Badge>
+                    </div>
                   )}
-                >
-                  {submitting ? (
-                    <Loader2 className="h-5 w-5 animate-spin" />
-                  ) : (
-                    <Send className="h-5 w-5" />
+                  <p className="text-lg md:text-xl leading-relaxed text-gray-800 font-semibold px-4 tracking-wide">
+                    {currentQ.blanked_sentence}
+                  </p>
+                  {showTranslation && currentQ.sentence_translation && (
+                    <p className="text-sm text-gray-500">
+                      {currentQ.sentence_translation}
+                    </p>
                   )}
-                </button>
-              )}
-            </div>
-          </div>
-        }
-      />
+                </div>
+
+                <div className="max-w-md mx-auto relative">
+                  <Input
+                    ref={inputRef}
+                    type="text"
+                    value={typedAnswer}
+                    inputMode={useVirtualKeyboard ? "none" : "text"}
+                    onChange={(e) => {
+                      setTypedAnswer(sanitizeAnswer(e.target.value));
+                      if (showResult && !isCorrect) setShowResult(false);
+                    }}
+                    onBeforeInput={(e) => {
+                      const ev = e.nativeEvent as InputEvent;
+                      if (ev.inputType === "insertReplacementText") {
+                        e.preventDefault();
+                      }
+                    }}
+                    onKeyDown={handleKeyDown}
+                    onPaste={(e) => e.preventDefault()}
+                    onDrop={(e) => e.preventDefault()}
+                    placeholder={
+                      showAnswerOnWrong &&
+                      lastAttemptWrong &&
+                      currentQ.correct_answer
+                        ? currentQ.correct_answer
+                        : t("wordCloze.inputPlaceholder") ||
+                          "Fill in the blank..."
+                    }
+                    disabled={(showResult && isCorrect) || submitting}
+                    className={cn(
+                      "text-center text-2xl h-14 pl-10 pr-10 bg-transparent shadow-none rounded-none border-0 border-b-2 transition-colors",
+                      "focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
+                      showResult &&
+                        isCorrect &&
+                        "border-green-500 text-green-700",
+                      showResult &&
+                        !isCorrect &&
+                        "border-red-500 text-red-600 placeholder:text-red-400",
+                      !(showResult && !isCorrect) &&
+                        !(showResult && isCorrect) &&
+                        "border-gray-300 focus:border-indigo-500",
+                    )}
+                    autoComplete="off"
+                    autoCapitalize="off"
+                    autoCorrect="off"
+                    spellCheck={false}
+                  />
+                  {!(showResult && isCorrect) && (
+                    <button
+                      type="button"
+                      onClick={() => handleSubmitAnswer()}
+                      disabled={!typedAnswer.trim() || submitting}
+                      aria-label={t("wordCloze.checkAnswer") || "Check"}
+                      className={cn(
+                        "absolute right-0 top-1/2 -translate-y-1/2 p-2 rounded-full transition-colors",
+                        "text-indigo-600 hover:bg-indigo-50",
+                        "disabled:text-gray-300 disabled:hover:bg-transparent disabled:cursor-not-allowed",
+                      )}
+                    >
+                      {submitting ? (
+                        <Loader2 className="h-5 w-5 animate-spin" />
+                      ) : (
+                        <Send className="h-5 w-5" />
+                      )}
+                    </button>
+                  )}
+                </div>
+              </div>
+            }
+          />
         </div>
         {useVirtualKeyboard && (
           <div

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -518,6 +518,8 @@ export default function WordClozeActivity({
     if (deviceMode !== "desktop" || roundCompleted || loading) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Enter") return;
+      // Issue #716: 過濾 auto-repeat，避免「送出 → 翻面 → 立刻下一題」。
+      if (e.repeat) return;
       if (cardFace === "front") {
         e.preventDefault();
         advanceToNext();

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -28,8 +28,6 @@ import {
   Loader2,
   Volume2,
   CheckCircle,
-  XCircle,
-  Clock,
   Send,
   FileText,
   Trophy,
@@ -42,6 +40,7 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/lib/api";
 import ScoreOverlay from "./shared/ScoreOverlay";
+import CountdownRing from "./shared/CountdownRing";
 import { WordCard } from "./shared/WordCard";
 import { aggregateTierCounts, weightedMastery } from "./wordFamiliarity";
 
@@ -199,7 +198,6 @@ export default function WordClozeActivity({
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
-  const [incorrectAnswer, setIncorrectAnswer] = useState<string | null>(null);
 
   const startPractice = useCallback(async () => {
     try {
@@ -399,7 +397,6 @@ export default function WordClozeActivity({
         // Issue #715: 答對 → 翻面（不立刻顯示 ScoreOverlay）→ onFlipped 後才顯示
         setCardFace("front");
       } else {
-        setIncorrectAnswer(answer);
         setLastAttemptWrong(true);
         // Issue #716: 清空 input 讓正解 placeholder 露出來
         setTypedAnswer("");
@@ -430,7 +427,6 @@ export default function WordClozeActivity({
         // Issue #715: 答對 → 翻面（不立刻顯示 ScoreOverlay）→ onFlipped 後才顯示
         setCardFace("front");
       } else {
-        setIncorrectAnswer(answer);
         setLastAttemptWrong(true);
         // Issue #716: 清空 input 讓正解 placeholder 露出來
         setTypedAnswer("");
@@ -465,7 +461,6 @@ export default function WordClozeActivity({
     setCardFace("back");
     setShowResult(false);
     setTypedAnswer("");
-    setIncorrectAnswer(null);
     setLastAttemptWrong(false);
     if (timeLimit) setTimeRemaining(timeLimit);
 
@@ -483,7 +478,6 @@ export default function WordClozeActivity({
     setCardFace("back");
     setShowResult(false);
     setTypedAnswer("");
-    setIncorrectAnswer(null);
     setLastAttemptWrong(false);
     if (timeLimit) setTimeRemaining(timeLimit);
     setCurrentIndex(currentIndex - 1);
@@ -802,30 +796,7 @@ export default function WordClozeActivity({
 
             {timeLimit && timeRemaining !== null && (
               <div className="flex justify-center">
-                <div
-                  className={cn(
-                    "flex items-center gap-2 px-4 py-2 rounded-full text-lg font-medium",
-                    timeRemaining === 0
-                      ? "bg-red-100 text-red-700"
-                      : timeRemaining <= 5
-                        ? "bg-red-100 text-red-700"
-                        : timeRemaining <= 10
-                          ? "bg-yellow-100 text-yellow-700"
-                          : "bg-gray-100 text-gray-700",
-                  )}
-                >
-                  <Clock className="h-5 w-5" />
-                  {timeRemaining === 0 ? (
-                    <span>{t("wordCloze.timeUp") || "Time's up!"}</span>
-                  ) : (
-                    <>
-                      <span>{timeRemaining}</span>
-                      <span className="text-sm">
-                        {t("wordCloze.seconds") || "s"}
-                      </span>
-                    </>
-                  )}
-                </div>
+                <CountdownRing seconds={timeRemaining} total={timeLimit} />
               </div>
             )}
 
@@ -866,19 +837,6 @@ export default function WordClozeActivity({
                 autoCorrect="off"
                 spellCheck={false}
               />
-
-              {showResult && !isCorrect && (
-                <div className="flex items-center justify-center gap-2 text-red-600">
-                  <XCircle className="h-5 w-5" />
-                  <span className="font-medium">
-                    {incorrectAnswer
-                      ? t("wordCloze.incorrectTryAgain") ||
-                        "Incorrect, try again!"
-                      : t("wordCloze.timeUpTryAgain") ||
-                        "Time's up! Try again."}
-                  </span>
-                </div>
-              )}
 
               {!(showResult && isCorrect) && (
                 <Button

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -779,12 +779,17 @@ export default function WordClozeActivity({
               </div>
             )}
 
-            <div className="max-w-2xl mx-auto text-center py-2 space-y-3">
-              <p className="text-2xl md:text-3xl leading-relaxed text-gray-800 font-semibold px-4 tracking-wide">
+            <div className="max-w-2xl mx-auto text-center py-2 space-y-2">
+              {currentQ.part_of_speech && (
+                <p className="text-sm italic text-gray-500">
+                  {currentQ.part_of_speech}
+                </p>
+              )}
+              <p className="text-xl md:text-2xl leading-relaxed text-gray-800 font-semibold px-4 tracking-wide">
                 {currentQ.blanked_sentence}
               </p>
               {showTranslation && currentQ.sentence_translation && (
-                <p className="text-base text-gray-500">
+                <p className="text-sm text-gray-500">
                   {currentQ.sentence_translation}
                 </p>
               )}

--- a/frontend/src/components/activities/WordSelectionActivity.tsx
+++ b/frontend/src/components/activities/WordSelectionActivity.tsx
@@ -42,7 +42,6 @@ import {
   XCircle,
   Trophy,
   RefreshCw,
-  Clock,
   Send,
   BookOpen,
   Info,
@@ -52,6 +51,7 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/lib/api";
 import ScoreOverlay from "./shared/ScoreOverlay";
+import CountdownRing from "./shared/CountdownRing";
 import { aggregateTierCounts, weightedMastery } from "./wordFamiliarity";
 
 interface OptionEntry {
@@ -478,6 +478,7 @@ export default function WordSelectionActivity({
       // Time expired - trigger wrong answer
       handleTimeoutAnswer();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [timeRemaining, showResult, submitting, words.length]);
 
   // Handle timeout answer (separate from regular answer to avoid loops)
@@ -883,12 +884,21 @@ export default function WordSelectionActivity({
       {/* Question content */}
       <div
         className={cn(
-          "space-y-6",
+          "relative space-y-6",
           // 橫式（圖左、右欄文字+選項）— 不加 items-start，
           // 用預設 items-stretch 讓兩欄等高，圖片高度由右欄決定
           useHorizontal && "flex flex-row gap-6 space-y-0",
         )}
       >
+        {/* Issue #716: countdown ring anchored top-right of the question card */}
+        {timeLimit && timeRemaining !== null && (
+          <CountdownRing
+            key={currentIndex}
+            seconds={timeRemaining}
+            total={timeLimit}
+            className="absolute top-0 right-0 z-10"
+          />
+        )}
         {/* Image */}
         {showImage && currentWord.image_url && (
           <div
@@ -911,7 +921,7 @@ export default function WordSelectionActivity({
           </div>
         )}
 
-        {/* 右側欄（橫式時把文字/音檔/題目/Timer/選項都放這裡） */}
+        {/* 右側欄（橫式時把文字/音檔/題目/選項都放這裡） */}
         <div className={cn("space-y-6", useHorizontal && "flex-1 min-w-0")}>
           {/* Word Text — show_image 模式時隱藏英文（避免答案太明顯），改顯示翻譯提示
               即使老師勾了 show_image 但實際沒附圖，仍套用此規則 — 否則英文題目+英文選項會秒解 */}
@@ -935,36 +945,6 @@ export default function WordSelectionActivity({
                 <Volume2 className="h-5 w-5" />
                 {t("wordSelection.playAudio") || "Play Audio"}
               </Button>
-            </div>
-          )}
-
-          {/* Timer Display - stays visible when time is up to prevent visual jump */}
-          {timeLimit && timeRemaining !== null && (
-            <div className="flex justify-center">
-              <div
-                className={cn(
-                  "flex items-center gap-2 px-4 py-2 rounded-full text-lg font-medium",
-                  timeRemaining === 0
-                    ? "bg-red-100 text-red-700"
-                    : timeRemaining <= 5
-                      ? "bg-red-100 text-red-700"
-                      : timeRemaining <= 10
-                        ? "bg-yellow-100 text-yellow-700"
-                        : "bg-gray-100 text-gray-700",
-                )}
-              >
-                <Clock className="h-5 w-5" />
-                {timeRemaining === 0 ? (
-                  <span>{t("wordSelection.timeUp") || "Time's up!"}</span>
-                ) : (
-                  <>
-                    <span>{timeRemaining}</span>
-                    <span className="text-sm">
-                      {t("wordSelection.seconds") || "s"}
-                    </span>
-                  </>
-                )}
-              </div>
             </div>
           )}
 

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -758,7 +758,15 @@ export default function WordSpellingActivity({
         onPrev={goToPrev}
         onNext={advanceToNext}
         back={
-          <div className="space-y-6">
+          <div className="relative space-y-6">
+            {timeLimit && timeRemaining !== null && (
+              <CountdownRing
+                key={currentIndex}
+                seconds={timeRemaining}
+                total={timeLimit}
+                className="absolute top-0 right-0 z-10"
+              />
+            )}
             {showTranslation && currentWord.translation && (
               <div className="text-center py-3 space-y-1">
                 <h2 className="text-3xl md:text-4xl font-bold text-gray-800 tracking-wide">
@@ -795,13 +803,8 @@ export default function WordSpellingActivity({
               </div>
             )}
 
-            {timeLimit && timeRemaining !== null && (
-              <div className="flex justify-center">
-                <CountdownRing seconds={timeRemaining} total={timeLimit} />
-              </div>
-            )}
 
-            <div className="max-w-md mx-auto space-y-3">
+            <div className="max-w-md mx-auto relative">
               <Input
                 ref={inputRef}
                 type="text"
@@ -822,7 +825,7 @@ export default function WordSpellingActivity({
                 }
                 disabled={(showResult && isCorrect) || submitting}
                 className={cn(
-                  "text-center text-2xl h-14 px-0 bg-transparent shadow-none rounded-none border-0 border-b-2 transition-colors",
+                  "text-center text-2xl h-14 pl-10 pr-10 bg-transparent shadow-none rounded-none border-0 border-b-2 transition-colors",
                   "focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
                   showResult && isCorrect && "border-green-500 text-green-700",
                   showResult &&
@@ -837,22 +840,24 @@ export default function WordSpellingActivity({
                 autoCorrect="off"
                 spellCheck={false}
               />
-
               {!(showResult && isCorrect) && (
-                <Button
+                <button
+                  type="button"
                   onClick={() => handleSubmitAnswer()}
                   disabled={!typedAnswer.trim() || submitting}
-                  className="w-full h-12 text-lg"
+                  aria-label={t("wordSpelling.checkAnswer") || "Check"}
+                  className={cn(
+                    "absolute right-0 top-1/2 -translate-y-1/2 p-2 rounded-full transition-colors",
+                    "text-indigo-600 hover:bg-indigo-50",
+                    "disabled:text-gray-300 disabled:hover:bg-transparent disabled:cursor-not-allowed",
+                  )}
                 >
                   {submitting ? (
                     <Loader2 className="h-5 w-5 animate-spin" />
                   ) : (
-                    <>
-                      <CheckCircle className="h-5 w-5 mr-2" />
-                      {t("wordSpelling.checkAnswer") || "Check"}
-                    </>
+                    <Send className="h-5 w-5" />
                   )}
-                </Button>
+                </button>
               )}
             </div>
           </div>

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -870,7 +870,7 @@ export default function WordSpellingActivity({
                 disabled={(showResult && isCorrect) || submitting}
                 className={cn(
                   "text-center text-2xl h-14 pl-10 pr-10 bg-transparent shadow-none rounded-none border-0 border-b-2 transition-colors",
-                  "placeholder:text-base focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
+                  "focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
                   showResult && isCorrect && "border-green-500 text-green-700",
                   showResult &&
                     !isCorrect &&

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -757,15 +757,13 @@ export default function WordSpellingActivity({
         word={currentWord.text}
         partOfSpeech={currentWord.part_of_speech ?? undefined}
         translation={currentWord.translation || undefined}
-        audioUrl={audioOnlyMode ? currentWord.audio_url : undefined}
+        audioUrl={currentWord.audio_url}
         exampleSentence={currentWord.example_sentence ?? undefined}
         exampleSentenceTranslation={
           currentWord.example_sentence_translation ?? undefined
         }
         exampleSentenceAudioUrl={
-          audioOnlyMode
-            ? (currentWord.example_sentence_audio_url ?? undefined)
-            : undefined
+          currentWord.example_sentence_audio_url ?? undefined
         }
         hasPrev={cardFace === "front" && currentIndex > 0}
         hasNext={cardFace === "front"}

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -765,11 +765,8 @@ export default function WordSpellingActivity({
         back={
           <div className="space-y-6">
             {showTranslation && currentWord.translation && (
-              <div className="text-center">
-                <p className="text-sm text-gray-500 mb-1">
-                  {t("wordSpelling.translationHint") || "Translation"}
-                </p>
-                <h2 className="text-2xl font-bold text-gray-800">
+              <div className="text-center py-4">
+                <h2 className="text-4xl md:text-5xl font-bold text-gray-800 tracking-wide">
                   {currentWord.translation}
                 </h2>
               </div>
@@ -843,10 +840,15 @@ export default function WordSpellingActivity({
                 }
                 disabled={(showResult && isCorrect) || submitting}
                 className={cn(
-                  "text-center text-xl h-14 rounded-xl border-2",
-                  showResult && isCorrect && "border-green-500 bg-green-50",
-                  showResult && !isCorrect && "border-red-500 bg-red-50",
-                  !showResult && "border-gray-300 focus:border-indigo-500",
+                  "text-center text-2xl h-14 px-0 bg-transparent shadow-none rounded-none border-0 border-b-2 transition-colors",
+                  "focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
+                  showResult && isCorrect && "border-green-500 text-green-700",
+                  showResult &&
+                    !isCorrect &&
+                    "border-red-500 text-red-600 placeholder:text-red-400",
+                  !(showResult && !isCorrect) &&
+                    !(showResult && isCorrect) &&
+                    "border-gray-300 focus:border-indigo-500",
                 )}
                 autoComplete="off"
                 autoCapitalize="off"

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -821,21 +821,17 @@ export default function WordSpellingActivity({
               </div>
             )}
 
-            {/* Issue #716: 音檔功能僅在 Play Audio 模式出現；同時移除重複的 "Type the correct spelling" 標語 */}
+            {/* Issue #716: Play Audio 模式用 WordCard 風格的小喇叭，置中。 */}
             {audioOnlyMode && currentWord.audio_url && (
-              <div className="flex flex-col items-center gap-2">
-                <Button
-                  variant="default"
-                  size="lg"
+              <div className="flex justify-center">
+                <button
+                  type="button"
                   onClick={playWordAudio}
-                  className="gap-2 h-16 px-8 text-lg bg-blue-600 hover:bg-blue-700 text-white shadow-lg"
+                  aria-label={t("wordSpelling.playAudio") || "Play Audio"}
+                  className="inline-flex items-center justify-center transition-colors shrink-0 bg-transparent h-12 w-12 text-blue-500 hover:text-blue-600"
                 >
                   <Volume2 className="h-7 w-7" />
-                  {t("wordSpelling.playAudio") || "Play Audio"}
-                </Button>
-                <p className="text-xs text-gray-500">
-                  {t("wordSpelling.tapToReplay") || "點擊播放，可以重複聆聽"}
-                </p>
+                </button>
               </div>
             )}
 

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -500,51 +500,22 @@ export default function WordSpellingActivity({
     setTypedAnswer((prev) => prev.slice(0, -1));
   }, [showResult, isCorrect]);
   const vkEnter = useCallback(() => {
-    // 卡正面（答對後）→ 下一題；卡背面 → 提交
-    if (cardFace === "front") {
-      advanceToNext();
-    } else if (!showResult && !submitting && typedAnswer.trim()) {
+    // Issue #716: 虛擬鍵盤 Enter 只負責送出；看正面時改用右箭頭手動切下一題。
+    if (
+      cardFace === "back" &&
+      !showResult &&
+      !submitting &&
+      typedAnswer.trim()
+    ) {
       handleSubmitAnswer();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cardFace, showResult, submitting, typedAnswer, advanceToNext]);
+  }, [cardFace, showResult, submitting, typedAnswer]);
 
   // ScoreOverlay 結束 → 關閉動畫，等學生用左右箭頭手動翻頁
   const handleOverlayComplete = () => {
     setScoreOverlayOpen(false);
   };
-
-  // Issue #716: 桌機 Enter — 作答時送出、看卡時切下一題。
-  // window 級監聽，不依賴 input 的 focus（翻面後焦點通常離開 input）。
-  useEffect(() => {
-    if (deviceMode !== "desktop" || roundCompleted || loading) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key !== "Enter") return;
-      // Issue #716: 過濾按住 Enter 的 auto-repeat，避免一次連續觸發
-      // 「送出 → 翻面 → 立刻下一題」造成卡片沒看到。
-      if (e.repeat) return;
-      if (cardFace === "front") {
-        e.preventDefault();
-        advanceToNext();
-      } else if (!showResult && !submitting && typedAnswer.trim()) {
-        e.preventDefault();
-        handleSubmitAnswer();
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-    // handleSubmitAnswer 是 component 級函式，這裡省略保持監聽穩定。
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    deviceMode,
-    cardFace,
-    showResult,
-    submitting,
-    typedAnswer,
-    roundCompleted,
-    loading,
-    advanceToNext,
-  ]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !showResult && !submitting && typedAnswer.trim()) {

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -770,139 +770,138 @@ export default function WordSpellingActivity({
       </div>
 
       <div
-        className={cn(
-          deviceMode === "tablet" && "flex items-stretch gap-4",
-        )}
+        className={cn(deviceMode === "tablet" && "flex items-stretch gap-4")}
       >
         <div className={cn("min-w-0", deviceMode === "tablet" && "flex-[6]")}>
-      <WordCard
-        viewMode={deviceMode === "mobile" ? "mobile" : "desktop"}
-        face={cardFace}
-        onFlipped={handleCardFlipped}
-        word={currentWord.text}
-        partOfSpeech={currentWord.part_of_speech ?? undefined}
-        translation={currentWord.translation || undefined}
-        audioUrl={currentWord.audio_url}
-        exampleSentence={currentWord.example_sentence ?? undefined}
-        exampleSentenceTranslation={
-          currentWord.example_sentence_translation ?? undefined
-        }
-        exampleSentenceAudioUrl={
-          currentWord.example_sentence_audio_url ?? undefined
-        }
-        hasPrev={false}
-        hasNext={cardFace === "front"}
-        onNext={advanceToNext}
-        back={
-          <div className="relative space-y-6">
-            {timeLimit && timeRemaining !== null && (
-              <CountdownRing
-                key={currentIndex}
-                seconds={timeRemaining}
-                total={timeLimit}
-                className="absolute top-0 right-0 z-10"
-              />
-            )}
-            {showTranslation && currentWord.translation && (
-              <div className="text-center py-3 space-y-1">
-                <h2 className="text-3xl md:text-4xl font-bold text-gray-800 tracking-wide">
-                  {currentWord.translation}
-                </h2>
-                {currentWord.part_of_speech && (
-                  <div className="flex justify-center">
-                    <Badge
-                      variant="secondary"
-                      className="bg-gray-200 text-gray-700 hover:bg-gray-200 font-normal"
-                    >
-                      {currentWord.part_of_speech}
-                    </Badge>
+          <WordCard
+            viewMode={deviceMode === "mobile" ? "mobile" : "desktop"}
+            face={cardFace}
+            onFlipped={handleCardFlipped}
+            word={currentWord.text}
+            partOfSpeech={currentWord.part_of_speech ?? undefined}
+            translation={currentWord.translation || undefined}
+            audioUrl={currentWord.audio_url}
+            exampleSentence={currentWord.example_sentence ?? undefined}
+            exampleSentenceTranslation={
+              currentWord.example_sentence_translation ?? undefined
+            }
+            exampleSentenceAudioUrl={
+              currentWord.example_sentence_audio_url ?? undefined
+            }
+            hasPrev={false}
+            hasNext={cardFace === "front"}
+            onNext={advanceToNext}
+            back={
+              <div className="relative space-y-6">
+                {timeLimit && timeRemaining !== null && (
+                  <CountdownRing
+                    key={currentIndex}
+                    seconds={timeRemaining}
+                    total={timeLimit}
+                    className="absolute top-0 right-0 z-10"
+                  />
+                )}
+                {showTranslation && currentWord.translation && (
+                  <div className="text-center py-3 space-y-1">
+                    <h2 className="text-3xl md:text-4xl font-bold text-gray-800 tracking-wide">
+                      {currentWord.translation}
+                    </h2>
+                    {currentWord.part_of_speech && (
+                      <div className="flex justify-center">
+                        <Badge
+                          variant="secondary"
+                          className="bg-gray-200 text-gray-700 hover:bg-gray-200 font-normal"
+                        >
+                          {currentWord.part_of_speech}
+                        </Badge>
+                      </div>
+                    )}
                   </div>
                 )}
-              </div>
-            )}
 
-            {/* Issue #716: Play Audio 模式用 WordCard 風格的小喇叭，置中。 */}
-            {audioOnlyMode && currentWord.audio_url && (
-              <div className="flex justify-center">
-                <button
-                  type="button"
-                  onClick={playWordAudio}
-                  aria-label={t("wordSpelling.playAudio") || "Play Audio"}
-                  className="inline-flex items-center justify-center transition-colors shrink-0 bg-transparent h-12 w-12 text-blue-500 hover:text-blue-600"
-                >
-                  <Volume2 className="h-7 w-7" />
-                </button>
-              </div>
-            )}
-
-
-            <div className="max-w-md mx-auto relative">
-              <Input
-                ref={inputRef}
-                type="text"
-                value={typedAnswer}
-                inputMode={useVirtualKeyboard ? "none" : "text"}
-                onChange={(e) => {
-                  // Issue #716: 過濾非字母／連字號字元，順便擋住手機建議選字
-                  // 一次塞多字（建議選字 / 自動修正）→ 過濾後通常變空字串。
-                  setTypedAnswer(sanitizeAnswer(e.target.value));
-                  if (showResult && !isCorrect) setShowResult(false);
-                }}
-                onBeforeInput={(e) => {
-                  const ev = e.nativeEvent as InputEvent;
-                  if (ev.inputType === "insertReplacementText") {
-                    e.preventDefault();
-                  }
-                }}
-                onKeyDown={handleKeyDown}
-                onPaste={(e) => e.preventDefault()}
-                onDrop={(e) => e.preventDefault()}
-                placeholder={
-                  showAnswerOnWrong && lastAttemptWrong && currentWord.text
-                    ? currentWord.text
-                    : t("wordSpelling.inputPlaceholder") ||
-                      "Type the word here..."
-                }
-                disabled={(showResult && isCorrect) || submitting}
-                className={cn(
-                  "text-center text-2xl h-14 pl-10 pr-10 bg-transparent shadow-none rounded-none border-0 border-b-2 transition-colors",
-                  "focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
-                  showResult && isCorrect && "border-green-500 text-green-700",
-                  showResult &&
-                    !isCorrect &&
-                    "border-red-500 text-red-600 placeholder:text-red-400",
-                  !(showResult && !isCorrect) &&
-                    !(showResult && isCorrect) &&
-                    "border-gray-300 focus:border-indigo-500",
+                {/* Issue #716: Play Audio 模式用 WordCard 風格的小喇叭，置中。 */}
+                {audioOnlyMode && currentWord.audio_url && (
+                  <div className="flex justify-center">
+                    <button
+                      type="button"
+                      onClick={playWordAudio}
+                      aria-label={t("wordSpelling.playAudio") || "Play Audio"}
+                      className="inline-flex items-center justify-center transition-colors shrink-0 bg-transparent h-12 w-12 text-blue-500 hover:text-blue-600"
+                    >
+                      <Volume2 className="h-7 w-7" />
+                    </button>
+                  </div>
                 )}
-                autoComplete="off"
-                autoCapitalize="off"
-                autoCorrect="off"
-                spellCheck={false}
-              />
-              {!(showResult && isCorrect) && (
-                <button
-                  type="button"
-                  onClick={() => handleSubmitAnswer()}
-                  disabled={!typedAnswer.trim() || submitting}
-                  aria-label={t("wordSpelling.checkAnswer") || "Check"}
-                  className={cn(
-                    "absolute right-0 top-1/2 -translate-y-1/2 p-2 rounded-full transition-colors",
-                    "text-indigo-600 hover:bg-indigo-50",
-                    "disabled:text-gray-300 disabled:hover:bg-transparent disabled:cursor-not-allowed",
+
+                <div className="max-w-md mx-auto relative">
+                  <Input
+                    ref={inputRef}
+                    type="text"
+                    value={typedAnswer}
+                    inputMode={useVirtualKeyboard ? "none" : "text"}
+                    onChange={(e) => {
+                      // Issue #716: 過濾非字母／連字號字元，順便擋住手機建議選字
+                      // 一次塞多字（建議選字 / 自動修正）→ 過濾後通常變空字串。
+                      setTypedAnswer(sanitizeAnswer(e.target.value));
+                      if (showResult && !isCorrect) setShowResult(false);
+                    }}
+                    onBeforeInput={(e) => {
+                      const ev = e.nativeEvent as InputEvent;
+                      if (ev.inputType === "insertReplacementText") {
+                        e.preventDefault();
+                      }
+                    }}
+                    onKeyDown={handleKeyDown}
+                    onPaste={(e) => e.preventDefault()}
+                    onDrop={(e) => e.preventDefault()}
+                    placeholder={
+                      showAnswerOnWrong && lastAttemptWrong && currentWord.text
+                        ? currentWord.text
+                        : t("wordSpelling.inputPlaceholder") ||
+                          "Type the word here..."
+                    }
+                    disabled={(showResult && isCorrect) || submitting}
+                    className={cn(
+                      "text-center text-2xl h-14 pl-10 pr-10 bg-transparent shadow-none rounded-none border-0 border-b-2 transition-colors",
+                      "focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
+                      showResult &&
+                        isCorrect &&
+                        "border-green-500 text-green-700",
+                      showResult &&
+                        !isCorrect &&
+                        "border-red-500 text-red-600 placeholder:text-red-400",
+                      !(showResult && !isCorrect) &&
+                        !(showResult && isCorrect) &&
+                        "border-gray-300 focus:border-indigo-500",
+                    )}
+                    autoComplete="off"
+                    autoCapitalize="off"
+                    autoCorrect="off"
+                    spellCheck={false}
+                  />
+                  {!(showResult && isCorrect) && (
+                    <button
+                      type="button"
+                      onClick={() => handleSubmitAnswer()}
+                      disabled={!typedAnswer.trim() || submitting}
+                      aria-label={t("wordSpelling.checkAnswer") || "Check"}
+                      className={cn(
+                        "absolute right-0 top-1/2 -translate-y-1/2 p-2 rounded-full transition-colors",
+                        "text-indigo-600 hover:bg-indigo-50",
+                        "disabled:text-gray-300 disabled:hover:bg-transparent disabled:cursor-not-allowed",
+                      )}
+                    >
+                      {submitting ? (
+                        <Loader2 className="h-5 w-5 animate-spin" />
+                      ) : (
+                        <Send className="h-5 w-5" />
+                      )}
+                    </button>
                   )}
-                >
-                  {submitting ? (
-                    <Loader2 className="h-5 w-5 animate-spin" />
-                  ) : (
-                    <Send className="h-5 w-5" />
-                  )}
-                </button>
-              )}
-            </div>
-          </div>
-        }
-      />
+                </div>
+              </div>
+            }
+          />
         </div>
         {useVirtualKeyboard && (
           <div

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -412,6 +412,8 @@ export default function WordSpellingActivity({
     } else {
       setIncorrectAnswer(answer);
       setLastAttemptWrong(true);
+      // Issue #716: 清空 input 讓正解 placeholder 露出來
+      setTypedAnswer("");
     }
 
     // Preview/demo: track local counts so the tier breakdown matches live mode.

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -733,7 +733,7 @@ export default function WordSpellingActivity({
   const currentWord = words[currentIndex];
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-3">
       {isPracticeMode && (
         <div className="flex items-center gap-2 text-sm text-blue-600 bg-blue-50 rounded-lg px-4 py-2">
           <BookOpen className="h-4 w-4" />

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -514,6 +514,35 @@ export default function WordSpellingActivity({
     setScoreOverlayOpen(false);
   };
 
+  // Issue #716: 桌機 Enter — 作答時送出、看卡時切下一題。
+  // window 級監聽，不依賴 input 的 focus（翻面後焦點通常離開 input）。
+  useEffect(() => {
+    if (deviceMode !== "desktop" || roundCompleted || loading) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Enter") return;
+      if (cardFace === "front") {
+        e.preventDefault();
+        advanceToNext();
+      } else if (!showResult && !submitting && typedAnswer.trim()) {
+        e.preventDefault();
+        handleSubmitAnswer();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // handleSubmitAnswer 是 component 級函式，這裡省略保持監聽穩定。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    deviceMode,
+    cardFace,
+    showResult,
+    submitting,
+    typedAnswer,
+    roundCompleted,
+    loading,
+    advanceToNext,
+  ]);
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !showResult && !submitting && typedAnswer.trim()) {
       handleSubmitAnswer();

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -41,8 +41,18 @@ import { cn } from "@/lib/utils";
 import { apiClient } from "@/lib/api";
 import ScoreOverlay from "./shared/ScoreOverlay";
 import CountdownRing from "./shared/CountdownRing";
+import VirtualKeyboard from "./shared/VirtualKeyboard";
 import { WordCard } from "./shared/WordCard";
+import { useInputDeviceMode } from "@/hooks/useInputDeviceMode";
 import { aggregateTierCounts, weightedMastery } from "./wordFamiliarity";
+
+// Issue #716: Spelling/cloze 答案只允許英文字母與連字號；其它（注音、
+// 數字、Emoji、貼上的多字元）一律過濾掉，順便擋住手機輸入法的建議選字。
+const ALLOWED_CHAR = /[a-zA-Z-]/;
+const sanitizeAnswer = (raw: string) =>
+  Array.from(raw)
+    .filter((c) => ALLOWED_CHAR.test(c))
+    .join("");
 
 interface SpellingWord {
   content_item_id: number;
@@ -89,6 +99,10 @@ export default function WordSpellingActivity({
   onComplete,
 }: WordSpellingActivityProps) {
   const { t } = useTranslation();
+  // Issue #716: 觸控裝置（手機 / 平板）改用 VirtualKeyboard，避免系統鍵盤的
+  // 「建議選字」讓學生直接點答案。桌機保留實體鍵盤。
+  const deviceMode = useInputDeviceMode();
+  const useVirtualKeyboard = deviceMode !== "desktop";
 
   // State
   const [loading, setLoading] = useState(true);
@@ -469,17 +483,31 @@ export default function WordSpellingActivity({
     }
   }, [currentIndex, words.length, timeLimit]);
 
-  // Issue #715: 上一題（只在正面顯示時可用）
-  const goToPrev = useCallback(() => {
-    if (currentIndex === 0) return;
-    setScoreOverlayOpen(false);
-    setCardFace("back");
-    setShowResult(false);
-    setTypedAnswer("");
-    setLastAttemptWrong(false);
-    if (timeLimit) setTimeRemaining(timeLimit);
-    setCurrentIndex(currentIndex - 1);
-  }, [currentIndex, timeLimit]);
+  // Issue #716: 移除「上一題」— 艾賓浩斯算法鼓勵把 10 題跑完，不回頭。
+
+  // Issue #716: VirtualKeyboard 輸入回調
+  const vkAppend = useCallback(
+    (ch: string) => {
+      const sanitized = sanitizeAnswer(ch);
+      if (!sanitized) return;
+      if (showResult && !isCorrect) setShowResult(false);
+      setTypedAnswer((prev) => prev + sanitized);
+    },
+    [showResult, isCorrect],
+  );
+  const vkBackspace = useCallback(() => {
+    if (showResult && !isCorrect) setShowResult(false);
+    setTypedAnswer((prev) => prev.slice(0, -1));
+  }, [showResult, isCorrect]);
+  const vkEnter = useCallback(() => {
+    // 卡正面（答對後）→ 下一題；卡背面 → 提交
+    if (cardFace === "front") {
+      advanceToNext();
+    } else if (!showResult && !submitting && typedAnswer.trim()) {
+      handleSubmitAnswer();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cardFace, showResult, submitting, typedAnswer, advanceToNext]);
 
   // ScoreOverlay 結束 → 關閉動畫，等學生用左右箭頭手動翻頁
   const handleOverlayComplete = () => {
@@ -702,7 +730,7 @@ export default function WordSpellingActivity({
   const currentWord = words[currentIndex];
 
   return (
-    <div className="space-y-6">
+    <div className={cn("space-y-6", deviceMode === "mobile" && "pb-72")}>
       {isPracticeMode && (
         <div className="flex items-center gap-2 text-sm text-blue-600 bg-blue-50 rounded-lg px-4 py-2">
           <BookOpen className="h-4 w-4" />
@@ -738,8 +766,14 @@ export default function WordSpellingActivity({
         />
       </div>
 
+      <div
+        className={cn(
+          deviceMode === "tablet" && "flex items-start gap-4",
+        )}
+      >
+        <div className={cn("min-w-0", deviceMode === "tablet" && "flex-[6]")}>
       <WordCard
-        viewMode="desktop"
+        viewMode={deviceMode === "mobile" ? "mobile" : "desktop"}
         face={cardFace}
         onFlipped={handleCardFlipped}
         word={currentWord.text}
@@ -753,9 +787,8 @@ export default function WordSpellingActivity({
         exampleSentenceAudioUrl={
           currentWord.example_sentence_audio_url ?? undefined
         }
-        hasPrev={cardFace === "front" && currentIndex > 0}
+        hasPrev={false}
         hasNext={cardFace === "front"}
-        onPrev={goToPrev}
         onNext={advanceToNext}
         back={
           <div className="relative space-y-6">
@@ -809,10 +842,18 @@ export default function WordSpellingActivity({
                 ref={inputRef}
                 type="text"
                 value={typedAnswer}
+                inputMode={useVirtualKeyboard ? "none" : "text"}
                 onChange={(e) => {
-                  setTypedAnswer(e.target.value);
-                  // Issue #716: 一打字立刻清除錯誤提示，不必按 Retry
+                  // Issue #716: 過濾非字母／連字號字元，順便擋住手機建議選字
+                  // 一次塞多字（建議選字 / 自動修正）→ 過濾後通常變空字串。
+                  setTypedAnswer(sanitizeAnswer(e.target.value));
                   if (showResult && !isCorrect) setShowResult(false);
+                }}
+                onBeforeInput={(e) => {
+                  const ev = e.nativeEvent as InputEvent;
+                  if (ev.inputType === "insertReplacementText") {
+                    e.preventDefault();
+                  }
                 }}
                 onKeyDown={handleKeyDown}
                 onPaste={(e) => e.preventDefault()}
@@ -863,6 +904,26 @@ export default function WordSpellingActivity({
           </div>
         }
       />
+        </div>
+        {deviceMode === "tablet" && (
+          <div className="flex-[4] min-w-0">
+            <VirtualKeyboard
+              onKey={vkAppend}
+              onBackspace={vkBackspace}
+              onEnter={vkEnter}
+            />
+          </div>
+        )}
+      </div>
+
+      {deviceMode === "mobile" && (
+        <VirtualKeyboard
+          onKey={vkAppend}
+          onBackspace={vkBackspace}
+          onEnter={vkEnter}
+          className="fixed bottom-0 left-0 right-0 z-50 border-t shadow-2xl"
+        />
+      )}
 
       <ScoreOverlay
         open={scoreOverlayOpen}

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -28,8 +28,6 @@ import {
   Loader2,
   Volume2,
   CheckCircle,
-  XCircle,
-  Clock,
   Send,
   Keyboard,
   Trophy,
@@ -42,6 +40,7 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/lib/api";
 import ScoreOverlay from "./shared/ScoreOverlay";
+import CountdownRing from "./shared/CountdownRing";
 import { WordCard } from "./shared/WordCard";
 import { aggregateTierCounts, weightedMastery } from "./wordFamiliarity";
 
@@ -208,7 +207,6 @@ export default function WordSpellingActivity({
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
-  const [incorrectAnswer, setIncorrectAnswer] = useState<string | null>(null);
 
   // Start practice session — picks a round of 10 unfamiliar words
   const startPractice = useCallback(async () => {
@@ -409,7 +407,6 @@ export default function WordSpellingActivity({
       // Issue #715: 答對 → 翻面（不立刻顯示 ScoreOverlay）→ onFlipped 後才顯示
       setCardFace("front");
     } else {
-      setIncorrectAnswer(answer);
       setLastAttemptWrong(true);
       // Issue #716: 清空 input 讓正解 placeholder 露出來
       setTypedAnswer("");
@@ -462,7 +459,6 @@ export default function WordSpellingActivity({
     setCardFace("back");
     setShowResult(false);
     setTypedAnswer("");
-    setIncorrectAnswer(null);
     setLastAttemptWrong(false);
     if (timeLimit) setTimeRemaining(timeLimit);
 
@@ -480,7 +476,6 @@ export default function WordSpellingActivity({
     setCardFace("back");
     setShowResult(false);
     setTypedAnswer("");
-    setIncorrectAnswer(null);
     setLastAttemptWrong(false);
     if (timeLimit) setTimeRemaining(timeLimit);
     setCurrentIndex(currentIndex - 1);
@@ -802,30 +797,7 @@ export default function WordSpellingActivity({
 
             {timeLimit && timeRemaining !== null && (
               <div className="flex justify-center">
-                <div
-                  className={cn(
-                    "flex items-center gap-2 px-4 py-2 rounded-full text-lg font-medium",
-                    timeRemaining === 0
-                      ? "bg-red-100 text-red-700"
-                      : timeRemaining <= 5
-                        ? "bg-red-100 text-red-700"
-                        : timeRemaining <= 10
-                          ? "bg-yellow-100 text-yellow-700"
-                          : "bg-gray-100 text-gray-700",
-                  )}
-                >
-                  <Clock className="h-5 w-5" />
-                  {timeRemaining === 0 ? (
-                    <span>{t("wordSpelling.timeUp") || "Time's up!"}</span>
-                  ) : (
-                    <>
-                      <span>{timeRemaining}</span>
-                      <span className="text-sm">
-                        {t("wordSpelling.seconds") || "s"}
-                      </span>
-                    </>
-                  )}
-                </div>
+                <CountdownRing seconds={timeRemaining} total={timeLimit} />
               </div>
             )}
 
@@ -865,19 +837,6 @@ export default function WordSpellingActivity({
                 autoCorrect="off"
                 spellCheck={false}
               />
-
-              {showResult && !isCorrect && (
-                <div className="flex items-center justify-center gap-2 text-red-600">
-                  <XCircle className="h-5 w-5" />
-                  <span className="font-medium">
-                    {incorrectAnswer
-                      ? t("wordSpelling.incorrectTryAgain") ||
-                        "Incorrect, try again!"
-                      : t("wordSpelling.timeUpTryAgain") ||
-                        "Time's up! Try again."}
-                  </span>
-                </div>
-              )}
 
               {!(showResult && isCorrect) && (
                 <Button

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -867,7 +867,7 @@ export default function WordSpellingActivity({
                 disabled={(showResult && isCorrect) || submitting}
                 className={cn(
                   "text-center text-2xl h-14 pl-10 pr-10 bg-transparent shadow-none rounded-none border-0 border-b-2 transition-colors",
-                  "focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
+                  "placeholder:text-base focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none",
                   showResult && isCorrect && "border-green-500 text-green-700",
                   showResult &&
                     !isCorrect &&

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -768,7 +768,7 @@ export default function WordSpellingActivity({
 
       <div
         className={cn(
-          deviceMode === "tablet" && "flex items-start gap-4",
+          deviceMode === "tablet" && "flex items-stretch gap-4",
         )}
       >
         <div className={cn("min-w-0", deviceMode === "tablet" && "flex-[6]")}>
@@ -908,7 +908,9 @@ export default function WordSpellingActivity({
         {useVirtualKeyboard && (
           <div
             className={cn(
-              deviceMode === "tablet" ? "flex-[4] min-w-0" : "mt-3",
+              deviceMode === "tablet"
+                ? "flex-[4] min-w-0 flex flex-col justify-center"
+                : "mt-3",
             )}
           >
             <VirtualKeyboard

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -46,9 +46,9 @@ import { WordCard } from "./shared/WordCard";
 import { useInputDeviceMode } from "@/hooks/useInputDeviceMode";
 import { aggregateTierCounts, weightedMastery } from "./wordFamiliarity";
 
-// Issue #716: Spelling/cloze 答案只允許英文字母與連字號；其它（注音、
+// Issue #716: 答案允許英文字母、連字號、空格（"United States"）；其它（注音、
 // 數字、Emoji、貼上的多字元）一律過濾掉，順便擋住手機輸入法的建議選字。
-const ALLOWED_CHAR = /[a-zA-Z-]/;
+const ALLOWED_CHAR = /[a-zA-Z\- ]/;
 const sanitizeAnswer = (raw: string) =>
   Array.from(raw)
     .filter((c) => ALLOWED_CHAR.test(c))

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -730,7 +730,7 @@ export default function WordSpellingActivity({
   const currentWord = words[currentIndex];
 
   return (
-    <div className={cn("space-y-6", deviceMode === "mobile" && "pb-72")}>
+    <div className="space-y-6">
       {isPracticeMode && (
         <div className="flex items-center gap-2 text-sm text-blue-600 bg-blue-50 rounded-lg px-4 py-2">
           <BookOpen className="h-4 w-4" />
@@ -905,8 +905,12 @@ export default function WordSpellingActivity({
         }
       />
         </div>
-        {deviceMode === "tablet" && (
-          <div className="flex-[4] min-w-0">
+        {useVirtualKeyboard && (
+          <div
+            className={cn(
+              deviceMode === "tablet" ? "flex-[4] min-w-0" : "mt-3",
+            )}
+          >
             <VirtualKeyboard
               onKey={vkAppend}
               onBackspace={vkBackspace}
@@ -915,15 +919,6 @@ export default function WordSpellingActivity({
           </div>
         )}
       </div>
-
-      {deviceMode === "mobile" && (
-        <VirtualKeyboard
-          onKey={vkAppend}
-          onBackspace={vkBackspace}
-          onEnter={vkEnter}
-          className="fixed bottom-0 left-0 right-0 z-50 border-t shadow-2xl"
-        />
-      )}
 
       <ScoreOverlay
         open={scoreOverlayOpen}

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -114,6 +114,8 @@ export default function WordSpellingActivity({
   // audio button becomes the primary hint, so make it visually prominent.
   const [audioOnlyMode, setAudioOnlyMode] = useState(false);
   const [showAnswerOnWrong, setShowAnswerOnWrong] = useState(false);
+  // Issue #716: 答錯後改用 placeholder 顯示正解，需要記錄上一次是否答錯
+  const [lastAttemptWrong, setLastAttemptWrong] = useState(false);
 
   // Proficiency
   const [proficiency, setProficiency] = useState<ProficiencyStatus>({
@@ -336,9 +338,11 @@ export default function WordSpellingActivity({
     }
   }, [words, currentIndex]);
 
-  // Auto-play audio once per new question (audio is the spelling hint)
+  // Auto-play audio once per new question (audio is the spelling hint).
+  // Issue #716: 僅 Play Audio (audioOnlyMode) 子模式播放；Display Translation 不播。
   useEffect(() => {
     if (
+      audioOnlyMode &&
       words[currentIndex]?.audio_url &&
       !showResult &&
       !roundCompleted &&
@@ -347,7 +351,7 @@ export default function WordSpellingActivity({
       playWordAudio();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentIndex, words.length, roundCompleted, loading]);
+  }, [currentIndex, words.length, roundCompleted, loading, audioOnlyMode]);
 
   // Timer
   useEffect(() => {
@@ -390,11 +394,11 @@ export default function WordSpellingActivity({
 
     const currentWord = words[currentIndex];
     const answer = isTimeout ? "" : typedAnswer.trim();
-    const expected = (currentWord.text || "").trim().toLowerCase();
+    // Issue #716: 答案區分大小寫，僅 trim
+    const expected = (currentWord.text || "").trim();
     // Defensive: if the backend somehow sent an empty word, treat as
     // incorrect rather than letting "" === "" mark every answer correct.
-    const correct =
-      !isTimeout && expected.length > 0 && answer.toLowerCase() === expected;
+    const correct = !isTimeout && expected.length > 0 && answer === expected;
 
     setIsCorrect(correct);
     setShowResult(true);
@@ -402,10 +406,12 @@ export default function WordSpellingActivity({
 
     if (correct) {
       setCorrectCount((prev) => prev + 1);
+      setLastAttemptWrong(false);
       // Issue #715: 答對 → 翻面（不立刻顯示 ScoreOverlay）→ onFlipped 後才顯示
       setCardFace("front");
     } else {
       setIncorrectAnswer(answer);
+      setLastAttemptWrong(true);
     }
 
     // Preview/demo: track local counts so the tier breakdown matches live mode.
@@ -456,6 +462,7 @@ export default function WordSpellingActivity({
     setShowResult(false);
     setTypedAnswer("");
     setIncorrectAnswer(null);
+    setLastAttemptWrong(false);
     if (timeLimit) setTimeRemaining(timeLimit);
 
     if (currentIndex < words.length - 1) {
@@ -473,6 +480,7 @@ export default function WordSpellingActivity({
     setShowResult(false);
     setTypedAnswer("");
     setIncorrectAnswer(null);
+    setLastAttemptWrong(false);
     if (timeLimit) setTimeRemaining(timeLimit);
     setCurrentIndex(currentIndex - 1);
   }, [currentIndex, timeLimit]);
@@ -749,13 +757,15 @@ export default function WordSpellingActivity({
         word={currentWord.text}
         partOfSpeech={currentWord.part_of_speech ?? undefined}
         translation={currentWord.translation || undefined}
-        audioUrl={currentWord.audio_url}
+        audioUrl={audioOnlyMode ? currentWord.audio_url : undefined}
         exampleSentence={currentWord.example_sentence ?? undefined}
         exampleSentenceTranslation={
           currentWord.example_sentence_translation ?? undefined
         }
         exampleSentenceAudioUrl={
-          currentWord.example_sentence_audio_url ?? undefined
+          audioOnlyMode
+            ? (currentWord.example_sentence_audio_url ?? undefined)
+            : undefined
         }
         hasPrev={cardFace === "front" && currentIndex > 0}
         hasNext={cardFace === "front"}
@@ -774,32 +784,23 @@ export default function WordSpellingActivity({
               </div>
             )}
 
-            {currentWord.audio_url && (
+            {/* Issue #716: 音檔功能僅在 Play Audio 模式出現；同時移除重複的 "Type the correct spelling" 標語 */}
+            {audioOnlyMode && currentWord.audio_url && (
               <div className="flex flex-col items-center gap-2">
                 <Button
-                  variant={audioOnlyMode ? "default" : "outline"}
+                  variant="default"
                   size="lg"
                   onClick={playWordAudio}
-                  className={cn(
-                    "gap-2",
-                    audioOnlyMode &&
-                      "h-16 px-8 text-lg bg-blue-600 hover:bg-blue-700 text-white shadow-lg",
-                  )}
+                  className="gap-2 h-16 px-8 text-lg bg-blue-600 hover:bg-blue-700 text-white shadow-lg"
                 >
-                  <Volume2 className={audioOnlyMode ? "h-7 w-7" : "h-5 w-5"} />
+                  <Volume2 className="h-7 w-7" />
                   {t("wordSpelling.playAudio") || "Play Audio"}
                 </Button>
-                {audioOnlyMode && (
-                  <p className="text-xs text-gray-500">
-                    {t("wordSpelling.tapToReplay") || "點擊播放，可以重複聆聽"}
-                  </p>
-                )}
+                <p className="text-xs text-gray-500">
+                  {t("wordSpelling.tapToReplay") || "點擊播放，可以重複聆聽"}
+                </p>
               </div>
             )}
-
-            <div className="text-center text-gray-600">
-              {t("wordSpelling.typeTheWord") || "Type the correct spelling:"}
-            </div>
 
             {timeLimit && timeRemaining !== null && (
               <div className="flex justify-center">
@@ -837,8 +838,13 @@ export default function WordSpellingActivity({
                 value={typedAnswer}
                 onChange={(e) => setTypedAnswer(e.target.value)}
                 onKeyDown={handleKeyDown}
+                onPaste={(e) => e.preventDefault()}
+                onDrop={(e) => e.preventDefault()}
                 placeholder={
-                  t("wordSpelling.inputPlaceholder") || "Type the word here..."
+                  showAnswerOnWrong && lastAttemptWrong && currentWord.text
+                    ? currentWord.text
+                    : t("wordSpelling.inputPlaceholder") ||
+                      "Type the word here..."
                 }
                 disabled={showResult || submitting}
                 className={cn(
@@ -865,12 +871,6 @@ export default function WordSpellingActivity({
                           "Time's up! Try again."}
                     </span>
                   </div>
-                  {showAnswerOnWrong && currentWord.text && (
-                    <p className="text-sm text-gray-700">
-                      {t("wordSpelling.correctAnswerLabel") || "正確答案"}:{" "}
-                      <span className="font-bold">{currentWord.text}</span>
-                    </p>
-                  )}
                   <Button
                     onClick={handleRetry}
                     variant="outline"

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -770,9 +770,14 @@ export default function WordSpellingActivity({
                   {currentWord.translation}
                 </h2>
                 {currentWord.part_of_speech && (
-                  <p className="text-sm italic text-gray-500">
-                    {currentWord.part_of_speech}
-                  </p>
+                  <div className="flex justify-center">
+                    <Badge
+                      variant="secondary"
+                      className="bg-gray-200 text-gray-700 hover:bg-gray-200 font-normal"
+                    >
+                      {currentWord.part_of_speech}
+                    </Badge>
+                  </div>
                 )}
               </div>
             )}

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -31,7 +31,6 @@ import {
   XCircle,
   Clock,
   Send,
-  RotateCcw,
   Keyboard,
   Trophy,
   RefreshCw,
@@ -492,14 +491,6 @@ export default function WordSpellingActivity({
     setScoreOverlayOpen(false);
   };
 
-  const handleRetry = () => {
-    setShowResult(false);
-    setTypedAnswer("");
-    setIncorrectAnswer(null);
-    if (timeLimit) setTimeRemaining(timeLimit);
-    inputRef.current?.focus();
-  };
-
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !showResult && !submitting && typedAnswer.trim()) {
       handleSubmitAnswer();
@@ -836,7 +827,11 @@ export default function WordSpellingActivity({
                 ref={inputRef}
                 type="text"
                 value={typedAnswer}
-                onChange={(e) => setTypedAnswer(e.target.value)}
+                onChange={(e) => {
+                  setTypedAnswer(e.target.value);
+                  // Issue #716: 一打字立刻清除錯誤提示，不必按 Retry
+                  if (showResult && !isCorrect) setShowResult(false);
+                }}
                 onKeyDown={handleKeyDown}
                 onPaste={(e) => e.preventDefault()}
                 onDrop={(e) => e.preventDefault()}
@@ -846,7 +841,7 @@ export default function WordSpellingActivity({
                     : t("wordSpelling.inputPlaceholder") ||
                       "Type the word here..."
                 }
-                disabled={showResult || submitting}
+                disabled={(showResult && isCorrect) || submitting}
                 className={cn(
                   "text-center text-xl h-14 rounded-xl border-2",
                   showResult && isCorrect && "border-green-500 bg-green-50",
@@ -860,29 +855,19 @@ export default function WordSpellingActivity({
               />
 
               {showResult && !isCorrect && (
-                <div className="text-center space-y-2">
-                  <div className="flex items-center justify-center gap-2 text-red-600">
-                    <XCircle className="h-5 w-5" />
-                    <span className="font-medium">
-                      {incorrectAnswer
-                        ? t("wordSpelling.incorrectTryAgain") ||
-                          "Incorrect, try again!"
-                        : t("wordSpelling.timeUpTryAgain") ||
-                          "Time's up! Try again."}
-                    </span>
-                  </div>
-                  <Button
-                    onClick={handleRetry}
-                    variant="outline"
-                    className="gap-2"
-                  >
-                    <RotateCcw className="h-4 w-4" />
-                    {t("wordSpelling.retry") || "Retry"}
-                  </Button>
+                <div className="flex items-center justify-center gap-2 text-red-600">
+                  <XCircle className="h-5 w-5" />
+                  <span className="font-medium">
+                    {incorrectAnswer
+                      ? t("wordSpelling.incorrectTryAgain") ||
+                        "Incorrect, try again!"
+                      : t("wordSpelling.timeUpTryAgain") ||
+                        "Time's up! Try again."}
+                  </span>
                 </div>
               )}
 
-              {!showResult && (
+              {!(showResult && isCorrect) && (
                 <Button
                   onClick={() => handleSubmitAnswer()}
                   disabled={!typedAnswer.trim() || submitting}

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -765,10 +765,15 @@ export default function WordSpellingActivity({
         back={
           <div className="space-y-6">
             {showTranslation && currentWord.translation && (
-              <div className="text-center py-4">
-                <h2 className="text-4xl md:text-5xl font-bold text-gray-800 tracking-wide">
+              <div className="text-center py-3 space-y-1">
+                <h2 className="text-3xl md:text-4xl font-bold text-gray-800 tracking-wide">
                   {currentWord.translation}
                 </h2>
+                {currentWord.part_of_speech && (
+                  <p className="text-sm italic text-gray-500">
+                    {currentWord.part_of_speech}
+                  </p>
+                )}
               </div>
             )}
 

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -520,6 +520,9 @@ export default function WordSpellingActivity({
     if (deviceMode !== "desktop" || roundCompleted || loading) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Enter") return;
+      // Issue #716: 過濾按住 Enter 的 auto-repeat，避免一次連續觸發
+      // 「送出 → 翻面 → 立刻下一題」造成卡片沒看到。
+      if (e.repeat) return;
       if (cardFace === "front") {
         e.preventDefault();
         advanceToNext();

--- a/frontend/src/components/activities/shared/CountdownRing.tsx
+++ b/frontend/src/components/activities/shared/CountdownRing.tsx
@@ -1,0 +1,90 @@
+/**
+ * CountdownRing - circular countdown indicator for timed activities.
+ *
+ * Compact 48px ring: SVG stroke shrinks as time elapses, colour shifts
+ * gray → yellow (≤10s) → red (≤5s), and the ring pulses in the red zone.
+ */
+
+import { cn } from "@/lib/utils";
+
+interface CountdownRingProps {
+  /** Current seconds remaining. 0 displays "0". */
+  seconds: number;
+  /** Original time budget for this question (controls progress). */
+  total: number;
+  className?: string;
+}
+
+const SIZE = 48;
+const STROKE = 4;
+const RADIUS = (SIZE - STROKE) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+export default function CountdownRing({
+  seconds,
+  total,
+  className,
+}: CountdownRingProps) {
+  const ratio = total > 0 ? Math.max(0, Math.min(1, seconds / total)) : 0;
+  const dashOffset = CIRCUMFERENCE * (1 - ratio);
+
+  const danger = seconds <= 5;
+  const warn = !danger && seconds <= 10;
+
+  const stroke = danger
+    ? "stroke-red-500"
+    : warn
+      ? "stroke-yellow-500"
+      : "stroke-indigo-500";
+  const text = danger
+    ? "text-red-600"
+    : warn
+      ? "text-yellow-700"
+      : "text-gray-700";
+
+  return (
+    <div
+      className={cn(
+        "relative inline-flex items-center justify-center",
+        danger && "animate-pulse",
+        className,
+      )}
+      style={{ width: SIZE, height: SIZE }}
+      aria-label={`${seconds} seconds remaining`}
+      role="timer"
+    >
+      <svg
+        width={SIZE}
+        height={SIZE}
+        className="-rotate-90"
+        viewBox={`0 0 ${SIZE} ${SIZE}`}
+      >
+        <circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          strokeWidth={STROKE}
+          className="stroke-gray-200 fill-none"
+        />
+        <circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          strokeWidth={STROKE}
+          strokeLinecap="round"
+          className={cn("fill-none transition-all duration-500", stroke)}
+          strokeDasharray={CIRCUMFERENCE}
+          strokeDashoffset={dashOffset}
+        />
+      </svg>
+      <span
+        className={cn(
+          "absolute text-sm font-semibold tabular-nums",
+          text,
+        )}
+      >
+        {seconds}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/activities/shared/CountdownRing.tsx
+++ b/frontend/src/components/activities/shared/CountdownRing.tsx
@@ -1,22 +1,26 @@
 /**
- * CountdownRing - circular countdown indicator for timed activities.
+ * CountdownRing - compact circular countdown for timed activities.
  *
- * Compact 48px ring: SVG stroke shrinks as time elapses, colour shifts
- * gray → yellow (≤10s) → red (≤5s), and the ring pulses in the red zone.
+ * The SVG stroke is drained via a CSS keyframe that runs for the full
+ * `total` duration (smooth linear motion, independent of React's 1Hz
+ * timer ticks). Colour shifts gray → yellow (≤10s) → red+pulse (≤5s).
+ *
+ * Caller is responsible for remounting (e.g. `key={questionIndex}`) so the
+ * keyframe restarts on a new question.
  */
 
 import { cn } from "@/lib/utils";
 
 interface CountdownRingProps {
-  /** Current seconds remaining. 0 displays "0". */
+  /** Current seconds remaining (drives the centre label + colour). */
   seconds: number;
-  /** Original time budget for this question (controls progress). */
+  /** Original time budget for this question (drives animation length). */
   total: number;
   className?: string;
 }
 
-const SIZE = 48;
-const STROKE = 4;
+const SIZE = 36;
+const STROKE = 3;
 const RADIUS = (SIZE - STROKE) / 2;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
@@ -25,9 +29,6 @@ export default function CountdownRing({
   total,
   className,
 }: CountdownRingProps) {
-  const ratio = total > 0 ? Math.max(0, Math.min(1, seconds / total)) : 0;
-  const dashOffset = CIRCUMFERENCE * (1 - ratio);
-
   const danger = seconds <= 5;
   const warn = !danger && seconds <= 10;
 
@@ -72,14 +73,19 @@ export default function CountdownRing({
           r={RADIUS}
           strokeWidth={STROKE}
           strokeLinecap="round"
-          className={cn("fill-none transition-all duration-500", stroke)}
           strokeDasharray={CIRCUMFERENCE}
-          strokeDashoffset={dashOffset}
+          className={cn("fill-none countdown-drain", stroke)}
+          style={
+            {
+              "--countdown-circ": `${CIRCUMFERENCE}px`,
+              animationDuration: `${total}s`,
+            } as React.CSSProperties
+          }
         />
       </svg>
       <span
         className={cn(
-          "absolute text-sm font-semibold tabular-nums",
+          "absolute text-xs font-semibold tabular-nums",
           text,
         )}
       >

--- a/frontend/src/components/activities/shared/CountdownRing.tsx
+++ b/frontend/src/components/activities/shared/CountdownRing.tsx
@@ -83,12 +83,7 @@ export default function CountdownRing({
           }
         />
       </svg>
-      <span
-        className={cn(
-          "absolute text-xs font-semibold tabular-nums",
-          text,
-        )}
-      >
+      <span className={cn("absolute text-xs font-semibold tabular-nums", text)}>
         {seconds}
       </span>
     </div>

--- a/frontend/src/components/activities/shared/VirtualKeyboard.tsx
+++ b/frontend/src/components/activities/shared/VirtualKeyboard.tsx
@@ -1,0 +1,83 @@
+/**
+ * VirtualKeyboard - on-screen QWERTY for spelling/cloze on touch devices.
+ *
+ * Why this exists: phones/tablets show a system-keyboard suggestion bar
+ * that lets students tap the answer instead of spelling it. Suppressing
+ * the system keyboard (`inputMode="none"` on the <input>) plus driving
+ * input from this component closes that loophole.
+ *
+ * Layout: QWERTY rows + shift + backspace + enter. Letters only — no
+ * digits, no symbols (caller-specified scope). Holds its own `shifted`
+ * state; a tap on a letter auto-releases shift (one-shot capitalisation).
+ *
+ * The component is layout-agnostic: caller positions it (mobile = fixed
+ * bottom overlay, tablet = right-side panel).
+ */
+
+import { useState } from "react";
+import Keyboard from "react-simple-keyboard";
+import "react-simple-keyboard/build/css/index.css";
+import { cn } from "@/lib/utils";
+
+interface VirtualKeyboardProps {
+  onKey: (char: string) => void;
+  onBackspace: () => void;
+  onEnter: () => void;
+  className?: string;
+}
+
+const LAYOUT = {
+  default: ["q w e r t y u i o p", "a s d f g h j k l", "{shift} z x c v b n m {bksp}", "{enter}"],
+  shift: ["Q W E R T Y U I O P", "A S D F G H J K L", "{shift} Z X C V B N M {bksp}", "{enter}"],
+};
+
+const DISPLAY = {
+  "{shift}": "⇧",
+  "{bksp}": "⌫",
+  "{enter}": "Enter",
+};
+
+export default function VirtualKeyboard({
+  onKey,
+  onBackspace,
+  onEnter,
+  className,
+}: VirtualKeyboardProps) {
+  const [shifted, setShifted] = useState(false);
+
+  const handleKeyPress = (button: string) => {
+    if (button === "{shift}") {
+      setShifted((s) => !s);
+      return;
+    }
+    if (button === "{bksp}") {
+      onBackspace();
+      return;
+    }
+    if (button === "{enter}") {
+      onEnter();
+      return;
+    }
+    onKey(button);
+    if (shifted) setShifted(false);
+  };
+
+  return (
+    <div className={cn("vk-wrapper bg-white p-2 rounded-md", className)}>
+      <Keyboard
+        layoutName={shifted ? "shift" : "default"}
+        layout={LAYOUT}
+        display={DISPLAY}
+        onKeyPress={handleKeyPress}
+        physicalKeyboardHighlight={false}
+        preventMouseDownDefault
+        buttonTheme={[
+          {
+            class: "vk-shift",
+            buttons: "{shift}",
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/activities/shared/VirtualKeyboard.tsx
+++ b/frontend/src/components/activities/shared/VirtualKeyboard.tsx
@@ -82,10 +82,9 @@ export default function VirtualKeyboard({
         physicalKeyboardHighlight={false}
         preventMouseDownDefault
         buttonTheme={[
-          {
-            class: "vk-shift",
-            buttons: "{shift}",
-          },
+          { class: "vk-shift", buttons: "{shift}" },
+          // Issue #716: 母音用紅色標示（教學常用標法）
+          { class: "vk-vowel", buttons: "a e i o u A E I O U" },
         ]}
       />
     </div>

--- a/frontend/src/components/activities/shared/VirtualKeyboard.tsx
+++ b/frontend/src/components/activities/shared/VirtualKeyboard.tsx
@@ -47,7 +47,7 @@ const DISPLAY = {
   "{shift}": "⇧",
   "{bksp}": "⌫",
   "{enter}": "Enter",
-  "{space}": " ",
+  "{space}": "Space",
 };
 
 export default function VirtualKeyboard({

--- a/frontend/src/components/activities/shared/VirtualKeyboard.tsx
+++ b/frontend/src/components/activities/shared/VirtualKeyboard.tsx
@@ -26,18 +26,20 @@ interface VirtualKeyboardProps {
   className?: string;
 }
 
-// Layout B (mobile-style): Enter sits on the bottom utility row, not on
-// its own line — matches how iOS/Gboard place return alongside shift/bksp.
+// Layout B (mobile-style): bottom utility row carries shift / bksp; a
+// dedicated 4th row holds space + Enter the way iOS / Gboard do it.
 const LAYOUT = {
   default: [
     "q w e r t y u i o p",
     "a s d f g h j k l",
-    "{shift} z x c v b n m {bksp} {enter}",
+    "{shift} z x c v b n m {bksp}",
+    "{space} {enter}",
   ],
   shift: [
     "Q W E R T Y U I O P",
     "A S D F G H J K L",
-    "{shift} Z X C V B N M {bksp} {enter}",
+    "{shift} Z X C V B N M {bksp}",
+    "{space} {enter}",
   ],
 };
 
@@ -45,6 +47,7 @@ const DISPLAY = {
   "{shift}": "⇧",
   "{bksp}": "⌫",
   "{enter}": "Enter",
+  "{space}": " ",
 };
 
 export default function VirtualKeyboard({
@@ -66,6 +69,11 @@ export default function VirtualKeyboard({
     }
     if (button === "{enter}") {
       onEnter();
+      return;
+    }
+    if (button === "{space}") {
+      onKey(" ");
+      if (shifted) setShifted(false);
       return;
     }
     onKey(button);

--- a/frontend/src/components/activities/shared/VirtualKeyboard.tsx
+++ b/frontend/src/components/activities/shared/VirtualKeyboard.tsx
@@ -26,9 +26,19 @@ interface VirtualKeyboardProps {
   className?: string;
 }
 
+// Layout B (mobile-style): Enter sits on the bottom utility row, not on
+// its own line — matches how iOS/Gboard place return alongside shift/bksp.
 const LAYOUT = {
-  default: ["q w e r t y u i o p", "a s d f g h j k l", "{shift} z x c v b n m {bksp}", "{enter}"],
-  shift: ["Q W E R T Y U I O P", "A S D F G H J K L", "{shift} Z X C V B N M {bksp}", "{enter}"],
+  default: [
+    "q w e r t y u i o p",
+    "a s d f g h j k l",
+    "{shift} z x c v b n m {bksp} {enter}",
+  ],
+  shift: [
+    "Q W E R T Y U I O P",
+    "A S D F G H J K L",
+    "{shift} Z X C V B N M {bksp} {enter}",
+  ],
 };
 
 const DISPLAY = {

--- a/frontend/src/components/activities/shared/WordCard.tsx
+++ b/frontend/src/components/activities/shared/WordCard.tsx
@@ -184,9 +184,8 @@ function NavArrow({
       className={cn(
         "absolute top-1/2 -translate-y-1/2 z-10",
         "flex items-center justify-center",
-        "h-10 w-10 md:h-12 md:w-12 rounded-full",
-        "bg-white/90 hover:bg-white border border-gray-200 shadow-md",
-        "text-gray-600 hover:text-gray-900 transition-colors",
+        "h-10 w-10 md:h-12 md:w-12",
+        "text-gray-400 hover:text-gray-700 transition-colors",
         isPrev ? "left-2 md:-left-6" : "right-2 md:-right-6",
       )}
     >

--- a/frontend/src/components/activities/shared/WordCard.tsx
+++ b/frontend/src/components/activities/shared/WordCard.tsx
@@ -315,8 +315,11 @@ function WordCardFront({
 
       <CardContent
         className={cn(
-          "flex-1 p-6 select-none flex flex-col justify-center",
-          viewMode === "desktop" && showImage && "p-8",
+          // Issue #716 (mobile): prev/next arrows live inside the card at
+          // left-2/right-2 (each 40px wide), so reserve >=48px horizontal
+          // gutter for content. Desktop pushes arrows outside via -left-6.
+          "flex-1 py-6 px-14 md:p-6 select-none flex flex-col justify-center",
+          viewMode === "desktop" && showImage && "md:p-8",
         )}
       >
         {/* 單字區（區塊置中、內容左對齊） */}

--- a/frontend/src/components/activities/shared/WordCard.tsx
+++ b/frontend/src/components/activities/shared/WordCard.tsx
@@ -186,7 +186,7 @@ function NavArrow({
         "flex items-center justify-center",
         "h-10 w-10 md:h-12 md:w-12",
         "text-gray-400 hover:text-gray-700 transition-colors",
-        isPrev ? "left-2" : "right-2",
+        isPrev ? "left-1" : "right-1",
       )}
     >
       {isPrev ? (
@@ -314,10 +314,10 @@ function WordCardFront({
 
       <CardContent
         className={cn(
-          // Issue #716 (mobile): prev/next arrows live inside the card at
-          // left-2/right-2 (each 40px wide), so reserve >=48px horizontal
-          // gutter for content. Desktop pushes arrows outside via -left-6.
-          "flex-1 py-6 px-14 md:p-6 select-none flex flex-col justify-center",
+          // Issue #716: only the right (next) arrow remains, so use an
+          // asymmetric gutter — small on the left, big enough on the right
+          // to clear the 40px arrow button sitting at right-1.
+          "flex-1 py-6 pl-4 pr-12 md:py-6 md:pl-6 md:pr-14 select-none flex flex-col justify-center",
           viewMode === "desktop" && showImage && "md:p-8",
         )}
       >

--- a/frontend/src/components/activities/shared/WordCard.tsx
+++ b/frontend/src/components/activities/shared/WordCard.tsx
@@ -186,7 +186,7 @@ function NavArrow({
         "flex items-center justify-center",
         "h-10 w-10 md:h-12 md:w-12",
         "text-gray-400 hover:text-gray-700 transition-colors",
-        isPrev ? "left-2 md:-left-6" : "right-2 md:-right-6",
+        isPrev ? "left-2" : "right-2",
       )}
     >
       {isPrev ? (

--- a/frontend/src/components/activities/shared/WordCard.tsx
+++ b/frontend/src/components/activities/shared/WordCard.tsx
@@ -186,7 +186,7 @@ function NavArrow({
         "flex items-center justify-center",
         "h-10 w-10 md:h-12 md:w-12",
         "text-gray-400 hover:text-gray-700 transition-colors",
-        isPrev ? "left-1" : "right-1",
+        isPrev ? "left-0" : "right-0",
       )}
     >
       {isPrev ? (
@@ -317,7 +317,7 @@ function WordCardFront({
           // Issue #716: only the right (next) arrow remains, so use an
           // asymmetric gutter — small on the left, big enough on the right
           // to clear the 40px arrow button sitting at right-1.
-          "flex-1 py-6 pl-4 pr-12 md:py-6 md:pl-6 md:pr-14 select-none flex flex-col justify-center",
+          "flex-1 py-6 pl-6 pr-12 md:py-6 md:pl-8 md:pr-14 select-none flex flex-col justify-center",
           viewMode === "desktop" && showImage && "md:p-8",
         )}
       >

--- a/frontend/src/hooks/useInputDeviceMode.ts
+++ b/frontend/src/hooks/useInputDeviceMode.ts
@@ -1,0 +1,51 @@
+/**
+ * useInputDeviceMode - distinguish desktop / mobile / tablet for input UX.
+ *
+ * Touch devices (phones, tablets) get a custom on-screen virtual keyboard
+ * because the system keyboard's suggestion bar lets students "cheat" on
+ * spelling/cloze activities. Desktops keep the native keyboard.
+ *
+ * Detection strategy (avoids UA sniffing):
+ *   isTouch  = (pointer: coarse) AND maxTouchPoints > 0
+ *   isTablet = viewport width >= 1024px
+ *
+ * Reactively updates on resize / pointer change so iPad rotation between
+ * portrait (mobile-ish) and landscape (tablet) switches modes correctly.
+ */
+
+import { useEffect, useState } from "react";
+
+export type InputDeviceMode = "desktop" | "mobile" | "tablet";
+
+const TABLET_BREAKPOINT = 1024;
+
+function detect(): InputDeviceMode {
+  if (typeof window === "undefined") return "desktop";
+  const coarse = window.matchMedia("(pointer: coarse)").matches;
+  const touchPoints = navigator.maxTouchPoints ?? 0;
+  const isTouch = coarse && touchPoints > 0;
+  if (!isTouch) return "desktop";
+  return window.innerWidth >= TABLET_BREAKPOINT ? "tablet" : "mobile";
+}
+
+export function useInputDeviceMode(): InputDeviceMode {
+  const [mode, setMode] = useState<InputDeviceMode>(detect);
+
+  useEffect(() => {
+    const update = () => setMode(detect());
+    const pointerMq = window.matchMedia("(pointer: coarse)");
+    const widthMq = window.matchMedia(`(min-width: ${TABLET_BREAKPOINT}px)`);
+    pointerMq.addEventListener("change", update);
+    widthMq.addEventListener("change", update);
+    window.addEventListener("resize", update);
+    window.addEventListener("orientationchange", update);
+    return () => {
+      pointerMq.removeEventListener("change", update);
+      widthMq.removeEventListener("change", update);
+      window.removeEventListener("resize", update);
+      window.removeEventListener("orientationchange", update);
+    };
+  }, []);
+
+  return mode;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -110,6 +110,19 @@ body {
   animation: slide-out-to-right 0.28s ease-in-out both;
 }
 
+/* Countdown ring: drain the stroke over the question's full duration.
+   The element sets `--countdown-circ` (circumference) and
+   `animation-duration` (total seconds) inline. */
+@keyframes countdown-drain {
+  from { stroke-dashoffset: 0; }
+  to { stroke-dashoffset: var(--countdown-circ); }
+}
+.countdown-drain {
+  animation-name: countdown-drain;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+}
+
 .bg-notebook {
   background-image: linear-gradient(to bottom, #e5e7eb 1px, transparent 1px);
   background-size: 100% 24px;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -110,6 +110,12 @@ body {
   animation: slide-out-to-right 0.28s ease-in-out both;
 }
 
+/* VirtualKeyboard: highlight vowels in red to mirror common teaching aids. */
+.simple-keyboard .hg-button.vk-vowel {
+  color: #dc2626; /* tailwind red-600 */
+  font-weight: 600;
+}
+
 /* Countdown ring: drain the stroke over the question's full duration.
    The element sets `--countdown-circ` (circumference) and
    `animation-duration` (total seconds) inline. */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -120,8 +120,12 @@ body {
    The element sets `--countdown-circ` (circumference) and
    `animation-duration` (total seconds) inline. */
 @keyframes countdown-drain {
-  from { stroke-dashoffset: 0; }
-  to { stroke-dashoffset: var(--countdown-circ); }
+  from {
+    stroke-dashoffset: 0;
+  }
+  to {
+    stroke-dashoffset: var(--countdown-circ);
+  }
 }
 .countdown-drain {
   animation-name: countdown-drain;


### PR DESCRIPTION
## Summary

關閉 #716 — 單字拼寫 / 單字克漏字拼寫作答畫面整體調整。

- 重做答錯顯示方式（placeholder 形式）、區分大小寫、禁止貼上
- 新增 CountdownRing / VirtualKeyboard / useInputDeviceMode 等共用元件
- 統一 spelling / cloze / selection / rearrangement 的計時 UI

## Test plan
- [x] Preview 環境測試通過（@myduotopia 已於 #716 留言 "測試通過"）
- [x] `✅ tested-in-staging` 標籤已加上
- [ ] 合併後在 staging 再驗證一次學生端 spelling / cloze 作答流程

🤖 Generated with [Claude Code](https://claude.com/claude-code)