### PR TITLE
feat(#723): admin Plan CRUD + Admin button on /blog

### DIFF
--- a/backend/config/plans.py
+++ b/backend/config/plans.py
@@ -45,3 +45,51 @@ ORG_ALLOWED_PACKAGES = ["pkg-20000"]
 
 # 點數包效期（天）
 CREDIT_PACKAGE_VALIDITY_DAYS = 365
+
+
+# === DB-backed overrides ===
+# `Plan` table allows admins to override price/quota without a deploy.
+# These helpers prefer the DB value and fall back to the config constants
+# so call sites work even before the migration runs or table is seeded.
+#
+# Callers that already have a DB session (e.g. router endpoints) should pass
+# it as ``db`` so reads share the request transaction (and so tests can
+# inject the test session). When ``db`` is None the helper opens its own
+# short-lived session against the configured database; failures fall through
+# to the config constants.
+def _get_plan_override(plan_name: str, db=None):
+    """Fetch the Plan row for ``plan_name``. Returns None on any error so
+    callers can fall back to config defaults without crashing."""
+    try:
+        from models.plan import Plan
+
+        if db is not None:
+            return db.query(Plan).filter(Plan.name == plan_name).first()
+
+        from database import SessionLocal
+
+        session = SessionLocal()
+        try:
+            return session.query(Plan).filter(Plan.name == plan_name).first()
+        finally:
+            session.close()
+    except Exception:
+        return None
+
+
+def get_plan_price(plan_name: str, db=None) -> int:
+    """Return the price for ``plan_name``. Prefer DB override; fall back to
+    PLAN_PRICES; finally DEFAULT_PRICE."""
+    row = _get_plan_override(plan_name, db=db)
+    if row is not None and row.price is not None:
+        return row.price
+    return PLAN_PRICES.get(plan_name, DEFAULT_PRICE)
+
+
+def get_plan_quota(plan_name: str, db=None) -> int:
+    """Return the monthly quota for ``plan_name``. Prefer DB override; fall
+    back to PLAN_QUOTAS; finally 0."""
+    row = _get_plan_override(plan_name, db=db)
+    if row is not None and row.quota is not None:
+        return row.quota
+    return PLAN_QUOTAS.get(plan_name, 0)

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,6 +34,7 @@ from routers import (
     azure_speech_token,
     admin,
     admin_subscriptions,
+    admin_plans,
     admin_monitoring,
     admin_billing,
     admin_audio_errors,
@@ -277,6 +278,7 @@ app.include_router(azure_speech_token.router)  # Azure Speech Token 路由
 app.include_router(teacher_review.router)  # 老師批改路由
 app.include_router(admin.router)  # 管理路由
 app.include_router(admin_subscriptions.router)  # Admin 訂閱管理路由（新）
+app.include_router(admin_plans.router)  # Admin 方案 CRUD 路由
 app.include_router(admin_monitoring.router)  # 監控路由（無需認證）
 app.include_router(admin_billing.router)  # Admin 帳單監控路由（Admin only）
 app.include_router(admin_audio_errors.router)  # Admin 錄音錯誤監控路由（Admin only）

--- a/backend/routers/admin_plans.py
+++ b/backend/routers/admin_plans.py
@@ -1,0 +1,88 @@
+"""
+Admin Plans API - manage subscription plan price / quota overrides.
+
+Plan names are still code constants (see `backend/config/plans.py`); this
+endpoint only edits per-plan numeric values stored in the `plans` table.
+Create/Delete are intentionally not exposed because consumers reference
+plan names by string identifier.
+"""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+from datetime import datetime
+
+from database import get_db
+from models import Plan, Teacher
+from routers.admin import get_current_admin
+
+
+router = APIRouter(prefix="/api/admin/plans", tags=["admin-plans"])
+
+
+# ============ Schemas ============
+class PlanResponse(BaseModel):
+    id: int
+    name: str
+    price: Optional[int] = None
+    quota: Optional[int] = None
+    display_order: int
+    is_active: bool
+    updated_at: Optional[datetime] = None
+    updated_by_admin_id: Optional[int] = None
+
+    class Config:
+        from_attributes = True
+
+
+class PlanUpdateRequest(BaseModel):
+    price: Optional[int] = Field(default=None, ge=0)
+    quota: Optional[int] = Field(default=None, ge=0)
+    is_active: Optional[bool] = None
+    display_order: Optional[int] = Field(default=None, ge=0)
+
+
+# ============ Endpoints ============
+@router.get("", response_model=List[PlanResponse])
+async def list_plans(
+    db: Session = Depends(get_db),
+    _: Teacher = Depends(get_current_admin),
+) -> List[PlanResponse]:
+    """List all plans, ordered by display_order then name."""
+    rows = (
+        db.query(Plan)
+        .order_by(Plan.display_order.asc(), Plan.name.asc())
+        .all()
+    )
+    return [PlanResponse.model_validate(r) for r in rows]
+
+
+@router.put("/{plan_name}", response_model=PlanResponse)
+async def update_plan(
+    plan_name: str,
+    request: PlanUpdateRequest,
+    db: Session = Depends(get_db),
+    admin: Teacher = Depends(get_current_admin),
+) -> PlanResponse:
+    """Update price / quota / is_active / display_order for a plan."""
+    row = db.query(Plan).filter(Plan.name == plan_name).first()
+    if row is None:
+        raise HTTPException(
+            status_code=404, detail=f"Plan '{plan_name}' not found"
+        )
+
+    payload = request.model_dump(exclude_unset=True)
+    if not payload:
+        raise HTTPException(
+            status_code=400, detail="No fields provided to update"
+        )
+
+    for field, value in payload.items():
+        setattr(row, field, value)
+    row.updated_by_admin_id = admin.id
+
+    db.commit()
+    db.refresh(row)
+    return PlanResponse.model_validate(row)

--- a/backend/routers/admin_plans.py
+++ b/backend/routers/admin_plans.py
@@ -51,11 +51,7 @@ async def list_plans(
     _: Teacher = Depends(get_current_admin),
 ) -> List[PlanResponse]:
     """List all plans, ordered by display_order then name."""
-    rows = (
-        db.query(Plan)
-        .order_by(Plan.display_order.asc(), Plan.name.asc())
-        .all()
-    )
+    rows = db.query(Plan).order_by(Plan.display_order.asc(), Plan.name.asc()).all()
     return [PlanResponse.model_validate(r) for r in rows]
 
 
@@ -69,15 +65,11 @@ async def update_plan(
     """Update price / quota / is_active / display_order for a plan."""
     row = db.query(Plan).filter(Plan.name == plan_name).first()
     if row is None:
-        raise HTTPException(
-            status_code=404, detail=f"Plan '{plan_name}' not found"
-        )
+        raise HTTPException(status_code=404, detail=f"Plan '{plan_name}' not found")
 
     payload = request.model_dump(exclude_unset=True)
     if not payload:
-        raise HTTPException(
-            status_code=400, detail="No fields provided to update"
-        )
+        raise HTTPException(status_code=400, detail="No fields provided to update")
 
     for field, value in payload.items():
         setattr(row, field, value)

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -74,11 +74,11 @@ class SubscriptionResponse(BaseModel):
 
 
 # ============ Helper Functions ============
-def get_plan_quota(plan_name: str) -> int:
-    """根據方案名稱獲取對應的 quota"""
-    from config.plans import PLAN_QUOTAS
+def get_plan_quota(plan_name: str, db: Session = None) -> int:
+    """根據方案名稱獲取對應的 quota（優先讀 Plan 表的 admin 覆寫值）"""
+    from config.plans import get_plan_quota as _get_plan_quota
 
-    return PLAN_QUOTAS.get(plan_name, 0)
+    return _get_plan_quota(plan_name, db=db)
 
 
 def parse_end_date(date_str: str) -> datetime:
@@ -138,7 +138,7 @@ async def create_subscription(
         )
 
     # 計算 quota (VIP 方案可自訂)
-    quota_total = get_plan_quota(request.plan_name)
+    quota_total = get_plan_quota(request.plan_name, db=db)
 
     # VIP 方案：使用自訂 quota
     if request.plan_name == "VIP":
@@ -265,7 +265,7 @@ async def edit_subscription(
                 current_period.quota_total = request.quota_total
         else:
             # 其他方案：使用預設 quota
-            base_quota = get_plan_quota(request.plan_name)
+            base_quota = get_plan_quota(request.plan_name, db=db)
 
             new_quota = base_quota
             if new_quota != current_period.quota_total:

--- a/backend/routers/cron.py
+++ b/backend/routers/cron.py
@@ -216,11 +216,11 @@ async def monthly_renewal_cron(
             # ========================================
             # 取得上個月訂閱資訊用於續訂
             # ========================================
-            from config.plans import PLAN_PRICES, PLAN_QUOTAS
+            from config.plans import get_plan_price, get_plan_quota
 
             plan_name = last_month_subscription.plan_name
-            amount = PLAN_PRICES.get(plan_name, 299)
-            quota_total = PLAN_QUOTAS.get(plan_name, 2000)
+            amount = get_plan_price(plan_name, db=db)
+            quota_total = get_plan_quota(plan_name, db=db)
 
             # 生成訂單編號
             order_number = f"RENEWAL_{teacher.id}_{today_taipei.strftime('%Y%m%d')}"

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -286,9 +286,9 @@ async def process_payment(
             period.status = "expired"
 
         # ✅ 創建新的訂閱週期記錄（包含 Trial 剩餘點數）
-        from config.plans import PLAN_QUOTAS
+        from config.plans import get_plan_quota
 
-        quota_total = PLAN_QUOTAS.get(payment_request.plan_name, 2000)
+        quota_total = get_plan_quota(payment_request.plan_name, db=db)
         new_period = SubscriptionPeriod(
             teacher_id=current_teacher.id,
             plan_name=payment_request.plan_name,

--- a/backend/services/subscription_calculator.py
+++ b/backend/services/subscription_calculator.py
@@ -11,12 +11,17 @@ from datetime import datetime, timezone
 from typing import Tuple
 from calendar import monthrange
 
-from config.plans import PLAN_PRICES as _PLAN_PRICES, DEFAULT_PRICE as _DEFAULT_PRICE
+from config.plans import (
+    PLAN_PRICES as _PLAN_PRICES,
+    DEFAULT_PRICE as _DEFAULT_PRICE,
+    get_plan_price,
+)
 
 
 class SubscriptionCalculator:
     """訂閱計算器"""
 
+    # Kept for backward compat; prefer ``get_plan_price`` so admin overrides apply.
     PLAN_PRICES = _PLAN_PRICES
 
     DEFAULT_PRICE = _DEFAULT_PRICE
@@ -35,9 +40,7 @@ class SubscriptionCalculator:
         Returns:
             (到期日, 應付金額, 詳細資訊)
         """
-        full_price = SubscriptionCalculator.PLAN_PRICES.get(
-            plan_name, SubscriptionCalculator.DEFAULT_PRICE
-        )
+        full_price = get_plan_price(plan_name)
 
         end_date = SubscriptionCalculator._add_one_month(start_date)
 
@@ -68,9 +71,7 @@ class SubscriptionCalculator:
             (新到期日, 應付金額)
         """
         new_end_date = SubscriptionCalculator._add_one_month(current_end_date)
-        amount = SubscriptionCalculator.PLAN_PRICES.get(
-            plan_name, SubscriptionCalculator.DEFAULT_PRICE
-        )
+        amount = get_plan_price(plan_name)
 
         return new_end_date, amount
 

--- a/backend/tests/test_admin_plans.py
+++ b/backend/tests/test_admin_plans.py
@@ -1,0 +1,243 @@
+"""Tests for admin plans CRUD endpoints (price/quota overrides)."""
+
+import pytest
+from models import Teacher, Plan
+from auth import get_password_hash, create_access_token
+
+
+@pytest.fixture
+def admin_teacher(shared_test_session):
+    teacher = Teacher(
+        email="admin-plans@duotopia.com",
+        password_hash=get_password_hash("admin_password"),
+        name="Admin Plans",
+        is_active=True,
+        is_admin=True,
+        email_verified=True,
+    )
+    shared_test_session.add(teacher)
+    shared_test_session.commit()
+    shared_test_session.refresh(teacher)
+    return teacher
+
+
+@pytest.fixture
+def regular_teacher(shared_test_session):
+    teacher = Teacher(
+        email="regular-plans@duotopia.com",
+        password_hash=get_password_hash("regular_password"),
+        name="Regular Plans",
+        is_active=True,
+        is_admin=False,
+        email_verified=True,
+    )
+    shared_test_session.add(teacher)
+    shared_test_session.commit()
+    shared_test_session.refresh(teacher)
+    return teacher
+
+
+@pytest.fixture
+def auth_headers_admin(admin_teacher):
+    token = create_access_token(
+        data={"sub": str(admin_teacher.id), "type": "teacher"}
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def auth_headers_regular(regular_teacher):
+    token = create_access_token(
+        data={"sub": str(regular_teacher.id), "type": "teacher"}
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def seed_plans(shared_test_session):
+    """Seed plans table with the same 5 plans the migration creates."""
+    rows = [
+        Plan(name="Free Trial", price=0, quota=2000, display_order=1),
+        Plan(name="Tutor Teachers", price=299, quota=2000, display_order=2),
+        Plan(name="School Teachers", price=599, quota=6000, display_order=3),
+        Plan(name="Demo Unlimited Plan", price=0, quota=999999, display_order=4),
+        Plan(name="VIP", price=0, quota=0, display_order=5),
+    ]
+    for r in rows:
+        shared_test_session.add(r)
+    shared_test_session.commit()
+    return rows
+
+
+# ============ GET /api/admin/plans ============
+def test_list_plans_as_admin_returns_seeded_rows(
+    seed_plans, auth_headers_admin, test_client
+):
+    response = test_client.get("/api/admin/plans", headers=auth_headers_admin)
+
+    assert response.status_code == 200
+    data = response.json()
+    names = [p["name"] for p in data]
+    assert "Tutor Teachers" in names
+    assert "School Teachers" in names
+    # Should be ordered by display_order
+    assert data[0]["name"] == "Free Trial"
+    assert data[1]["name"] == "Tutor Teachers"
+    # Fields surface to the client
+    tutor = next(p for p in data if p["name"] == "Tutor Teachers")
+    assert tutor["price"] == 299
+    assert tutor["quota"] == 2000
+    assert tutor["is_active"] is True
+
+
+def test_list_plans_non_admin_forbidden(
+    seed_plans, auth_headers_regular, test_client
+):
+    response = test_client.get("/api/admin/plans", headers=auth_headers_regular)
+    assert response.status_code == 403
+
+
+def test_list_plans_unauthenticated_rejected(seed_plans, test_client):
+    response = test_client.get("/api/admin/plans")
+    assert response.status_code in (401, 403)
+
+
+# ============ PUT /api/admin/plans/{name} ============
+def test_update_plan_price_and_quota_as_admin(
+    seed_plans, admin_teacher, auth_headers_admin, test_client, shared_test_session
+):
+    response = test_client.put(
+        "/api/admin/plans/Tutor Teachers",
+        headers=auth_headers_admin,
+        json={"price": 350, "quota": 2500, "is_active": True},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["name"] == "Tutor Teachers"
+    assert body["price"] == 350
+    assert body["quota"] == 2500
+
+    # Persisted in DB
+    shared_test_session.expire_all()
+    row = (
+        shared_test_session.query(Plan)
+        .filter(Plan.name == "Tutor Teachers")
+        .first()
+    )
+    assert row.price == 350
+    assert row.quota == 2500
+    assert row.updated_by_admin_id == admin_teacher.id
+
+
+def test_update_plan_partial_only_price(
+    seed_plans, auth_headers_admin, test_client, shared_test_session
+):
+    response = test_client.put(
+        "/api/admin/plans/School Teachers",
+        headers=auth_headers_admin,
+        json={"price": 699},
+    )
+    assert response.status_code == 200
+
+    shared_test_session.expire_all()
+    row = (
+        shared_test_session.query(Plan)
+        .filter(Plan.name == "School Teachers")
+        .first()
+    )
+    assert row.price == 699
+    assert row.quota == 6000  # untouched
+
+
+def test_update_plan_toggle_inactive(
+    seed_plans, auth_headers_admin, test_client, shared_test_session
+):
+    response = test_client.put(
+        "/api/admin/plans/VIP",
+        headers=auth_headers_admin,
+        json={"is_active": False},
+    )
+    assert response.status_code == 200
+    assert response.json()["is_active"] is False
+
+
+def test_update_plan_unknown_name_returns_404(
+    seed_plans, auth_headers_admin, test_client
+):
+    response = test_client.put(
+        "/api/admin/plans/Nonexistent Plan",
+        headers=auth_headers_admin,
+        json={"price": 100},
+    )
+    assert response.status_code == 404
+
+
+def test_update_plan_negative_price_rejected(
+    seed_plans, auth_headers_admin, test_client
+):
+    response = test_client.put(
+        "/api/admin/plans/Tutor Teachers",
+        headers=auth_headers_admin,
+        json={"price": -1},
+    )
+    assert response.status_code == 422
+
+
+def test_update_plan_negative_quota_rejected(
+    seed_plans, auth_headers_admin, test_client
+):
+    response = test_client.put(
+        "/api/admin/plans/Tutor Teachers",
+        headers=auth_headers_admin,
+        json={"quota": -10},
+    )
+    assert response.status_code == 422
+
+
+def test_update_plan_non_admin_forbidden(
+    seed_plans, auth_headers_regular, test_client
+):
+    response = test_client.put(
+        "/api/admin/plans/Tutor Teachers",
+        headers=auth_headers_regular,
+        json={"price": 100},
+    )
+    assert response.status_code == 403
+
+
+# ============ Helper integration: get_plan_price / get_plan_quota ============
+def test_get_plan_price_prefers_db_override(seed_plans, shared_test_session):
+    """After admin edits Plan row, get_plan_price returns the new value."""
+    from config.plans import get_plan_price
+
+    row = (
+        shared_test_session.query(Plan)
+        .filter(Plan.name == "Tutor Teachers")
+        .first()
+    )
+    row.price = 450
+    shared_test_session.commit()
+
+    assert get_plan_price("Tutor Teachers", db=shared_test_session) == 450
+
+
+def test_get_plan_quota_prefers_db_override(seed_plans, shared_test_session):
+    from config.plans import get_plan_quota
+
+    row = (
+        shared_test_session.query(Plan)
+        .filter(Plan.name == "School Teachers")
+        .first()
+    )
+    row.quota = 8000
+    shared_test_session.commit()
+
+    assert get_plan_quota("School Teachers", db=shared_test_session) == 8000
+
+
+def test_get_plan_price_falls_back_when_no_row(shared_test_session):
+    """No Plan row → falls back to PLAN_PRICES constant."""
+    from config.plans import get_plan_price
+
+    assert get_plan_price("Tutor Teachers", db=shared_test_session) == 299

--- a/backend/tests/test_admin_plans.py
+++ b/backend/tests/test_admin_plans.py
@@ -39,9 +39,7 @@ def regular_teacher(shared_test_session):
 
 @pytest.fixture
 def auth_headers_admin(admin_teacher):
-    token = create_access_token(
-        data={"sub": str(admin_teacher.id), "type": "teacher"}
-    )
+    token = create_access_token(data={"sub": str(admin_teacher.id), "type": "teacher"})
     return {"Authorization": f"Bearer {token}"}
 
 
@@ -90,9 +88,7 @@ def test_list_plans_as_admin_returns_seeded_rows(
     assert tutor["is_active"] is True
 
 
-def test_list_plans_non_admin_forbidden(
-    seed_plans, auth_headers_regular, test_client
-):
+def test_list_plans_non_admin_forbidden(seed_plans, auth_headers_regular, test_client):
     response = test_client.get("/api/admin/plans", headers=auth_headers_regular)
     assert response.status_code == 403
 
@@ -120,11 +116,7 @@ def test_update_plan_price_and_quota_as_admin(
 
     # Persisted in DB
     shared_test_session.expire_all()
-    row = (
-        shared_test_session.query(Plan)
-        .filter(Plan.name == "Tutor Teachers")
-        .first()
-    )
+    row = shared_test_session.query(Plan).filter(Plan.name == "Tutor Teachers").first()
     assert row.price == 350
     assert row.quota == 2500
     assert row.updated_by_admin_id == admin_teacher.id
@@ -141,11 +133,7 @@ def test_update_plan_partial_only_price(
     assert response.status_code == 200
 
     shared_test_session.expire_all()
-    row = (
-        shared_test_session.query(Plan)
-        .filter(Plan.name == "School Teachers")
-        .first()
-    )
+    row = shared_test_session.query(Plan).filter(Plan.name == "School Teachers").first()
     assert row.price == 699
     assert row.quota == 6000  # untouched
 
@@ -195,9 +183,7 @@ def test_update_plan_negative_quota_rejected(
     assert response.status_code == 422
 
 
-def test_update_plan_non_admin_forbidden(
-    seed_plans, auth_headers_regular, test_client
-):
+def test_update_plan_non_admin_forbidden(seed_plans, auth_headers_regular, test_client):
     response = test_client.put(
         "/api/admin/plans/Tutor Teachers",
         headers=auth_headers_regular,
@@ -211,11 +197,7 @@ def test_get_plan_price_prefers_db_override(seed_plans, shared_test_session):
     """After admin edits Plan row, get_plan_price returns the new value."""
     from config.plans import get_plan_price
 
-    row = (
-        shared_test_session.query(Plan)
-        .filter(Plan.name == "Tutor Teachers")
-        .first()
-    )
+    row = shared_test_session.query(Plan).filter(Plan.name == "Tutor Teachers").first()
     row.price = 450
     shared_test_session.commit()
 
@@ -225,11 +207,7 @@ def test_get_plan_price_prefers_db_override(seed_plans, shared_test_session):
 def test_get_plan_quota_prefers_db_override(seed_plans, shared_test_session):
     from config.plans import get_plan_quota
 
-    row = (
-        shared_test_session.query(Plan)
-        .filter(Plan.name == "School Teachers")
-        .first()
-    )
+    row = shared_test_session.query(Plan).filter(Plan.name == "School Teachers").first()
     row.quota = 8000
     shared_test_session.commit()
 

--- a/frontend/src/components/blog/BlogHeader.tsx
+++ b/frontend/src/components/blog/BlogHeader.tsx
@@ -28,6 +28,18 @@ export default function BlogHeader() {
           />
         </Link>
         <div className="flex items-center gap-1.5 sm:gap-3">
+          {isTeacherAuth && teacherUser?.is_admin && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                window.open("/admin/blog", "_blank", "noopener,noreferrer")
+              }
+              className="text-xs sm:text-sm px-2 sm:px-3 h-8 sm:h-9 font-semibold text-amber-700"
+            >
+              Admin
+            </Button>
+          )}
           <Link to="/blog">
             <Button
               variant="ghost"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1476,6 +1476,46 @@ class ApiClient {
       body: JSON.stringify(data),
     });
   }
+
+  // ============ Admin Plans Methods ============
+  async listAdminPlans() {
+    return this.request<
+      Array<{
+        id: number;
+        name: string;
+        price: number | null;
+        quota: number | null;
+        display_order: number;
+        is_active: boolean;
+        updated_at: string | null;
+        updated_by_admin_id: number | null;
+      }>
+    >("/api/admin/plans", { method: "GET" });
+  }
+
+  async updateAdminPlan(
+    planName: string,
+    data: {
+      price?: number;
+      quota?: number;
+      is_active?: boolean;
+      display_order?: number;
+    },
+  ) {
+    return this.request<{
+      id: number;
+      name: string;
+      price: number | null;
+      quota: number | null;
+      display_order: number;
+      is_active: boolean;
+      updated_at: string | null;
+      updated_by_admin_id: number | null;
+    }>(`/api/admin/plans/${encodeURIComponent(planName)}`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    });
+  }
 }
 
 // Export singleton instance

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -1,10 +1,17 @@
 import { useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Crown, DollarSign, AlertTriangle, Building } from "lucide-react";
+import {
+  Crown,
+  DollarSign,
+  AlertTriangle,
+  Building,
+  Tag,
+} from "lucide-react";
 import AdminSubscriptionDashboard from "./AdminSubscriptionDashboard";
 import AdminBillingDashboard from "./AdminBillingDashboard";
 import AdminAudioErrorDashboard from "./AdminAudioErrorDashboard";
 import AdminOrganizations from "./AdminOrganizations";
+import AdminPlansPage from "./AdminPlansPage";
 import AdminLayout from "@/components/admin/AdminLayout";
 
 export default function AdminDashboard() {
@@ -54,6 +61,14 @@ export default function AdminDashboard() {
             <span className="hidden sm:inline">組織管理</span>
             <span className="sm:hidden">組織</span>
           </TabsTrigger>
+          <TabsTrigger
+            value="plans"
+            className="flex items-center gap-2 px-4 py-3 text-sm md:text-base font-medium text-gray-500 bg-transparent border-b-2 border-transparent rounded-none data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:border-blue-600 data-[state=active]:font-semibold data-[state=active]:shadow-none hover:text-gray-700 transition-colors"
+          >
+            <Tag className="h-4 w-4 md:h-5 md:w-5 flex-shrink-0" />
+            <span className="hidden sm:inline">方案管理</span>
+            <span className="sm:hidden">方案</span>
+          </TabsTrigger>
         </TabsList>
 
         {/* Subscription Management Tab */}
@@ -74,6 +89,11 @@ export default function AdminDashboard() {
         {/* Organization Management Tab */}
         <TabsContent value="organizations" className="space-y-4">
           <AdminOrganizations />
+        </TabsContent>
+
+        {/* Plans Management Tab */}
+        <TabsContent value="plans" className="space-y-4">
+          <AdminPlansPage />
         </TabsContent>
       </Tabs>
     </AdminLayout>

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -1,12 +1,6 @@
 import { useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  Crown,
-  DollarSign,
-  AlertTriangle,
-  Building,
-  Tag,
-} from "lucide-react";
+import { Crown, DollarSign, AlertTriangle, Building, Tag } from "lucide-react";
 import AdminSubscriptionDashboard from "./AdminSubscriptionDashboard";
 import AdminBillingDashboard from "./AdminBillingDashboard";
 import AdminAudioErrorDashboard from "./AdminAudioErrorDashboard";

--- a/frontend/src/pages/admin/AdminPlansPage.tsx
+++ b/frontend/src/pages/admin/AdminPlansPage.tsx
@@ -1,0 +1,298 @@
+import { useState, useEffect, useCallback } from "react";
+import { apiClient } from "@/lib/api";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Crown, Pencil, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+
+interface Plan {
+  id: number;
+  name: string;
+  price: number | null;
+  quota: number | null;
+  display_order: number;
+  is_active: boolean;
+  updated_at: string | null;
+  updated_by_admin_id: number | null;
+}
+
+interface FormState {
+  price: string;
+  quota: string;
+  is_active: boolean;
+}
+
+const initialFormState: FormState = {
+  price: "",
+  quota: "",
+  is_active: true,
+};
+
+export default function AdminPlansPage() {
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [selectedPlan, setSelectedPlan] = useState<Plan | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [formData, setFormData] = useState<FormState>(initialFormState);
+  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
+
+  const fetchPlans = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient.listAdminPlans();
+      setPlans(data);
+    } catch (err) {
+      console.error("Failed to fetch plans:", err);
+      setError(err instanceof Error ? err.message : "Failed to load plans");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPlans();
+  }, [fetchPlans]);
+
+  const openEditDialog = (plan: Plan) => {
+    setSelectedPlan(plan);
+    setFormData({
+      price: plan.price?.toString() ?? "",
+      quota: plan.quota?.toString() ?? "",
+      is_active: plan.is_active,
+    });
+    setFormErrors({});
+    setIsEditDialogOpen(true);
+  };
+
+  const validateForm = (): boolean => {
+    const errors: Record<string, string> = {};
+
+    if (formData.price !== "") {
+      const n = Number(formData.price);
+      if (Number.isNaN(n) || n < 0 || !Number.isInteger(n)) {
+        errors.price = "價格必須是 0 或正整數";
+      }
+    }
+    if (formData.quota !== "") {
+      const n = Number(formData.quota);
+      if (Number.isNaN(n) || n < 0 || !Number.isInteger(n)) {
+        errors.quota = "配額必須是 0 或正整數";
+      }
+    }
+
+    setFormErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleSave = async () => {
+    if (!selectedPlan || !validateForm()) return;
+
+    setIsSaving(true);
+    try {
+      const payload: {
+        price?: number;
+        quota?: number;
+        is_active?: boolean;
+      } = {};
+      if (formData.price !== "") payload.price = Number(formData.price);
+      if (formData.quota !== "") payload.quota = Number(formData.quota);
+      if (formData.is_active !== selectedPlan.is_active) {
+        payload.is_active = formData.is_active;
+      }
+
+      if (Object.keys(payload).length === 0) {
+        toast.info("沒有變更，已關閉編輯");
+        setIsEditDialogOpen(false);
+        return;
+      }
+
+      await apiClient.updateAdminPlan(selectedPlan.name, payload);
+      toast.success(`已更新「${selectedPlan.name}」`);
+      setIsEditDialogOpen(false);
+      await fetchPlans();
+    } catch (err) {
+      console.error("Failed to update plan:", err);
+      toast.error(err instanceof Error ? err.message : "更新失敗");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return "-";
+    return new Date(dateString).toLocaleString("zh-TW", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Crown className="h-5 w-5 text-amber-600" />
+          方案管理
+        </CardTitle>
+        <p className="text-sm text-gray-500 mt-1">
+          可調整既有方案的價格與配額；方案名稱由程式碼定義，無法新增或刪除。
+        </p>
+      </CardHeader>
+      <CardContent>
+        {error && (
+          <Alert variant="destructive" className="mb-4">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {loading ? (
+          <div className="py-8 text-center text-gray-500">載入中...</div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>方案名稱</TableHead>
+                <TableHead>價格（TWD/月）</TableHead>
+                <TableHead>每月配額（點數）</TableHead>
+                <TableHead>狀態</TableHead>
+                <TableHead>最後更新</TableHead>
+                <TableHead className="text-right">操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {plans.map((plan) => (
+                <TableRow key={plan.id}>
+                  <TableCell className="font-medium">{plan.name}</TableCell>
+                  <TableCell>{plan.price ?? "-"}</TableCell>
+                  <TableCell>{plan.quota ?? "-"}</TableCell>
+                  <TableCell>
+                    {plan.is_active ? (
+                      <Badge variant="default">啟用中</Badge>
+                    ) : (
+                      <Badge variant="secondary">已停用</Badge>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-sm text-gray-500">
+                    {formatDate(plan.updated_at)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => openEditDialog(plan)}
+                    >
+                      <Pencil className="h-3.5 w-3.5 mr-1.5" />
+                      編輯
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+
+      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>編輯方案：{selectedPlan?.name}</DialogTitle>
+            <DialogDescription>
+              調整價格與配額。空白表示不變更該欄位。
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="plan-price">價格（TWD/月）</Label>
+              <Input
+                id="plan-price"
+                type="number"
+                min={0}
+                value={formData.price}
+                onChange={(e) =>
+                  setFormData({ ...formData, price: e.target.value })
+                }
+              />
+              {formErrors.price && (
+                <p className="text-xs text-red-600">{formErrors.price}</p>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="plan-quota">每月配額（點數）</Label>
+              <Input
+                id="plan-quota"
+                type="number"
+                min={0}
+                value={formData.quota}
+                onChange={(e) =>
+                  setFormData({ ...formData, quota: e.target.value })
+                }
+              />
+              {formErrors.quota && (
+                <p className="text-xs text-red-600">{formErrors.quota}</p>
+              )}
+            </div>
+
+            <div className="flex items-center justify-between border-t pt-3">
+              <div>
+                <Label htmlFor="plan-active">啟用此方案</Label>
+                <p className="text-xs text-gray-500">
+                  停用後不影響既有訂閱，僅控制是否能新訂。
+                </p>
+              </div>
+              <Switch
+                id="plan-active"
+                checked={formData.is_active}
+                onCheckedChange={(checked) =>
+                  setFormData({ ...formData, is_active: checked })
+                }
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setIsEditDialogOpen(false)}
+              disabled={isSaving}
+            >
+              取消
+            </Button>
+            <Button onClick={handleSave} disabled={isSaving}>
+              {isSaving ? "儲存中..." : "儲存"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -956,7 +956,7 @@ export default function AdminSubscriptionDashboard() {
                 <Table className="min-w-[800px]">
                   <TableHeader>
                     <TableRow>
-                      <TableHead className="text-xs md:text-sm">
+                      <TableHead className="text-xs md:text-sm w-[260px]">
                         {t("adminSubscription.table.email")}
                       </TableHead>
                       <TableHead className="text-xs md:text-sm">
@@ -1001,14 +1001,19 @@ export default function AdminSubscriptionDashboard() {
                               toggleTeacherExpand(teacher.teacher_id)
                             }
                           >
-                            <TableCell className="font-mono text-sm">
+                            <TableCell className="font-mono text-sm w-[260px] max-w-[260px]">
                               <div className="flex items-center gap-2">
                                 {expandedTeacherId === teacher.teacher_id ? (
-                                  <ChevronDown className="w-4 h-4 text-gray-500" />
+                                  <ChevronDown className="w-4 h-4 text-gray-500 flex-shrink-0" />
                                 ) : (
-                                  <ChevronRight className="w-4 h-4 text-gray-500" />
+                                  <ChevronRight className="w-4 h-4 text-gray-500 flex-shrink-0" />
                                 )}
-                                {teacher.teacher_email}
+                                <span
+                                  className="truncate"
+                                  title={teacher.teacher_email}
+                                >
+                                  {teacher.teacher_email}
+                                </span>
                               </div>
                             </TableCell>
                             <TableCell>{teacher.teacher_name}</TableCell>
@@ -1129,6 +1134,12 @@ export default function AdminSubscriptionDashboard() {
                                   className="bg-gray-50 p-0"
                                 >
                                   <div className="p-4">
+                                    <div className="mb-3 text-sm text-gray-600 font-mono break-all">
+                                      Email:{" "}
+                                      <span className="text-gray-900">
+                                        {teacher.teacher_email}
+                                      </span>
+                                    </div>
                                     <h4 className="font-semibold mb-3 text-sm">
                                       {t("adminSubscription.periodTable.title")}
                                     </h4>

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -974,7 +974,7 @@ export default function AdminSubscriptionDashboard() {
                       <TableHead className="text-xs md:text-sm">
                         {t("adminSubscription.table.quota")}
                       </TableHead>
-                      <TableHead className="text-xs md:text-sm">
+                      <TableHead className="text-xs md:text-sm w-24">
                         {t("adminSubscription.table.status")}
                       </TableHead>
                       <TableHead className="text-xs md:text-sm">
@@ -1073,25 +1073,25 @@ export default function AdminSubscriptionDashboard() {
                             <TableCell>
                               {teacher.current_subscription?.status ===
                               "active" ? (
-                                <span className="px-2 py-1 bg-green-100 text-green-800 rounded text-xs">
+                                <span className="inline-block whitespace-nowrap px-2 py-1 bg-green-100 text-green-800 rounded text-xs">
                                   {t("adminSubscription.status.active")}
                                 </span>
                               ) : teacher.has_trial_bonus ? (
-                                <span className="px-2 py-1 bg-purple-100 text-purple-800 rounded text-xs">
+                                <span className="inline-block whitespace-nowrap px-2 py-1 bg-purple-100 text-purple-800 rounded text-xs">
                                   {t(
                                     "adminSubscription.status.trial",
                                     "Free Trial",
                                   )}
                                 </span>
                               ) : !teacher.email_verified ? (
-                                <span className="px-2 py-1 bg-yellow-100 text-yellow-800 rounded text-xs">
+                                <span className="inline-block whitespace-nowrap px-2 py-1 bg-yellow-100 text-yellow-800 rounded text-xs">
                                   {t(
                                     "adminSubscription.status.unverified",
                                     "Unverified",
                                   )}
                                 </span>
                               ) : (
-                                <span className="px-2 py-1 bg-gray-100 text-gray-800 rounded text-xs">
+                                <span className="inline-block whitespace-nowrap px-2 py-1 bg-gray-100 text-gray-800 rounded text-xs">
                                   {t("adminSubscription.status.none")}
                                 </span>
                               )}


### PR DESCRIPTION
## Summary
Implements [#723](https://github.com/myduotopia/duotopia/issues/723) admin features. Builds on the `plans` table schema landed in #743.

- **Admin Plans CRUD**: New `方案管理` tab in `/admin` dashboard. Admins can edit price / monthly quota / `is_active` for each of the 5 existing plans. Create/Delete intentionally not exposed (plan names are code constants referenced by string throughout subscription logic).
- **Helper refactor**: `config/plans.py` gets `get_plan_price(name, db=None)` / `get_plan_quota(name, db=None)` that prefer DB overrides and fall back to constants. `subscription_calculator`, `cron` auto-renew, `payment` checkout, and `admin_subscriptions` now read through these helpers so admin edits actually affect prices/quotas at runtime.
- **`/blog` Admin button**: Conditional Admin button in top-right of `BlogHeader`, only shown when `useTeacherAuthStore().user?.is_admin === true`. Opens `/admin/blog` in a new tab.

## API
- `GET /api/admin/plans` — list all plans ordered by `display_order`.
- `PUT /api/admin/plans/{plan_name}` — update `price` / `quota` / `is_active` / `display_order`. Returns 404 for unknown plan, 422 for negative values.

Both require `is_admin` (mirrors existing admin endpoints' auth pattern).

## Test plan
- [x] Backend pytest: 13/13 new admin_plans tests pass; 24/24 subscription_calculator tests still pass.
- [x] Frontend: `tsc --noEmit` clean, `eslint` clean, `npm run build` clean.
- [ ] Manual: log in as admin → `/blog` shows Admin button → click opens `/admin/blog` in new tab.
- [ ] Manual: log in as non-admin → no Admin button visible on `/blog`.
- [ ] Manual: `/admin` → 方案管理 tab → edit a plan's price → reload → verify persisted → confirm new checkout reflects new price.

## Files changed (12)
- `backend/config/plans.py` — `get_plan_price` / `get_plan_quota` helpers
- `backend/routers/admin_plans.py` — new router
- `backend/routers/{admin_subscriptions,cron,payment}.py` — use helpers
- `backend/services/subscription_calculator.py` — use helper
- `backend/main.py` — register router
- `backend/tests/test_admin_plans.py` — 13 tests
- `frontend/src/lib/api.ts` — `listAdminPlans` / `updateAdminPlan`
- `frontend/src/pages/admin/AdminPlansPage.tsx` — new tab page
- `frontend/src/pages/admin/AdminDashboard.tsx` — register tab
- `frontend/src/components/blog/BlogHeader.tsx` — Admin button

Fixes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)