### PR TITLE
chore(#723): add plans table migration + Plan model

### DIFF
--- a/backend/alembic/versions/20260513_1000_add_plans_table.py
+++ b/backend/alembic/versions/20260513_1000_add_plans_table.py
@@ -1,0 +1,83 @@
+"""Add plans table for admin-editable price/quota overrides
+
+Revision ID: 20260513_1000
+Revises: 20260509_1300
+Create Date: 2026-05-13 10:00:00
+
+Plan names remain code constants in `backend/config/plans.py`. This table
+stores per-plan overrides for `price` and `quota`, plus an `is_active`
+flag and ordering, so admins can adjust them from the admin console
+without a deploy.
+
+Migration is idempotent: safe to re-run.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "20260513_1000"
+down_revision: Union[str, None] = "20260509_1300"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create plans table (idempotent)
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS plans (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(100) NOT NULL UNIQUE,
+            price INTEGER,
+            quota INTEGER,
+            display_order INTEGER NOT NULL DEFAULT 0,
+            is_active BOOLEAN NOT NULL DEFAULT TRUE,
+            updated_by_admin_id INTEGER,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+
+    # Index on name (created automatically by UNIQUE, but make it explicit)
+    op.execute("CREATE INDEX IF NOT EXISTS ix_plans_name ON plans (name)")
+
+    # FK to teachers (admin who last edited). Created after table so the
+    # check works even if FK already exists.
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint WHERE conname = 'fk_plans_updated_by_admin'
+            ) THEN
+                ALTER TABLE plans
+                ADD CONSTRAINT fk_plans_updated_by_admin
+                FOREIGN KEY (updated_by_admin_id)
+                REFERENCES teachers(id) ON DELETE SET NULL;
+            END IF;
+        END $$;
+        """
+    )
+
+    # Seed default plans from config constants. ON CONFLICT keeps existing
+    # rows untouched so re-running won't overwrite admin edits.
+    op.execute(
+        """
+        INSERT INTO plans (name, price, quota, display_order, is_active)
+        VALUES
+            ('Free Trial', 0, 2000, 1, TRUE),
+            ('Tutor Teachers', 299, 2000, 2, TRUE),
+            ('School Teachers', 599, 6000, 3, TRUE),
+            ('Demo Unlimited Plan', 0, 999999, 4, TRUE),
+            ('VIP', 0, 0, 5, TRUE)
+        ON CONFLICT (name) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    # Intentional no-op: dropping the table would lose admin-edited values
+    # and break running services that read overrides via get_plan_price/quota.
+    pass

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -34,6 +34,9 @@ from .subscription import (
 # Credit package models
 from .credit_package import CreditPackage
 
+# Plan models (admin-editable price/quota overrides)
+from .plan import Plan
+
 # Organization models
 from .organization import (
     Organization,
@@ -103,6 +106,8 @@ __all__ = [
     "InvoiceStatusHistory",
     # Credit packages
     "CreditPackage",
+    # Plans
+    "Plan",
     # Organizations
     "Organization",
     "School",

--- a/backend/models/plan.py
+++ b/backend/models/plan.py
@@ -1,0 +1,59 @@
+"""
+Plan model - subscription plan price/quota overrides editable by admin.
+
+Plan names are still defined as code constants in `backend/config/plans.py`
+(consumers import PLAN_TUTOR, PLAN_SCHOOL, etc. by name). This table only
+overrides the numeric attributes (price, monthly quota, display order, active
+flag) so admins can adjust them without a deploy.
+
+Use `config.plans.get_plan_price(name)` and `get_plan_quota(name)` to read —
+those helpers prefer the DB row and fall back to the config constants.
+"""
+
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from database import Base
+
+
+class Plan(Base):
+    """訂閱方案 - 由管理員可調整價格／配額的設定"""
+
+    __tablename__ = "plans"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    # Matches `plan_name` strings used in code constants (PLAN_TUTOR etc.)
+    name = Column(String(100), nullable=False, unique=True, index=True)
+
+    # Monetary price (TWD per month). NULL means inherit config default.
+    price = Column(Integer, nullable=True)
+
+    # Monthly quota of points granted on subscription start.
+    quota = Column(Integer, nullable=True)
+
+    # Display order in admin UI / checkout list.
+    display_order = Column(Integer, nullable=False, default=0)
+
+    # Soft toggle. When false, plan is hidden from checkout (but existing
+    # subscriptions with this plan_name continue to work).
+    is_active = Column(Boolean, nullable=False, default=True)
+
+    # Audit
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+    updated_by_admin_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    updated_by = relationship("Teacher", foreign_keys=[updated_by_admin_id])
+
+    def __repr__(self):
+        return (
+            f"<Plan name={self.name} price={self.price} "
+            f"quota={self.quota} active={self.is_active}>"
+        )


### PR DESCRIPTION
## Summary
- Adds `plans` table via idempotent Alembic migration (`CREATE TABLE IF NOT EXISTS` + `ON CONFLICT DO NOTHING` seed of the 5 existing plan names).
- Adds matching `Plan` SQLAlchemy model with admin-editable fields (`price`, `quota`, `is_active`, `display_order`, audit columns).
- **Schema only** — no router / API / frontend. Lands the table first so the feature PR for #723 can rebase cleanly on top.

## Why split this out
The feature PR (admin Plans CRUD UI + `/api/admin/plans` router + helper refactors across subscription/cron/payment) is sizable. Landing the migration alone lets staging apply the schema change in isolation; the feature PR will be rebased onto staging after this merges.

## Migration safety
- `CREATE TABLE IF NOT EXISTS` — safe to re-run.
- FK to `teachers(id)` added via `DO $$ ... IF NOT EXISTS ...` pg_constraint check.
- Seed uses `ON CONFLICT (name) DO NOTHING` so existing rows are preserved on re-run.
- `downgrade()` is intentionally a no-op (dropping would lose admin-edited values).

## Test plan
- [ ] CI green on staging
- [ ] After merge, manually verify `\d plans` on staging Supabase shows the table with 5 seed rows
- [ ] Rebase `fix/issue-723-admin-blog-and-plan-crud` onto new staging head

Related to #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)