### PR TITLE
refactor(#708): auto-resolve score_category from practice_mode + play_audio

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ deploy-feature <issue>
 3. **Per-Issue Test Environment** - 每個 issue 有獨立測試環境
 4. **Use feature branches** - 不直接 commit 到 staging
 5. **批改頁新增作業類型** - 同路由 + `practice_mode` 分 Panel，禁止新增路由或複製 `GradingPage.tsx`。詳細步驟見 [`docs/design/grading-page-architecture.md`](./docs/design/grading-page-architecture.md)
+6. **計分類別（score_category）** - 由 `practice_mode` + `play_audio` 自動推導，唯一判定函式：[`backend/utils/score_category.py`](./backend/utils/score_category.py)。對照表與新增模式時的更新流程見 [`docs/design/score-category-mapping.md`](./docs/design/score-category-mapping.md)。請勿在前端傳 `score_category` — 後端會覆寫。
 
 ## Database Migration 鐵則
 

--- a/backend/models/base.py
+++ b/backend/models/base.py
@@ -140,12 +140,15 @@ class PracticeMode(str, enum.Enum):
 
 
 class ScoreCategory(str, enum.Enum):
-    """分數記錄分類"""
+    """分數記錄分類 — 由 practice_mode + play_audio 自動推導。
+
+    對照表見 docs/design/score-category-mapping.md。
+    """
 
     SPEAKING = "speaking"  # 口說
     LISTENING = "listening"  # 聽力
     WRITING = "writing"  # 寫作
-    VOCABULARY = "vocabulary"  # 單字（Phase 2 新增）
+    READING = "reading"  # 閱讀
 
 
 class ProgramVisibility(str, enum.Enum):

--- a/backend/routers/assignments/crud.py
+++ b/backend/routers/assignments/crud.py
@@ -33,6 +33,7 @@ from models import (
     AssignmentStatus,
 )
 from utils.permissions import has_read_org_materials_permission
+from utils.score_category import resolve_score_category
 from .validators import (
     CreateAssignmentRequest,
     UpdateAssignmentRequest,
@@ -219,7 +220,11 @@ async def create_assignment(
         show_image=request.show_image,
         show_translation=request.show_translation,
         show_option_images=bool(request.show_option_images),  # Issue #631
-        score_category=request.score_category,
+        # score_category is auto-resolved; any client-supplied value is ignored.
+        # See docs/design/score-category-mapping.md
+        score_category=resolve_score_category(
+            request.practice_mode, request.play_audio or False
+        ),
     )
     db.add(assignment)
     db.flush()  # 取得 assignment.id
@@ -809,6 +814,14 @@ async def patch_assignment(
     for field in advanced_fields:
         if field in provided:
             setattr(assignment, field, getattr(request, field))
+
+    # If play_audio changed, recompute score_category (practice_mode is
+    # immutable on PATCH so we only need to react to audio toggles).
+    # See docs/design/score-category-mapping.md
+    if "play_audio" in provided:
+        assignment.score_category = resolve_score_category(
+            assignment.practice_mode, assignment.play_audio
+        )
 
     # Issue #631: 互斥校驗 — 部分更新後若兩者皆 True 則拒絕
     if assignment.show_image and assignment.show_option_images:

--- a/backend/routers/teachers/instant_practice.py
+++ b/backend/routers/teachers/instant_practice.py
@@ -31,6 +31,7 @@ from models import (
     AssignmentStatus,
 )
 from utils.permissions import check_content_access
+from utils.score_category import resolve_score_category
 from .dependencies import get_current_teacher
 
 logger = logging.getLogger(__name__)
@@ -206,6 +207,9 @@ async def create_instant_practice(
         show_word=request.show_word,
         show_image=request.show_image,
         show_option_images=bool(request.show_option_images),  # Issue #631
+        score_category=resolve_score_category(
+            request.practice_mode, request.play_audio
+        ),
     )
     db.add(assignment)
     db.flush()

--- a/backend/tests/unit/test_score_category.py
+++ b/backend/tests/unit/test_score_category.py
@@ -1,0 +1,80 @@
+"""Unit tests for score_category resolution (Issue #708 PR-1).
+
+Mapping under test (see docs/design/score-category-mapping.md):
+  word_reading / reading           -> speaking (any audio)
+  word_cloze                       -> reading  (any audio)
+  rearrangement + audio off        -> reading
+  rearrangement + audio on         -> listening (falls through to general rule)
+  anything else + audio off        -> writing
+  anything else + audio on         -> listening
+"""
+import pytest
+
+from utils.score_category import resolve_score_category
+
+
+class TestSpeakingModes:
+    """Reading-aloud modes are always 'speaking', regardless of audio."""
+
+    @pytest.mark.parametrize("audio", [False, True])
+    def test_word_reading(self, audio):
+        assert resolve_score_category("word_reading", audio) == "speaking"
+
+    @pytest.mark.parametrize("audio", [False, True])
+    def test_reading(self, audio):
+        assert resolve_score_category("reading", audio) == "speaking"
+
+
+class TestAlwaysReading:
+    """word_cloze is 'reading' regardless of audio."""
+
+    @pytest.mark.parametrize("audio", [False, True])
+    def test_word_cloze(self, audio):
+        assert resolve_score_category("word_cloze", audio) == "reading"
+
+
+class TestRearrangement:
+    """rearrangement: reading when silent, listening when audio on."""
+
+    def test_silent(self):
+        assert resolve_score_category("rearrangement", False) == "reading"
+
+    def test_with_audio(self):
+        assert resolve_score_category("rearrangement", True) == "listening"
+
+
+class TestGeneralRule:
+    """Other modes: writing when silent, listening when audio on."""
+
+    @pytest.mark.parametrize(
+        "mode", ["word_selection", "word_spelling", "tug_of_war", "future_mode"]
+    )
+    def test_silent_is_writing(self, mode):
+        assert resolve_score_category(mode, False) == "writing"
+
+    @pytest.mark.parametrize(
+        "mode", ["word_selection", "word_spelling", "tug_of_war", "future_mode"]
+    )
+    def test_audio_is_listening(self, mode):
+        assert resolve_score_category(mode, True) == "listening"
+
+
+class TestEdgeCases:
+    """None / empty inputs fall through to the general rule, never crash."""
+
+    def test_none_mode_silent_is_writing(self):
+        assert resolve_score_category(None, False) == "writing"
+
+    def test_none_mode_audio_is_listening(self):
+        assert resolve_score_category(None, True) == "listening"
+
+    def test_empty_mode(self):
+        assert resolve_score_category("", False) == "writing"
+
+    def test_uppercase_mode_is_normalized(self):
+        # Defensive: callers shouldn't send uppercase, but if they do we
+        # still match the lowercase rule rather than fall through silently.
+        assert resolve_score_category("WORD_READING", False) == "speaking"
+
+    def test_none_audio_treated_as_off(self):
+        assert resolve_score_category("rearrangement", None) == "reading"

--- a/backend/utils/score_category.py
+++ b/backend/utils/score_category.py
@@ -1,0 +1,46 @@
+"""Score category resolution.
+
+Single source of truth for mapping (practice_mode, play_audio) -> ScoreCategory.
+See docs/design/score-category-mapping.md for the full table.
+"""
+from typing import Optional
+
+from models.base import ScoreCategory
+
+
+# practice_mode values that are inherently "speaking" (student reads aloud)
+_SPEAKING_MODES = frozenset({"reading", "word_reading"})
+
+# practice_mode values that are inherently "reading" regardless of audio
+_ALWAYS_READING_MODES = frozenset({"word_cloze"})
+
+# practice_mode values that go to "reading" only when audio is off
+_READING_WHEN_SILENT_MODES = frozenset({"rearrangement"})
+
+
+def resolve_score_category(
+    practice_mode: Optional[str], play_audio: Optional[bool]
+) -> str:
+    """Return the score_category string for an assignment.
+
+    Rules (see docs/design/score-category-mapping.md):
+      1. word_reading / reading           -> speaking (any audio)
+      2. word_cloze                       -> reading  (any audio)
+      3. rearrangement + audio off        -> reading
+      4. anything else + audio off        -> writing
+      5. anything else + audio on         -> listening
+
+    Always returns a value from ScoreCategory (never None). For an unknown
+    practice_mode we fall through to the audio-based default, which gives
+    sane behavior for future modes without code changes.
+    """
+    mode = (practice_mode or "").strip().lower()
+    audio_on = bool(play_audio)
+
+    if mode in _SPEAKING_MODES:
+        return ScoreCategory.SPEAKING.value
+    if mode in _ALWAYS_READING_MODES:
+        return ScoreCategory.READING.value
+    if mode in _READING_WHEN_SILENT_MODES and not audio_on:
+        return ScoreCategory.READING.value
+    return ScoreCategory.LISTENING.value if audio_on else ScoreCategory.WRITING.value

--- a/docs/design/score-category-mapping.md
+++ b/docs/design/score-category-mapping.md
@@ -1,0 +1,68 @@
+# Score Category Mapping
+
+> 作業計分類別（`score_category`）的自動判定規則。
+
+## 為什麼需要這份對照表
+
+成績單與分數統計需要把作業歸到四大語言技能之一：
+
+- **口說 (speaking)** — 學生開口朗讀／錄音
+- **閱讀 (reading)** — 學生看文字、靠閱讀理解作答（無音檔輔助）
+- **寫作 (writing)** — 學生用打字／選字作答，且沒有音檔輔助
+- **聽力 (listening)** — 作答時有播放音檔（學生需靠聽覺輔助）
+
+過去 `score_category` 是「教師建立作業時手動指定」的欄位，但實際上幾乎沒有 UI 在設定，
+導致大量作業 `score_category` 為 `NULL`，且即使有值也未必正確。
+
+從 issue #708 起，`score_category` 改為**由 `practice_mode` 與 `play_audio` 自動推導**，
+不再接受外部覆寫。所有既有資料以下表回填。
+
+## 對照表
+
+| # | Practice Mode | Audio (`play_audio`) | Category | 中文 |
+|---|--------------|---------------------|----------|------|
+| 1 | `word_reading`（單字朗讀） | 任意 | `speaking` | 口說 |
+| 2 | `reading`（例句朗讀） | 任意 | `speaking` | 口說 |
+| 3 | `word_cloze`（單字克漏字） | 任意 | `reading` | 閱讀 |
+| 4 | `rearrangement`（例句重組） | `false` | `reading` | 閱讀 |
+| 5 | 其他 practice_mode | `false` | `writing` | 寫作 |
+| 6 | 其他 practice_mode | `true` | `listening` | 聽力 |
+
+### 規則邏輯（白話）
+
+1. **朗讀類**（單字朗讀／例句朗讀）→ 一律 **口說**，因為作答行為本身就是開口。
+2. **克漏字**（`word_cloze`）→ 一律 **閱讀**，因為主要靠看上下文判斷答案，即使搭配音檔也只是輔助。
+3. **例句重組**（`rearrangement`）無音檔 → **閱讀**；有音檔 → 落到通則 6，視為 **聽力**。
+4. **通則**：
+   - 沒有音檔 → **寫作**（靠打字／選字作答）
+   - 有音檔 → **聽力**（需要靠聽辨輔助）
+
+### 衍生對照（常見 practice_mode 全展開）
+
+| Practice Mode | `play_audio=false` | `play_audio=true` |
+|---------------|-------------------|------------------|
+| `word_reading` | speaking | speaking |
+| `reading` | speaking | speaking |
+| `word_cloze` | reading | reading |
+| `rearrangement` | reading | listening |
+| `word_selection` | writing | listening |
+| `word_spelling` | writing | listening |
+| `tug_of_war` | writing | listening |
+| 未來新模式 | writing | listening |
+
+## 程式碼落實位置
+
+| 位置 | 用途 |
+|------|------|
+| [`backend/models/base.py`](../../backend/models/base.py) | `ScoreCategory` enum（`speaking` / `listening` / `writing` / `reading`） |
+| [`backend/utils/score_category.py`](../../backend/utils/score_category.py) | `resolve_score_category(practice_mode, play_audio)` 唯一判定函式 |
+| [`backend/routers/assignments/crud.py`](../../backend/routers/assignments/crud.py) | 建立／更新作業時呼叫 helper，覆寫 request 傳入的值 |
+| [`backend/routers/teachers/instant_practice.py`](../../backend/routers/teachers/instant_practice.py) | 即刻練習建立暫存作業時同樣套用 |
+| Alembic migration `add_score_category_auto_backfill` | 把既有資料依新規則重算 |
+
+## 未來新增 practice_mode 時要做什麼
+
+1. 在上面的「衍生對照」表加一列；
+2. 若該模式不符合「通則」或「朗讀類／克漏字／重組」既有分支，請更新 `resolve_score_category`
+   並補上對應的單元測試（[`backend/tests/unit/test_score_category.py`](../../backend/tests/unit/test_score_category.py)）；
+3. 若新增類別會影響成績單顯示順序，請同步檢視 [grade-report-architecture.md](./grade-report-architecture.md)（issue #708 PR-2 加入）。

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -899,7 +899,6 @@
       "speaking": "Speaking",
       "listening": "Listening",
       "writing": "Writing",
-      "vocabulary": "Vocabulary",
       "reading": "Reading"
     },
     "practiceMode": {

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -59,7 +59,6 @@
       "speaking": "スピーキング",
       "listening": "リスニング",
       "writing": "ライティング",
-      "vocabulary": "語彙",
       "reading": "リーディング"
     },
     "practiceMode": {

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -59,7 +59,6 @@
       "speaking": "말하기",
       "listening": "듣기",
       "writing": "쓰기",
-      "vocabulary": "어휘",
       "reading": "읽기"
     },
     "practiceMode": {

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -955,7 +955,6 @@
       "speaking": "口說",
       "listening": "聽力",
       "writing": "寫作",
-      "vocabulary": "字彙",
       "reading": "閱讀"
     },
     "practiceMode": {

--- a/frontend/src/pages/student/StudentAssignmentList.tsx
+++ b/frontend/src/pages/student/StudentAssignmentList.tsx
@@ -44,12 +44,12 @@ const PRACTICE_MODE_ICONS: Record<string, React.ReactNode> = {
   word_cloze: <FileText className="h-7 w-7 sm:h-8 sm:w-8" />,
 };
 
-// Score category colors
+// Score category colors — keys must match ScoreCategory enum values
+// (see docs/design/score-category-mapping.md)
 const SCORE_CATEGORY_COLORS: Record<string, string> = {
   speaking: "bg-orange-100 text-orange-700 border-orange-200",
   listening: "bg-purple-100 text-purple-700 border-purple-200",
   writing: "bg-blue-100 text-blue-700 border-blue-200",
-  vocabulary: "bg-emerald-100 text-emerald-700 border-emerald-200",
   reading: "bg-pink-100 text-pink-700 border-pink-200",
 };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -234,7 +234,7 @@ export interface StudentAssignmentCard {
   estimated_time?: string;
   content_type?: string;
   practice_mode?: string; // 'reading' | 'rearrangement' | 'word_selection' | 'word_reading'
-  score_category?: string; // 'speaking' | 'listening' | 'writing' | 'vocabulary' | 'reading'
+  score_category?: string; // 'speaking' | 'listening' | 'writing' | 'reading' — auto-resolved from practice_mode + play_audio; see docs/design/score-category-mapping.md
   classroom_name?: string;
   teacher_name?: string;
   score?: number;


### PR DESCRIPTION
## Summary

Companion to #744 (the data backfill, already merged). This is the second of three PRs splitting issue #708:

- ✅ **#744 (PR-1a, merged)** — data backfill migration.
- 🟢 **This PR (PR-1b)** — auto-resolution helper + wiring + enum rename + frontend cleanup + design doc + tests.
- ⏳ **PR-2 (next)** — the 班級成績單／學生成績單 download feature.

After this lands, every newly-created or edited assignment has a `score_category` that is consistent with its `practice_mode` + `play_audio`, and every existing row already reflects the same rule (thanks to #744).

## Mapping

| Rule | practice_mode | audio | score_category |
|------|--------------|-------|---------------|
| 1 | \`word_reading\`, \`reading\` | any | \`speaking\` |
| 2 | \`word_cloze\` | any | \`reading\` |
| 3 | \`rearrangement\` | off | \`reading\` |
| 4 | (other) | off | \`writing\` |
| 5 | (other) | on | \`listening\` |

Full rationale + a maintenance guide for future practice modes lives in [\`docs/design/score-category-mapping.md\`](docs/design/score-category-mapping.md). Pointer added to \`CLAUDE.md\` under Project-Specific Rules #6.

## Changes

**Backend**
- \`backend/utils/score_category.py\` *(new)* — \`resolve_score_category(practice_mode, play_audio)\` helper. Single source of truth.
- \`backend/models/base.py\` — \`ScoreCategory.VOCABULARY\` → \`READING\`. Safe rename: the column is \`VARCHAR(20)\`, not a PG enum, and #744 already remapped existing rows.
- \`backend/routers/assignments/crud.py\` — POST overrides client-supplied \`score_category\`; PATCH recomputes when \`play_audio\` is toggled.
- \`backend/routers/teachers/instant_practice.py\` — same auto-resolution on instant-practice assignment creation.
- \`backend/tests/unit/test_score_category.py\` *(new)* — 21 tests; every rule branch + edge cases (\`None\`, empty, casing, unknown modes).

**Frontend** (housekeeping only — no behavior change)
- \`frontend/src/types/index.ts\` — type-union comment updated.
- \`frontend/src/pages/student/StudentAssignmentList.tsx\` — drop dead \`vocabulary\` color key.
- \`frontend/src/i18n/locales/{zh-TW,en,ja,ko}/translation.json\` — drop dead \`vocabulary\` scoreCategory key.

**Docs**
- \`docs/design/score-category-mapping.md\` *(new)*
- \`CLAUDE.md\` — Project-Specific Rules #6 pointing at the mapping doc

## Test plan

- [x] \`pytest tests/unit/test_score_category.py\` — 21 passed
- [x] \`pytest tests/unit/test_assignment_schemas.py tests/unit/test_assignment_workflows.py tests/integration/api/test_assignment_bulk_operations.py\` — 43 passed
- [x] \`black --check\` + \`flake8\` clean on touched files
- [x] \`npm run typecheck\` passes
- [x] \`alembic heads\` single (\`20260513_1700\` from #744)
- [ ] CI green
- [ ] Manual: create a \`rearrangement\` assignment with \`play_audio=true\`, confirm DB row gets \`score_category='listening'\`; toggle audio off via PATCH and confirm it flips to \`'reading'\`.

## Notes for reviewer

- \`backend/routers/assignments/crud.py\` PUT \`update_assignment\` does NOT update practice settings (it only touches title/desc/due_date/contents), so no score_category change needed there. Confirmed by reading the body of the handler.
- A handful of pre-existing failures in \`test_assignment_content_copy_mechanism.py\` and \`test_assignment_models.py\` are present on staging too — not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)