### PR TITLE
chore(#708): backfill assignments.score_category from practice_mode + play_audio

### DIFF
--- a/backend/alembic/versions/20260513_1700_backfill_score_category.py
+++ b/backend/alembic/versions/20260513_1700_backfill_score_category.py
@@ -1,0 +1,70 @@
+"""Backfill assignments.score_category from (practice_mode, play_audio).
+
+Issue #708 PR-1 (migration-only split).
+
+Previously score_category was an optional column callers could pass in
+(but almost no UI did), so most rows are NULL or wrong. From issue #708
+onwards the backend always sets it via
+utils.score_category.resolve_score_category(); this migration retro-fits
+every existing row to the same rule so the grade-report feature (PR-2)
+sees correct historical data.
+
+The migration is idempotent: re-running it yields the same result. It
+performs no schema change — only a data UPDATE — so it is safe to run on
+any environment that already has the score_category column (added by
+e263ed443762).
+
+Mapping (see docs/design/score-category-mapping.md, landing alongside the
+helper in the companion PR):
+  word_reading / reading        -> speaking (any audio)
+  word_cloze                    -> reading  (any audio)
+  rearrangement + audio off     -> reading
+  anything else + audio off     -> writing
+  anything else + audio on      -> listening
+
+Revision ID: 20260513_1700
+Revises: 20260513_1000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "20260513_1700"
+down_revision: Union[str, None] = "20260513_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Single UPDATE — PostgreSQL evaluates the CASE per row. We touch every
+    # row (not just NULLs) because existing non-NULL values include legacy
+    # 'vocabulary' and possibly stale manual choices that don't match the
+    # new rules. Running twice produces the same result.
+    op.execute(
+        """
+        UPDATE assignments
+        SET score_category = CASE
+            WHEN practice_mode IN ('word_reading', 'reading') THEN 'speaking'
+            WHEN practice_mode = 'word_cloze' THEN 'reading'
+            WHEN practice_mode = 'rearrangement' AND COALESCE(play_audio, FALSE) = FALSE THEN 'reading'
+            WHEN COALESCE(play_audio, FALSE) = TRUE THEN 'listening'
+            ELSE 'writing'
+        END
+        WHERE score_category IS DISTINCT FROM (
+            CASE
+                WHEN practice_mode IN ('word_reading', 'reading') THEN 'speaking'
+                WHEN practice_mode = 'word_cloze' THEN 'reading'
+                WHEN practice_mode = 'rearrangement' AND COALESCE(play_audio, FALSE) = FALSE THEN 'reading'
+                WHEN COALESCE(play_audio, FALSE) = TRUE THEN 'listening'
+                ELSE 'writing'
+            END
+        );
+        """
+    )
+
+
+def downgrade() -> None:
+    # Data-only migration; no schema to revert. Reverting the data would
+    # require knowing the prior per-row value, which we don't store.
+    pass


### PR DESCRIPTION
## Summary

Issue #708 splits into two parts:

- **This PR (PR-1a)** — data migration only. Recomputes `assignments.score_category` for every existing row using the new (practice_mode, play_audio) -> category mapping, so the upcoming grade-report feature sees correct historical data.
- **PR-1b (follow-up)** — the `resolve_score_category` helper, enum rename (`VOCABULARY` → `READING`), the corresponding wiring in `assignments/crud.py` and `teachers/instant_practice.py`, frontend cleanup, design doc, and unit tests.
- **PR-2 (later)** — the actual 班級成績單／學生成績單 download feature.

The split keeps the data backfill on its own so the down_revision can sit cleanly on top of the latest staging head (`20260513_1000`) without rebase churn.

## Mapping

| Rule | practice_mode | audio | score_category |
|------|--------------|-------|---------------|
| 1 | `word_reading`, `reading` | any | `speaking` |
| 2 | `word_cloze` | any | `reading` |
| 3 | `rearrangement` | off | `reading` |
| 4 | (other) | off | `writing` |
| 5 | (other) | on | `listening` |

Full rationale + maintenance guide ships in `docs/design/score-category-mapping.md` in PR-1b.

## Migration safety

- **Idempotent**: `WHERE score_category IS DISTINCT FROM <new value>` short-circuits rows already at the target value, so re-running is a no-op.
- **No schema change**: `score_category` is already `VARCHAR(20)` (not a PG enum), so no `ALTER TYPE` / `DROP` / `RENAME` — complies with `CLAUDE.md` migration 鐵則.
- **Chain**: revises `20260513_1000` (plans table, latest staging head). `alembic heads` shows a single head after this PR.
- **Safe in isolation**: even without PR-1b deployed, the backfill produces consistent values (just stops being maintained by the helper until PR-1b lands).

## Test plan

- [x] `alembic heads` returns a single head locally
- [x] `black --check` + `flake8` clean
- [ ] CI green
- [ ] After merge: PR-1b can land without further migration changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)