### PR TITLE
fix(#706): 單字集副本編輯 TTS 資料遺失 + 隱藏開放編輯器/Add Item

### DIFF
--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -4180,156 +4180,157 @@ const VocabularySetPanel = forwardRef<
       <div className="flex flex-1 gap-4 min-h-0">
         {/* Left: Batch Work Area (Desktop only) — hidden for assignment copy */}
         {!isAssignmentCopy && (
-        <BatchWorkPanel
-          text={batchPasteText}
-          onTextChange={setBatchPasteText}
-          maxItems={BATCH_PASTE_MAX}
-          placeholder="apple&#10;banana&#10;orange"
-          autoTranslate={batchPasteAutoTranslate}
-          onAutoTranslateChange={setBatchPasteAutoTranslate}
-          selectedLanguage={lastSelectedWordLang}
-          onLanguageChange={(lang) => {
-            const newLang = lang as WordTranslationLanguage;
-            setLastSelectedWordLang(newLang);
-            setRows((prev) =>
-              prev.map((row) => ({ ...row, selectedWordLanguage: newLang })),
-            );
-          }}
-          translationLanguages={WORD_TRANSLATION_LANGUAGES}
-          customLanguage={customTranslationLang}
-          onCustomLanguageChange={setCustomTranslationLang}
-          autoTTS={batchPasteAutoTTS}
-          onAutoTTSChange={setBatchPasteAutoTTS}
-          ttsSettings={{
-            accent: batchTTSAccent,
-            gender: batchTTSGender,
-            speed: batchTTSSpeed,
-          }}
-          onTTSSettingsChange={(s) => {
-            setBatchTTSAccent(s.accent);
-            setBatchTTSGender(s.gender);
-            setBatchTTSSpeed(s.speed);
-          }}
-          onConfirm={() =>
-            handleBatchPaste(batchPasteAutoTTS, batchPasteAutoTranslate)
-          }
-          onPause={() => {
-            batchPauseRef.current = true;
-          }}
-          isBusy={isBatchPasting}
-          progress={batchProgress}
-        >
-          {/* AI Generate Examples */}
-          <div className="mt-4 bg-purple-50 rounded-lg border border-purple-200 overflow-hidden">
-            <div className="flex items-center gap-2 p-3">
-              <input
-                type="checkbox"
-                checked={aiGenerateExpanded}
-                onChange={(e) => setAiGenerateExpanded(e.target.checked)}
-                className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-              />
-              <Sparkles className="h-4 w-4" />
-              <span className="text-sm font-semibold text-gray-800">
-                {t("vocabularySet.modals.aiGenerateExamplesTitle")}
-              </span>
-              <span className="text-[10px] font-bold text-purple-600 bg-purple-100 px-1.5 py-0.5 rounded">
-                Beta
-              </span>
-            </div>
-            {aiGenerateExpanded && (
-              <div className="px-3 pb-3 space-y-3">
-                {/* Difficulty Level */}
-                <div>
-                  <label className="text-xs text-gray-600 mb-1 block">
-                    {t("vocabularySet.labels.difficultyLevel")}
-                  </label>
-                  <div className="flex flex-wrap gap-1">
-                    {["A1", "A2", "B1", "B2", "C1", "C2"].map((level) => (
-                      <button
-                        key={level}
-                        onClick={() => setAiGenerateLevel(level)}
-                        className={`px-2.5 py-1 rounded text-xs font-medium transition-all ${
-                          aiGenerateLevel === level
-                            ? "bg-gradient-to-r from-cyan-400 to-teal-400 text-white shadow-sm"
-                            : "bg-gray-200 text-gray-700 hover:bg-gray-300"
-                        }`}
-                      >
-                        {level}
-                      </button>
-                    ))}
+          <BatchWorkPanel
+            text={batchPasteText}
+            onTextChange={setBatchPasteText}
+            maxItems={BATCH_PASTE_MAX}
+            placeholder="apple&#10;banana&#10;orange"
+            autoTranslate={batchPasteAutoTranslate}
+            onAutoTranslateChange={setBatchPasteAutoTranslate}
+            selectedLanguage={lastSelectedWordLang}
+            onLanguageChange={(lang) => {
+              const newLang = lang as WordTranslationLanguage;
+              setLastSelectedWordLang(newLang);
+              setRows((prev) =>
+                prev.map((row) => ({ ...row, selectedWordLanguage: newLang })),
+              );
+            }}
+            translationLanguages={WORD_TRANSLATION_LANGUAGES}
+            customLanguage={customTranslationLang}
+            onCustomLanguageChange={setCustomTranslationLang}
+            autoTTS={batchPasteAutoTTS}
+            onAutoTTSChange={setBatchPasteAutoTTS}
+            ttsSettings={{
+              accent: batchTTSAccent,
+              gender: batchTTSGender,
+              speed: batchTTSSpeed,
+            }}
+            onTTSSettingsChange={(s) => {
+              setBatchTTSAccent(s.accent);
+              setBatchTTSGender(s.gender);
+              setBatchTTSSpeed(s.speed);
+            }}
+            onConfirm={() =>
+              handleBatchPaste(batchPasteAutoTTS, batchPasteAutoTranslate)
+            }
+            onPause={() => {
+              batchPauseRef.current = true;
+            }}
+            isBusy={isBatchPasting}
+            progress={batchProgress}
+          >
+            {/* AI Generate Examples */}
+            <div className="mt-4 bg-purple-50 rounded-lg border border-purple-200 overflow-hidden">
+              <div className="flex items-center gap-2 p-3">
+                <input
+                  type="checkbox"
+                  checked={aiGenerateExpanded}
+                  onChange={(e) => setAiGenerateExpanded(e.target.checked)}
+                  className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <Sparkles className="h-4 w-4" />
+                <span className="text-sm font-semibold text-gray-800">
+                  {t("vocabularySet.modals.aiGenerateExamplesTitle")}
+                </span>
+                <span className="text-[10px] font-bold text-purple-600 bg-purple-100 px-1.5 py-0.5 rounded">
+                  Beta
+                </span>
+              </div>
+              {aiGenerateExpanded && (
+                <div className="px-3 pb-3 space-y-3">
+                  {/* Difficulty Level */}
+                  <div>
+                    <label className="text-xs text-gray-600 mb-1 block">
+                      {t("vocabularySet.labels.difficultyLevel")}
+                    </label>
+                    <div className="flex flex-wrap gap-1">
+                      {["A1", "A2", "B1", "B2", "C1", "C2"].map((level) => (
+                        <button
+                          key={level}
+                          onClick={() => setAiGenerateLevel(level)}
+                          className={`px-2.5 py-1 rounded text-xs font-medium transition-all ${
+                            aiGenerateLevel === level
+                              ? "bg-gradient-to-r from-cyan-400 to-teal-400 text-white shadow-sm"
+                              : "bg-gray-200 text-gray-700 hover:bg-gray-300"
+                          }`}
+                        >
+                          {level}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* AI Prompt */}
+                  <div>
+                    <label className="text-xs text-gray-600 mb-1 block">
+                      {t("vocabularySet.labels.aiPrompt")}
+                    </label>
+                    <textarea
+                      value={aiGeneratePrompt}
+                      onChange={(e) => setAiGeneratePrompt(e.target.value)}
+                      placeholder={t(
+                        "vocabularySet.placeholders.aiPromptExample",
+                      )}
+                      className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm resize-none"
+                      rows={2}
+                    />
+                  </div>
+
+                  {/* Sentence translation language selector */}
+                  <div className="space-y-1.5">
+                    <label className="text-xs text-gray-600 block">
+                      {t("vocabularySet.labels.translateTo")}
+                    </label>
+                    <select
+                      value={aiGenerateTranslateLang}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        setAiGenerateTranslateLang(val);
+                        if (val !== "other")
+                          setCustomSentenceTranslationLang("");
+                        // 切換語言時清空所有例句翻譯欄位
+                        setRows((prev) =>
+                          prev.map((row) => ({
+                            ...row,
+                            example_sentence_translation: "",
+                            example_sentence_japanese: "",
+                            example_sentence_korean: "",
+                            selectedSentenceLanguage: (val || undefined) as
+                              | SentenceTranslationLanguage
+                              | undefined,
+                          })),
+                        );
+                      }}
+                      className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                    >
+                      <option value="">
+                        {t("contentEditor.labels.selectLanguage")}
+                      </option>
+                      {SENTENCE_TRANSLATION_LANGUAGES.map((lang) => (
+                        <option key={lang.value} value={lang.value}>
+                          {lang.label}
+                        </option>
+                      ))}
+                      <option value="other">
+                        {t("contentEditor.labels.otherLanguage")}
+                      </option>
+                    </select>
+                    {aiGenerateTranslateLang === "other" && (
+                      <input
+                        type="text"
+                        value={customSentenceTranslationLang}
+                        onChange={(e) =>
+                          setCustomSentenceTranslationLang(e.target.value)
+                        }
+                        placeholder={t("contentEditor.labels.enterLanguage")}
+                        className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                      />
+                    )}
                   </div>
                 </div>
-
-                {/* AI Prompt */}
-                <div>
-                  <label className="text-xs text-gray-600 mb-1 block">
-                    {t("vocabularySet.labels.aiPrompt")}
-                  </label>
-                  <textarea
-                    value={aiGeneratePrompt}
-                    onChange={(e) => setAiGeneratePrompt(e.target.value)}
-                    placeholder={t(
-                      "vocabularySet.placeholders.aiPromptExample",
-                    )}
-                    className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm resize-none"
-                    rows={2}
-                  />
-                </div>
-
-                {/* Sentence translation language selector */}
-                <div className="space-y-1.5">
-                  <label className="text-xs text-gray-600 block">
-                    {t("vocabularySet.labels.translateTo")}
-                  </label>
-                  <select
-                    value={aiGenerateTranslateLang}
-                    onChange={(e) => {
-                      const val = e.target.value;
-                      setAiGenerateTranslateLang(val);
-                      if (val !== "other") setCustomSentenceTranslationLang("");
-                      // 切換語言時清空所有例句翻譯欄位
-                      setRows((prev) =>
-                        prev.map((row) => ({
-                          ...row,
-                          example_sentence_translation: "",
-                          example_sentence_japanese: "",
-                          example_sentence_korean: "",
-                          selectedSentenceLanguage: (val || undefined) as
-                            | SentenceTranslationLanguage
-                            | undefined,
-                        })),
-                      );
-                    }}
-                    className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
-                  >
-                    <option value="">
-                      {t("contentEditor.labels.selectLanguage")}
-                    </option>
-                    {SENTENCE_TRANSLATION_LANGUAGES.map((lang) => (
-                      <option key={lang.value} value={lang.value}>
-                        {lang.label}
-                      </option>
-                    ))}
-                    <option value="other">
-                      {t("contentEditor.labels.otherLanguage")}
-                    </option>
-                  </select>
-                  {aiGenerateTranslateLang === "other" && (
-                    <input
-                      type="text"
-                      value={customSentenceTranslationLang}
-                      onChange={(e) =>
-                        setCustomSentenceTranslationLang(e.target.value)
-                      }
-                      placeholder={t("contentEditor.labels.enterLanguage")}
-                      className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
-                    />
-                  )}
-                </div>
-              </div>
-            )}
-          </div>
-        </BatchWorkPanel>
+              )}
+            </div>
+          </BatchWorkPanel>
         )}
 
         {/* Right: Word Editor Area */}

--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -303,10 +303,7 @@ interface ApiContentItem {
   selectedSentenceLanguage?: SentenceTranslationLanguage;
 }
 
-// Single source of truth for API item -> ContentRow conversion. Reused by the
-// initial content load and by handlers that re-fetch after a save (e.g. TTS
-// regen) to avoid silently dropping fields like image_url / example_sentence /
-// translations (Issue #706).
+// Must stay in sync with the API response shape — used by every reload path to avoid silently dropping fields.
 function mapApiItemToRow(item: ApiContentItem, index: number): ContentRow {
   let definition = "";
   let translation = "";
@@ -371,7 +368,7 @@ function mapApiItemToRow(item: ApiContentItem, index: number): ContentRow {
     example_sentence_korean,
     example_sentence_audio_url: item.example_sentence_audio_url || "",
     partsOfSpeech: item.parts_of_speech || [],
-    distractors: item.distractors || undefined,
+    distractors: item.distractors,
   };
 }
 

--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -4178,7 +4178,8 @@ const VocabularySetPanel = forwardRef<
 
       {/* Desktop: Side-by-side layout / Mobile: Editor only */}
       <div className="flex flex-1 gap-4 min-h-0">
-        {/* Left: Batch Work Area (Desktop only) */}
+        {/* Left: Batch Work Area (Desktop only) — hidden for assignment copy */}
+        {!isAssignmentCopy && (
         <BatchWorkPanel
           text={batchPasteText}
           onTextChange={setBatchPasteText}
@@ -4329,6 +4330,7 @@ const VocabularySetPanel = forwardRef<
             )}
           </div>
         </BatchWorkPanel>
+        )}
 
         {/* Right: Word Editor Area */}
         <div className="flex-1 flex flex-col min-h-0">
@@ -4388,15 +4390,17 @@ const VocabularySetPanel = forwardRef<
                   );
                 })}
 
-                {/* Add Row Button */}
-                <button
-                  onClick={handleAddRow}
-                  className="w-full py-2 border-2 border-dashed border-gray-300 rounded-lg hover:border-blue-400 flex items-center justify-center gap-2 text-gray-600 hover:text-blue-600"
-                  disabled={rows.length >= BATCH_PASTE_MAX}
-                >
-                  <Plus className="h-5 w-5" />
-                  {t("contentEditor.buttons.addItem")}
-                </button>
+                {/* Add Row Button — hidden for assignment copy */}
+                {!isAssignmentCopy && (
+                  <button
+                    onClick={handleAddRow}
+                    className="w-full py-2 border-2 border-dashed border-gray-300 rounded-lg hover:border-blue-400 flex items-center justify-center gap-2 text-gray-600 hover:text-blue-600"
+                    disabled={rows.length >= BATCH_PASTE_MAX}
+                  >
+                    <Plus className="h-5 w-5" />
+                    {t("contentEditor.buttons.addItem")}
+                  </button>
+                )}
               </div>
             </SortableContext>
           </DndContext>

--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -280,6 +280,101 @@ interface ContentRow {
 
 export type Distractor = string | { text: string; image_url?: string | null };
 
+interface ApiContentItem {
+  text?: string;
+  definition?: string;
+  audio_url?: string;
+  image_url?: string;
+  example_sentence?: string;
+  example_sentence_translation?: string;
+  parts_of_speech?: string[];
+  distractors?: Distractor[];
+  vocabulary_translation?: string;
+  vocabulary_translation_lang?: WordTranslationLanguage;
+  example_sentence_translation_lang?: SentenceTranslationLanguage;
+  english_definition?: string;
+  selectedWordLanguage?: WordTranslationLanguage;
+  translation?: string;
+  japanese_translation?: string;
+  korean_translation?: string;
+  example_sentence_japanese?: string;
+  example_sentence_korean?: string;
+  example_sentence_audio_url?: string;
+  selectedSentenceLanguage?: SentenceTranslationLanguage;
+}
+
+// Single source of truth for API item -> ContentRow conversion. Reused by the
+// initial content load and by handlers that re-fetch after a save (e.g. TTS
+// regen) to avoid silently dropping fields like image_url / example_sentence /
+// translations (Issue #706).
+function mapApiItemToRow(item: ApiContentItem, index: number): ContentRow {
+  let definition = "";
+  let translation = "";
+  let japanese_translation = "";
+  let korean_translation = "";
+  let selectedWordLanguage: WordTranslationLanguage = "chinese";
+
+  if (item.vocabulary_translation_lang && item.vocabulary_translation) {
+    selectedWordLanguage = item.vocabulary_translation_lang;
+    definition = item.definition || "";
+    if (selectedWordLanguage === "chinese") {
+      definition = item.vocabulary_translation;
+    } else if (selectedWordLanguage === "english") {
+      translation = item.vocabulary_translation;
+    } else if (selectedWordLanguage === "japanese") {
+      japanese_translation = item.vocabulary_translation;
+    } else if (selectedWordLanguage === "korean") {
+      korean_translation = item.vocabulary_translation;
+    }
+  } else {
+    definition = item.definition || "";
+  }
+
+  let example_sentence_translation = "";
+  let example_sentence_japanese = "";
+  let example_sentence_korean = "";
+  let selectedSentenceLanguage: SentenceTranslationLanguage = "chinese";
+
+  if (
+    item.example_sentence_translation_lang &&
+    item.example_sentence_translation
+  ) {
+    selectedSentenceLanguage = item.example_sentence_translation_lang;
+    if (item.example_sentence_translation_lang === "chinese") {
+      example_sentence_translation = item.example_sentence_translation;
+    } else if (item.example_sentence_translation_lang === "japanese") {
+      example_sentence_japanese = item.example_sentence_translation;
+    } else if (item.example_sentence_translation_lang === "korean") {
+      example_sentence_korean = item.example_sentence_translation;
+    }
+  } else {
+    example_sentence_translation = item.example_sentence_translation || "";
+    example_sentence_japanese = item.example_sentence_japanese || "";
+    example_sentence_korean = item.example_sentence_korean || "";
+    selectedSentenceLanguage = item.selectedSentenceLanguage || "chinese";
+  }
+
+  return {
+    id: (index + 1).toString(),
+    text: item.text || "",
+    definition,
+    translation,
+    japanese_translation,
+    korean_translation,
+    audioUrl: item.audio_url || "",
+    imageUrl: item.image_url || "",
+    selectedWordLanguage,
+    selectedSentenceLanguage,
+    example_sentence: item.example_sentence || "",
+    example_sentence_translation,
+    example_sentence_japanese,
+    example_sentence_korean,
+    example_sentence_audio_url: item.example_sentence_audio_url || "",
+    partsOfSpeech: item.parts_of_speech || [],
+    distractors: item.distractors || undefined,
+  };
+}
+
 function getDistractorText(d: Distractor): string {
   if (typeof d === "string") return d;
   return d?.text ?? "";
@@ -1839,117 +1934,8 @@ const VocabularySetPanel = forwardRef<
 
       // Convert items to rows format
       if (data.items && Array.isArray(data.items)) {
-        const convertedRows = data.items.map(
-          (
-            item: {
-              text?: string;
-              definition?: string;
-              audio_url?: string;
-              image_url?: string;
-              example_sentence?: string;
-              example_sentence_translation?: string;
-              parts_of_speech?: string[];
-              distractors?: string[];
-              // 統一翻譯欄位（canonical）
-              vocabulary_translation?: string;
-              vocabulary_translation_lang?: WordTranslationLanguage;
-              example_sentence_translation_lang?: SentenceTranslationLanguage;
-              // 向後相容（ReadingAssessmentPanel 仍使用，VocabularySetPanel 不讀取）
-              english_definition?: string;
-              selectedWordLanguage?: WordTranslationLanguage;
-              translation?: string;
-              japanese_translation?: string;
-              korean_translation?: string;
-              example_sentence_japanese?: string;
-              example_sentence_korean?: string;
-              example_sentence_audio_url?: string;
-              selectedSentenceLanguage?: SentenceTranslationLanguage;
-            },
-            index: number,
-          ) => {
-            // 處理單字翻譯：優先使用新的統一欄位
-            let definition = "";
-            let translation = "";
-            let japanese_translation = "";
-            let korean_translation = "";
-            let selectedWordLanguage: WordTranslationLanguage = "chinese";
-
-            if (
-              item.vocabulary_translation_lang &&
-              item.vocabulary_translation
-            ) {
-              // 使用新的統一欄位格式
-              selectedWordLanguage = item.vocabulary_translation_lang;
-              // 永遠先載入中文翻譯，避免切換其他語言後中文遺失 (#366)
-              definition = item.definition || "";
-              // 再把 vocabulary_translation 放到對應語言欄位
-              if (selectedWordLanguage === "chinese") {
-                definition = item.vocabulary_translation;
-              } else if (selectedWordLanguage === "english") {
-                translation = item.vocabulary_translation;
-              } else if (selectedWordLanguage === "japanese") {
-                japanese_translation = item.vocabulary_translation;
-              } else if (selectedWordLanguage === "korean") {
-                korean_translation = item.vocabulary_translation;
-              }
-            } else {
-              // Fallback：vocabulary_translation 不存在時，從 definition 讀取中文
-              definition = item.definition || "";
-            }
-
-            // 處理例句翻譯：優先使用新的統一欄位
-            let example_sentence_translation = "";
-            let example_sentence_japanese = "";
-            let example_sentence_korean = "";
-            let selectedSentenceLanguage: SentenceTranslationLanguage =
-              "chinese";
-
-            if (
-              item.example_sentence_translation_lang &&
-              item.example_sentence_translation
-            ) {
-              // 使用新的統一欄位格式
-              selectedSentenceLanguage = item.example_sentence_translation_lang;
-              if (item.example_sentence_translation_lang === "chinese") {
-                example_sentence_translation =
-                  item.example_sentence_translation;
-              } else if (
-                item.example_sentence_translation_lang === "japanese"
-              ) {
-                example_sentence_japanese = item.example_sentence_translation;
-              } else if (item.example_sentence_translation_lang === "korean") {
-                example_sentence_korean = item.example_sentence_translation;
-              }
-            } else {
-              // 向後相容：使用舊的欄位格式
-              example_sentence_translation =
-                item.example_sentence_translation || "";
-              example_sentence_japanese = item.example_sentence_japanese || "";
-              example_sentence_korean = item.example_sentence_korean || "";
-              selectedSentenceLanguage =
-                item.selectedSentenceLanguage || "chinese";
-            }
-
-            return {
-              id: (index + 1).toString(),
-              text: item.text || "",
-              definition,
-              translation,
-              japanese_translation,
-              korean_translation,
-              audioUrl: item.audio_url || "",
-              imageUrl: item.image_url || "",
-              selectedWordLanguage,
-              selectedSentenceLanguage,
-              example_sentence: item.example_sentence || "",
-              example_sentence_translation,
-              example_sentence_japanese,
-              example_sentence_korean,
-              example_sentence_audio_url: item.example_sentence_audio_url || "",
-              partsOfSpeech: item.parts_of_speech || [],
-              distractors: item.distractors || undefined,
-            };
-          },
+        const convertedRows = data.items.map((item, index) =>
+          mapApiItemToRow(item as ApiContentItem, index),
         );
         setRows(convertedRows);
 
@@ -2308,21 +2294,8 @@ const VocabularySetPanel = forwardRef<
               editingContent.id,
             );
             if (response && response.items) {
-              const updatedRows = response.items.map(
-                (
-                  item: {
-                    text?: string;
-                    translation?: string;
-                    definition?: string;
-                    audio_url?: string;
-                  },
-                  index: number,
-                ) => ({
-                  id: String(index + 1),
-                  text: item.text || "",
-                  definition: item.definition || "",
-                  audioUrl: item.audio_url || "",
-                }),
+              const updatedRows = response.items.map((item, index) =>
+                mapApiItemToRow(item as ApiContentItem, index),
               );
               setRows(updatedRows);
             }

--- a/frontend/src/pages/teacher/TeacherAssignmentDetailPage.tsx
+++ b/frontend/src/pages/teacher/TeacherAssignmentDetailPage.tsx
@@ -1350,7 +1350,7 @@ export default function TeacherAssignmentDetailPage() {
             open={editingContentId !== null}
             onOpenChange={(open) => !open && setEditingContentId(null)}
           >
-            <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+            <DialogContent className="max-w-[100vw] sm:max-w-4xl h-[100dvh] sm:h-auto sm:max-h-[90vh] overflow-y-auto rounded-none sm:rounded-lg p-4 sm:p-6">
               <DialogHeader>
                 <DialogTitle>
                   {t("assignmentDetail.labels.editContent", "編輯作業內容")}

--- a/frontend/src/pages/teacher/TeacherAssignmentDetailPage.tsx
+++ b/frontend/src/pages/teacher/TeacherAssignmentDetailPage.tsx
@@ -1350,7 +1350,13 @@ export default function TeacherAssignmentDetailPage() {
             open={editingContentId !== null}
             onOpenChange={(open) => !open && setEditingContentId(null)}
           >
-            <DialogContent className="max-w-[100vw] sm:max-w-4xl h-[100dvh] sm:h-auto sm:max-h-[90vh] overflow-y-auto rounded-none sm:rounded-lg p-4 sm:p-6">
+            <DialogContent
+              className={`max-w-[100vw] h-[100dvh] sm:h-auto sm:max-h-[90vh] overflow-y-auto rounded-none sm:rounded-lg p-4 sm:p-6 ${
+                assignment?.practice_mode === "word_selection"
+                  ? "sm:max-w-3xl"
+                  : "sm:max-w-4xl"
+              }`}
+            >
               <DialogHeader>
                 <DialogTitle>
                   {t("assignmentDetail.labels.editContent", "編輯作業內容")}


### PR DESCRIPTION
## Summary
- 修復編輯副本 TTS 重新生成後 image_url / example_sentence / 翻譯 / parts_of_speech / distractors 等欄位遺失的 bug（抽出 `mapApiItemToRow` helper，重新載入時完整保留欄位）
- 編輯副本（`isAssignmentCopy`）時隱藏左欄 BatchWorkPanel（請貼上單字 / AI 翻譯 / AI 語音 / AI 例句 / 魔術貼上）與 Add Item 按鈕
- 編輯副本 Dialog：手機版 100vw × 100dvh 滿版顯示；桌機 word_selection 模式縮為 `max-w-3xl` 配合左欄消失

Fixes #706

## Test plan
- [ ] 單字集 → 單字朗讀派發後編輯副本，刪除單一 item 音檔並重新生成，確認其餘 items 完整顯示
- [ ] 作業管理 edit 副本介面確認左欄 BatchWorkPanel 與 Add Item 按鈕已隱藏
- [ ] 手機版開啟編輯副本 Dialog 滿版顯示
- [ ] 桌機 word_selection 編輯副本 Dialog 寬度為 `max-w-3xl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)