### PR TITLE
refactor(#752): 派發 sheet 排版重構（左 rail + 右 panel + 即時預覽）

### DIFF
--- a/docs/design/preview-architecture.md
+++ b/docs/design/preview-architecture.md
@@ -1,0 +1,109 @@
+# 派發 Sheet 即時預覽架構
+
+> **建立於 2026-05-15（issue #752）** · 影響：所有學生作答 Activity 元件、派發對話框預覽
+
+## TL;DR
+
+派發 sheet 的「學生畫面預覽」**直接重用**學生端 Activity 元件本身（不 mock、不複製）。
+這樣老師看到的 = 學生實際看到的，零維護成本，但代價是**改動 Activity 元件就必須驗證預覽**。
+
+**所有 `frontend/src/components/activities/*Activity.tsx`（與 `ReadingAssessmentTemplate.tsx`）改動 UI 或行為時，請打開「指派新作業」對話框、選對應練習模式，確認預覽仍正常。**
+
+---
+
+## 為什麼這樣設計
+
+替代方案的取捨：
+
+| 方案 | 老師看到的 ≈ 學生看到的？ | 維護成本 | 採用？ |
+|------|---|---|---|
+| Mock UI（手刻一份預覽元件） | 容易 drift（學生端改了 mock 沒改） | 高 | ❌ |
+| iframe 嵌入學生頁 | 一致 | iframe 通訊複雜、auth 麻煩 | ❌ |
+| **重用學生 Activity 元件 + previewItems prop** | **100% 一致** | 低，但元件改動需驗證預覽 | ✅ |
+
+## 架構
+
+兩條 code path：
+
+```
+                    ┌──────────────────────────────────────────────┐
+                    │          XxxActivity.tsx                     │
+                    │  （fetch / submit / Azure / quota 都在這）    │
+                    └─────────────┬─────────────────┬──────────────┘
+                                  │                 │
+                  ┌───────────────┴────┐     ┌──────┴──────────────┐
+                  │ 學生作答頁         │     │ 派發 sheet 預覽      │
+                  │ assignmentId 真實  │     │ XxxPreview.tsx      │
+                  │ isPreviewMode=false│     │ 提供 previewItems   │
+                  │ → 走 fetch 與 API  │     │ → 跳過 fetch/submit │
+                  └────────────────────┘     └─────────────────────┘
+```
+
+### 兩種預覽 wrapper 子類
+
+#### A. previewItems 路徑（`isLivePreview` 旗標）
+
+對於可以「外部餵題目」的元件，wrapper 抓 content（teacher API），轉換成元件需要的資料格式，
+透過 `previewItems` / `previewWords` / `previewQuestions` prop 餵進元件，元件偵測到該 prop
+存在就跳過自己的 fetch + 跳過所有 submit / upload / quota 路徑。
+
+| 模式 | Activity | Preview Wrapper | 資料來源 |
+|---|---|---|---|
+| word_reading | WordReadingActivity | WordReadingPreview | `/api/teachers/contents/282` |
+| word_selection | WordSelectionActivity | WordSelectionPreview | `/api/teachers/contents/282` + 前端組 4 選項 |
+| word_spelling | WordSpellingActivity | WordSpellingPreview | `/api/teachers/contents/282` |
+| word_cloze | WordClozeActivity | WordClozeContextPreview | `/api/teachers/contents/282` + 前端把單字替換為 _____ |
+
+#### B. demo 路徑
+
+對於太複雜不想改造的元件（例如 reading 用的 `GroupedQuestionsTemplate`），wrapper 直接重用
+**既有的公開 demo 基礎設施**：抓 `/api/demo/config` 的 `demo_*_assignment_id`，丟給
+`StudentActivityPageContent` + `isDemoMode={true} isPreviewMode={true}`，這就是
+`https://duotopia.co/demo/<id>` 的同一條 code path。
+
+| 模式 | Preview Wrapper | demo_config key |
+|---|---|---|
+| reading | ReadingPreview | `demo_reading_assignment_id`（=74）|
+| rearrangement | RearrangementPreview | `demo_rearrangement_assignment_id`（=77）|
+
+**取捨**：demo 路徑下，預覽顯示的設定來自 demo assignment 自己存的值，
+**不會跟著老師當下調 toggle 變動**。reading / rearrangement 影響有限可接受；
+其他模式若也想走 demo 路徑就要承擔此 trade-off。
+
+---
+
+## 改 Activity 元件時的檢查清單
+
+當你動到 `frontend/src/components/activities/*Activity.tsx` 或 `ReadingAssessmentTemplate.tsx`：
+
+- [ ] 打開「指派新作業」對話框（從 `/teacher/programs` 或 `/teacher/classroom/<id>`）
+- [ ] 選對應的練習模式
+- [ ] 確認預覽渲染正常、沒報錯
+- [ ] 切該模式的 toggle（show_translation、play_audio、show_image 等），確認預覽即時反映（previewItems 路徑）或顯示提示文字（demo 路徑）
+- [ ] 如果新增了從 API 來的設定，記得：
+  - 加進對應 PreviewWrapper 的 `previewSettings` 型別
+  - AssignmentDialog 把 `formData.<新欄位>` 傳進去
+- [ ] 如果新增了 fetch / upload / submit，記得用 `isLivePreview` 旗標（或 `previewItems`/`previewWords`/`previewQuestions` 是否存在）gating
+
+## Code Path 防呆
+
+每個會被預覽共用的元件頂端 JSDoc 都有警示：
+
+```ts
+/**
+ * XxxActivity - …
+ *
+ * ⚠️ 此元件同時被學生作答頁與派發 sheet 預覽共用。
+ *    改動前必讀：docs/design/preview-architecture.md
+ */
+```
+
+每個 PreviewWrapper 也指回這份 doc。
+
+## 已知限制 / Trade-offs
+
+- **previewItems 路徑**：5 個元件需要小改（加 prop + 跳 fetch）。新增模式時要照同套路。
+- **demo 路徑**：設定來自 demo assignment 不跟著 formData 變。
+- **音檔**：vocab content 拿來預覽 reading 時沒有 example_sentence_audio_url（音檔須老師派發後補生成）。已在預覽顯示提示「正式作業可聽到音檔」。
+- **shuffle**：以前實作 Fisher-Yates 真的洗牌會閃白（item.id 改變觸發 reset effect）。改成顯示提示「學生實際作答時題目順序會被打亂」就好。
+- **AI 分析額度**：`isLivePreview` 路徑跳過 `/api/speech/upload-analysis` 避免扣老師點數。Azure SDK 本身的 token 取得不扣點。

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -68,9 +68,11 @@ import {
   type ScoreCategory,
 } from "@/utils/scoreCategory";
 import WordReadingPreview from "@/components/activities/WordReadingPreview";
+import WordSelectionPreview from "@/components/activities/WordSelectionPreview";
 
 // Issue #752 PoC: 預覽固定使用 contact@duotopia.co 的「翰林佳音 第二冊 Unit 1 Warm up」
 const PREVIEW_CONTENT_ID_WORD_READING = 282;
+const PREVIEW_CONTENT_ID_WORD_SELECTION = 282;
 
 interface Student {
   id: number;
@@ -3482,6 +3484,24 @@ export function AssignmentDialog({
                                 formData.time_limit_per_question,
                               show_image: formData.show_image,
                               show_translation: formData.show_translation,
+                              shuffle_questions: formData.shuffle_questions,
+                            }}
+                          />
+                        </Card>
+                      ) : formData.practice_mode === "word_selection" ? (
+                        <Card className="p-3 border-gray-200">
+                          <h4 className="text-xs font-semibold mb-2 text-gray-700">
+                            學生畫面預覽（demo 教材）
+                          </h4>
+                          <WordSelectionPreview
+                            contentId={PREVIEW_CONTENT_ID_WORD_SELECTION}
+                            settings={{
+                              show_image: formData.show_image,
+                              show_option_images: formData.show_option_images,
+                              play_audio: formData.play_audio,
+                              target_proficiency: formData.target_proficiency,
+                              time_limit_per_question:
+                                formData.time_limit_per_question,
                               shuffle_questions: formData.shuffle_questions,
                             }}
                           />

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -1442,7 +1442,12 @@ export function AssignmentDialog({
       <SheetContent
         side="right"
         aria-describedby={undefined}
-        className="!w-full !max-w-[calc(100vw-16rem)] h-full flex flex-col p-0 sm:!max-w-[calc(100vw-16rem)]"
+        className={cn(
+          "!w-full h-full flex flex-col p-0 transition-[max-width] duration-300 ease-out",
+          currentStep === 1 && !formData.practice_mode
+            ? "!max-w-[320px] sm:!max-w-[320px]"
+            : "!max-w-[calc(100vw-16rem)] sm:!max-w-[calc(100vw-16rem)]",
+        )}
       >
         {/* Compact Header with Clear Steps - 響應式方案 C */}
         <div className="px-6 py-3 border-b bg-gray-50">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2826,9 +2826,9 @@ export function AssignmentDialog({
                     </p>
                   </div>
 
-                  <div className="flex-1 flex gap-6 max-w-4xl mx-auto w-full">
+                  <div className="flex-1 min-h-0 flex gap-6 max-w-4xl mx-auto w-full">
                     {/* 左 rail：練習模式 row list */}
-                    <div className="w-[220px] shrink-0 space-y-2">
+                    <div className="w-[220px] shrink-0 space-y-2 overflow-y-auto pr-1">
                       {PRACTICE_MODES.map((m) => {
                         const selected = formData.practice_mode === m.id;
                         return (
@@ -2874,7 +2874,7 @@ export function AssignmentDialog({
                     </div>
 
                     {/* 右 panel：Hero + 進階設定 */}
-                    <div className="flex-1 min-w-0 space-y-4">
+                    <div className="flex-1 min-w-0 space-y-4 overflow-y-auto pr-1">
                       {currentMode && (
                         <div className="flex items-start gap-4 p-4 rounded-xl bg-gray-50">
                           <span className="text-4xl shrink-0">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -1459,7 +1459,7 @@ export function AssignmentDialog({
       <SheetContent
         side="right"
         aria-describedby={undefined}
-        className="!w-full !max-w-[calc(100vw-16rem)] h-full flex flex-col p-0 sm:!max-w-[calc(100vw-16rem)]"
+        className="!w-full !max-w-full md:!max-w-[calc(100vw-16rem)] h-full flex flex-col p-0"
       >
         {/* Compact Header with Clear Steps - 響應式方案 C */}
         <div className="px-6 py-3 border-b bg-gray-50">
@@ -2852,8 +2852,8 @@ export function AssignmentDialog({
                     })}
                   </div>
 
-                  <div className="flex-1 min-h-0 w-full grid grid-cols-4 gap-4">
-                    {/* 左：設定區（1/4） */}
+                  <div className="flex-1 min-h-0 w-full grid grid-cols-1 md:grid-cols-4 gap-4">
+                    {/* 左：設定區（mobile 全寬 / desktop 1/4） */}
                     <div className="col-span-1 min-w-0 space-y-4 overflow-y-auto pr-1 h-full">
                       {currentMode && (
                         <div className="p-4 rounded-xl bg-gray-50">
@@ -3488,8 +3488,8 @@ export function AssignmentDialog({
 
                     </div>
 
-                    {/* 右：學生畫面預覽（3/4） */}
-                    <div className="col-span-3 min-w-0 overflow-y-auto pr-1 h-full">
+                    {/* 右：學生畫面預覽（mobile 隱藏 / desktop 3/4） */}
+                    <div className="hidden md:block md:col-span-3 min-w-0 overflow-y-auto pr-1 h-full">
                       {formData.practice_mode === "word_reading" ? (
                         <Card className="p-3 border-gray-200">
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -1408,7 +1408,7 @@ export function AssignmentDialog({
         setFormData((prev) => ({
           ...prev,
           practice_mode: "word_reading",
-          time_limit_per_question: 0, // 單字朗讀預設不限時
+          time_limit_per_question: 10, // 單字朗讀固定 10 秒
         }));
       } else {
         // 例句集預設為例句朗讀模式
@@ -2739,7 +2739,7 @@ export function AssignmentDialog({
                     setFormData((prev) => ({
                       ...prev,
                       practice_mode: "word_reading",
-                      time_limit_per_question: 0,
+                      time_limit_per_question: 10,
                     })),
                 },
                 {
@@ -3208,61 +3208,63 @@ export function AssignmentDialog({
 
                       <div className="grid grid-cols-1 gap-y-2">
                         {/* 時間限制 */}
-                        <div className="space-y-1.5">
-                          <Label className="text-xs text-gray-600">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.timeLimit",
-                            )}
-                          </Label>
-                          <select
-                            value={formData.time_limit_per_question}
-                            onChange={(e) =>
-                              setFormData((prev) => ({
-                                ...prev,
-                                time_limit_per_question: Number(
-                                  e.target.value,
-                                ) as 0 | 10 | 20 | 30 | 40,
-                              }))
-                            }
-                            className="w-full h-9 px-3 rounded-md border border-gray-200 text-sm"
-                          >
-                            <option value={0}>
+                        {/* 時間限制 — word_reading 固定 10 秒，不顯示選擇器 */}
+                        {formData.practice_mode !== "word_reading" && (
+                          <div className="space-y-1.5">
+                            <Label className="text-xs text-gray-600">
                               {t(
-                                "dialogs.assignmentDialog.practiceMode.unlimited",
+                                "dialogs.assignmentDialog.practiceMode.timeLimit",
                               )}
-                              {(formData.practice_mode === "word_reading" ||
-                                formData.practice_mode === "word_spelling" ||
-                                formData.practice_mode === "word_cloze") &&
-                                ` (${t("dialogs.assignmentDialog.practiceMode.default")})`}
-                            </option>
-                            <option value={10}>
-                              10{" "}
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.seconds",
-                              )}
-                            </option>
-                            <option value={20}>
-                              20{" "}
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.seconds",
-                              )}
-                            </option>
-                            <option value={30}>
-                              30{" "}
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.seconds",
-                              )}
-                              {formData.practice_mode === "word_selection" &&
-                                ` (${t("dialogs.assignmentDialog.practiceMode.default")})`}
-                            </option>
-                            <option value={40}>
-                              40{" "}
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.seconds",
-                              )}
-                            </option>
-                          </select>
-                        </div>
+                            </Label>
+                            <select
+                              value={formData.time_limit_per_question}
+                              onChange={(e) =>
+                                setFormData((prev) => ({
+                                  ...prev,
+                                  time_limit_per_question: Number(
+                                    e.target.value,
+                                  ) as 0 | 10 | 20 | 30 | 40,
+                                }))
+                              }
+                              className="w-full h-9 px-3 rounded-md border border-gray-200 text-sm"
+                            >
+                              <option value={0}>
+                                {t(
+                                  "dialogs.assignmentDialog.practiceMode.unlimited",
+                                )}
+                                {(formData.practice_mode === "word_spelling" ||
+                                  formData.practice_mode === "word_cloze") &&
+                                  ` (${t("dialogs.assignmentDialog.practiceMode.default")})`}
+                              </option>
+                              <option value={10}>
+                                10{" "}
+                                {t(
+                                  "dialogs.assignmentDialog.practiceMode.seconds",
+                                )}
+                              </option>
+                              <option value={20}>
+                                20{" "}
+                                {t(
+                                  "dialogs.assignmentDialog.practiceMode.seconds",
+                                )}
+                              </option>
+                              <option value={30}>
+                                30{" "}
+                                {t(
+                                  "dialogs.assignmentDialog.practiceMode.seconds",
+                                )}
+                                {formData.practice_mode === "word_selection" &&
+                                  ` (${t("dialogs.assignmentDialog.practiceMode.default")})`}
+                              </option>
+                              <option value={40}>
+                                40{" "}
+                                {t(
+                                  "dialogs.assignmentDialog.practiceMode.seconds",
+                                )}
+                              </option>
+                            </select>
+                          </div>
+                        )}
 
                         {/* 打亂順序 — word_reading 保留；word_selection/spelling/cloze 移除（艾賓浩斯每輪自選） */}
                         {formData.practice_mode === "word_reading" && (

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2872,7 +2872,7 @@ export function AssignmentDialog({
                           "dialogs.assignmentDialog.practiceMode.advancedSettings",
                         )}
                       </h4>
-                      <div className="grid grid-cols-2 gap-x-3 gap-y-2">
+                      <div className="grid grid-cols-1 gap-y-2">
                         {/* 時間限制 */}
                         <div className="space-y-1.5">
                           <Label className="text-xs text-gray-600">
@@ -3208,7 +3208,7 @@ export function AssignmentDialog({
                         </div>
                       )}
 
-                      <div className="grid grid-cols-2 gap-x-3 gap-y-2">
+                      <div className="grid grid-cols-1 gap-y-2">
                         {/* 時間限制 */}
                         <div className="space-y-1.5">
                           <Label className="text-xs text-gray-600">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -63,6 +63,10 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import { useWorkspaceSafe } from "@/contexts/WorkspaceContext";
+import {
+  getScoreCategory,
+  type ScoreCategory,
+} from "@/utils/scoreCategory";
 
 interface Student {
   id: number;
@@ -2676,232 +2680,218 @@ export function AssignmentDialog({
             </div>
           )}
 
-          {/* Step 1: Practice Mode Settings (was Step 2) */}
-          {currentStep === 1 && (
-            <div className="h-full flex flex-col">
-              <div className="mb-4">
-                <p className="text-sm text-gray-600">
-                  {t("dialogs.assignmentDialog.practiceMode.description")}
-                </p>
-              </div>
-
-              <div className="flex-1 flex flex-col justify-center max-w-2xl mx-auto w-full">
-                {/* 作答模式選擇 - 顯示所有練習模式 */}
-                <div className="space-y-6">
-                  {/* ===== 所有練習模式卡片 (2x2 grid) ===== */}
-                  <div className="grid grid-cols-2 gap-4">
-                    {/* 例句朗讀 */}
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          practice_mode: "reading",
-                          time_limit_per_question:
-                            prev.time_limit_per_question === 0
-                              ? 30
-                              : prev.time_limit_per_question,
-                        }))
-                      }
-                      className={`p-6 rounded-xl border-2 transition-all ${
-                        formData.practice_mode === "reading"
-                          ? "border-blue-500 bg-blue-50 shadow-md"
-                          : "border-gray-200 hover:border-gray-300 hover:shadow-sm"
-                      }`}
+          {/* Step 1: Practice Mode Settings */}
+          {currentStep === 1 &&
+            (() => {
+              const PRACTICE_MODES: Array<{
+                id:
+                  | "reading"
+                  | "rearrangement"
+                  | "word_reading"
+                  | "word_selection"
+                  | "word_spelling"
+                  | "word_cloze";
+                emoji: string;
+                titleKey: string;
+                descKey: string;
+                onClick: () => void;
+              }> = [
+                {
+                  id: "reading",
+                  emoji: "🎙️",
+                  titleKey: "dialogs.assignmentDialog.practiceMode.reading",
+                  descKey: "dialogs.assignmentDialog.practiceMode.readingDesc",
+                  onClick: () =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      practice_mode: "reading",
+                      time_limit_per_question:
+                        prev.time_limit_per_question === 0
+                          ? 30
+                          : prev.time_limit_per_question,
+                    })),
+                },
+                {
+                  id: "rearrangement",
+                  emoji: "🔀",
+                  titleKey:
+                    "dialogs.assignmentDialog.practiceMode.rearrangement",
+                  descKey:
+                    "dialogs.assignmentDialog.practiceMode.rearrangementDesc",
+                  onClick: () =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      practice_mode: "rearrangement",
+                    })),
+                },
+                {
+                  id: "word_reading",
+                  emoji: "🎙️",
+                  titleKey:
+                    "dialogs.assignmentDialog.practiceMode.wordReading",
+                  descKey:
+                    "dialogs.assignmentDialog.practiceMode.wordReadingDesc",
+                  onClick: () =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      practice_mode: "word_reading",
+                      time_limit_per_question: 0,
+                    })),
+                },
+                {
+                  id: "word_selection",
+                  emoji: "🧠",
+                  titleKey:
+                    "dialogs.assignmentDialog.practiceMode.wordSelection",
+                  descKey:
+                    "dialogs.assignmentDialog.practiceMode.wordSelectionDesc",
+                  onClick: () =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      practice_mode: "word_selection",
+                      time_limit_per_question: 30,
+                    })),
+                },
+                {
+                  id: "word_spelling",
+                  emoji: "✏️",
+                  titleKey:
+                    "dialogs.assignmentDialog.practiceMode.wordSpelling",
+                  descKey:
+                    "dialogs.assignmentDialog.practiceMode.wordSpellingDesc",
+                  onClick: () =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      practice_mode: "word_spelling",
+                      time_limit_per_question: 30,
+                      show_translation: true,
+                      play_audio: false,
+                      show_answer: false,
+                      target_proficiency: 80,
+                      shuffle_questions: false,
+                    })),
+                },
+                {
+                  id: "word_cloze",
+                  emoji: "📝",
+                  titleKey: "dialogs.assignmentDialog.practiceMode.wordCloze",
+                  descKey:
+                    "dialogs.assignmentDialog.practiceMode.wordClozeDesc",
+                  onClick: () =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      practice_mode: "word_cloze",
+                      time_limit_per_question: 30,
+                      show_translation: true,
+                      play_audio: false,
+                      show_answer: false,
+                      target_proficiency: 80,
+                      shuffle_questions: false,
+                    })),
+                },
+              ];
+              const currentMode = PRACTICE_MODES.find(
+                (m) => m.id === formData.practice_mode,
+              );
+              const currentCategory: ScoreCategory = getScoreCategory(
+                formData.practice_mode,
+                formData.play_audio,
+              );
+              const badgeStyles: Record<ScoreCategory, string> = {
+                speaking: "bg-purple-100 text-purple-700",
+                listening: "bg-amber-100 text-amber-700",
+                reading: "bg-emerald-100 text-emerald-700",
+                writing: "bg-sky-100 text-sky-700",
+              };
+              return (
+                <div className="h-full flex flex-col">
+                  <div className="flex items-center gap-3 mb-2">
+                    <h2 className="text-lg font-semibold text-gray-900">
+                      {t("dialogs.assignmentDialog.steps.practiceMode")}
+                    </h2>
+                    <span
+                      className={cn(
+                        "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold",
+                        badgeStyles[currentCategory],
+                      )}
                     >
-                      <div className="flex flex-col items-center gap-3">
-                        <span className="text-4xl">🎙️</span>
-                        <div className="text-center">
-                          <div className="font-semibold text-lg">
-                            {t("dialogs.assignmentDialog.practiceMode.reading")}
-                          </div>
-                          <div className="text-sm text-gray-500 mt-1">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.readingDesc",
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    </button>
-
-                    {/* 例句重組 */}
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          practice_mode: "rearrangement",
-                        }))
-                      }
-                      className={`p-6 rounded-xl border-2 transition-all ${
-                        formData.practice_mode === "rearrangement"
-                          ? "border-blue-500 bg-blue-50 shadow-md"
-                          : "border-gray-200 hover:border-gray-300 hover:shadow-sm"
-                      }`}
-                    >
-                      <div className="flex flex-col items-center gap-3">
-                        <span className="text-4xl">🔀</span>
-                        <div className="text-center">
-                          <div className="font-semibold text-lg">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.rearrangement",
-                            )}
-                          </div>
-                          <div className="text-sm text-gray-500 mt-1">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.rearrangementDesc",
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    </button>
-
-                    {/* 單字朗讀 */}
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          practice_mode: "word_reading",
-                          time_limit_per_question: 0,
-                        }))
-                      }
-                      className={`p-6 rounded-xl border-2 transition-all ${
-                        formData.practice_mode === "word_reading"
-                          ? "border-blue-500 bg-blue-50 shadow-md"
-                          : "border-gray-200 hover:border-gray-300 hover:shadow-sm"
-                      }`}
-                    >
-                      <div className="flex flex-col items-center gap-3">
-                        <span className="text-4xl">🎙️</span>
-                        <div className="text-center">
-                          <div className="font-semibold text-lg">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.wordReading",
-                            )}
-                          </div>
-                          <div className="text-sm text-gray-500 mt-1">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.wordReadingDesc",
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    </button>
-
-                    {/* 單字選擇 */}
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          practice_mode: "word_selection",
-                          time_limit_per_question: 30,
-                        }))
-                      }
-                      className={`p-6 rounded-xl border-2 transition-all ${
-                        formData.practice_mode === "word_selection"
-                          ? "border-blue-500 bg-blue-50 shadow-md"
-                          : "border-gray-200 hover:border-gray-300 hover:shadow-sm"
-                      }`}
-                    >
-                      <div className="flex flex-col items-center gap-3">
-                        <span className="text-4xl">🧠</span>
-                        <div className="text-center">
-                          <div className="font-semibold text-lg">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.wordSelection",
-                            )}
-                          </div>
-                          <div className="text-sm text-gray-500 mt-1">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.wordSelectionDesc",
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    </button>
-
-                    {/* 單字拼寫 */}
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          practice_mode: "word_spelling",
-                          time_limit_per_question: 30,
-                          // 預設：顯示翻譯、不播音檔、不顯示答案、達標 80%
-                          show_translation: true,
-                          play_audio: false,
-                          show_answer: false,
-                          target_proficiency: 80,
-                          shuffle_questions: false,
-                        }))
-                      }
-                      className={`p-6 rounded-xl border-2 transition-all ${
-                        formData.practice_mode === "word_spelling"
-                          ? "border-blue-500 bg-blue-50 shadow-md"
-                          : "border-gray-200 hover:border-gray-300 hover:shadow-sm"
-                      }`}
-                    >
-                      <div className="flex flex-col items-center gap-3">
-                        <span className="text-4xl">✏️</span>
-                        <div className="text-center">
-                          <div className="font-semibold text-lg">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.wordSpelling",
-                            ) || "單字拼寫"}
-                          </div>
-                          <div className="text-sm text-gray-500 mt-1">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.wordSpellingDesc",
-                            ) || "看翻譯或聽音檔，拼寫正確的單字"}
-                          </div>
-                        </div>
-                      </div>
-                    </button>
-
-                    {/* 克漏字 */}
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          practice_mode: "word_cloze",
-                          time_limit_per_question: 30,
-                          // 預設：顯示翻譯、不播音檔、不顯示答案、達標 80%
-                          show_translation: true,
-                          play_audio: false,
-                          show_answer: false,
-                          target_proficiency: 80,
-                          shuffle_questions: false,
-                        }))
-                      }
-                      className={`p-6 rounded-xl border-2 transition-all ${
-                        formData.practice_mode === "word_cloze"
-                          ? "border-blue-500 bg-blue-50 shadow-md"
-                          : "border-gray-200 hover:border-gray-300 hover:shadow-sm"
-                      }`}
-                    >
-                      <div className="flex flex-col items-center gap-3">
-                        <span className="text-4xl">📝</span>
-                        <div className="text-center">
-                          <div className="font-semibold text-lg">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.wordCloze",
-                            ) || "克漏字"}
-                          </div>
-                          <div className="text-sm text-gray-500 mt-1">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.wordClozeDesc",
-                            ) || "看例句填空，輸入正確的單字變形"}
-                          </div>
-                        </div>
-                      </div>
-                    </button>
+                      {t(
+                        `dialogs.assignmentDialog.practiceMode.scoreCategory.${currentCategory}`,
+                      )}
+                    </span>
+                  </div>
+                  <div className="mb-4">
+                    <p className="text-sm text-gray-600">
+                      {t("dialogs.assignmentDialog.practiceMode.description")}
+                    </p>
                   </div>
 
-                  {/* ===== 例句集細節設定 (reading / rearrangement) ===== */}
+                  <div className="flex-1 flex gap-6 max-w-4xl mx-auto w-full">
+                    {/* 左 rail：練習模式 row list */}
+                    <div className="w-[220px] shrink-0 space-y-2">
+                      {PRACTICE_MODES.map((m) => {
+                        const selected = formData.practice_mode === m.id;
+                        return (
+                          <button
+                            key={m.id}
+                            type="button"
+                            onClick={m.onClick}
+                            className={cn(
+                              "w-full flex items-center gap-3 p-3 rounded-lg border text-left transition-all",
+                              selected
+                                ? "border-blue-500 bg-blue-50 shadow-sm"
+                                : "border-gray-200 hover:border-gray-300 hover:bg-gray-50",
+                            )}
+                          >
+                            <span className="text-xl shrink-0">
+                              {m.emoji}
+                            </span>
+                            <div className="min-w-0 flex-1">
+                              <div
+                                className={cn(
+                                  "text-sm font-semibold truncate",
+                                  selected
+                                    ? "text-blue-700"
+                                    : "text-gray-900",
+                                )}
+                              >
+                                {t(m.titleKey)}
+                              </div>
+                              <div
+                                className={cn(
+                                  "text-xs truncate",
+                                  selected
+                                    ? "text-blue-600"
+                                    : "text-gray-500",
+                                )}
+                              >
+                                {t(m.descKey)}
+                              </div>
+                            </div>
+                          </button>
+                        );
+                      })}
+                    </div>
+
+                    {/* 右 panel：Hero + 進階設定 */}
+                    <div className="flex-1 min-w-0 space-y-4">
+                      {currentMode && (
+                        <div className="flex items-start gap-4 p-4 rounded-xl bg-gray-50">
+                          <span className="text-4xl shrink-0">
+                            {currentMode.emoji}
+                          </span>
+                          <div className="min-w-0">
+                            <div className="text-base font-semibold text-gray-900">
+                              {t(currentMode.titleKey)}
+                            </div>
+                            <div className="text-sm text-gray-600 mt-0.5">
+                              {t(currentMode.descKey)}
+                            </div>
+                          </div>
+                        </div>
+                      )}
+
+                      {/* ===== 例句集細節設定 (reading / rearrangement) ===== */}
                   {(formData.practice_mode === "reading" ||
                     formData.practice_mode === "rearrangement") && (
                     <Card className="p-4 border-gray-200">
@@ -3500,10 +3490,11 @@ export function AssignmentDialog({
                       </div>
                     </Card>
                   )}
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
-          )}
+              );
+            })()}
 
           {/* Step 3: Select Students */}
           {currentStep === 3 && (

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -70,10 +70,7 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import { useWorkspaceSafe } from "@/contexts/WorkspaceContext";
-import {
-  getScoreCategory,
-  type ScoreCategory,
-} from "@/utils/scoreCategory";
+import { getScoreCategory, type ScoreCategory } from "@/utils/scoreCategory";
 import WordReadingPreview from "@/components/activities/WordReadingPreview";
 import WordSelectionPreview from "@/components/activities/WordSelectionPreview";
 import WordSpellingPreview from "@/components/activities/WordSpellingPreview";
@@ -2782,8 +2779,7 @@ export function AssignmentDialog({
                 {
                   id: "word_reading",
                   Icon: Volume2,
-                  titleKey:
-                    "dialogs.assignmentDialog.practiceMode.wordReading",
+                  titleKey: "dialogs.assignmentDialog.practiceMode.wordReading",
                   descKey:
                     "dialogs.assignmentDialog.practiceMode.wordReadingDesc",
                   chipSelected:
@@ -2964,612 +2960,624 @@ export function AssignmentDialog({
                       )}
 
                       {/* ===== 例句集細節設定 (reading / rearrangement) ===== */}
-                  {(formData.practice_mode === "reading" ||
-                    formData.practice_mode === "rearrangement") && (
-                    <Card className="p-3 border-gray-200">
-                      <h4 className="text-xs font-semibold mb-2 text-gray-700">
-                        {t(
-                          "dialogs.assignmentDialog.practiceMode.advancedSettings",
-                        )}
-                      </h4>
-                      <div className="grid grid-cols-1 gap-y-2">
-                        {/* 時間限制 — reading 固定 30 秒，不顯示選擇器 */}
-                        {formData.practice_mode !== "reading" && (
-                        <div className="space-y-1.5">
-                          <Label className="text-xs text-gray-600">
+                      {(formData.practice_mode === "reading" ||
+                        formData.practice_mode === "rearrangement") && (
+                        <Card className="p-3 border-gray-200">
+                          <h4 className="text-xs font-semibold mb-2 text-gray-700">
                             {t(
-                              "dialogs.assignmentDialog.practiceMode.timeLimit",
+                              "dialogs.assignmentDialog.practiceMode.advancedSettings",
                             )}
-                          </Label>
-                          <select
-                            value={formData.time_limit_per_question}
-                            onChange={(e) =>
-                              setFormData((prev) => ({
-                                ...prev,
-                                time_limit_per_question: Number(
-                                  e.target.value,
-                                ) as 0 | 10 | 20 | 30 | 40,
-                              }))
-                            }
-                            className="w-full h-9 px-3 rounded-md border border-gray-200 text-sm"
-                          >
-                            <option value={0}>
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.unlimited",
-                              )}
-                            </option>
-                            <option value={10}>
-                              10{" "}
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.seconds",
-                              )}
-                            </option>
-                            <option value={20}>
-                              20{" "}
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.seconds",
-                              )}
-                            </option>
-                            <option value={30}>
-                              30{" "}
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.seconds",
-                              )}{" "}
-                              (
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.default",
-                              )}
-                              )
-                            </option>
-                            <option value={40}>
-                              40{" "}
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.seconds",
-                              )}
-                            </option>
-                          </select>
-                        </div>
-                        )}
-
-                        {/* 打亂順序 */}
-                        <div className="space-y-1.5">
-                          <Label className="text-xs text-gray-600">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.shuffleQuestions",
-                            )}
-                          </Label>
-                          <div className="flex items-center h-9">
-                            <input
-                              type="checkbox"
-                              checked={formData.shuffle_questions}
-                              onChange={(e) =>
-                                setFormData((prev) => ({
-                                  ...prev,
-                                  shuffle_questions: e.target.checked,
-                                }))
-                              }
-                              className="h-4 w-4 rounded border-gray-300"
-                            />
-                            <span className="ml-2 text-sm text-gray-600">
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.shuffleQuestionsDesc",
-                              )}
-                            </span>
-                          </div>
-                        </div>
-
-                        {/* 例句重組專用選項 - 顯示答案 */}
-                        {formData.practice_mode === "rearrangement" && (
-                          <div className="space-y-1.5">
-                            <Label className="text-xs text-gray-600">
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.showAnswer",
-                              )}
-                            </Label>
-                            <div className="flex items-center h-9">
-                              <input
-                                type="checkbox"
-                                checked={formData.show_answer}
-                                onChange={(e) =>
-                                  setFormData((prev) => ({
-                                    ...prev,
-                                    show_answer: e.target.checked,
-                                  }))
-                                }
-                                className="h-4 w-4 rounded border-gray-300"
-                              />
-                              <span className="ml-2 text-sm text-gray-600">
-                                {t(
-                                  "dialogs.assignmentDialog.practiceMode.showAnswerDesc",
-                                )}
-                              </span>
-                            </div>
-                          </div>
-                        )}
-                      </div>
-
-                      {/* 例句重組專用選項 - 播放音檔 */}
-                      {formData.practice_mode === "rearrangement" && (
-                        <div className="mt-4 pt-4 border-t">
-                          <Label className="text-xs text-gray-600 mb-2 block">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.playAudio",
-                            )}
-                          </Label>
-                          <div className="flex gap-3">
-                            <button
-                              type="button"
-                              onClick={() =>
-                                setFormData((prev) => ({
-                                  ...prev,
-                                  play_audio: true,
-                                }))
-                              }
-                              className={`flex-1 p-3 rounded-lg border text-sm ${
-                                formData.play_audio
-                                  ? "border-blue-500 bg-blue-50 text-blue-700"
-                                  : "border-gray-200 hover:border-gray-300"
-                              }`}
-                            >
-                              🔊{" "}
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.playAudioYes",
-                              )}
-                              <span className="block text-xs text-gray-500 mt-0.5">
-                                {t(
-                                  "dialogs.assignmentDialog.practiceMode.scoreListening",
-                                )}
-                              </span>
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() =>
-                                setFormData((prev) => ({
-                                  ...prev,
-                                  play_audio: false,
-                                }))
-                              }
-                              className={`flex-1 p-3 rounded-lg border text-sm ${
-                                !formData.play_audio
-                                  ? "border-blue-500 bg-blue-50 text-blue-700"
-                                  : "border-gray-200 hover:border-gray-300"
-                              }`}
-                            >
-                              🔇{" "}
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.playAudioNo",
-                              )}
-                              <span className="block text-xs text-gray-500 mt-0.5">
-                                {t(
-                                  "dialogs.assignmentDialog.practiceMode.scoreWriting",
-                                )}
-                              </span>
-                            </button>
-                          </div>
-                        </div>
-                      )}
-                    </Card>
-                  )}
-
-                  {/* ===== 單字集細節設定 (word_reading / word_selection / word_spelling / word_cloze) ===== */}
-                  {(formData.practice_mode === "word_reading" ||
-                    formData.practice_mode === "word_selection" ||
-                    formData.practice_mode === "word_spelling" ||
-                    formData.practice_mode === "word_cloze") && (
-                    <Card className="p-3 border-gray-200">
-                      <h4 className="text-xs font-semibold mb-2 text-gray-700">
-                        {t(
-                          "dialogs.assignmentDialog.practiceMode.advancedSettings",
-                        )}
-                      </h4>
-
-                      {/* 達標熟悉度（word_selection / word_spelling / word_cloze 共用） */}
-                      {(formData.practice_mode === "word_selection" ||
-                        formData.practice_mode === "word_spelling" ||
-                        formData.practice_mode === "word_cloze") && (
-                        <div className="mb-3 pb-3 border-b">
-                          <div className="flex items-center justify-between mb-2">
-                            <Label className="text-xs text-gray-600">
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.targetProficiency",
-                              )}
-                            </Label>
-                            <span className="text-sm font-medium text-blue-600">
-                              {formData.target_proficiency}%
-                            </span>
-                          </div>
-                          <input
-                            type="range"
-                            min={50}
-                            max={100}
-                            step={5}
-                            value={formData.target_proficiency}
-                            onChange={(e) =>
-                              setFormData((prev) => ({
-                                ...prev,
-                                target_proficiency: Number(e.target.value),
-                              }))
-                            }
-                            className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-500"
-                          />
-                          <p className="text-xs text-gray-500 mt-1">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.targetProficiencyDesc",
-                            )}
-                          </p>
-                        </div>
-                      )}
-
-                      {/* 題目呈現方式：word_selection 用 show_word；spelling/cloze 用 show_translation */}
-                      {(formData.practice_mode === "word_selection" ||
-                        formData.practice_mode === "word_spelling" ||
-                        formData.practice_mode === "word_cloze") && (
-                        <div className="mb-3 pb-3 border-b">
-                          <Label className="text-xs text-gray-600 mb-2 block">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.questionDisplay",
-                            )}
-                          </Label>
-                          <div className="flex gap-3">
-                            <button
-                              type="button"
-                              onClick={() => {
-                                if (
-                                  formData.practice_mode === "word_selection"
-                                ) {
-                                  setFormData((prev) => ({
-                                    ...prev,
-                                    show_word: true,
-                                    play_audio: false,
-                                  }));
-                                } else {
-                                  // spelling / cloze: 顯示翻譯
-                                  setFormData((prev) => ({
-                                    ...prev,
-                                    show_translation: true,
-                                    play_audio: false,
-                                  }));
-                                }
-                              }}
-                              className={`flex-1 p-3 rounded-lg border text-sm ${
-                                (
-                                  formData.practice_mode === "word_selection"
-                                    ? formData.show_word && !formData.play_audio
-                                    : formData.show_translation &&
-                                      !formData.play_audio
-                                )
-                                  ? "border-blue-500 bg-blue-50 text-blue-700"
-                                  : "border-gray-200 hover:border-gray-300"
-                              }`}
-                            >
-                              👁️{" "}
-                              {formData.practice_mode === "word_selection"
-                                ? t(
-                                    "dialogs.assignmentDialog.practiceMode.displayWord",
-                                  )
-                                : t(
-                                    "dialogs.assignmentDialog.practiceMode.displayTranslation",
-                                  )}
-                              <span className="block text-xs text-gray-500 mt-0.5">
-                                {formData.practice_mode === "word_selection"
-                                  ? t(
-                                      "dialogs.assignmentDialog.practiceMode.displayWordDesc",
-                                    )
-                                  : t(
-                                      "dialogs.assignmentDialog.practiceMode.displayTranslationDesc",
-                                    )}
-                              </span>
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => {
-                                if (
-                                  formData.practice_mode === "word_selection"
-                                ) {
-                                  setFormData((prev) => ({
-                                    ...prev,
-                                    show_word: false,
-                                    play_audio: true,
-                                  }));
-                                } else {
-                                  // spelling / cloze: 切到播放音檔 → 強制 show_answer=true
-                                  setFormData((prev) => ({
-                                    ...prev,
-                                    show_translation: false,
-                                    play_audio: true,
-                                    show_answer: true,
-                                  }));
-                                }
-                              }}
-                              className={`flex-1 p-3 rounded-lg border text-sm ${
-                                (
-                                  formData.practice_mode === "word_selection"
-                                    ? !formData.show_word && formData.play_audio
-                                    : !formData.show_translation &&
-                                      formData.play_audio
-                                )
-                                  ? "border-blue-500 bg-blue-50 text-blue-700"
-                                  : "border-gray-200 hover:border-gray-300"
-                              }`}
-                            >
-                              🔊{" "}
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.playAudioWord",
-                              )}
-                              <span className="block text-xs text-gray-500 mt-0.5">
-                                {formData.practice_mode === "word_selection"
-                                  ? t(
-                                      "dialogs.assignmentDialog.practiceMode.playAudioWordDesc",
-                                    )
-                                  : t(
-                                      "dialogs.assignmentDialog.practiceMode.playAudioFillDesc",
-                                    )}
-                              </span>
-                            </button>
-                          </div>
-                        </div>
-                      )}
-
-                      <div className="grid grid-cols-1 gap-y-2">
-                        {/* 時間限制 */}
-                        {/* 時間限制 — word_reading 固定 10 秒，不顯示選擇器 */}
-                        {formData.practice_mode !== "word_reading" && (
-                          <div className="space-y-1.5">
-                            <Label className="text-xs text-gray-600">
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.timeLimit",
-                              )}
-                            </Label>
-                            <select
-                              value={formData.time_limit_per_question}
-                              onChange={(e) =>
-                                setFormData((prev) => ({
-                                  ...prev,
-                                  time_limit_per_question: Number(
-                                    e.target.value,
-                                  ) as 0 | 10 | 20 | 30 | 40,
-                                }))
-                              }
-                              className="w-full h-9 px-3 rounded-md border border-gray-200 text-sm"
-                            >
-                              <option value={0}>
-                                {t(
-                                  "dialogs.assignmentDialog.practiceMode.unlimited",
-                                )}
-                                {(formData.practice_mode === "word_spelling" ||
-                                  formData.practice_mode === "word_cloze") &&
-                                  ` (${t("dialogs.assignmentDialog.practiceMode.default")})`}
-                              </option>
-                              <option value={10}>
-                                10{" "}
-                                {t(
-                                  "dialogs.assignmentDialog.practiceMode.seconds",
-                                )}
-                              </option>
-                              <option value={20}>
-                                20{" "}
-                                {t(
-                                  "dialogs.assignmentDialog.practiceMode.seconds",
-                                )}
-                              </option>
-                              <option value={30}>
-                                30{" "}
-                                {t(
-                                  "dialogs.assignmentDialog.practiceMode.seconds",
-                                )}
-                                {formData.practice_mode === "word_selection" &&
-                                  ` (${t("dialogs.assignmentDialog.practiceMode.default")})`}
-                              </option>
-                              <option value={40}>
-                                40{" "}
-                                {t(
-                                  "dialogs.assignmentDialog.practiceMode.seconds",
-                                )}
-                              </option>
-                            </select>
-                          </div>
-                        )}
-
-                        {/* 打亂順序 — word_reading 保留；word_selection/spelling/cloze 移除（艾賓浩斯每輪自選） */}
-                        {formData.practice_mode === "word_reading" && (
-                          <div className="space-y-1.5">
-                            <Label className="text-xs text-gray-600">
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.shuffleQuestions",
-                              )}
-                            </Label>
-                            <div className="flex items-center h-9">
-                              <input
-                                type="checkbox"
-                                checked={formData.shuffle_questions}
-                                onChange={(e) =>
-                                  setFormData((prev) => ({
-                                    ...prev,
-                                    shuffle_questions: e.target.checked,
-                                  }))
-                                }
-                                className="h-4 w-4 rounded border-gray-300"
-                              />
-                              <span className="ml-2 text-sm text-gray-600">
-                                {t(
-                                  "dialogs.assignmentDialog.practiceMode.shuffleQuestionsDesc",
-                                )}
-                              </span>
-                            </div>
-                          </div>
-                        )}
-
-                        {/* 顯示答案 — word_selection / word_spelling / word_cloze 共用
-                            spelling/cloze 在 play_audio=true 時強制勾選 + 反灰 */}
-                        {(formData.practice_mode === "word_selection" ||
-                          formData.practice_mode === "word_spelling" ||
-                          formData.practice_mode === "word_cloze") && (
-                          <div className="space-y-1.5">
-                            <Label className="text-xs text-gray-600">
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.showAnswer",
-                              )}
-                            </Label>
-                            <div className="flex items-center h-9">
-                              <input
-                                type="checkbox"
-                                checked={formData.show_answer}
-                                disabled={
-                                  (formData.practice_mode === "word_spelling" ||
-                                    formData.practice_mode === "word_cloze") &&
-                                  formData.play_audio
-                                }
-                                onChange={(e) =>
-                                  setFormData((prev) => ({
-                                    ...prev,
-                                    show_answer: e.target.checked,
-                                  }))
-                                }
-                                className="h-4 w-4 rounded border-gray-300 disabled:opacity-50 disabled:cursor-not-allowed"
-                              />
-                              <span className="ml-2 text-sm text-gray-600">
-                                {t(
-                                  "dialogs.assignmentDialog.practiceMode.wordSelectionShowAnswerDesc",
-                                )}
-                              </span>
-                            </div>
-                            {(formData.practice_mode === "word_spelling" ||
-                              formData.practice_mode === "word_cloze") &&
-                              formData.play_audio && (
-                                <p className="text-xs text-red-600">
-                                  {t(
-                                    "dialogs.assignmentDialog.practiceMode.showAnswerLockedByAudio",
-                                  )}
-                                </p>
-                              )}
-                          </div>
-                        )}
-
-                        {/* 單字朗讀 - 顯示翻譯（spelling/cloze 已移到上方 toggle） */}
-                        {formData.practice_mode === "word_reading" && (
-                          <div className="space-y-1.5">
-                            <Label className="text-xs text-gray-600">
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.showTranslation",
-                              )}
-                            </Label>
-                            <div className="flex items-center h-9">
-                              <input
-                                type="checkbox"
-                                checked={formData.show_translation}
-                                onChange={(e) =>
-                                  setFormData((prev) => ({
-                                    ...prev,
-                                    show_translation: e.target.checked,
-                                  }))
-                                }
-                                className="h-4 w-4 rounded border-gray-300"
-                              />
-                              <span className="ml-2 text-sm text-gray-600">
-                                {t(
-                                  "dialogs.assignmentDialog.practiceMode.showTranslationDesc",
-                                )}
-                              </span>
-                            </div>
-                          </div>
-                        )}
-
-                        {/* 顯示題目圖片 */}
-                        <div className="space-y-1.5">
-                          <Label className="text-xs text-gray-600">
-                            {t(
-                              "dialogs.assignmentDialog.practiceMode.showImage",
-                            )}
-                          </Label>
-                          <div className="flex items-center h-9">
-                            <input
-                              type="checkbox"
-                              checked={formData.show_image}
-                              onChange={(e) =>
-                                setFormData((prev) => ({
-                                  ...prev,
-                                  show_image: e.target.checked,
-                                  // Issue #631: show_image 與 show_option_images 互斥
-                                  show_option_images: e.target.checked
-                                    ? false
-                                    : prev.show_option_images,
-                                }))
-                              }
-                              className="h-4 w-4 rounded border-gray-300"
-                            />
-                            <span className="ml-2 text-sm text-gray-600">
-                              {t(
-                                "dialogs.assignmentDialog.practiceMode.showImageDesc",
-                              )}
-                            </span>
-                          </div>
-                        </div>
-
-                        {/* 顯示選項圖片（單字選擇專用，與顯示題目圖片互斥）Issue #631 */}
-                        {formData.practice_mode === "word_selection" &&
-                          (() => {
-                            const hasMissingImage = cartItems.some(
-                              (i) => i.hasMissingImage,
-                            );
-                            const disabled =
-                              hasMissingImage && !formData.show_option_images;
-                            return (
+                          </h4>
+                          <div className="grid grid-cols-1 gap-y-2">
+                            {/* 時間限制 — reading 固定 30 秒，不顯示選擇器 */}
+                            {formData.practice_mode !== "reading" && (
                               <div className="space-y-1.5">
                                 <Label className="text-xs text-gray-600">
                                   {t(
-                                    "dialogs.assignmentDialog.practiceMode.showOptionImages",
+                                    "dialogs.assignmentDialog.practiceMode.timeLimit",
+                                  )}
+                                </Label>
+                                <select
+                                  value={formData.time_limit_per_question}
+                                  onChange={(e) =>
+                                    setFormData((prev) => ({
+                                      ...prev,
+                                      time_limit_per_question: Number(
+                                        e.target.value,
+                                      ) as 0 | 10 | 20 | 30 | 40,
+                                    }))
+                                  }
+                                  className="w-full h-9 px-3 rounded-md border border-gray-200 text-sm"
+                                >
+                                  <option value={0}>
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.unlimited",
+                                    )}
+                                  </option>
+                                  <option value={10}>
+                                    10{" "}
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.seconds",
+                                    )}
+                                  </option>
+                                  <option value={20}>
+                                    20{" "}
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.seconds",
+                                    )}
+                                  </option>
+                                  <option value={30}>
+                                    30{" "}
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.seconds",
+                                    )}{" "}
+                                    (
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.default",
+                                    )}
+                                    )
+                                  </option>
+                                  <option value={40}>
+                                    40{" "}
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.seconds",
+                                    )}
+                                  </option>
+                                </select>
+                              </div>
+                            )}
+
+                            {/* 打亂順序 */}
+                            <div className="space-y-1.5">
+                              <Label className="text-xs text-gray-600">
+                                {t(
+                                  "dialogs.assignmentDialog.practiceMode.shuffleQuestions",
+                                )}
+                              </Label>
+                              <div className="flex items-center h-9">
+                                <input
+                                  type="checkbox"
+                                  checked={formData.shuffle_questions}
+                                  onChange={(e) =>
+                                    setFormData((prev) => ({
+                                      ...prev,
+                                      shuffle_questions: e.target.checked,
+                                    }))
+                                  }
+                                  className="h-4 w-4 rounded border-gray-300"
+                                />
+                                <span className="ml-2 text-sm text-gray-600">
+                                  {t(
+                                    "dialogs.assignmentDialog.practiceMode.shuffleQuestionsDesc",
+                                  )}
+                                </span>
+                              </div>
+                            </div>
+
+                            {/* 例句重組專用選項 - 顯示答案 */}
+                            {formData.practice_mode === "rearrangement" && (
+                              <div className="space-y-1.5">
+                                <Label className="text-xs text-gray-600">
+                                  {t(
+                                    "dialogs.assignmentDialog.practiceMode.showAnswer",
                                   )}
                                 </Label>
                                 <div className="flex items-center h-9">
                                   <input
                                     type="checkbox"
-                                    checked={formData.show_option_images}
-                                    disabled={disabled}
+                                    checked={formData.show_answer}
                                     onChange={(e) =>
                                       setFormData((prev) => ({
                                         ...prev,
-                                        show_option_images: e.target.checked,
-                                        show_image: e.target.checked
-                                          ? false
-                                          : prev.show_image,
+                                        show_answer: e.target.checked,
                                       }))
                                     }
-                                    className="h-4 w-4 rounded border-gray-300 disabled:cursor-not-allowed disabled:opacity-50"
+                                    className="h-4 w-4 rounded border-gray-300"
                                   />
-                                  <span
-                                    className={cn(
-                                      "ml-2 text-sm",
-                                      disabled
-                                        ? "text-gray-400"
-                                        : "text-gray-600",
-                                    )}
-                                    title={
-                                      disabled
-                                        ? t(
-                                            "dialogs.assignmentDialog.practiceMode.showOptionImagesMissing",
-                                          )
-                                        : undefined
-                                    }
-                                  >
+                                  <span className="ml-2 text-sm text-gray-600">
                                     {t(
-                                      "dialogs.assignmentDialog.practiceMode.showOptionImagesDesc",
+                                      "dialogs.assignmentDialog.practiceMode.showAnswerDesc",
                                     )}
                                   </span>
                                 </div>
-                                {disabled && (
-                                  <p className="text-xs text-amber-600 mt-1">
-                                    {t(
-                                      "dialogs.assignmentDialog.practiceMode.showOptionImagesMissing",
-                                    )}
-                                  </p>
-                                )}
                               </div>
-                            );
-                          })()}
-                      </div>
-                    </Card>
-                  )}
+                            )}
+                          </div>
 
+                          {/* 例句重組專用選項 - 播放音檔 */}
+                          {formData.practice_mode === "rearrangement" && (
+                            <div className="mt-4 pt-4 border-t">
+                              <Label className="text-xs text-gray-600 mb-2 block">
+                                {t(
+                                  "dialogs.assignmentDialog.practiceMode.playAudio",
+                                )}
+                              </Label>
+                              <div className="flex gap-3">
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    setFormData((prev) => ({
+                                      ...prev,
+                                      play_audio: true,
+                                    }))
+                                  }
+                                  className={`flex-1 p-3 rounded-lg border text-sm ${
+                                    formData.play_audio
+                                      ? "border-blue-500 bg-blue-50 text-blue-700"
+                                      : "border-gray-200 hover:border-gray-300"
+                                  }`}
+                                >
+                                  🔊{" "}
+                                  {t(
+                                    "dialogs.assignmentDialog.practiceMode.playAudioYes",
+                                  )}
+                                  <span className="block text-xs text-gray-500 mt-0.5">
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.scoreListening",
+                                    )}
+                                  </span>
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    setFormData((prev) => ({
+                                      ...prev,
+                                      play_audio: false,
+                                    }))
+                                  }
+                                  className={`flex-1 p-3 rounded-lg border text-sm ${
+                                    !formData.play_audio
+                                      ? "border-blue-500 bg-blue-50 text-blue-700"
+                                      : "border-gray-200 hover:border-gray-300"
+                                  }`}
+                                >
+                                  🔇{" "}
+                                  {t(
+                                    "dialogs.assignmentDialog.practiceMode.playAudioNo",
+                                  )}
+                                  <span className="block text-xs text-gray-500 mt-0.5">
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.scoreWriting",
+                                    )}
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          )}
+                        </Card>
+                      )}
+
+                      {/* ===== 單字集細節設定 (word_reading / word_selection / word_spelling / word_cloze) ===== */}
+                      {(formData.practice_mode === "word_reading" ||
+                        formData.practice_mode === "word_selection" ||
+                        formData.practice_mode === "word_spelling" ||
+                        formData.practice_mode === "word_cloze") && (
+                        <Card className="p-3 border-gray-200">
+                          <h4 className="text-xs font-semibold mb-2 text-gray-700">
+                            {t(
+                              "dialogs.assignmentDialog.practiceMode.advancedSettings",
+                            )}
+                          </h4>
+
+                          {/* 達標熟悉度（word_selection / word_spelling / word_cloze 共用） */}
+                          {(formData.practice_mode === "word_selection" ||
+                            formData.practice_mode === "word_spelling" ||
+                            formData.practice_mode === "word_cloze") && (
+                            <div className="mb-3 pb-3 border-b">
+                              <div className="flex items-center justify-between mb-2">
+                                <Label className="text-xs text-gray-600">
+                                  {t(
+                                    "dialogs.assignmentDialog.practiceMode.targetProficiency",
+                                  )}
+                                </Label>
+                                <span className="text-sm font-medium text-blue-600">
+                                  {formData.target_proficiency}%
+                                </span>
+                              </div>
+                              <input
+                                type="range"
+                                min={50}
+                                max={100}
+                                step={5}
+                                value={formData.target_proficiency}
+                                onChange={(e) =>
+                                  setFormData((prev) => ({
+                                    ...prev,
+                                    target_proficiency: Number(e.target.value),
+                                  }))
+                                }
+                                className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-500"
+                              />
+                              <p className="text-xs text-gray-500 mt-1">
+                                {t(
+                                  "dialogs.assignmentDialog.practiceMode.targetProficiencyDesc",
+                                )}
+                              </p>
+                            </div>
+                          )}
+
+                          {/* 題目呈現方式：word_selection 用 show_word；spelling/cloze 用 show_translation */}
+                          {(formData.practice_mode === "word_selection" ||
+                            formData.practice_mode === "word_spelling" ||
+                            formData.practice_mode === "word_cloze") && (
+                            <div className="mb-3 pb-3 border-b">
+                              <Label className="text-xs text-gray-600 mb-2 block">
+                                {t(
+                                  "dialogs.assignmentDialog.practiceMode.questionDisplay",
+                                )}
+                              </Label>
+                              <div className="flex gap-3">
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    if (
+                                      formData.practice_mode ===
+                                      "word_selection"
+                                    ) {
+                                      setFormData((prev) => ({
+                                        ...prev,
+                                        show_word: true,
+                                        play_audio: false,
+                                      }));
+                                    } else {
+                                      // spelling / cloze: 顯示翻譯
+                                      setFormData((prev) => ({
+                                        ...prev,
+                                        show_translation: true,
+                                        play_audio: false,
+                                      }));
+                                    }
+                                  }}
+                                  className={`flex-1 p-3 rounded-lg border text-sm ${
+                                    (
+                                      formData.practice_mode ===
+                                      "word_selection"
+                                        ? formData.show_word &&
+                                          !formData.play_audio
+                                        : formData.show_translation &&
+                                          !formData.play_audio
+                                    )
+                                      ? "border-blue-500 bg-blue-50 text-blue-700"
+                                      : "border-gray-200 hover:border-gray-300"
+                                  }`}
+                                >
+                                  👁️{" "}
+                                  {formData.practice_mode === "word_selection"
+                                    ? t(
+                                        "dialogs.assignmentDialog.practiceMode.displayWord",
+                                      )
+                                    : t(
+                                        "dialogs.assignmentDialog.practiceMode.displayTranslation",
+                                      )}
+                                  <span className="block text-xs text-gray-500 mt-0.5">
+                                    {formData.practice_mode === "word_selection"
+                                      ? t(
+                                          "dialogs.assignmentDialog.practiceMode.displayWordDesc",
+                                        )
+                                      : t(
+                                          "dialogs.assignmentDialog.practiceMode.displayTranslationDesc",
+                                        )}
+                                  </span>
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    if (
+                                      formData.practice_mode ===
+                                      "word_selection"
+                                    ) {
+                                      setFormData((prev) => ({
+                                        ...prev,
+                                        show_word: false,
+                                        play_audio: true,
+                                      }));
+                                    } else {
+                                      // spelling / cloze: 切到播放音檔 → 強制 show_answer=true
+                                      setFormData((prev) => ({
+                                        ...prev,
+                                        show_translation: false,
+                                        play_audio: true,
+                                        show_answer: true,
+                                      }));
+                                    }
+                                  }}
+                                  className={`flex-1 p-3 rounded-lg border text-sm ${
+                                    (
+                                      formData.practice_mode ===
+                                      "word_selection"
+                                        ? !formData.show_word &&
+                                          formData.play_audio
+                                        : !formData.show_translation &&
+                                          formData.play_audio
+                                    )
+                                      ? "border-blue-500 bg-blue-50 text-blue-700"
+                                      : "border-gray-200 hover:border-gray-300"
+                                  }`}
+                                >
+                                  🔊{" "}
+                                  {t(
+                                    "dialogs.assignmentDialog.practiceMode.playAudioWord",
+                                  )}
+                                  <span className="block text-xs text-gray-500 mt-0.5">
+                                    {formData.practice_mode === "word_selection"
+                                      ? t(
+                                          "dialogs.assignmentDialog.practiceMode.playAudioWordDesc",
+                                        )
+                                      : t(
+                                          "dialogs.assignmentDialog.practiceMode.playAudioFillDesc",
+                                        )}
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          )}
+
+                          <div className="grid grid-cols-1 gap-y-2">
+                            {/* 時間限制 */}
+                            {/* 時間限制 — word_reading 固定 10 秒，不顯示選擇器 */}
+                            {formData.practice_mode !== "word_reading" && (
+                              <div className="space-y-1.5">
+                                <Label className="text-xs text-gray-600">
+                                  {t(
+                                    "dialogs.assignmentDialog.practiceMode.timeLimit",
+                                  )}
+                                </Label>
+                                <select
+                                  value={formData.time_limit_per_question}
+                                  onChange={(e) =>
+                                    setFormData((prev) => ({
+                                      ...prev,
+                                      time_limit_per_question: Number(
+                                        e.target.value,
+                                      ) as 0 | 10 | 20 | 30 | 40,
+                                    }))
+                                  }
+                                  className="w-full h-9 px-3 rounded-md border border-gray-200 text-sm"
+                                >
+                                  <option value={0}>
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.unlimited",
+                                    )}
+                                    {(formData.practice_mode ===
+                                      "word_spelling" ||
+                                      formData.practice_mode ===
+                                        "word_cloze") &&
+                                      ` (${t("dialogs.assignmentDialog.practiceMode.default")})`}
+                                  </option>
+                                  <option value={10}>
+                                    10{" "}
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.seconds",
+                                    )}
+                                  </option>
+                                  <option value={20}>
+                                    20{" "}
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.seconds",
+                                    )}
+                                  </option>
+                                  <option value={30}>
+                                    30{" "}
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.seconds",
+                                    )}
+                                    {formData.practice_mode ===
+                                      "word_selection" &&
+                                      ` (${t("dialogs.assignmentDialog.practiceMode.default")})`}
+                                  </option>
+                                  <option value={40}>
+                                    40{" "}
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.seconds",
+                                    )}
+                                  </option>
+                                </select>
+                              </div>
+                            )}
+
+                            {/* 打亂順序 — word_reading 保留；word_selection/spelling/cloze 移除（艾賓浩斯每輪自選） */}
+                            {formData.practice_mode === "word_reading" && (
+                              <div className="space-y-1.5">
+                                <Label className="text-xs text-gray-600">
+                                  {t(
+                                    "dialogs.assignmentDialog.practiceMode.shuffleQuestions",
+                                  )}
+                                </Label>
+                                <div className="flex items-center h-9">
+                                  <input
+                                    type="checkbox"
+                                    checked={formData.shuffle_questions}
+                                    onChange={(e) =>
+                                      setFormData((prev) => ({
+                                        ...prev,
+                                        shuffle_questions: e.target.checked,
+                                      }))
+                                    }
+                                    className="h-4 w-4 rounded border-gray-300"
+                                  />
+                                  <span className="ml-2 text-sm text-gray-600">
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.shuffleQuestionsDesc",
+                                    )}
+                                  </span>
+                                </div>
+                              </div>
+                            )}
+
+                            {/* 顯示答案 — word_selection / word_spelling / word_cloze 共用
+                            spelling/cloze 在 play_audio=true 時強制勾選 + 反灰 */}
+                            {(formData.practice_mode === "word_selection" ||
+                              formData.practice_mode === "word_spelling" ||
+                              formData.practice_mode === "word_cloze") && (
+                              <div className="space-y-1.5">
+                                <Label className="text-xs text-gray-600">
+                                  {t(
+                                    "dialogs.assignmentDialog.practiceMode.showAnswer",
+                                  )}
+                                </Label>
+                                <div className="flex items-center h-9">
+                                  <input
+                                    type="checkbox"
+                                    checked={formData.show_answer}
+                                    disabled={
+                                      (formData.practice_mode ===
+                                        "word_spelling" ||
+                                        formData.practice_mode ===
+                                          "word_cloze") &&
+                                      formData.play_audio
+                                    }
+                                    onChange={(e) =>
+                                      setFormData((prev) => ({
+                                        ...prev,
+                                        show_answer: e.target.checked,
+                                      }))
+                                    }
+                                    className="h-4 w-4 rounded border-gray-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                                  />
+                                  <span className="ml-2 text-sm text-gray-600">
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.wordSelectionShowAnswerDesc",
+                                    )}
+                                  </span>
+                                </div>
+                                {(formData.practice_mode === "word_spelling" ||
+                                  formData.practice_mode === "word_cloze") &&
+                                  formData.play_audio && (
+                                    <p className="text-xs text-red-600">
+                                      {t(
+                                        "dialogs.assignmentDialog.practiceMode.showAnswerLockedByAudio",
+                                      )}
+                                    </p>
+                                  )}
+                              </div>
+                            )}
+
+                            {/* 單字朗讀 - 顯示翻譯（spelling/cloze 已移到上方 toggle） */}
+                            {formData.practice_mode === "word_reading" && (
+                              <div className="space-y-1.5">
+                                <Label className="text-xs text-gray-600">
+                                  {t(
+                                    "dialogs.assignmentDialog.practiceMode.showTranslation",
+                                  )}
+                                </Label>
+                                <div className="flex items-center h-9">
+                                  <input
+                                    type="checkbox"
+                                    checked={formData.show_translation}
+                                    onChange={(e) =>
+                                      setFormData((prev) => ({
+                                        ...prev,
+                                        show_translation: e.target.checked,
+                                      }))
+                                    }
+                                    className="h-4 w-4 rounded border-gray-300"
+                                  />
+                                  <span className="ml-2 text-sm text-gray-600">
+                                    {t(
+                                      "dialogs.assignmentDialog.practiceMode.showTranslationDesc",
+                                    )}
+                                  </span>
+                                </div>
+                              </div>
+                            )}
+
+                            {/* 顯示題目圖片 */}
+                            <div className="space-y-1.5">
+                              <Label className="text-xs text-gray-600">
+                                {t(
+                                  "dialogs.assignmentDialog.practiceMode.showImage",
+                                )}
+                              </Label>
+                              <div className="flex items-center h-9">
+                                <input
+                                  type="checkbox"
+                                  checked={formData.show_image}
+                                  onChange={(e) =>
+                                    setFormData((prev) => ({
+                                      ...prev,
+                                      show_image: e.target.checked,
+                                      // Issue #631: show_image 與 show_option_images 互斥
+                                      show_option_images: e.target.checked
+                                        ? false
+                                        : prev.show_option_images,
+                                    }))
+                                  }
+                                  className="h-4 w-4 rounded border-gray-300"
+                                />
+                                <span className="ml-2 text-sm text-gray-600">
+                                  {t(
+                                    "dialogs.assignmentDialog.practiceMode.showImageDesc",
+                                  )}
+                                </span>
+                              </div>
+                            </div>
+
+                            {/* 顯示選項圖片（單字選擇專用，與顯示題目圖片互斥）Issue #631 */}
+                            {formData.practice_mode === "word_selection" &&
+                              (() => {
+                                const hasMissingImage = cartItems.some(
+                                  (i) => i.hasMissingImage,
+                                );
+                                const disabled =
+                                  hasMissingImage &&
+                                  !formData.show_option_images;
+                                return (
+                                  <div className="space-y-1.5">
+                                    <Label className="text-xs text-gray-600">
+                                      {t(
+                                        "dialogs.assignmentDialog.practiceMode.showOptionImages",
+                                      )}
+                                    </Label>
+                                    <div className="flex items-center h-9">
+                                      <input
+                                        type="checkbox"
+                                        checked={formData.show_option_images}
+                                        disabled={disabled}
+                                        onChange={(e) =>
+                                          setFormData((prev) => ({
+                                            ...prev,
+                                            show_option_images:
+                                              e.target.checked,
+                                            show_image: e.target.checked
+                                              ? false
+                                              : prev.show_image,
+                                          }))
+                                        }
+                                        className="h-4 w-4 rounded border-gray-300 disabled:cursor-not-allowed disabled:opacity-50"
+                                      />
+                                      <span
+                                        className={cn(
+                                          "ml-2 text-sm",
+                                          disabled
+                                            ? "text-gray-400"
+                                            : "text-gray-600",
+                                        )}
+                                        title={
+                                          disabled
+                                            ? t(
+                                                "dialogs.assignmentDialog.practiceMode.showOptionImagesMissing",
+                                              )
+                                            : undefined
+                                        }
+                                      >
+                                        {t(
+                                          "dialogs.assignmentDialog.practiceMode.showOptionImagesDesc",
+                                        )}
+                                      </span>
+                                    </div>
+                                    {disabled && (
+                                      <p className="text-xs text-amber-600 mt-1">
+                                        {t(
+                                          "dialogs.assignmentDialog.practiceMode.showOptionImagesMissing",
+                                        )}
+                                      </p>
+                                    )}
+                                  </div>
+                                );
+                              })()}
+                          </div>
+                        </Card>
+                      )}
                     </div>
 
                     {/* 右：學生畫面預覽（viewport ≥ 960px 才顯示；min-w 320 確保可讀） */}

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -40,6 +40,13 @@ import {
   Globe,
   Building2,
   Settings,
+  Mic,
+  Shuffle,
+  MousePointerClick,
+  Volume2,
+  Keyboard,
+  Brain,
+  type LucideIcon,
 } from "lucide-react";
 import {
   DndContext,
@@ -2701,14 +2708,15 @@ export function AssignmentDialog({
                   | "word_selection"
                   | "word_spelling"
                   | "word_cloze";
-                emoji: string;
+                Icon: LucideIcon;
                 titleKey: string;
                 descKey: string;
+                isMemoryBased?: boolean; // 採用艾賓浩斯記憶曲線
                 onClick: () => void;
               }> = [
                 {
                   id: "reading",
-                  emoji: "🎙️",
+                  Icon: Mic,
                   titleKey: "dialogs.assignmentDialog.practiceMode.reading",
                   descKey: "dialogs.assignmentDialog.practiceMode.readingDesc",
                   onClick: () =>
@@ -2720,7 +2728,7 @@ export function AssignmentDialog({
                 },
                 {
                   id: "rearrangement",
-                  emoji: "🔀",
+                  Icon: Shuffle,
                   titleKey:
                     "dialogs.assignmentDialog.practiceMode.rearrangement",
                   descKey:
@@ -2733,7 +2741,7 @@ export function AssignmentDialog({
                 },
                 {
                   id: "word_reading",
-                  emoji: "🎙️",
+                  Icon: Volume2,
                   titleKey:
                     "dialogs.assignmentDialog.practiceMode.wordReading",
                   descKey:
@@ -2747,11 +2755,12 @@ export function AssignmentDialog({
                 },
                 {
                   id: "word_selection",
-                  emoji: "🧠",
+                  Icon: MousePointerClick,
                   titleKey:
                     "dialogs.assignmentDialog.practiceMode.wordSelection",
                   descKey:
                     "dialogs.assignmentDialog.practiceMode.wordSelectionDesc",
+                  isMemoryBased: true,
                   onClick: () =>
                     setFormData((prev) => ({
                       ...prev,
@@ -2761,11 +2770,12 @@ export function AssignmentDialog({
                 },
                 {
                   id: "word_spelling",
-                  emoji: "✏️",
+                  Icon: Keyboard,
                   titleKey:
                     "dialogs.assignmentDialog.practiceMode.wordSpelling",
                   descKey:
                     "dialogs.assignmentDialog.practiceMode.wordSpellingDesc",
+                  isMemoryBased: true,
                   onClick: () =>
                     setFormData((prev) => ({
                       ...prev,
@@ -2780,10 +2790,11 @@ export function AssignmentDialog({
                 },
                 {
                   id: "word_cloze",
-                  emoji: "📝",
+                  Icon: FileText,
                   titleKey: "dialogs.assignmentDialog.practiceMode.wordCloze",
                   descKey:
                     "dialogs.assignmentDialog.practiceMode.wordClozeDesc",
+                  isMemoryBased: true,
                   onClick: () =>
                     setFormData((prev) => ({
                       ...prev,
@@ -2828,8 +2839,14 @@ export function AssignmentDialog({
                               : "border-gray-200 text-gray-700 hover:border-gray-300 hover:bg-gray-50",
                           )}
                         >
-                          <span className="text-base">{m.emoji}</span>
+                          <m.Icon className="h-4 w-4 shrink-0" />
                           <span>{t(m.titleKey)}</span>
+                          {m.isMemoryBased && (
+                            <Brain
+                              className="h-3.5 w-3.5 shrink-0 opacity-70"
+                              aria-label="採用艾賓浩斯記憶曲線"
+                            />
+                          )}
                         </button>
                       );
                     })}
@@ -2841,9 +2858,7 @@ export function AssignmentDialog({
                       {currentMode && (
                         <div className="p-4 rounded-xl bg-gray-50">
                           <div className="flex items-center gap-3">
-                            <span className="text-4xl shrink-0">
-                              {currentMode.emoji}
-                            </span>
+                            <currentMode.Icon className="h-8 w-8 shrink-0 text-gray-700" />
                             <div className="text-base font-semibold text-gray-900">
                               {t(currentMode.titleKey)}
                             </div>
@@ -3551,14 +3566,18 @@ export function AssignmentDialog({
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">
                             學生畫面預覽（demo 教材）
                           </h4>
-                          <RearrangementPreview />
+                          <RearrangementPreview
+                            shuffleQuestions={formData.shuffle_questions}
+                          />
                         </Card>
                       ) : formData.practice_mode === "reading" ? (
                         <Card className="p-3 border-gray-200">
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">
                             學生畫面預覽（demo 教材）
                           </h4>
-                          <ReadingPreview />
+                          <ReadingPreview
+                            shuffleQuestions={formData.shuffle_questions}
+                          />
                         </Card>
                       ) : (
                         <div className="h-full flex items-center justify-center text-sm text-gray-400 border border-dashed border-gray-200 rounded-lg">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2910,8 +2910,8 @@ export function AssignmentDialog({
                   </div>
 
                   <div className="flex-1 min-h-0 w-full flex flex-col md:flex-row gap-4">
-                    {/* 左：設定區（mobile 全寬 / desktop 固定 320px） */}
-                    <div className="md:w-80 md:shrink-0 space-y-4 overflow-y-auto pr-1 h-full">
+                    {/* 左：設定區（< 960px 全寬 / ≥ 960px 固定 320px） */}
+                    <div className="w-full min-[960px]:w-80 min-[960px]:shrink-0 space-y-4 overflow-y-auto pr-1 h-full">
                       {currentMode && (
                         <div className="p-4 rounded-xl bg-gray-50">
                           <div className="flex items-center gap-3">
@@ -3545,8 +3545,8 @@ export function AssignmentDialog({
 
                     </div>
 
-                    {/* 右：學生畫面預覽（viewport ≥ 1100px 才顯示，避免被擠扁；min-w 確保可讀） */}
-                    <div className="hidden min-[1100px]:block flex-1 min-w-[480px] overflow-y-auto pr-1 h-full">
+                    {/* 右：學生畫面預覽（viewport ≥ 960px 才顯示；min-w 320 確保可讀） */}
+                    <div className="hidden min-[960px]:block flex-1 min-w-[320px] overflow-y-auto pr-1 h-full">
                       {formData.practice_mode === "word_reading" ? (
                         <Card className="p-3 border-gray-200">
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -1442,12 +1442,7 @@ export function AssignmentDialog({
       <SheetContent
         side="right"
         aria-describedby={undefined}
-        className={cn(
-          "!w-full h-full flex flex-col p-0 transition-[max-width] duration-300 ease-out",
-          currentStep === 1 && !formData.practice_mode
-            ? "!max-w-[340px] sm:!max-w-[340px]"
-            : "!max-w-[calc(100vw-16rem)] sm:!max-w-[calc(100vw-16rem)]",
-        )}
+        className="!w-full !max-w-[calc(100vw-16rem)] h-full flex flex-col p-0 sm:!max-w-[calc(100vw-16rem)]"
       >
         {/* Compact Header with Clear Steps - 響應式方案 C */}
         <div className="px-6 py-3 border-b bg-gray-50">
@@ -2831,55 +2826,32 @@ export function AssignmentDialog({
                     </p>
                   </div>
 
-                  <div className="flex-1 min-h-0 flex gap-6 w-full">
-                    {/* 左 rail：練習模式 row list */}
-                    <div className="w-[260px] shrink-0 space-y-2 overflow-y-auto pr-1">
-                      {PRACTICE_MODES.map((m) => {
-                        const selected = formData.practice_mode === m.id;
-                        return (
-                          <button
-                            key={m.id}
-                            type="button"
-                            onClick={m.onClick}
-                            className={cn(
-                              "w-full flex items-center gap-3 p-2 rounded-lg border text-left transition-all",
-                              selected
-                                ? "border-blue-500 bg-blue-50 shadow-sm"
-                                : "border-gray-200 hover:border-gray-300 hover:bg-gray-50",
-                            )}
-                          >
-                            <span className="text-xl shrink-0">
-                              {m.emoji}
-                            </span>
-                            <div className="min-w-0 flex-1">
-                              <div
-                                className={cn(
-                                  "text-sm font-semibold truncate",
-                                  selected
-                                    ? "text-blue-700"
-                                    : "text-gray-900",
-                                )}
-                              >
-                                {t(m.titleKey)}
-                              </div>
-                              <div
-                                className={cn(
-                                  "text-xs leading-snug",
-                                  selected
-                                    ? "text-blue-600"
-                                    : "text-gray-500",
-                                )}
-                              >
-                                {t(m.descKey)}
-                              </div>
-                            </div>
-                          </button>
-                        );
-                      })}
-                    </div>
+                  {/* 上方 chip 列：練習模式選擇 */}
+                  <div className="flex flex-wrap gap-2 mb-4">
+                    {PRACTICE_MODES.map((m) => {
+                      const selected = formData.practice_mode === m.id;
+                      return (
+                        <button
+                          key={m.id}
+                          type="button"
+                          onClick={m.onClick}
+                          className={cn(
+                            "flex items-center gap-2 px-3 py-2 rounded-full border text-sm transition-all",
+                            selected
+                              ? "border-blue-500 bg-blue-50 text-blue-700 shadow-sm font-semibold"
+                              : "border-gray-200 text-gray-700 hover:border-gray-300 hover:bg-gray-50",
+                          )}
+                        >
+                          <span className="text-base">{m.emoji}</span>
+                          <span>{t(m.titleKey)}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
 
-                    {/* 右 panel：Hero + 進階設定 */}
-                    <div className="flex-1 min-w-0 space-y-4 overflow-y-auto pr-1">
+                  <div className="flex-1 min-h-0 w-full">
+                    {/* 設定區：Hero + 進階設定 */}
+                    <div className="space-y-4 overflow-y-auto pr-1 h-full">
                       {currentMode && (
                         <div className="flex items-start gap-4 p-4 rounded-xl bg-gray-50">
                           <span className="text-4xl shrink-0">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2909,9 +2909,9 @@ export function AssignmentDialog({
                     </div>
                   </div>
 
-                  <div className="flex-1 min-h-0 w-full grid grid-cols-1 md:grid-cols-4 gap-4">
-                    {/* 左：設定區（mobile 全寬 / desktop 1/4） */}
-                    <div className="col-span-1 min-w-0 space-y-4 overflow-y-auto pr-1 h-full">
+                  <div className="flex-1 min-h-0 w-full flex flex-col md:flex-row gap-4">
+                    {/* 左：設定區（mobile 全寬 / desktop 固定 320px） */}
+                    <div className="md:w-80 md:shrink-0 space-y-4 overflow-y-auto pr-1 h-full">
                       {currentMode && (
                         <div className="p-4 rounded-xl bg-gray-50">
                           <div className="flex items-center gap-3">
@@ -3545,8 +3545,8 @@ export function AssignmentDialog({
 
                     </div>
 
-                    {/* 右：學生畫面預覽（mobile 隱藏 / desktop 3/4） */}
-                    <div className="hidden md:block md:col-span-3 min-w-0 overflow-y-auto pr-1 h-full">
+                    {/* 右：學生畫面預覽（mobile 隱藏 / desktop 吃剩餘空間，太窄自動切 mobile 樣式） */}
+                    <div className="hidden md:block flex-1 min-w-0 overflow-y-auto pr-1 h-full">
                       {formData.practice_mode === "word_reading" ? (
                         <Card className="p-3 border-gray-200">
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2740,6 +2740,13 @@ export function AssignmentDialog({
                 titleKey: string;
                 descKey: string;
                 isMemoryBased?: boolean; // 採用艾賓浩斯記憶曲線
+                /**
+                 * 顏色與學生端 StudentAssignmentList.tsx 對齊。
+                 * chipSelected: chip 選中時的 border + bg + text
+                 * iconColor: Hero 區塊 icon 顏色
+                 */
+                chipSelected: string;
+                iconColor: string;
                 onClick: () => void;
               }> = [
                 {
@@ -2747,6 +2754,9 @@ export function AssignmentDialog({
                   Icon: Mic,
                   titleKey: "dialogs.assignmentDialog.practiceMode.reading",
                   descKey: "dialogs.assignmentDialog.practiceMode.readingDesc",
+                  chipSelected:
+                    "border-orange-500 bg-orange-50 text-orange-700",
+                  iconColor: "text-orange-600",
                   onClick: () =>
                     setFormData((prev) => ({
                       ...prev,
@@ -2761,6 +2771,8 @@ export function AssignmentDialog({
                     "dialogs.assignmentDialog.practiceMode.rearrangement",
                   descKey:
                     "dialogs.assignmentDialog.practiceMode.rearrangementDesc",
+                  chipSelected: "border-blue-500 bg-blue-50 text-blue-700",
+                  iconColor: "text-blue-600",
                   onClick: () =>
                     setFormData((prev) => ({
                       ...prev,
@@ -2774,6 +2786,9 @@ export function AssignmentDialog({
                     "dialogs.assignmentDialog.practiceMode.wordReading",
                   descKey:
                     "dialogs.assignmentDialog.practiceMode.wordReadingDesc",
+                  chipSelected:
+                    "border-purple-500 bg-purple-50 text-purple-700",
+                  iconColor: "text-purple-600",
                   onClick: () =>
                     setFormData((prev) => ({
                       ...prev,
@@ -2789,6 +2804,9 @@ export function AssignmentDialog({
                   descKey:
                     "dialogs.assignmentDialog.practiceMode.wordSelectionDesc",
                   isMemoryBased: true,
+                  chipSelected:
+                    "border-emerald-500 bg-emerald-50 text-emerald-700",
+                  iconColor: "text-emerald-600",
                   onClick: () =>
                     setFormData((prev) => ({
                       ...prev,
@@ -2804,6 +2822,8 @@ export function AssignmentDialog({
                   descKey:
                     "dialogs.assignmentDialog.practiceMode.wordSpellingDesc",
                   isMemoryBased: true,
+                  chipSelected: "border-amber-500 bg-amber-50 text-amber-700",
+                  iconColor: "text-amber-600",
                   onClick: () =>
                     setFormData((prev) => ({
                       ...prev,
@@ -2823,6 +2843,8 @@ export function AssignmentDialog({
                   descKey:
                     "dialogs.assignmentDialog.practiceMode.wordClozeDesc",
                   isMemoryBased: true,
+                  chipSelected: "border-pink-500 bg-pink-50 text-pink-700",
+                  iconColor: "text-pink-600",
                   onClick: () =>
                     setFormData((prev) => ({
                       ...prev,
@@ -2891,7 +2913,7 @@ export function AssignmentDialog({
                             className={cn(
                               "shrink-0 flex items-center gap-2 px-3 py-2 rounded-full border text-sm transition-all",
                               selected
-                                ? "border-blue-500 bg-blue-50 text-blue-700 shadow-sm font-semibold"
+                                ? cn(m.chipSelected, "shadow-sm font-semibold")
                                 : "border-gray-200 text-gray-700 hover:border-gray-300 hover:bg-gray-50",
                             )}
                           >
@@ -2915,7 +2937,12 @@ export function AssignmentDialog({
                       {currentMode && (
                         <div className="p-4 rounded-xl bg-gray-50">
                           <div className="flex items-center gap-3">
-                            <currentMode.Icon className="h-8 w-8 shrink-0 text-gray-700" />
+                            <currentMode.Icon
+                              className={cn(
+                                "h-8 w-8 shrink-0",
+                                currentMode.iconColor,
+                              )}
+                            />
                             <div className="text-base font-semibold text-gray-900">
                               {t(currentMode.titleKey)}
                             </div>

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2805,25 +2805,22 @@ export function AssignmentDialog({
               };
               return (
                 <div className="h-full flex flex-col">
-                  <div className="flex items-center gap-3 mb-2">
+                  <div className="flex items-center gap-3 mb-4">
                     <h2 className="text-lg font-semibold text-gray-900">
                       {t("dialogs.assignmentDialog.steps.practiceMode")}
                     </h2>
-                    <span
-                      className={cn(
-                        "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold",
-                        badgeStyles[currentCategory],
-                      )}
-                    >
-                      {t(
-                        `dialogs.assignmentDialog.practiceMode.scoreCategory.${currentCategory}`,
-                      )}
-                    </span>
-                  </div>
-                  <div className="mb-4">
-                    <p className="text-sm text-gray-600">
-                      {t("dialogs.assignmentDialog.practiceMode.description")}
-                    </p>
+                    {currentMode && (
+                      <span
+                        className={cn(
+                          "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold",
+                          badgeStyles[currentCategory],
+                        )}
+                      >
+                        {t(
+                          `dialogs.assignmentDialog.practiceMode.scoreCategory.${currentCategory}`,
+                        )}
+                      </span>
+                    )}
                   </div>
 
                   {/* 上方 chip 列：練習模式選擇 */}

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2805,21 +2805,6 @@ export function AssignmentDialog({
               };
               return (
                 <div className="h-full flex flex-col">
-                  {currentMode && (
-                    <div className="flex items-center gap-3 mb-4">
-                      <span
-                        className={cn(
-                          "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold",
-                          badgeStyles[currentCategory],
-                        )}
-                      >
-                        {t(
-                          `dialogs.assignmentDialog.practiceMode.scoreCategory.${currentCategory}`,
-                        )}
-                      </span>
-                    </div>
-                  )}
-
                   {/* 上方 chip 列：練習模式選擇 */}
                   <div className="flex flex-wrap gap-2 mb-4">
                     {PRACTICE_MODES.map((m) => {
@@ -2852,8 +2837,20 @@ export function AssignmentDialog({
                             {currentMode.emoji}
                           </span>
                           <div className="min-w-0">
-                            <div className="text-base font-semibold text-gray-900">
-                              {t(currentMode.titleKey)}
+                            <div className="flex items-center gap-2">
+                              <div className="text-base font-semibold text-gray-900">
+                                {t(currentMode.titleKey)}
+                              </div>
+                              <span
+                                className={cn(
+                                  "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold",
+                                  badgeStyles[currentCategory],
+                                )}
+                              >
+                                {t(
+                                  `dialogs.assignmentDialog.practiceMode.scoreCategory.${currentCategory}`,
+                                )}
+                              </span>
                             </div>
                             <div className="text-sm text-gray-600 mt-0.5">
                               {t(currentMode.descKey)}

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -67,6 +67,10 @@ import {
   getScoreCategory,
   type ScoreCategory,
 } from "@/utils/scoreCategory";
+import WordReadingPreview from "@/components/activities/WordReadingPreview";
+
+// Issue #752 PoC: 預覽固定使用 contact@duotopia.co 的「翰林佳音 第二冊 Unit 1 Warm up」
+const PREVIEW_CONTENT_ID_WORD_READING = 282;
 
 interface Student {
   id: number;
@@ -3459,6 +3463,24 @@ export function AssignmentDialog({
                             );
                           })()}
                       </div>
+                    </Card>
+                  )}
+
+                  {/* Issue #752 PoC: word_reading 即時預覽 */}
+                  {formData.practice_mode === "word_reading" && (
+                    <Card className="p-4 border-gray-200">
+                      <h4 className="text-sm font-medium mb-3 text-gray-700">
+                        學生畫面預覽（demo 教材）
+                      </h4>
+                      <WordReadingPreview
+                        contentId={PREVIEW_CONTENT_ID_WORD_READING}
+                        settings={{
+                          time_limit_per_question:
+                            formData.time_limit_per_question,
+                          show_image: formData.show_image,
+                          show_translation: formData.show_translation,
+                        }}
+                      />
                     </Card>
                   )}
                     </div>

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2805,11 +2805,8 @@ export function AssignmentDialog({
               };
               return (
                 <div className="h-full flex flex-col">
-                  <div className="flex items-center gap-3 mb-4">
-                    <h2 className="text-lg font-semibold text-gray-900">
-                      {t("dialogs.assignmentDialog.steps.practiceMode")}
-                    </h2>
-                    {currentMode && (
+                  {currentMode && (
+                    <div className="flex items-center gap-3 mb-4">
                       <span
                         className={cn(
                           "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold",
@@ -2820,8 +2817,8 @@ export function AssignmentDialog({
                           `dialogs.assignmentDialog.practiceMode.scoreCategory.${currentCategory}`,
                         )}
                       </span>
-                    )}
-                  </div>
+                    </div>
+                  )}
 
                   {/* 上方 chip 列：練習模式選擇 */}
                   <div className="flex flex-wrap gap-2 mb-4">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -76,7 +76,6 @@ import ReadingPreview from "@/components/activities/ReadingPreview";
 
 // Issue #752 PoC: 預覽固定使用 contact@duotopia.co 的「翰林佳音 第二冊 Unit 1」
 const PREVIEW_VOCAB_CONTENT_ID = 282; // Warm up（單字集）
-const PREVIEW_SENTENCES_CONTENT_ID = 283; // Dialogue（例句集）
 
 interface Student {
   id: number;
@@ -3552,16 +3551,7 @@ export function AssignmentDialog({
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">
                             學生畫面預覽（demo 教材）
                           </h4>
-                          <RearrangementPreview
-                            contentId={PREVIEW_SENTENCES_CONTENT_ID}
-                            settings={{
-                              play_audio: formData.play_audio,
-                              show_answer: formData.show_answer,
-                              time_limit_per_question:
-                                formData.time_limit_per_question,
-                              shuffle_questions: formData.shuffle_questions,
-                            }}
-                          />
+                          <RearrangementPreview />
                         </Card>
                       ) : formData.practice_mode === "reading" ? (
                         <Card className="p-3 border-gray-200">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -1442,7 +1442,7 @@ export function AssignmentDialog({
       <SheetContent
         side="right"
         aria-describedby={undefined}
-        className="!w-full !max-w-5xl h-full flex flex-col p-0 sm:!max-w-5xl"
+        className="!w-full !max-w-[calc(100vw-16rem)] h-full flex flex-col p-0 sm:!max-w-[calc(100vw-16rem)]"
       >
         {/* Compact Header with Clear Steps - 響應式方案 C */}
         <div className="px-6 py-3 border-b bg-gray-50">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -3585,7 +3585,9 @@ export function AssignmentDialog({
                       {formData.practice_mode === "word_reading" ? (
                         <Card className="p-3 border-gray-200">
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">
-                            學生畫面預覽（demo 教材）
+                            {t(
+                              "dialogs.assignmentDialog.practiceMode.studentPreview",
+                            )}
                           </h4>
                           <WordReadingPreview
                             contentId={PREVIEW_VOCAB_CONTENT_ID}
@@ -3601,7 +3603,9 @@ export function AssignmentDialog({
                       ) : formData.practice_mode === "word_selection" ? (
                         <Card className="p-3 border-gray-200">
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">
-                            學生畫面預覽（demo 教材）
+                            {t(
+                              "dialogs.assignmentDialog.practiceMode.studentPreview",
+                            )}
                           </h4>
                           <WordSelectionPreview
                             contentId={PREVIEW_VOCAB_CONTENT_ID}
@@ -3619,7 +3623,9 @@ export function AssignmentDialog({
                       ) : formData.practice_mode === "word_spelling" ? (
                         <Card className="p-3 border-gray-200">
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">
-                            學生畫面預覽（demo 教材）
+                            {t(
+                              "dialogs.assignmentDialog.practiceMode.studentPreview",
+                            )}
                           </h4>
                           <WordSpellingPreview
                             contentId={PREVIEW_VOCAB_CONTENT_ID}
@@ -3638,7 +3644,9 @@ export function AssignmentDialog({
                       ) : formData.practice_mode === "word_cloze" ? (
                         <Card className="p-3 border-gray-200">
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">
-                            學生畫面預覽（demo 教材）
+                            {t(
+                              "dialogs.assignmentDialog.practiceMode.studentPreview",
+                            )}
                           </h4>
                           <WordClozeContextPreview
                             contentId={PREVIEW_VOCAB_CONTENT_ID}
@@ -3656,7 +3664,9 @@ export function AssignmentDialog({
                       ) : formData.practice_mode === "rearrangement" ? (
                         <Card className="p-3 border-gray-200">
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">
-                            學生畫面預覽（demo 教材）
+                            {t(
+                              "dialogs.assignmentDialog.practiceMode.studentPreview",
+                            )}
                           </h4>
                           <RearrangementPreview
                             shuffleQuestions={formData.shuffle_questions}
@@ -3665,7 +3675,9 @@ export function AssignmentDialog({
                       ) : formData.practice_mode === "reading" ? (
                         <Card className="p-3 border-gray-200">
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">
-                            學生畫面預覽（demo 教材）
+                            {t(
+                              "dialogs.assignmentDialog.practiceMode.studentPreview",
+                            )}
                           </h4>
                           <ReadingPreview
                             shuffleQuestions={formData.shuffle_questions}

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2851,31 +2851,34 @@ export function AssignmentDialog({
               };
               return (
                 <div className="h-full flex flex-col">
-                  {/* 上方 chip 列：橫向卷 + 內容超寬時顯示箭頭 */}
+                  {/* 上方 chip 列：橫向卷 + 箭頭永遠顯示 + 邊緣漸層 */}
                   <div className="relative mb-4">
+                    <button
+                      type="button"
+                      onClick={() => scrollChips("left")}
+                      className="absolute left-0 top-1/2 -translate-y-1/2 z-20 h-7 w-7 flex items-center justify-center rounded-full bg-white shadow border border-gray-200 hover:bg-gray-50"
+                      aria-label="向左滑動"
+                    >
+                      <ChevronLeft className="h-4 w-4 text-gray-600" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => scrollChips("right")}
+                      className="absolute right-0 top-1/2 -translate-y-1/2 z-20 h-7 w-7 flex items-center justify-center rounded-full bg-white shadow border border-gray-200 hover:bg-gray-50"
+                      aria-label="向右滑動"
+                    >
+                      <ChevronRight className="h-4 w-4 text-gray-600" />
+                    </button>
+                    {/* 邊緣漸層：暗示「還有更多」（overflow 才顯示） */}
                     {chipCanScrollLeft && (
-                      <button
-                        type="button"
-                        onClick={() => scrollChips("left")}
-                        className="absolute left-0 top-1/2 -translate-y-1/2 z-10 h-7 w-7 flex items-center justify-center rounded-full bg-white shadow border border-gray-200 hover:bg-gray-50"
-                        aria-label="向左滑動"
-                      >
-                        <ChevronLeft className="h-4 w-4 text-gray-600" />
-                      </button>
+                      <div className="pointer-events-none absolute left-7 top-0 bottom-0 z-10 w-6 bg-gradient-to-r from-white to-transparent" />
                     )}
                     {chipCanScrollRight && (
-                      <button
-                        type="button"
-                        onClick={() => scrollChips("right")}
-                        className="absolute right-0 top-1/2 -translate-y-1/2 z-10 h-7 w-7 flex items-center justify-center rounded-full bg-white shadow border border-gray-200 hover:bg-gray-50"
-                        aria-label="向右滑動"
-                      >
-                        <ChevronRight className="h-4 w-4 text-gray-600" />
-                      </button>
+                      <div className="pointer-events-none absolute right-7 top-0 bottom-0 z-10 w-6 bg-gradient-to-l from-white to-transparent" />
                     )}
                     <div
                       ref={chipRowRef}
-                      className="flex gap-2 overflow-x-auto [&::-webkit-scrollbar]:hidden"
+                      className="flex gap-2 overflow-x-auto px-9 [&::-webkit-scrollbar]:hidden"
                       style={{ scrollbarWidth: "none" }}
                     >
                       {PRACTICE_MODES.map((m) => {

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2826,7 +2826,7 @@ export function AssignmentDialog({
                     </p>
                   </div>
 
-                  <div className="flex-1 min-h-0 flex gap-6 max-w-4xl mx-auto w-full">
+                  <div className="flex-1 min-h-0 flex gap-6 w-full">
                     {/* 左 rail：練習模式 row list */}
                     <div className="w-[220px] shrink-0 space-y-2 overflow-y-auto pr-1">
                       {PRACTICE_MODES.map((m) => {
@@ -2837,7 +2837,7 @@ export function AssignmentDialog({
                             type="button"
                             onClick={m.onClick}
                             className={cn(
-                              "w-full flex items-center gap-3 p-3 rounded-lg border text-left transition-all",
+                              "w-full flex items-center gap-3 p-2 rounded-lg border text-left transition-all",
                               selected
                                 ? "border-blue-500 bg-blue-50 shadow-sm"
                                 : "border-gray-200 hover:border-gray-300 hover:bg-gray-50",

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2832,9 +2832,9 @@ export function AssignmentDialog({
                     })}
                   </div>
 
-                  <div className="flex-1 min-h-0 w-full">
-                    {/* 設定區：Hero + 進階設定 */}
-                    <div className="space-y-4 overflow-y-auto pr-1 h-full">
+                  <div className="flex-1 min-h-0 w-full flex gap-4">
+                    {/* 左：設定區 */}
+                    <div className="w-[440px] shrink-0 space-y-4 overflow-y-auto pr-1 h-full">
                       {currentMode && (
                         <div className="flex items-start gap-4 p-4 rounded-xl bg-gray-50">
                           <span className="text-4xl shrink-0">
@@ -3466,23 +3466,32 @@ export function AssignmentDialog({
                     </Card>
                   )}
 
-                  {/* Issue #752 PoC: word_reading 即時預覽 */}
-                  {formData.practice_mode === "word_reading" && (
-                    <Card className="p-3 border-gray-200">
-                      <h4 className="text-xs font-semibold mb-2 text-gray-700">
-                        學生畫面預覽（demo 教材）
-                      </h4>
-                      <WordReadingPreview
-                        contentId={PREVIEW_CONTENT_ID_WORD_READING}
-                        settings={{
-                          time_limit_per_question:
-                            formData.time_limit_per_question,
-                          show_image: formData.show_image,
-                          show_translation: formData.show_translation,
-                        }}
-                      />
-                    </Card>
-                  )}
+                    </div>
+
+                    {/* 右：學生畫面預覽 */}
+                    <div className="flex-1 min-w-0 overflow-y-auto pr-1 h-full">
+                      {formData.practice_mode === "word_reading" ? (
+                        <Card className="p-3 border-gray-200">
+                          <h4 className="text-xs font-semibold mb-2 text-gray-700">
+                            學生畫面預覽（demo 教材）
+                          </h4>
+                          <WordReadingPreview
+                            contentId={PREVIEW_CONTENT_ID_WORD_READING}
+                            settings={{
+                              time_limit_per_question:
+                                formData.time_limit_per_question,
+                              show_image: formData.show_image,
+                              show_translation: formData.show_translation,
+                            }}
+                          />
+                        </Card>
+                      ) : (
+                        <div className="h-full flex items-center justify-center text-sm text-gray-400 border border-dashed border-gray-200 rounded-lg">
+                          {currentMode
+                            ? "此模式預覽尚未實作"
+                            : "選擇一個模式查看預覽"}
+                        </div>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import {
   Sheet,
   SheetContent,
@@ -449,6 +449,34 @@ export function AssignmentDialog({
     show_image: true, // 顯示題目圖片
     show_option_images: false, // 顯示選項圖片（單字選擇專用，與 show_image 互斥，Issue #631）
   });
+
+  // Issue #752: 練習模式 chip 列橫向滑動 + 箭頭按鈕（內容超寬時才顯示）
+  const chipRowRef = useRef<HTMLDivElement>(null);
+  const [chipCanScrollLeft, setChipCanScrollLeft] = useState(false);
+  const [chipCanScrollRight, setChipCanScrollRight] = useState(false);
+  useEffect(() => {
+    const el = chipRowRef.current;
+    if (!el) return;
+    const update = () => {
+      setChipCanScrollLeft(el.scrollLeft > 0);
+      setChipCanScrollRight(
+        el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
+      );
+    };
+    update();
+    el.addEventListener("scroll", update, { passive: true });
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener("scroll", update);
+      ro.disconnect();
+    };
+  }, [currentStep]);
+  const scrollChips = (dir: "left" | "right") => {
+    const el = chipRowRef.current;
+    if (!el) return;
+    el.scrollBy({ left: dir === "left" ? -200 : 200, behavior: "smooth" });
+  };
 
   // 內部載入學生列表（當外部未傳入時，單班級模式）
   const loadStudents = async () => {
@@ -2823,33 +2851,59 @@ export function AssignmentDialog({
               };
               return (
                 <div className="h-full flex flex-col">
-                  {/* 上方 chip 列：練習模式選擇 */}
-                  <div className="flex flex-wrap gap-2 mb-4">
-                    {PRACTICE_MODES.map((m) => {
-                      const selected = formData.practice_mode === m.id;
-                      return (
-                        <button
-                          key={m.id}
-                          type="button"
-                          onClick={m.onClick}
-                          className={cn(
-                            "flex items-center gap-2 px-3 py-2 rounded-full border text-sm transition-all",
-                            selected
-                              ? "border-blue-500 bg-blue-50 text-blue-700 shadow-sm font-semibold"
-                              : "border-gray-200 text-gray-700 hover:border-gray-300 hover:bg-gray-50",
-                          )}
-                        >
-                          <m.Icon className="h-4 w-4 shrink-0" />
-                          <span>{t(m.titleKey)}</span>
-                          {m.isMemoryBased && (
-                            <Brain
-                              className="h-3.5 w-3.5 shrink-0 opacity-70"
-                              aria-label="採用艾賓浩斯記憶曲線"
-                            />
-                          )}
-                        </button>
-                      );
-                    })}
+                  {/* 上方 chip 列：橫向卷 + 內容超寬時顯示箭頭 */}
+                  <div className="relative mb-4">
+                    {chipCanScrollLeft && (
+                      <button
+                        type="button"
+                        onClick={() => scrollChips("left")}
+                        className="absolute left-0 top-1/2 -translate-y-1/2 z-10 h-7 w-7 flex items-center justify-center rounded-full bg-white shadow border border-gray-200 hover:bg-gray-50"
+                        aria-label="向左滑動"
+                      >
+                        <ChevronLeft className="h-4 w-4 text-gray-600" />
+                      </button>
+                    )}
+                    {chipCanScrollRight && (
+                      <button
+                        type="button"
+                        onClick={() => scrollChips("right")}
+                        className="absolute right-0 top-1/2 -translate-y-1/2 z-10 h-7 w-7 flex items-center justify-center rounded-full bg-white shadow border border-gray-200 hover:bg-gray-50"
+                        aria-label="向右滑動"
+                      >
+                        <ChevronRight className="h-4 w-4 text-gray-600" />
+                      </button>
+                    )}
+                    <div
+                      ref={chipRowRef}
+                      className="flex gap-2 overflow-x-auto [&::-webkit-scrollbar]:hidden"
+                      style={{ scrollbarWidth: "none" }}
+                    >
+                      {PRACTICE_MODES.map((m) => {
+                        const selected = formData.practice_mode === m.id;
+                        return (
+                          <button
+                            key={m.id}
+                            type="button"
+                            onClick={m.onClick}
+                            className={cn(
+                              "shrink-0 flex items-center gap-2 px-3 py-2 rounded-full border text-sm transition-all",
+                              selected
+                                ? "border-blue-500 bg-blue-50 text-blue-700 shadow-sm font-semibold"
+                                : "border-gray-200 text-gray-700 hover:border-gray-300 hover:bg-gray-50",
+                            )}
+                          >
+                            <m.Icon className="h-4 w-4 shrink-0" />
+                            <span>{t(m.titleKey)}</span>
+                            {m.isMemoryBased && (
+                              <Brain
+                                className="h-3.5 w-3.5 shrink-0 opacity-70"
+                                aria-label="採用艾賓浩斯記憶曲線"
+                              />
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
                   </div>
 
                   <div className="flex-1 min-h-0 w-full grid grid-cols-1 md:grid-cols-4 gap-4">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -69,10 +69,12 @@ import {
 } from "@/utils/scoreCategory";
 import WordReadingPreview from "@/components/activities/WordReadingPreview";
 import WordSelectionPreview from "@/components/activities/WordSelectionPreview";
+import WordSpellingPreview from "@/components/activities/WordSpellingPreview";
+import WordClozeContextPreview from "@/components/activities/WordClozeContextPreview";
 
-// Issue #752 PoC: 預覽固定使用 contact@duotopia.co 的「翰林佳音 第二冊 Unit 1 Warm up」
-const PREVIEW_CONTENT_ID_WORD_READING = 282;
-const PREVIEW_CONTENT_ID_WORD_SELECTION = 282;
+// Issue #752 PoC: 預覽固定使用 contact@duotopia.co 的「翰林佳音 第二冊 Unit 1」
+const PREVIEW_VOCAB_CONTENT_ID = 282; // Warm up（單字集）
+// PREVIEW_SENTENCES_CONTENT_ID = 283 (Dialogue) — 之後 reading / rearrangement 預覽用
 
 interface Student {
   id: number;
@@ -3478,7 +3480,7 @@ export function AssignmentDialog({
                             學生畫面預覽（demo 教材）
                           </h4>
                           <WordReadingPreview
-                            contentId={PREVIEW_CONTENT_ID_WORD_READING}
+                            contentId={PREVIEW_VOCAB_CONTENT_ID}
                             settings={{
                               time_limit_per_question:
                                 formData.time_limit_per_question,
@@ -3494,11 +3496,48 @@ export function AssignmentDialog({
                             學生畫面預覽（demo 教材）
                           </h4>
                           <WordSelectionPreview
-                            contentId={PREVIEW_CONTENT_ID_WORD_SELECTION}
+                            contentId={PREVIEW_VOCAB_CONTENT_ID}
                             settings={{
                               show_image: formData.show_image,
                               show_option_images: formData.show_option_images,
                               play_audio: formData.play_audio,
+                              target_proficiency: formData.target_proficiency,
+                              time_limit_per_question:
+                                formData.time_limit_per_question,
+                              shuffle_questions: formData.shuffle_questions,
+                            }}
+                          />
+                        </Card>
+                      ) : formData.practice_mode === "word_spelling" ? (
+                        <Card className="p-3 border-gray-200">
+                          <h4 className="text-xs font-semibold mb-2 text-gray-700">
+                            學生畫面預覽（demo 教材）
+                          </h4>
+                          <WordSpellingPreview
+                            contentId={PREVIEW_VOCAB_CONTENT_ID}
+                            settings={{
+                              show_translation: formData.show_translation,
+                              show_image: formData.show_image,
+                              play_audio: formData.play_audio,
+                              show_answer: formData.show_answer,
+                              target_proficiency: formData.target_proficiency,
+                              time_limit_per_question:
+                                formData.time_limit_per_question,
+                              shuffle_questions: formData.shuffle_questions,
+                            }}
+                          />
+                        </Card>
+                      ) : formData.practice_mode === "word_cloze" ? (
+                        <Card className="p-3 border-gray-200">
+                          <h4 className="text-xs font-semibold mb-2 text-gray-700">
+                            學生畫面預覽（demo 教材）
+                          </h4>
+                          <WordClozeContextPreview
+                            contentId={PREVIEW_VOCAB_CONTENT_ID}
+                            settings={{
+                              show_translation: formData.show_translation,
+                              play_audio: formData.play_audio,
+                              show_answer: formData.show_answer,
                               target_proficiency: formData.target_proficiency,
                               time_limit_per_question:
                                 formData.time_limit_per_question,

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -3482,6 +3482,7 @@ export function AssignmentDialog({
                                 formData.time_limit_per_question,
                               show_image: formData.show_image,
                               show_translation: formData.show_translation,
+                              shuffle_questions: formData.shuffle_questions,
                             }}
                           />
                         </Card>

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -3545,8 +3545,8 @@ export function AssignmentDialog({
 
                     </div>
 
-                    {/* 右：學生畫面預覽（mobile 隱藏 / desktop 吃剩餘空間，太窄自動切 mobile 樣式） */}
-                    <div className="hidden md:block flex-1 min-w-0 overflow-y-auto pr-1 h-full">
+                    {/* 右：學生畫面預覽（viewport ≥ 1100px 才顯示，避免被擠扁；min-w 確保可讀） */}
+                    <div className="hidden min-[1100px]:block flex-1 min-w-[480px] overflow-y-auto pr-1 h-full">
                       {formData.practice_mode === "word_reading" ? (
                         <Card className="p-3 border-gray-200">
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -1416,10 +1416,11 @@ export function AssignmentDialog({
           time_limit_per_question: 10, // 單字朗讀固定 10 秒
         }));
       } else {
-        // 例句集預設為例句朗讀模式
+        // 例句集預設為例句朗讀模式（固定 30 秒）
         setFormData((prev) => ({
           ...prev,
           practice_mode: "reading",
+          time_limit_per_question: 30,
         }));
       }
     }
@@ -2714,10 +2715,7 @@ export function AssignmentDialog({
                     setFormData((prev) => ({
                       ...prev,
                       practice_mode: "reading",
-                      time_limit_per_question:
-                        prev.time_limit_per_question === 0
-                          ? 30
-                          : prev.time_limit_per_question,
+                      time_limit_per_question: 30, // reading 固定 30 秒
                     })),
                 },
                 {
@@ -2876,7 +2874,8 @@ export function AssignmentDialog({
                         )}
                       </h4>
                       <div className="grid grid-cols-1 gap-y-2">
-                        {/* 時間限制 */}
+                        {/* 時間限制 — reading 固定 30 秒，不顯示選擇器 */}
+                        {formData.practice_mode !== "reading" && (
                         <div className="space-y-1.5">
                           <Label className="text-xs text-gray-600">
                             {t(
@@ -2931,6 +2930,7 @@ export function AssignmentDialog({
                             </option>
                           </select>
                         </div>
+                        )}
 
                         {/* 打亂順序 */}
                         <div className="space-y-1.5">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -430,14 +430,14 @@ export function AssignmentDialog({
     due_date: undefined as Date | undefined,
     start_date: undefined as Date | undefined,
     // ===== 例句集作答模式設定 =====
-    practice_mode: "" as
+    practice_mode: "word_selection" as
       | ""
       | "reading"
       | "rearrangement"
       | "word_reading"
       | "word_selection"
       | "word_spelling"
-      | "word_cloze", // 作答模式（空字串 = 未選擇）
+      | "word_cloze", // 作答模式（預設單字選擇）
     time_limit_per_question: 30 as 0 | 10 | 20 | 30 | 40, // 每題時間限制 (0 = 不限時)
     shuffle_questions: false, // 是否打亂順序
     show_answer: false, // 答題結束後是否顯示正確答案（例句重組專用）
@@ -631,7 +631,7 @@ export function AssignmentDialog({
         assign_to_all: true,
         due_date: undefined,
         start_date: new Date(),
-        practice_mode: "",
+        practice_mode: "word_selection",
         time_limit_per_question: 30 as 0 | 10 | 20 | 30 | 40,
         shuffle_questions: false,
         show_answer: false,
@@ -1325,7 +1325,7 @@ export function AssignmentDialog({
       assign_to_all: true,
       due_date: undefined,
       start_date: undefined,
-      practice_mode: "",
+      practice_mode: "word_selection",
       time_limit_per_question: 30 as 0 | 10 | 20 | 30 | 40,
       shuffle_questions: false,
       show_answer: false,

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2836,29 +2836,27 @@ export function AssignmentDialog({
                     {/* 左：設定區（1/4） */}
                     <div className="col-span-1 min-w-0 space-y-4 overflow-y-auto pr-1 h-full">
                       {currentMode && (
-                        <div className="flex items-start gap-4 p-4 rounded-xl bg-gray-50">
-                          <span className="text-4xl shrink-0">
-                            {currentMode.emoji}
-                          </span>
-                          <div className="min-w-0">
-                            <div className="flex items-center gap-2">
-                              <div className="text-base font-semibold text-gray-900">
-                                {t(currentMode.titleKey)}
-                              </div>
-                              <span
-                                className={cn(
-                                  "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold",
-                                  badgeStyles[currentCategory],
-                                )}
-                              >
-                                {t(
-                                  `dialogs.assignmentDialog.practiceMode.scoreCategory.${currentCategory}`,
-                                )}
-                              </span>
+                        <div className="p-4 rounded-xl bg-gray-50">
+                          <div className="flex items-center gap-3">
+                            <span className="text-4xl shrink-0">
+                              {currentMode.emoji}
+                            </span>
+                            <div className="text-base font-semibold text-gray-900">
+                              {t(currentMode.titleKey)}
                             </div>
-                            <div className="text-sm text-gray-600 mt-0.5">
-                              {t(currentMode.descKey)}
-                            </div>
+                            <span
+                              className={cn(
+                                "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold",
+                                badgeStyles[currentCategory],
+                              )}
+                            >
+                              {t(
+                                `dialogs.assignmentDialog.practiceMode.scoreCategory.${currentCategory}`,
+                              )}
+                            </span>
+                          </div>
+                          <div className="text-sm text-gray-600 mt-2">
+                            {t(currentMode.descKey)}
                           </div>
                         </div>
                       )}

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2832,9 +2832,9 @@ export function AssignmentDialog({
                     })}
                   </div>
 
-                  <div className="flex-1 min-h-0 w-full flex gap-4">
-                    {/* 左：設定區 */}
-                    <div className="w-[440px] shrink-0 space-y-4 overflow-y-auto pr-1 h-full">
+                  <div className="flex-1 min-h-0 w-full grid grid-cols-4 gap-4">
+                    {/* 左：設定區（1/4） */}
+                    <div className="col-span-1 min-w-0 space-y-4 overflow-y-auto pr-1 h-full">
                       {currentMode && (
                         <div className="flex items-start gap-4 p-4 rounded-xl bg-gray-50">
                           <span className="text-4xl shrink-0">
@@ -3468,8 +3468,8 @@ export function AssignmentDialog({
 
                     </div>
 
-                    {/* 右：學生畫面預覽 */}
-                    <div className="flex-1 min-w-0 overflow-y-auto pr-1 h-full">
+                    {/* 右：學生畫面預覽（3/4） */}
+                    <div className="col-span-3 min-w-0 overflow-y-auto pr-1 h-full">
                       {formData.practice_mode === "word_reading" ? (
                         <Card className="p-3 border-gray-200">
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -3582,6 +3582,13 @@ export function AssignmentDialog({
 
                     {/* 右：學生畫面預覽（viewport ≥ 960px 才顯示；min-w 320 確保可讀） */}
                     <div className="hidden min-[960px]:block flex-1 min-w-[320px] overflow-y-auto pr-1 h-full">
+                      {formData.practice_mode && (
+                        <div className="mb-2 text-xs text-blue-700 bg-blue-50 border border-blue-200 rounded px-3 py-1.5">
+                          {t(
+                            "dialogs.assignmentDialog.practiceMode.studentPreviewDisclaimer",
+                          )}
+                        </div>
+                      )}
                       {formData.practice_mode === "word_reading" ? (
                         <Card className="p-3 border-gray-200">
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2866,13 +2866,13 @@ export function AssignmentDialog({
                       {/* ===== 例句集細節設定 (reading / rearrangement) ===== */}
                   {(formData.practice_mode === "reading" ||
                     formData.practice_mode === "rearrangement") && (
-                    <Card className="p-4 border-gray-200">
-                      <h4 className="text-sm font-medium mb-3 text-gray-700">
+                    <Card className="p-3 border-gray-200">
+                      <h4 className="text-xs font-semibold mb-2 text-gray-700">
                         {t(
                           "dialogs.assignmentDialog.practiceMode.advancedSettings",
                         )}
                       </h4>
-                      <div className="grid grid-cols-2 gap-4">
+                      <div className="grid grid-cols-2 gap-x-3 gap-y-2">
                         {/* 時間限制 */}
                         <div className="space-y-1.5">
                           <Label className="text-xs text-gray-600">
@@ -3054,8 +3054,8 @@ export function AssignmentDialog({
                     formData.practice_mode === "word_selection" ||
                     formData.practice_mode === "word_spelling" ||
                     formData.practice_mode === "word_cloze") && (
-                    <Card className="p-4 border-gray-200">
-                      <h4 className="text-sm font-medium mb-3 text-gray-700">
+                    <Card className="p-3 border-gray-200">
+                      <h4 className="text-xs font-semibold mb-2 text-gray-700">
                         {t(
                           "dialogs.assignmentDialog.practiceMode.advancedSettings",
                         )}
@@ -3065,7 +3065,7 @@ export function AssignmentDialog({
                       {(formData.practice_mode === "word_selection" ||
                         formData.practice_mode === "word_spelling" ||
                         formData.practice_mode === "word_cloze") && (
-                        <div className="mb-4 pb-4 border-b">
+                        <div className="mb-3 pb-3 border-b">
                           <div className="flex items-center justify-between mb-2">
                             <Label className="text-xs text-gray-600">
                               {t(
@@ -3102,7 +3102,7 @@ export function AssignmentDialog({
                       {(formData.practice_mode === "word_selection" ||
                         formData.practice_mode === "word_spelling" ||
                         formData.practice_mode === "word_cloze") && (
-                        <div className="mb-4 pb-4 border-b">
+                        <div className="mb-3 pb-3 border-b">
                           <Label className="text-xs text-gray-600 mb-2 block">
                             {t(
                               "dialogs.assignmentDialog.practiceMode.questionDisplay",
@@ -3208,7 +3208,7 @@ export function AssignmentDialog({
                         </div>
                       )}
 
-                      <div className="grid grid-cols-2 gap-4">
+                      <div className="grid grid-cols-2 gap-x-3 gap-y-2">
                         {/* 時間限制 */}
                         <div className="space-y-1.5">
                           <Label className="text-xs text-gray-600">
@@ -3468,8 +3468,8 @@ export function AssignmentDialog({
 
                   {/* Issue #752 PoC: word_reading 即時預覽 */}
                   {formData.practice_mode === "word_reading" && (
-                    <Card className="p-4 border-gray-200">
-                      <h4 className="text-sm font-medium mb-3 text-gray-700">
+                    <Card className="p-3 border-gray-200">
+                      <h4 className="text-xs font-semibold mb-2 text-gray-700">
                         學生畫面預覽（demo 教材）
                       </h4>
                       <WordReadingPreview

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -71,10 +71,12 @@ import WordReadingPreview from "@/components/activities/WordReadingPreview";
 import WordSelectionPreview from "@/components/activities/WordSelectionPreview";
 import WordSpellingPreview from "@/components/activities/WordSpellingPreview";
 import WordClozeContextPreview from "@/components/activities/WordClozeContextPreview";
+import RearrangementPreview from "@/components/activities/RearrangementPreview";
+import ReadingPreview from "@/components/activities/ReadingPreview";
 
 // Issue #752 PoC: 預覽固定使用 contact@duotopia.co 的「翰林佳音 第二冊 Unit 1」
 const PREVIEW_VOCAB_CONTENT_ID = 282; // Warm up（單字集）
-// PREVIEW_SENTENCES_CONTENT_ID = 283 (Dialogue) — 之後 reading / rearrangement 預覽用
+const PREVIEW_SENTENCES_CONTENT_ID = 283; // Dialogue（例句集）
 
 interface Student {
   id: number;
@@ -3539,6 +3541,36 @@ export function AssignmentDialog({
                               play_audio: formData.play_audio,
                               show_answer: formData.show_answer,
                               target_proficiency: formData.target_proficiency,
+                              time_limit_per_question:
+                                formData.time_limit_per_question,
+                              shuffle_questions: formData.shuffle_questions,
+                            }}
+                          />
+                        </Card>
+                      ) : formData.practice_mode === "rearrangement" ? (
+                        <Card className="p-3 border-gray-200">
+                          <h4 className="text-xs font-semibold mb-2 text-gray-700">
+                            學生畫面預覽（demo 教材）
+                          </h4>
+                          <RearrangementPreview
+                            contentId={PREVIEW_SENTENCES_CONTENT_ID}
+                            settings={{
+                              play_audio: formData.play_audio,
+                              show_answer: formData.show_answer,
+                              time_limit_per_question:
+                                formData.time_limit_per_question,
+                              shuffle_questions: formData.shuffle_questions,
+                            }}
+                          />
+                        </Card>
+                      ) : formData.practice_mode === "reading" ? (
+                        <Card className="p-3 border-gray-200">
+                          <h4 className="text-xs font-semibold mb-2 text-gray-700">
+                            學生畫面預覽（demo 教材）
+                          </h4>
+                          <ReadingPreview
+                            contentId={PREVIEW_SENTENCES_CONTENT_ID}
+                            settings={{
                               time_limit_per_question:
                                 formData.time_limit_per_question,
                               shuffle_questions: formData.shuffle_questions,

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -1445,7 +1445,7 @@ export function AssignmentDialog({
         className={cn(
           "!w-full h-full flex flex-col p-0 transition-[max-width] duration-300 ease-out",
           currentStep === 1 && !formData.practice_mode
-            ? "!max-w-[320px] sm:!max-w-[320px]"
+            ? "!max-w-[340px] sm:!max-w-[340px]"
             : "!max-w-[calc(100vw-16rem)] sm:!max-w-[calc(100vw-16rem)]",
         )}
       >
@@ -2833,7 +2833,7 @@ export function AssignmentDialog({
 
                   <div className="flex-1 min-h-0 flex gap-6 w-full">
                     {/* 左 rail：練習模式 row list */}
-                    <div className="w-[220px] shrink-0 space-y-2 overflow-y-auto pr-1">
+                    <div className="w-[260px] shrink-0 space-y-2 overflow-y-auto pr-1">
                       {PRACTICE_MODES.map((m) => {
                         const selected = formData.practice_mode === m.id;
                         return (
@@ -2864,7 +2864,7 @@ export function AssignmentDialog({
                               </div>
                               <div
                                 className={cn(
-                                  "text-xs truncate",
+                                  "text-xs leading-snug",
                                   selected
                                     ? "text-blue-600"
                                     : "text-gray-500",

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -2920,14 +2920,11 @@ export function AssignmentDialog({
                             }
                             className="w-full h-9 px-3 rounded-md border border-gray-200 text-sm"
                           >
-                            {/* Unlimited option only available for rearrangement mode */}
-                            {formData.practice_mode === "rearrangement" && (
-                              <option value={0}>
-                                {t(
-                                  "dialogs.assignmentDialog.practiceMode.unlimited",
-                                )}
-                              </option>
-                            )}
+                            <option value={0}>
+                              {t(
+                                "dialogs.assignmentDialog.practiceMode.unlimited",
+                              )}
+                            </option>
                             <option value={10}>
                               10{" "}
                               {t(
@@ -3254,7 +3251,7 @@ export function AssignmentDialog({
                                 ...prev,
                                 time_limit_per_question: Number(
                                   e.target.value,
-                                ) as 0 | 20 | 30 | 40,
+                                ) as 0 | 10 | 20 | 30 | 40,
                               }))
                             }
                             className="w-full h-9 px-3 rounded-md border border-gray-200 text-sm"
@@ -3267,6 +3264,12 @@ export function AssignmentDialog({
                                 formData.practice_mode === "word_spelling" ||
                                 formData.practice_mode === "word_cloze") &&
                                 ` (${t("dialogs.assignmentDialog.practiceMode.default")})`}
+                            </option>
+                            <option value={10}>
+                              10{" "}
+                              {t(
+                                "dialogs.assignmentDialog.practiceMode.seconds",
+                              )}
                             </option>
                             <option value={20}>
                               20{" "}

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -3568,14 +3568,7 @@ export function AssignmentDialog({
                           <h4 className="text-xs font-semibold mb-2 text-gray-700">
                             學生畫面預覽（demo 教材）
                           </h4>
-                          <ReadingPreview
-                            contentId={PREVIEW_SENTENCES_CONTENT_ID}
-                            settings={{
-                              time_limit_per_question:
-                                formData.time_limit_per_question,
-                              shuffle_questions: formData.shuffle_questions,
-                            }}
-                          />
+                          <ReadingPreview />
                         </Card>
                       ) : (
                         <div className="h-full flex items-center justify-center text-sm text-gray-400 border border-dashed border-gray-200 rounded-lg">

--- a/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
+++ b/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
@@ -35,6 +35,8 @@ interface ReadingAssessmentProps {
   recordingDisabled?: boolean; // true → 麥克風 / Analyze 鎖定
   attemptsHint?: React.ReactNode; // 愛心指示器
   onAnalysisSuccess?: () => void; // Azure 分析成功時觸發 +1
+  // Issue #752: dialog 內即時預覽 — 跳過 background upload（避免扣老師點數）
+  isLivePreview?: boolean;
 }
 
 export default function ReadingAssessmentTemplate({
@@ -51,6 +53,7 @@ export default function ReadingAssessmentTemplate({
   recordingDisabled = false,
   attemptsHint,
   onAnalysisSuccess,
+  isLivePreview = false,
 }: ReadingAssessmentProps) {
   const { t } = useTranslation();
   const [audioUrl, setAudioUrl] = useState<string | undefined>(
@@ -163,8 +166,8 @@ export default function ReadingAssessmentTemplate({
       setAssessmentResult(result);
       toast.success(t("readingAssessment.toast.aiComplete"));
 
-      // 🎯 背景上傳（不阻塞 UI）
-      if (!readOnly && audioUrl.startsWith("blob:")) {
+      // 🎯 背景上傳（不阻塞 UI）— 預覽模式跳過避免扣老師點數
+      if (!readOnly && !isLivePreview && audioUrl.startsWith("blob:")) {
         uploadAnalysisInBackground(audioBlob, result);
       }
     } catch (error) {

--- a/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
+++ b/frontend/src/components/activities/ReadingAssessmentTemplate.tsx
@@ -1,3 +1,9 @@
+/**
+ * ReadingAssessmentTemplate — 例句朗讀單題顯示元件
+ *
+ * ⚠️ 此元件同時被學生作答頁與派發 sheet 預覽共用。
+ *    改動前必讀：docs/design/preview-architecture.md
+ */
 import { useState, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";

--- a/frontend/src/components/activities/ReadingPreview.tsx
+++ b/frontend/src/components/activities/ReadingPreview.tsx
@@ -87,18 +87,18 @@ export default function ReadingPreview({
           🔀 學生實際作答時題目順序會被打亂（預覽固定按原順序顯示）
         </div>
       )}
-    <StudentActivityPageContent
-      activities={data.activities}
-      assignmentTitle={data.title}
-      assignmentId={data.assignment_id}
-      practiceMode={data.practice_mode || null}
-      showAnswer={data.show_answer || false}
-      timeLimitPerQuestion={data.time_limit_per_question ?? 0}
-      isDemoMode={true}
-      isPreviewMode={true}
-      onBack={() => {}}
-      onSubmit={async () => {}}
-    />
+      <StudentActivityPageContent
+        activities={data.activities}
+        assignmentTitle={data.title}
+        assignmentId={data.assignment_id}
+        practiceMode={data.practice_mode || null}
+        showAnswer={data.show_answer || false}
+        timeLimitPerQuestion={data.time_limit_per_question ?? 0}
+        isDemoMode={true}
+        isPreviewMode={true}
+        onBack={() => {}}
+        onSubmit={async () => {}}
+      />
     </div>
   );
 }

--- a/frontend/src/components/activities/ReadingPreview.tsx
+++ b/frontend/src/components/activities/ReadingPreview.tsx
@@ -1,50 +1,51 @@
 /**
  * ReadingPreview — 派發 sheet 內的 reading 即時預覽
  *
- * 從指定的 EXAMPLE_SENTENCES content 抓第一句，餵給 ReadingAssessmentTemplate
- * （純 presentational）。預覽僅顯示一題，不做題目導覽。
+ * 直接重用既有的 demo 路徑：抓 /api/demo/config 拿 demo_reading_assignment_id，
+ * 再用 demoApi.getPreview() 拿 activities，最後渲染 StudentActivityPageContent
+ * （isDemoMode + isPreviewMode 開），與 https://duotopia.co/demo/<id> 同等體驗。
+ *
+ * 取捨：設定（play_audio、time_limit 等）來自 demo assignment 自己存的值，
+ * 不是老師當下調整的 formData。reading 模式 score_category 固定為 speaking，
+ * 影響不大。
  */
 import { useEffect, useState } from "react";
-import ReadingAssessmentTemplate from "./ReadingAssessmentTemplate";
-import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
+import { demoApi } from "@/lib/demoApi";
+import StudentActivityPageContent, {
+  type Activity,
+} from "@/pages/student/StudentActivityPageContent";
 
-interface ReadingPreviewProps {
-  contentId: number;
-  settings: {
-    time_limit_per_question?: number;
-    shuffle_questions?: boolean;
-  };
+interface DemoActivityResponse {
+  assignment_id: number;
+  title: string;
+  practice_mode?: string | null;
+  show_answer?: boolean;
+  time_limit_per_question?: number;
+  total_activities: number;
+  activities: Activity[];
 }
 
-interface ContentItem {
-  id: number;
-  text: string;
-  audio_url?: string;
-}
-
-export default function ReadingPreview({
-  contentId,
-  settings,
-}: ReadingPreviewProps) {
-  const { token } = useTeacherAuthStore();
-  const [items, setItems] = useState<ContentItem[]>([]);
+export default function ReadingPreview() {
+  const [data, setData] = useState<DemoActivityResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    async function fetchContent() {
+    async function load() {
       setLoading(true);
       setError(null);
       try {
-        const apiUrl = import.meta.env.VITE_API_URL || "";
-        const resp = await fetch(`${apiUrl}/api/teachers/contents/${contentId}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-        const data = await resp.json();
+        const config = await demoApi.getConfig();
+        const idStr = config.demo_reading_assignment_id;
+        if (!idStr) {
+          throw new Error("Demo reading assignment ID not configured");
+        }
+        const resp = (await demoApi.getPreview(
+          parseInt(idStr, 10),
+        )) as DemoActivityResponse;
         if (!cancelled) {
-          setItems(data.items || []);
+          setData(resp);
           setLoading(false);
         }
       } catch (e) {
@@ -54,53 +55,35 @@ export default function ReadingPreview({
         }
       }
     }
-    if (token) fetchContent();
+    load();
     return () => {
       cancelled = true;
     };
-  }, [contentId, token]);
+  }, []);
 
-  if (!token) {
-    return (
-      <div className="p-4 text-sm text-gray-500">
-        Preview unavailable (no teacher token)
-      </div>
-    );
-  }
   if (loading) {
     return <div className="p-4 text-sm text-gray-500">Loading preview…</div>;
   }
-  if (error) {
+  if (error || !data) {
     return (
-      <div className="p-4 text-sm text-red-600">Preview error: {error}</div>
-    );
-  }
-
-  const first = items[0];
-  if (!first) {
-    return (
-      <div className="p-4 text-sm text-gray-500">此教材沒有可預覽的例句</div>
+      <div className="p-4 text-sm text-red-600">
+        Preview error: {error || "no data"}
+      </div>
     );
   }
 
   return (
-    <div className="space-y-2">
-      {settings.shuffle_questions && (
-        <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-1.5">
-          🔀 學生實際作答時題目順序會被打亂（預覽固定按原順序顯示）
-        </div>
-      )}
-      <div className="text-xs text-gray-500">
-        預覽僅顯示第一題；學生實際作答會看到全部 {items.length} 題
-      </div>
-      <ReadingAssessmentTemplate
-        content={first.text}
-        targetText={first.text}
-        exampleAudioUrl={first.audio_url}
-        timeLimit={settings.time_limit_per_question ?? 0}
-        canUseAiAnalysis={true}
-        isLivePreview={true}
-      />
-    </div>
+    <StudentActivityPageContent
+      activities={data.activities}
+      assignmentTitle={data.title}
+      assignmentId={data.assignment_id}
+      practiceMode={data.practice_mode || null}
+      showAnswer={data.show_answer || false}
+      timeLimitPerQuestion={data.time_limit_per_question ?? 0}
+      isDemoMode={true}
+      isPreviewMode={true}
+      onBack={() => {}}
+      onSubmit={async () => {}}
+    />
   );
 }

--- a/frontend/src/components/activities/ReadingPreview.tsx
+++ b/frontend/src/components/activities/ReadingPreview.tsx
@@ -8,6 +8,8 @@
  * 取捨：設定（play_audio、time_limit 等）來自 demo assignment 自己存的值，
  * 不是老師當下調整的 formData。reading 模式 score_category 固定為 speaking，
  * 影響不大。
+ *
+ * ⚠️ 改動前必讀：docs/design/preview-architecture.md
  */
 import { useEffect, useState } from "react";
 import { demoApi } from "@/lib/demoApi";

--- a/frontend/src/components/activities/ReadingPreview.tsx
+++ b/frontend/src/components/activities/ReadingPreview.tsx
@@ -25,7 +25,13 @@ interface DemoActivityResponse {
   activities: Activity[];
 }
 
-export default function ReadingPreview() {
+interface ReadingPreviewProps {
+  shuffleQuestions?: boolean;
+}
+
+export default function ReadingPreview({
+  shuffleQuestions,
+}: ReadingPreviewProps = {}) {
   const [data, setData] = useState<DemoActivityResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -73,6 +79,12 @@ export default function ReadingPreview() {
   }
 
   return (
+    <div className="space-y-2">
+      {shuffleQuestions && (
+        <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-1.5">
+          🔀 學生實際作答時題目順序會被打亂（預覽固定按原順序顯示）
+        </div>
+      )}
     <StudentActivityPageContent
       activities={data.activities}
       assignmentTitle={data.title}
@@ -85,5 +97,6 @@ export default function ReadingPreview() {
       onBack={() => {}}
       onSubmit={async () => {}}
     />
+    </div>
   );
 }

--- a/frontend/src/components/activities/ReadingPreview.tsx
+++ b/frontend/src/components/activities/ReadingPreview.tsx
@@ -28,6 +28,12 @@ interface DemoActivityResponse {
 }
 
 interface ReadingPreviewProps {
+  /**
+   * When true, render the "questions will be shuffled" banner.
+   * Note: this prop controls the banner only — preview content always
+   * follows the demo assignment's own stored shuffle setting. The actual
+   * student-facing shuffle takes effect when the assignment is dispatched.
+   */
   shuffleQuestions?: boolean;
 }
 

--- a/frontend/src/components/activities/ReadingPreview.tsx
+++ b/frontend/src/components/activities/ReadingPreview.tsx
@@ -1,0 +1,106 @@
+/**
+ * ReadingPreview — 派發 sheet 內的 reading 即時預覽
+ *
+ * 從指定的 EXAMPLE_SENTENCES content 抓第一句，餵給 ReadingAssessmentTemplate
+ * （純 presentational）。預覽僅顯示一題，不做題目導覽。
+ */
+import { useEffect, useState } from "react";
+import ReadingAssessmentTemplate from "./ReadingAssessmentTemplate";
+import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
+
+interface ReadingPreviewProps {
+  contentId: number;
+  settings: {
+    time_limit_per_question?: number;
+    shuffle_questions?: boolean;
+  };
+}
+
+interface ContentItem {
+  id: number;
+  text: string;
+  audio_url?: string;
+}
+
+export default function ReadingPreview({
+  contentId,
+  settings,
+}: ReadingPreviewProps) {
+  const { token } = useTeacherAuthStore();
+  const [items, setItems] = useState<ContentItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchContent() {
+      setLoading(true);
+      setError(null);
+      try {
+        const apiUrl = import.meta.env.VITE_API_URL || "";
+        const resp = await fetch(`${apiUrl}/api/teachers/contents/${contentId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        if (!cancelled) {
+          setItems(data.items || []);
+          setLoading(false);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "Failed to load preview");
+          setLoading(false);
+        }
+      }
+    }
+    if (token) fetchContent();
+    return () => {
+      cancelled = true;
+    };
+  }, [contentId, token]);
+
+  if (!token) {
+    return (
+      <div className="p-4 text-sm text-gray-500">
+        Preview unavailable (no teacher token)
+      </div>
+    );
+  }
+  if (loading) {
+    return <div className="p-4 text-sm text-gray-500">Loading preview…</div>;
+  }
+  if (error) {
+    return (
+      <div className="p-4 text-sm text-red-600">Preview error: {error}</div>
+    );
+  }
+
+  const first = items[0];
+  if (!first) {
+    return (
+      <div className="p-4 text-sm text-gray-500">此教材沒有可預覽的例句</div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {settings.shuffle_questions && (
+        <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-1.5">
+          🔀 學生實際作答時題目順序會被打亂（預覽固定按原順序顯示）
+        </div>
+      )}
+      <div className="text-xs text-gray-500">
+        預覽僅顯示第一題；學生實際作答會看到全部 {items.length} 題
+      </div>
+      <ReadingAssessmentTemplate
+        content={first.text}
+        targetText={first.text}
+        exampleAudioUrl={first.audio_url}
+        timeLimit={settings.time_limit_per_question ?? 0}
+        canUseAiAnalysis={true}
+        isLivePreview={true}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/activities/RearrangementActivity.tsx
+++ b/frontend/src/components/activities/RearrangementActivity.tsx
@@ -7,6 +7,9 @@
  * - 錯誤限制：<=10字 3次, 11-25字 5次
  * - 可選音檔播放（聽力模式）
  * - 計時功能
+ *
+ * ⚠️ 此元件同時被學生作答頁與派發 sheet 預覽共用。
+ *    改動前必讀：docs/design/preview-architecture.md
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";

--- a/frontend/src/components/activities/RearrangementActivity.tsx
+++ b/frontend/src/components/activities/RearrangementActivity.tsx
@@ -55,6 +55,8 @@ interface RearrangementActivityProps {
   onQuestionStateChange?: (
     questionStates: Map<number, RearrangementQuestionState>,
   ) => void;
+  // Issue #752: dialog 內即時預覽 — 跳過 API fetch，直接吃 props
+  previewQuestions?: RearrangementQuestion[];
 }
 
 export interface RearrangementQuestionState {
@@ -83,9 +85,11 @@ const RearrangementActivity: React.FC<RearrangementActivityProps> = ({
   onQuestionIndexChange,
   onQuestionsLoaded,
   onQuestionStateChange,
+  previewQuestions,
 }) => {
+  const isLivePreview = !!previewQuestions;
   const { t } = useTranslation();
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!isLivePreview);
   const [questions, setQuestions] = useState<RearrangementQuestion[]>([]);
   const [internalQuestionIndex, setInternalQuestionIndex] = useState(0);
   const [questionStates, setQuestionStates] = useState<
@@ -151,6 +155,32 @@ const RearrangementActivity: React.FC<RearrangementActivityProps> = ({
   // 載入題目
   const lastLoadedAssignmentRef = useRef<number | null>(null);
   useEffect(() => {
+    if (isLivePreview && previewQuestions) {
+      // Issue #752: 直接吃 props，不打 API
+      setQuestions(previewQuestions);
+      questionsRef.current = previewQuestions;
+      const initialStates = new Map<number, QuestionState>();
+      previewQuestions.forEach((q) => {
+        initialStates.set(q.content_item_id, {
+          selectedWords: [],
+          remainingWords: [...q.shuffled_words],
+          errorCount: 0,
+          expectedScore: 100,
+          completed: false,
+          challengeFailed: false,
+          timeRemaining: q.time_limit,
+          hasSeenAnswer: false,
+          maxScore: 100,
+        });
+      });
+      setQuestionStates(initialStates);
+      setLoading(false);
+      return () => {
+        if (timerRef.current) {
+          clearInterval(timerRef.current);
+        }
+      };
+    }
     if (lastLoadedAssignmentRef.current === studentAssignmentId) return;
     lastLoadedAssignmentRef.current = studentAssignmentId;
     hasPlayedFirstAudioRef.current = false; // 重置狀態
@@ -160,7 +190,7 @@ const RearrangementActivity: React.FC<RearrangementActivityProps> = ({
         clearInterval(timerRef.current);
       }
     };
-  }, [studentAssignmentId]);
+  }, [studentAssignmentId, isLivePreview, previewQuestions]);
 
   // 第一題音檔自動播放（題目載入完成後）
   useEffect(() => {
@@ -412,7 +442,7 @@ const RearrangementActivity: React.FC<RearrangementActivityProps> = ({
       setResultModalOpen(true);
 
       // 呼叫 API 儲存完成分數
-      if (!isPreviewMode && !isDemoMode && !isPracticeMode) {
+      if (!isPreviewMode && !isDemoMode && !isLivePreview && !isPracticeMode) {
         try {
           await apiClient.post(
             `/api/students/assignments/${studentAssignmentId}/rearrangement-complete`,
@@ -585,7 +615,7 @@ const RearrangementActivity: React.FC<RearrangementActivityProps> = ({
       setResultModalOpen(true); // 打開結果 Modal
 
       // 學生模式：完成時呼叫 API 儲存分數（練習模式不存）
-      if (!isPreviewMode && !isDemoMode && !isPracticeMode) {
+      if (!isPreviewMode && !isDemoMode && !isLivePreview && !isPracticeMode) {
         try {
           await apiClient.post(
             `/api/students/assignments/${studentAssignmentId}/rearrangement-complete`,

--- a/frontend/src/components/activities/RearrangementPreview.tsx
+++ b/frontend/src/components/activities/RearrangementPreview.tsx
@@ -88,18 +88,18 @@ export default function RearrangementPreview({
           🔀 學生實際作答時題目順序會被打亂（預覽固定按原順序顯示）
         </div>
       )}
-    <StudentActivityPageContent
-      activities={data.activities}
-      assignmentTitle={data.title}
-      assignmentId={data.assignment_id}
-      practiceMode={data.practice_mode || null}
-      showAnswer={data.show_answer || false}
-      timeLimitPerQuestion={data.time_limit_per_question ?? 0}
-      isDemoMode={true}
-      isPreviewMode={true}
-      onBack={() => {}}
-      onSubmit={async () => {}}
-    />
+      <StudentActivityPageContent
+        activities={data.activities}
+        assignmentTitle={data.title}
+        assignmentId={data.assignment_id}
+        practiceMode={data.practice_mode || null}
+        showAnswer={data.show_answer || false}
+        timeLimitPerQuestion={data.time_limit_per_question ?? 0}
+        isDemoMode={true}
+        isPreviewMode={true}
+        onBack={() => {}}
+        onSubmit={async () => {}}
+      />
     </div>
   );
 }

--- a/frontend/src/components/activities/RearrangementPreview.tsx
+++ b/frontend/src/components/activities/RearrangementPreview.tsx
@@ -9,6 +9,8 @@
  *
  * 取捨：預覽顯示的設定來自 demo assignment 自己存的值，不會跟著老師
  * 當下調 toggle 變動。
+ *
+ * ⚠️ 改動前必讀：docs/design/preview-architecture.md
  */
 import { useEffect, useState } from "react";
 import { demoApi } from "@/lib/demoApi";

--- a/frontend/src/components/activities/RearrangementPreview.tsx
+++ b/frontend/src/components/activities/RearrangementPreview.tsx
@@ -29,6 +29,12 @@ interface DemoActivityResponse {
 }
 
 interface RearrangementPreviewProps {
+  /**
+   * When true, render the "questions will be shuffled" banner.
+   * Note: this prop controls the banner only — preview content always
+   * follows the demo assignment's own stored shuffle setting. The actual
+   * student-facing shuffle takes effect when the assignment is dispatched.
+   */
   shuffleQuestions?: boolean;
 }
 

--- a/frontend/src/components/activities/RearrangementPreview.tsx
+++ b/frontend/src/components/activities/RearrangementPreview.tsx
@@ -26,7 +26,13 @@ interface DemoActivityResponse {
   activities: Activity[];
 }
 
-export default function RearrangementPreview() {
+interface RearrangementPreviewProps {
+  shuffleQuestions?: boolean;
+}
+
+export default function RearrangementPreview({
+  shuffleQuestions,
+}: RearrangementPreviewProps = {}) {
   const [data, setData] = useState<DemoActivityResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -74,6 +80,12 @@ export default function RearrangementPreview() {
   }
 
   return (
+    <div className="space-y-2">
+      {shuffleQuestions && (
+        <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-1.5">
+          🔀 學生實際作答時題目順序會被打亂（預覽固定按原順序顯示）
+        </div>
+      )}
     <StudentActivityPageContent
       activities={data.activities}
       assignmentTitle={data.title}
@@ -86,5 +98,6 @@ export default function RearrangementPreview() {
       onBack={() => {}}
       onSubmit={async () => {}}
     />
+    </div>
   );
 }

--- a/frontend/src/components/activities/RearrangementPreview.tsx
+++ b/frontend/src/components/activities/RearrangementPreview.tsx
@@ -1,65 +1,52 @@
 /**
  * RearrangementPreview — 派發 sheet 內的 rearrangement 即時預覽
  *
- * 從指定的 EXAMPLE_SENTENCES content 抓例句，前端把每句切成單字並洗牌，
- * 餵給 RearrangementActivity 的 previewQuestions 路徑，不打 student/preview/demo
- * 任何 API。
+ * 直接重用既有的 demo 路徑：抓 /api/demo/config 拿
+ * demo_rearrangement_assignment_id（=77，Unit 1 Dialogue），用
+ * demoApi.getPreview() 拿 activities，渲染 StudentActivityPageContent
+ * （isDemoMode + isPreviewMode），與 https://duotopia.co/demo/77 完全
+ * 同條 code path。
+ *
+ * 取捨：預覽顯示的設定來自 demo assignment 自己存的值，不會跟著老師
+ * 當下調 toggle 變動。
  */
-import { useEffect, useMemo, useState } from "react";
-import RearrangementActivity, {
-  type RearrangementQuestion,
-} from "./RearrangementActivity";
-import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
+import { useEffect, useState } from "react";
+import { demoApi } from "@/lib/demoApi";
+import StudentActivityPageContent, {
+  type Activity,
+} from "@/pages/student/StudentActivityPageContent";
 
-interface RearrangementPreviewProps {
-  contentId: number;
-  settings: {
-    play_audio?: boolean;
-    show_answer?: boolean;
-    time_limit_per_question?: number;
-    shuffle_questions?: boolean;
-  };
+interface DemoActivityResponse {
+  assignment_id: number;
+  title: string;
+  practice_mode?: string | null;
+  show_answer?: boolean;
+  time_limit_per_question?: number;
+  total_activities: number;
+  activities: Activity[];
 }
 
-interface ContentItem {
-  id: number;
-  text: string;
-  translation?: string;
-  audio_url?: string;
-}
-
-function shuffleArray<T>(arr: T[]): T[] {
-  const out = [...arr];
-  for (let i = out.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [out[i], out[j]] = [out[j], out[i]];
-  }
-  return out;
-}
-
-export default function RearrangementPreview({
-  contentId,
-  settings,
-}: RearrangementPreviewProps) {
-  const { token } = useTeacherAuthStore();
-  const [items, setItems] = useState<ContentItem[]>([]);
+export default function RearrangementPreview() {
+  const [data, setData] = useState<DemoActivityResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    async function fetchContent() {
+    async function load() {
       setLoading(true);
       setError(null);
       try {
-        const apiUrl = import.meta.env.VITE_API_URL || "";
-        const resp = await fetch(`${apiUrl}/api/teachers/contents/${contentId}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-        const data = await resp.json();
+        const config = await demoApi.getConfig();
+        const idStr = config.demo_rearrangement_assignment_id;
+        if (!idStr) {
+          throw new Error("Demo rearrangement assignment ID not configured");
+        }
+        const resp = (await demoApi.getPreview(
+          parseInt(idStr, 10),
+        )) as DemoActivityResponse;
         if (!cancelled) {
-          setItems(data.items || []);
+          setData(resp);
           setLoading(false);
         }
       } catch (e) {
@@ -69,69 +56,35 @@ export default function RearrangementPreview({
         }
       }
     }
-    if (token) fetchContent();
+    load();
     return () => {
       cancelled = true;
     };
-  }, [contentId, token]);
+  }, []);
 
-  const previewQuestions = useMemo<RearrangementQuestion[]>(() => {
-    const timeLimit = settings.time_limit_per_question ?? 30;
-    return items
-      .filter((item) => item.text)
-      .map((item) => {
-        // 去除話者前綴（如「Jamie:」）讓單字數比較合理
-        const cleanText = item.text.replace(/^[A-Za-z]+:\s*/, "");
-        const words = cleanText.split(/\s+/).filter(Boolean);
-        return {
-          content_item_id: item.id,
-          shuffled_words: shuffleArray(words),
-          word_count: words.length,
-          max_errors: 3,
-          time_limit: timeLimit > 0 ? timeLimit : 30,
-          play_audio: settings.play_audio ?? false,
-          audio_url: item.audio_url,
-          translation: item.translation,
-          original_text: cleanText,
-        };
-      });
-  }, [items, settings.time_limit_per_question, settings.play_audio]);
-
-  if (!token) {
-    return (
-      <div className="p-4 text-sm text-gray-500">
-        Preview unavailable (no teacher token)
-      </div>
-    );
-  }
   if (loading) {
     return <div className="p-4 text-sm text-gray-500">Loading preview…</div>;
   }
-  if (error) {
+  if (error || !data) {
     return (
-      <div className="p-4 text-sm text-red-600">Preview error: {error}</div>
-    );
-  }
-  if (previewQuestions.length === 0) {
-    return (
-      <div className="p-4 text-sm text-gray-500">
-        此教材沒有可用的例句，無法產生重組預覽
+      <div className="p-4 text-sm text-red-600">
+        Preview error: {error || "no data"}
       </div>
     );
   }
 
   return (
-    <div className="space-y-2">
-      {settings.shuffle_questions && (
-        <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-1.5">
-          🔀 學生實際作答時題目順序會被打亂（預覽固定按原順序顯示）
-        </div>
-      )}
-      <RearrangementActivity
-        studentAssignmentId={0}
-        previewQuestions={previewQuestions}
-        showAnswer={settings.show_answer}
-      />
-    </div>
+    <StudentActivityPageContent
+      activities={data.activities}
+      assignmentTitle={data.title}
+      assignmentId={data.assignment_id}
+      practiceMode={data.practice_mode || null}
+      showAnswer={data.show_answer || false}
+      timeLimitPerQuestion={data.time_limit_per_question ?? 0}
+      isDemoMode={true}
+      isPreviewMode={true}
+      onBack={() => {}}
+      onSubmit={async () => {}}
+    />
   );
 }

--- a/frontend/src/components/activities/RearrangementPreview.tsx
+++ b/frontend/src/components/activities/RearrangementPreview.tsx
@@ -1,0 +1,137 @@
+/**
+ * RearrangementPreview — 派發 sheet 內的 rearrangement 即時預覽
+ *
+ * 從指定的 EXAMPLE_SENTENCES content 抓例句，前端把每句切成單字並洗牌，
+ * 餵給 RearrangementActivity 的 previewQuestions 路徑，不打 student/preview/demo
+ * 任何 API。
+ */
+import { useEffect, useMemo, useState } from "react";
+import RearrangementActivity, {
+  type RearrangementQuestion,
+} from "./RearrangementActivity";
+import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
+
+interface RearrangementPreviewProps {
+  contentId: number;
+  settings: {
+    play_audio?: boolean;
+    show_answer?: boolean;
+    time_limit_per_question?: number;
+    shuffle_questions?: boolean;
+  };
+}
+
+interface ContentItem {
+  id: number;
+  text: string;
+  translation?: string;
+  audio_url?: string;
+}
+
+function shuffleArray<T>(arr: T[]): T[] {
+  const out = [...arr];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+export default function RearrangementPreview({
+  contentId,
+  settings,
+}: RearrangementPreviewProps) {
+  const { token } = useTeacherAuthStore();
+  const [items, setItems] = useState<ContentItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchContent() {
+      setLoading(true);
+      setError(null);
+      try {
+        const apiUrl = import.meta.env.VITE_API_URL || "";
+        const resp = await fetch(`${apiUrl}/api/teachers/contents/${contentId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        if (!cancelled) {
+          setItems(data.items || []);
+          setLoading(false);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "Failed to load preview");
+          setLoading(false);
+        }
+      }
+    }
+    if (token) fetchContent();
+    return () => {
+      cancelled = true;
+    };
+  }, [contentId, token]);
+
+  const previewQuestions = useMemo<RearrangementQuestion[]>(() => {
+    const timeLimit = settings.time_limit_per_question ?? 30;
+    return items
+      .filter((item) => item.text)
+      .map((item) => {
+        // 去除話者前綴（如「Jamie:」）讓單字數比較合理
+        const cleanText = item.text.replace(/^[A-Za-z]+:\s*/, "");
+        const words = cleanText.split(/\s+/).filter(Boolean);
+        return {
+          content_item_id: item.id,
+          shuffled_words: shuffleArray(words),
+          word_count: words.length,
+          max_errors: 3,
+          time_limit: timeLimit > 0 ? timeLimit : 30,
+          play_audio: settings.play_audio ?? false,
+          audio_url: item.audio_url,
+          translation: item.translation,
+          original_text: cleanText,
+        };
+      });
+  }, [items, settings.time_limit_per_question, settings.play_audio]);
+
+  if (!token) {
+    return (
+      <div className="p-4 text-sm text-gray-500">
+        Preview unavailable (no teacher token)
+      </div>
+    );
+  }
+  if (loading) {
+    return <div className="p-4 text-sm text-gray-500">Loading preview…</div>;
+  }
+  if (error) {
+    return (
+      <div className="p-4 text-sm text-red-600">Preview error: {error}</div>
+    );
+  }
+  if (previewQuestions.length === 0) {
+    return (
+      <div className="p-4 text-sm text-gray-500">
+        此教材沒有可用的例句，無法產生重組預覽
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {settings.shuffle_questions && (
+        <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-1.5">
+          🔀 學生實際作答時題目順序會被打亂（預覽固定按原順序顯示）
+        </div>
+      )}
+      <RearrangementActivity
+        studentAssignmentId={0}
+        previewQuestions={previewQuestions}
+        showAnswer={settings.show_answer}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -214,7 +214,13 @@ export default function WordClozeActivity({
       very_unfamiliar,
       total: proficiency.total_words,
     };
-  }, [isPreviewMode, isDemoMode, isLivePreview, previewTierCounts, proficiency]);
+  }, [
+    isPreviewMode,
+    isDemoMode,
+    isLivePreview,
+    previewTierCounts,
+    proficiency,
+  ]);
 
   const displayWordsMastered = displayTierCounts.master;
 

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -93,6 +93,15 @@ interface WordClozeActivityProps {
   isDemoMode?: boolean;
   initialPracticeMode?: boolean;
   onComplete?: () => void;
+  // Issue #752: dialog 內即時預覽
+  previewQuestions?: ClozeQuestion[];
+  previewSettings?: {
+    show_translation?: boolean;
+    play_audio?: boolean;
+    show_answer?: boolean;
+    target_proficiency?: number;
+    time_limit_per_question?: number | null;
+  };
 }
 
 export default function WordClozeActivity({
@@ -101,13 +110,16 @@ export default function WordClozeActivity({
   isDemoMode = false,
   initialPracticeMode = false,
   onComplete,
+  previewQuestions,
+  previewSettings,
 }: WordClozeActivityProps) {
+  const isLivePreview = !!previewQuestions;
   const { t } = useTranslation();
   // Issue #716: 觸控裝置改用 VirtualKeyboard，避免系統建議選字。
   const deviceMode = useInputDeviceMode();
   const useVirtualKeyboard = deviceMode !== "desktop";
 
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!isLivePreview);
   const [questions, setQuestions] = useState<ClozeQuestion[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [sessionId, setSessionId] = useState<number | null>(null);
@@ -177,12 +189,12 @@ export default function WordClozeActivity({
   );
 
   const displayProficiency =
-    isPreviewMode || isDemoMode
+    isPreviewMode || isDemoMode || isLivePreview
       ? previewProficiency
       : proficiency.current_mastery;
 
   const displayTierCounts = useMemo(() => {
-    if (isPreviewMode || isDemoMode) return previewTierCounts;
+    if (isPreviewMode || isDemoMode || isLivePreview) return previewTierCounts;
     const master = proficiency.words_master ?? proficiency.words_mastered ?? 0;
     const familiar = proficiency.words_familiar ?? 0;
     const medium = proficiency.words_medium ?? 0;
@@ -199,7 +211,7 @@ export default function WordClozeActivity({
       very_unfamiliar,
       total: proficiency.total_words,
     };
-  }, [isPreviewMode, isDemoMode, previewTierCounts, proficiency]);
+  }, [isPreviewMode, isDemoMode, isLivePreview, previewTierCounts, proficiency]);
 
   const displayWordsMastered = displayTierCounts.master;
 
@@ -278,7 +290,7 @@ export default function WordClozeActivity({
       setShowResult(false);
       setCorrectCount(0);
 
-      if (isPreviewMode || isDemoMode) {
+      if (isPreviewMode || isDemoMode || isLivePreview) {
         const newIds = (data.questions || []).map(
           (q: ClozeQuestion) => q.content_item_id,
         );
@@ -305,7 +317,7 @@ export default function WordClozeActivity({
   }, [assignmentId, isPreviewMode, isDemoMode, t]);
 
   const fetchProficiency = useCallback(async () => {
-    if (isPreviewMode || isDemoMode) return;
+    if (isPreviewMode || isDemoMode || isLivePreview) return;
     try {
       const data = await apiClient.get<ProficiencyStatus>(
         `/api/students/assignments/${assignmentId}/vocabulary/cloze/proficiency`,
@@ -317,8 +329,37 @@ export default function WordClozeActivity({
   }, [assignmentId, isPreviewMode, isDemoMode]);
 
   useEffect(() => {
+    if (isLivePreview && previewQuestions) {
+      setQuestions(previewQuestions);
+      setSessionId(null);
+      setIsPracticeMode(false);
+      setAudioOnlyMode(previewSettings?.play_audio ?? false);
+      setShowTranslation(
+        (previewSettings?.show_translation ?? true) &&
+          !(previewSettings?.play_audio ?? false),
+      );
+      setShowAnswerOnWrong(
+        (previewSettings?.show_answer ?? false) ||
+          (previewSettings?.play_audio ?? false),
+      );
+      setTimeLimit(previewSettings?.time_limit_per_question ?? null);
+      setTimeRemaining(previewSettings?.time_limit_per_question ?? null);
+      setProficiency({
+        current_mastery: 0,
+        target_mastery: previewSettings?.target_proficiency ?? 80,
+        achieved: false,
+        words_mastered: 0,
+        total_words: previewQuestions.length,
+      });
+      setCurrentIndex(0);
+      setRoundCompleted(false);
+      setTypedAnswer("");
+      setShowResult(false);
+      setLoading(false);
+      return;
+    }
     startPractice();
-  }, [startPractice]);
+  }, [startPractice, isLivePreview, previewQuestions, previewSettings]);
 
   useEffect(() => {
     if (!loading && !roundCompleted && inputRef.current) {
@@ -397,7 +438,7 @@ export default function WordClozeActivity({
 
     setSubmitting(true);
 
-    if (isPreviewMode || isDemoMode) {
+    if (isPreviewMode || isDemoMode || isLivePreview) {
       // Issue #716: case-sensitive comparison (trim only) — match backend.
       const expected = (currentQ.correct_answer || "").trim();
       const correct = !isTimeout && expected.length > 0 && answer === expected;
@@ -528,7 +569,7 @@ export default function WordClozeActivity({
   };
 
   const handleSubmitAssignment = async () => {
-    if (isPreviewMode || isDemoMode) {
+    if (isPreviewMode || isDemoMode || isLivePreview) {
       toast.success(t("wordCloze.toast.completed") || "Assignment completed!");
       setShowAchievementDialog(false);
       onComplete?.();

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -342,8 +342,8 @@ export default function WordClozeActivity({
         (previewSettings?.show_answer ?? false) ||
           (previewSettings?.play_audio ?? false),
       );
-      setTimeLimit(previewSettings?.time_limit_per_question ?? null);
-      setTimeRemaining(previewSettings?.time_limit_per_question ?? null);
+      setTimeLimit(previewSettings?.time_limit_per_question || null);
+      setTimeRemaining(previewSettings?.time_limit_per_question || null);
       setProficiency({
         current_mastery: 0,
         target_mastery: previewSettings?.target_proficiency ?? 80,

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -8,6 +8,9 @@
  * - Correct → animation → next question.
  * - Incorrect → retry button (same question stays).
  * - On round completion: stats + Next Round / Submit.
+ *
+ * ⚠️ 此元件同時被學生作答頁與派發 sheet 預覽共用。
+ *    改動前必讀：docs/design/preview-architecture.md
  */
 
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";

--- a/frontend/src/components/activities/WordClozeContextPreview.tsx
+++ b/frontend/src/components/activities/WordClozeContextPreview.tsx
@@ -127,6 +127,25 @@ export default function WordClozeContextPreview({
     [items],
   );
 
+  // 穩定的 previewSettings reference — 否則 WordClozeActivity 的 useEffect
+  // 會在 AssignmentDialog 每次表單按鍵時重觸發，把預覽 reset 回第 1 題
+  const previewSettings = useMemo(
+    () => ({
+      show_translation: settings.show_translation,
+      play_audio: settings.play_audio,
+      show_answer: settings.show_answer,
+      target_proficiency: settings.target_proficiency,
+      time_limit_per_question: settings.time_limit_per_question ?? null,
+    }),
+    [
+      settings.show_translation,
+      settings.play_audio,
+      settings.show_answer,
+      settings.target_proficiency,
+      settings.time_limit_per_question,
+    ],
+  );
+
   if (!token) {
     return (
       <div className="p-4 text-sm text-gray-500">
@@ -165,13 +184,7 @@ export default function WordClozeContextPreview({
       <WordClozeActivity
         assignmentId={0}
         previewQuestions={previewQuestions}
-        previewSettings={{
-          show_translation: settings.show_translation,
-          play_audio: settings.play_audio,
-          show_answer: settings.show_answer,
-          target_proficiency: settings.target_proficiency,
-          time_limit_per_question: settings.time_limit_per_question ?? null,
-        }}
+        previewSettings={previewSettings}
       />
     </div>
   );

--- a/frontend/src/components/activities/WordClozeContextPreview.tsx
+++ b/frontend/src/components/activities/WordClozeContextPreview.tsx
@@ -4,6 +4,8 @@
  * 從指定的 vocab content 抓單字 + example_sentence，前端把例句中的單字
  * 替換成空格組成 cloze 題，餵給 WordClozeActivity 的 previewQuestions /
  * previewSettings 路徑，不打 student/preview/demo 任何 API。
+ *
+ * ⚠️ 改動前必讀：docs/design/preview-architecture.md
  */
 import { useEffect, useMemo, useState } from "react";
 import WordClozeActivity from "./WordClozeActivity";

--- a/frontend/src/components/activities/WordClozeContextPreview.tsx
+++ b/frontend/src/components/activities/WordClozeContextPreview.tsx
@@ -54,7 +54,7 @@ function buildBlankedSentence(sentence: string, word: string): string {
   if (!sentence || !word) return sentence;
   // 不分大小寫替換第一次出現的整字（盡量），其餘位置交給 placeholder 顯示
   const re = new RegExp(
-    `\\b${word.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}\\b`,
+    `\\b${word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
     "i",
   );
   return sentence.replace(re, "_____");

--- a/frontend/src/components/activities/WordClozeContextPreview.tsx
+++ b/frontend/src/components/activities/WordClozeContextPreview.tsx
@@ -1,0 +1,164 @@
+/**
+ * WordClozeContextPreview — 派發 sheet 內的 word_cloze 即時預覽
+ *
+ * 從指定的 vocab content 抓單字 + example_sentence，前端把例句中的單字
+ * 替換成空格組成 cloze 題，餵給 WordClozeActivity 的 previewQuestions /
+ * previewSettings 路徑，不打 student/preview/demo 任何 API。
+ */
+import { useEffect, useMemo, useState } from "react";
+import WordClozeActivity from "./WordClozeActivity";
+import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
+
+interface WordClozeContextPreviewProps {
+  contentId: number;
+  settings: {
+    show_translation?: boolean;
+    play_audio?: boolean;
+    show_answer?: boolean;
+    target_proficiency?: number;
+    time_limit_per_question?: number;
+    shuffle_questions?: boolean;
+  };
+}
+
+interface ContentItem {
+  id: number;
+  text: string;
+  translation?: string;
+  audio_url?: string;
+  example_sentence?: string;
+  example_sentence_translation?: string;
+  example_sentence_audio_url?: string;
+  part_of_speech?: string;
+}
+
+interface ClozeQuestion {
+  content_item_id: number;
+  base_word: string;
+  translation: string;
+  blanked_sentence: string;
+  sentence_translation: string;
+  audio_url?: string;
+  correct_answer: string;
+  correct_answer_length: number;
+  part_of_speech?: string | null;
+  example_sentence?: string | null;
+  example_sentence_translation?: string | null;
+  example_sentence_audio_url?: string | null;
+  word_audio_url?: string | null;
+}
+
+function buildBlankedSentence(sentence: string, word: string): string {
+  if (!sentence || !word) return sentence;
+  // 不分大小寫替換第一次出現的整字（盡量），其餘位置交給 placeholder 顯示
+  const re = new RegExp(`\\b${word.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}\\b`, "i");
+  return sentence.replace(re, "_____");
+}
+
+export default function WordClozeContextPreview({
+  contentId,
+  settings,
+}: WordClozeContextPreviewProps) {
+  const { token } = useTeacherAuthStore();
+  const [items, setItems] = useState<ContentItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchContent() {
+      setLoading(true);
+      setError(null);
+      try {
+        const apiUrl = import.meta.env.VITE_API_URL || "";
+        const resp = await fetch(`${apiUrl}/api/teachers/contents/${contentId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        if (!cancelled) {
+          setItems(data.items || []);
+          setLoading(false);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "Failed to load preview");
+          setLoading(false);
+        }
+      }
+    }
+    if (token) fetchContent();
+    return () => {
+      cancelled = true;
+    };
+  }, [contentId, token]);
+
+  const previewQuestions = useMemo<ClozeQuestion[]>(
+    () =>
+      items
+        .filter((item) => item.example_sentence) // 沒例句的單字無法做 cloze
+        .map((item) => ({
+          content_item_id: item.id,
+          base_word: item.text,
+          translation: item.translation || "",
+          blanked_sentence: buildBlankedSentence(
+            item.example_sentence || "",
+            item.text,
+          ),
+          sentence_translation: item.example_sentence_translation || "",
+          audio_url: item.example_sentence_audio_url,
+          correct_answer: item.text,
+          correct_answer_length: item.text.length,
+          part_of_speech: item.part_of_speech ?? null,
+          example_sentence: item.example_sentence ?? null,
+          example_sentence_translation: item.example_sentence_translation ?? null,
+          example_sentence_audio_url: item.example_sentence_audio_url ?? null,
+          word_audio_url: item.audio_url ?? null,
+        })),
+    [items],
+  );
+
+  if (!token) {
+    return (
+      <div className="p-4 text-sm text-gray-500">
+        Preview unavailable (no teacher token)
+      </div>
+    );
+  }
+  if (loading) {
+    return <div className="p-4 text-sm text-gray-500">Loading preview…</div>;
+  }
+  if (error) {
+    return (
+      <div className="p-4 text-sm text-red-600">Preview error: {error}</div>
+    );
+  }
+  if (previewQuestions.length === 0) {
+    return (
+      <div className="p-4 text-sm text-gray-500">
+        此教材沒有可用的例句，無法產生克漏字預覽
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {settings.shuffle_questions && (
+        <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-1.5">
+          🔀 學生實際作答時題目順序會被打亂（預覽固定按原順序顯示）
+        </div>
+      )}
+      <WordClozeActivity
+        assignmentId={0}
+        previewQuestions={previewQuestions}
+        previewSettings={{
+          show_translation: settings.show_translation,
+          play_audio: settings.play_audio,
+          show_answer: settings.show_answer,
+          target_proficiency: settings.target_proficiency,
+          time_limit_per_question: settings.time_limit_per_question ?? null,
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/activities/WordClozeContextPreview.tsx
+++ b/frontend/src/components/activities/WordClozeContextPreview.tsx
@@ -143,6 +143,11 @@ export default function WordClozeContextPreview({
 
   return (
     <div className="space-y-2">
+      {settings.play_audio && (
+        <div className="text-xs text-blue-700 bg-blue-50 border border-blue-200 rounded px-3 py-1.5">
+          🔊 預覽無法預聽音檔，正式作業可聽到音檔
+        </div>
+      )}
       {settings.shuffle_questions && (
         <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-1.5">
           🔀 學生實際作答時題目順序會被打亂（預覽固定按原順序顯示）

--- a/frontend/src/components/activities/WordClozeContextPreview.tsx
+++ b/frontend/src/components/activities/WordClozeContextPreview.tsx
@@ -53,7 +53,10 @@ interface ClozeQuestion {
 function buildBlankedSentence(sentence: string, word: string): string {
   if (!sentence || !word) return sentence;
   // 不分大小寫替換第一次出現的整字（盡量），其餘位置交給 placeholder 顯示
-  const re = new RegExp(`\\b${word.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}\\b`, "i");
+  const re = new RegExp(
+    `\\b${word.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}\\b`,
+    "i",
+  );
   return sentence.replace(re, "_____");
 }
 
@@ -73,9 +76,12 @@ export default function WordClozeContextPreview({
       setError(null);
       try {
         const apiUrl = import.meta.env.VITE_API_URL || "";
-        const resp = await fetch(`${apiUrl}/api/teachers/contents/${contentId}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const resp = await fetch(
+          `${apiUrl}/api/teachers/contents/${contentId}`,
+          {
+            headers: { Authorization: `Bearer ${token}` },
+          },
+        );
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         const data = await resp.json();
         if (!cancelled) {
@@ -113,7 +119,8 @@ export default function WordClozeContextPreview({
           correct_answer_length: item.text.length,
           part_of_speech: item.part_of_speech ?? null,
           example_sentence: item.example_sentence ?? null,
-          example_sentence_translation: item.example_sentence_translation ?? null,
+          example_sentence_translation:
+            item.example_sentence_translation ?? null,
           example_sentence_audio_url: item.example_sentence_audio_url ?? null,
           word_audio_url: item.audio_url ?? null,
         })),

--- a/frontend/src/components/activities/WordReadingActivity.tsx
+++ b/frontend/src/components/activities/WordReadingActivity.tsx
@@ -548,33 +548,35 @@ export default function WordReadingActivity({
 
   return (
     <div className="space-y-6">
-      {/* Progress Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Badge variant="outline">
-            {t("wordReading.wordReading") || "Word Reading"}
-          </Badge>
-          <span className="text-sm text-gray-600">
-            {t("wordReading.itemProgress", {
-              current: currentIndex + 1,
-              total: items.length,
-            }) || `${currentIndex + 1} / ${items.length}`}
-          </span>
+      {/* Header group (status + progress + nav dots) — 內距壓縮 */}
+      <div className="space-y-2">
+        {/* Progress Header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Badge variant="outline" className="text-xs">
+              {t("wordReading.wordReading") || "Word Reading"}
+            </Badge>
+            <span className="text-xs text-gray-600">
+              {t("wordReading.itemProgress", {
+                current: currentIndex + 1,
+                total: items.length,
+              }) || `${currentIndex + 1} / ${items.length}`}
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5 text-xs text-gray-600">
+            <CheckCircle className="h-3.5 w-3.5 text-green-500" />
+            <span>
+              {t("wordReading.completedCount", { count: completedCount }) ||
+                `${completedCount} completed`}
+            </span>
+          </div>
         </div>
-        <div className="flex items-center gap-2 text-sm text-gray-600">
-          <CheckCircle className="h-4 w-4 text-green-500" />
-          <span>
-            {t("wordReading.completedCount", { count: completedCount }) ||
-              `${completedCount} completed`}
-          </span>
-        </div>
-      </div>
 
-      {/* Progress Bar */}
-      <Progress value={progress} className="h-2" />
+        {/* Progress Bar */}
+        <Progress value={progress} className="h-1.5" />
 
-      {/* Item Navigation Dots */}
-      <div className="flex gap-1 overflow-x-auto pb-1 mx-auto w-fit max-w-full">
+        {/* Item Navigation Dots */}
+        <div className="flex gap-1 overflow-x-auto pb-1 mx-auto w-fit max-w-full">
         {items.map((item, index) => {
           const isActive = index === currentIndex;
           const isCompleted = !!item.recording_url;
@@ -623,6 +625,7 @@ export default function WordReadingActivity({
             </button>
           );
         })}
+        </div>
       </div>
 
       {/* Word Reading Template */}

--- a/frontend/src/components/activities/WordReadingActivity.tsx
+++ b/frontend/src/components/activities/WordReadingActivity.tsx
@@ -580,54 +580,54 @@ export default function WordReadingActivity({
 
         {/* Item Navigation Dots */}
         <div className="flex gap-1 overflow-x-auto pb-1 mx-auto w-fit max-w-full">
-        {items.map((item, index) => {
-          const isActive = index === currentIndex;
-          const isCompleted = !!item.recording_url;
-          const hasAssessment = !!item.ai_assessment;
-          // Issue #689 後續：點點顏色委派 getItemPassFailStatus 統一處理。
-          // RETURNED 模式下純看 teacher_passed；其他狀態才用 AI 分數 fallback。
-          const aiScore =
-            item.ai_assessment?.pronunciation_score ??
-            item.ai_assessment?.accuracy_score ??
-            null;
-          const { passed: passedByScore, failed: failedByScore } =
-            getItemPassFailStatus({
-              teacherPassed: item.teacher_passed ?? null,
-              aiScore,
-              assignmentStatus: assignmentStatus ?? null,
-            });
-          const colorClass = passedByScore
-            ? "bg-green-100 text-green-800 border-green-400"
-            : failedByScore
-              ? "bg-red-100 text-red-800 border-red-400"
-              : hasAssessment || isCompleted
-                ? "bg-yellow-100 text-yellow-800 border-yellow-400"
-                : "bg-white text-gray-600 border-gray-300 hover:border-blue-400";
-          const titleText = passedByScore
-            ? t("wordReading.passed") || "通過"
-            : failedByScore
-              ? t("wordReading.notPassed") || "未通過"
-              : hasAssessment
-                ? t("wordReading.assessed") || "Assessed"
-                : isCompleted
-                  ? t("wordReading.recorded") || "Recorded"
-                  : t("wordReading.notRecorded") || "Not recorded";
+          {items.map((item, index) => {
+            const isActive = index === currentIndex;
+            const isCompleted = !!item.recording_url;
+            const hasAssessment = !!item.ai_assessment;
+            // Issue #689 後續：點點顏色委派 getItemPassFailStatus 統一處理。
+            // RETURNED 模式下純看 teacher_passed；其他狀態才用 AI 分數 fallback。
+            const aiScore =
+              item.ai_assessment?.pronunciation_score ??
+              item.ai_assessment?.accuracy_score ??
+              null;
+            const { passed: passedByScore, failed: failedByScore } =
+              getItemPassFailStatus({
+                teacherPassed: item.teacher_passed ?? null,
+                aiScore,
+                assignmentStatus: assignmentStatus ?? null,
+              });
+            const colorClass = passedByScore
+              ? "bg-green-100 text-green-800 border-green-400"
+              : failedByScore
+                ? "bg-red-100 text-red-800 border-red-400"
+                : hasAssessment || isCompleted
+                  ? "bg-yellow-100 text-yellow-800 border-yellow-400"
+                  : "bg-white text-gray-600 border-gray-300 hover:border-blue-400";
+            const titleText = passedByScore
+              ? t("wordReading.passed") || "通過"
+              : failedByScore
+                ? t("wordReading.notPassed") || "未通過"
+                : hasAssessment
+                  ? t("wordReading.assessed") || "Assessed"
+                  : isCompleted
+                    ? t("wordReading.recorded") || "Recorded"
+                    : t("wordReading.notRecorded") || "Not recorded";
 
-          return (
-            <button
-              key={item.id}
-              onClick={() => setCurrentIndex(index)}
-              className={cn(
-                "w-8 h-8 rounded border transition-all flex items-center justify-center text-xs font-medium flex-shrink-0",
-                isActive && "border-2 border-blue-600",
-                colorClass,
-              )}
-              title={titleText}
-            >
-              {index + 1}
-            </button>
-          );
-        })}
+            return (
+              <button
+                key={item.id}
+                onClick={() => setCurrentIndex(index)}
+                className={cn(
+                  "w-8 h-8 rounded border transition-all flex items-center justify-center text-xs font-medium flex-shrink-0",
+                  isActive && "border-2 border-blue-600",
+                  colorClass,
+                )}
+                title={titleText}
+              >
+                {index + 1}
+              </button>
+            );
+          })}
         </div>
       </div>
 

--- a/frontend/src/components/activities/WordReadingActivity.tsx
+++ b/frontend/src/components/activities/WordReadingActivity.tsx
@@ -80,6 +80,14 @@ interface WordReadingActivityProps {
   // Issue #689: 用於前端錄音次數限制重置條件
   assignmentStatus?: AssignmentStatusLike | null;
   returnedAt?: string | null;
+  // Issue #752: dialog 內即時預覽 — 跳過 API fetch，直接吃 props
+  previewItems?: WordItem[];
+  previewSettings?: {
+    time_limit_per_question?: number;
+    show_image?: boolean;
+    show_translation?: boolean;
+    can_use_ai_analysis?: boolean;
+  };
 }
 
 export default function WordReadingActivity({
@@ -95,7 +103,10 @@ export default function WordReadingActivity({
   timeLimitPerQuestion: timeLimitProp,
   assignmentStatus,
   returnedAt,
+  previewItems,
+  previewSettings,
 }: WordReadingActivityProps) {
+  const isLivePreview = !!previewItems;
   const { t } = useTranslation();
   const { token: studentToken } = useStudentAuthStore();
   // 預覽模式使用傳入的 authToken（老師 token），否則使用學生 token
@@ -150,6 +161,7 @@ export default function WordReadingActivity({
     !readOnly &&
     !isPreviewMode &&
     !isDemoMode &&
+    !isLivePreview &&
     canUseAiAnalysisProp !== false;
   const recordingDisabledForCurrent =
     currentItemLockedInReturnedMode || (gateActive && !currentCanRecord);
@@ -212,8 +224,17 @@ export default function WordReadingActivity({
   }, [assignmentId, token, isPreviewMode, isDemoMode, t]);
 
   useEffect(() => {
+    if (isLivePreview && previewItems) {
+      setItems(previewItems);
+      setTimeLimitFromApi(previewSettings?.time_limit_per_question ?? 0);
+      setShowImageFromApi(previewSettings?.show_image ?? true);
+      setShowTranslationFromApi(previewSettings?.show_translation ?? true);
+      setCanUseAiAnalysisFromApi(previewSettings?.can_use_ai_analysis ?? true);
+      setLoading(false);
+      return;
+    }
     loadItems();
-  }, [loadItems]);
+  }, [loadItems, isLivePreview, previewItems, previewSettings]);
 
   // Handle recording complete
   const handleRecordingComplete = async (blob: Blob, url: string) => {
@@ -231,8 +252,8 @@ export default function WordReadingActivity({
       return updated;
     });
 
-    // Skip upload in preview mode or demo mode
-    if (isPreviewMode || isDemoMode) {
+    // Skip upload in preview mode, demo mode, or live preview
+    if (isPreviewMode || isDemoMode || isLivePreview) {
       toast.success(
         t("wordReading.toast.recordedPreview") ||
           "Recording saved (preview mode)",
@@ -365,7 +386,7 @@ export default function WordReadingActivity({
 
     // 背景呼叫後端 DELETE API：需要 persisted progress，且非 preview/demo
     if (!currentItem?.progress_id) return;
-    if (isPreviewMode || isDemoMode) return;
+    if (isPreviewMode || isDemoMode || isLivePreview) return;
 
     const apiUrl = import.meta.env.VITE_API_URL || "";
     const deleteUrl = `${apiUrl}/api/speech/assessment/${assignmentId}/progress/${currentItem.progress_id}`;
@@ -377,7 +398,7 @@ export default function WordReadingActivity({
 
   // Submit assignment
   const handleSubmit = async () => {
-    if (isPreviewMode || isDemoMode) {
+    if (isPreviewMode || isDemoMode || isLivePreview) {
       toast.info(
         t("wordReading.toast.cannotSubmitPreview") ||
           "Cannot submit in preview mode",

--- a/frontend/src/components/activities/WordReadingActivity.tsx
+++ b/frontend/src/components/activities/WordReadingActivity.tsx
@@ -9,6 +9,9 @@
  * - 處理錄音上傳
  * - 顯示 AI 評估結果
  * - 提交作業
+ *
+ * ⚠️ 此元件同時被學生作答頁與派發 sheet 預覽共用。
+ *    改動前必讀：docs/design/preview-architecture.md
  */
 
 import { useState, useEffect, useCallback } from "react";

--- a/frontend/src/components/activities/WordReadingPreview.tsx
+++ b/frontend/src/components/activities/WordReadingPreview.tsx
@@ -18,6 +18,7 @@ interface WordReadingPreviewProps {
     time_limit_per_question?: number;
     show_image?: boolean;
     show_translation?: boolean;
+    shuffle_questions?: boolean;
   };
 }
 
@@ -87,15 +88,22 @@ export default function WordReadingPreview({
   }
 
   return (
-    <WordReadingActivity
-      assignmentId={0}
-      previewItems={items}
-      previewSettings={{
-        time_limit_per_question: settings.time_limit_per_question,
-        show_image: settings.show_image,
-        show_translation: settings.show_translation,
-        can_use_ai_analysis: true,
-      }}
-    />
+    <div className="space-y-2">
+      {settings.shuffle_questions && (
+        <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-1.5">
+          🔀 學生實際作答時題目順序會被打亂（預覽固定按原順序顯示）
+        </div>
+      )}
+      <WordReadingActivity
+        assignmentId={0}
+        previewItems={items}
+        previewSettings={{
+          time_limit_per_question: settings.time_limit_per_question,
+          show_image: settings.show_image,
+          show_translation: settings.show_translation,
+          can_use_ai_analysis: true,
+        }}
+      />
+    </div>
   );
 }

--- a/frontend/src/components/activities/WordReadingPreview.tsx
+++ b/frontend/src/components/activities/WordReadingPreview.tsx
@@ -7,6 +7,8 @@
  *
  * 不會打 student/preview/demo 任何路徑——透過 WordReadingActivity 的
  * `previewItems` + `previewSettings` 走完全離線渲染。
+ *
+ * ⚠️ 改動前必讀：docs/design/preview-architecture.md
  */
 import { useEffect, useState } from "react";
 import WordReadingActivity from "./WordReadingActivity";

--- a/frontend/src/components/activities/WordReadingPreview.tsx
+++ b/frontend/src/components/activities/WordReadingPreview.tsx
@@ -49,9 +49,12 @@ export default function WordReadingPreview({
       setError(null);
       try {
         const apiUrl = import.meta.env.VITE_API_URL || "";
-        const resp = await fetch(`${apiUrl}/api/teachers/contents/${contentId}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const resp = await fetch(
+          `${apiUrl}/api/teachers/contents/${contentId}`,
+          {
+            headers: { Authorization: `Bearer ${token}` },
+          },
+        );
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         const data = await resp.json();
         if (!cancelled) {
@@ -83,9 +86,7 @@ export default function WordReadingPreview({
   }
   if (error) {
     return (
-      <div className="p-4 text-sm text-red-600">
-        Preview error: {error}
-      </div>
+      <div className="p-4 text-sm text-red-600">Preview error: {error}</div>
     );
   }
 

--- a/frontend/src/components/activities/WordReadingPreview.tsx
+++ b/frontend/src/components/activities/WordReadingPreview.tsx
@@ -10,7 +10,7 @@
  *
  * ⚠️ 改動前必讀：docs/design/preview-architecture.md
  */
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import WordReadingActivity from "./WordReadingActivity";
 import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
 
@@ -74,6 +74,23 @@ export default function WordReadingPreview({
     };
   }, [contentId, token]);
 
+  // 穩定的 previewSettings reference — 否則 WordReadingActivity 的 useEffect
+  // 會在 AssignmentDialog 每次表單按鍵時重觸發，把預覽 reset 回第 1 題。
+  // can_use_ai_analysis 在預覽強制 false，避免老師預覽時被扣 AI 分析點數。
+  const previewSettings = useMemo(
+    () => ({
+      time_limit_per_question: settings.time_limit_per_question,
+      show_image: settings.show_image,
+      show_translation: settings.show_translation,
+      can_use_ai_analysis: false,
+    }),
+    [
+      settings.time_limit_per_question,
+      settings.show_image,
+      settings.show_translation,
+    ],
+  );
+
   if (!token) {
     return (
       <div className="p-4 text-sm text-gray-500">
@@ -100,12 +117,7 @@ export default function WordReadingPreview({
       <WordReadingActivity
         assignmentId={0}
         previewItems={items}
-        previewSettings={{
-          time_limit_per_question: settings.time_limit_per_question,
-          show_image: settings.show_image,
-          show_translation: settings.show_translation,
-          can_use_ai_analysis: true,
-        }}
+        previewSettings={previewSettings}
       />
     </div>
   );

--- a/frontend/src/components/activities/WordReadingPreview.tsx
+++ b/frontend/src/components/activities/WordReadingPreview.tsx
@@ -94,7 +94,7 @@ export default function WordReadingPreview({
         time_limit_per_question: settings.time_limit_per_question,
         show_image: settings.show_image,
         show_translation: settings.show_translation,
-        can_use_ai_analysis: false,
+        can_use_ai_analysis: true,
       }}
     />
   );

--- a/frontend/src/components/activities/WordReadingPreview.tsx
+++ b/frontend/src/components/activities/WordReadingPreview.tsx
@@ -1,0 +1,101 @@
+/**
+ * WordReadingPreview — 派發 sheet 內的 word_reading 即時預覽
+ *
+ * 用途：在 AssignmentDialog 設定區下方掛載，老師調整設定時可看見
+ * 學生畫面樣貌。資料來自指定的公開 content（content_id），設定來自
+ * 老師當下調整的 formData。
+ *
+ * 不會打 student/preview/demo 任何路徑——透過 WordReadingActivity 的
+ * `previewItems` + `previewSettings` 走完全離線渲染。
+ */
+import { useEffect, useState } from "react";
+import WordReadingActivity from "./WordReadingActivity";
+import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
+
+interface WordReadingPreviewProps {
+  contentId: number;
+  settings: {
+    time_limit_per_question?: number;
+    show_image?: boolean;
+    show_translation?: boolean;
+  };
+}
+
+interface ContentItem {
+  id: number;
+  text: string;
+  translation?: string;
+  audio_url?: string;
+  image_url?: string;
+  part_of_speech?: string;
+}
+
+export default function WordReadingPreview({
+  contentId,
+  settings,
+}: WordReadingPreviewProps) {
+  const { token } = useTeacherAuthStore();
+  const [items, setItems] = useState<ContentItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchContent() {
+      setLoading(true);
+      setError(null);
+      try {
+        const apiUrl = import.meta.env.VITE_API_URL || "";
+        const resp = await fetch(`${apiUrl}/api/teachers/contents/${contentId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        if (!cancelled) {
+          setItems(data.items || []);
+          setLoading(false);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "Failed to load preview");
+          setLoading(false);
+        }
+      }
+    }
+    if (token) fetchContent();
+    return () => {
+      cancelled = true;
+    };
+  }, [contentId, token]);
+
+  if (!token) {
+    return (
+      <div className="p-4 text-sm text-gray-500">
+        Preview unavailable (no teacher token)
+      </div>
+    );
+  }
+  if (loading) {
+    return <div className="p-4 text-sm text-gray-500">Loading preview…</div>;
+  }
+  if (error) {
+    return (
+      <div className="p-4 text-sm text-red-600">
+        Preview error: {error}
+      </div>
+    );
+  }
+
+  return (
+    <WordReadingActivity
+      assignmentId={0}
+      previewItems={items}
+      previewSettings={{
+        time_limit_per_question: settings.time_limit_per_question,
+        show_image: settings.show_image,
+        show_translation: settings.show_translation,
+        can_use_ai_analysis: false,
+      }}
+    />
+  );
+}

--- a/frontend/src/components/activities/WordSelectionActivity.tsx
+++ b/frontend/src/components/activities/WordSelectionActivity.tsx
@@ -20,6 +20,9 @@
  * - 4 個選項顯示英文（後端依 show_image 切換 distractors 語言）
  * - 答案比對使用後端傳的 correct_text（fallback: 依 showImage flag 決定 text/translation）
  * - 不顯示文字提示語（畫面已直覺）
+ *
+ * ⚠️ 此元件同時被學生作答頁與派發 sheet 預覽共用。
+ *    改動前必讀：docs/design/preview-architecture.md
  */
 
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";

--- a/frontend/src/components/activities/WordSelectionActivity.tsx
+++ b/frontend/src/components/activities/WordSelectionActivity.tsx
@@ -238,7 +238,13 @@ export default function WordSelectionActivity({
       very_unfamiliar,
       total: proficiency.total_words,
     };
-  }, [isPreviewMode, isDemoMode, isLivePreview, previewTierCounts, proficiency]);
+  }, [
+    isPreviewMode,
+    isDemoMode,
+    isLivePreview,
+    previewTierCounts,
+    proficiency,
+  ]);
 
   // Computed: 顯示用的已熟練單字數（同等於 master tier 數）
   const displayWordsMastered = displayTierCounts.master;

--- a/frontend/src/components/activities/WordSelectionActivity.tsx
+++ b/frontend/src/components/activities/WordSelectionActivity.tsx
@@ -410,8 +410,8 @@ export default function WordSelectionActivity({
       setShowImage(previewSettings?.show_image ?? true);
       setShowOptionImages(previewSettings?.show_option_images ?? false);
       setPlayAudio(previewSettings?.play_audio ?? false);
-      setTimeLimit(previewSettings?.time_limit_per_question ?? null);
-      setTimeRemaining(previewSettings?.time_limit_per_question ?? null);
+      setTimeLimit(previewSettings?.time_limit_per_question || null);
+      setTimeRemaining(previewSettings?.time_limit_per_question || null);
       setProficiency({
         current_mastery: 0,
         target_mastery: previewSettings?.target_proficiency ?? 80,

--- a/frontend/src/components/activities/WordSelectionActivity.tsx
+++ b/frontend/src/components/activities/WordSelectionActivity.tsx
@@ -94,6 +94,15 @@ interface WordSelectionActivityProps {
   initialPracticeMode?: boolean; // True when assignment is already GRADED (re-practice)
   showAnswer?: boolean; // 答錯後是否揭示正確答案
   onComplete?: () => void;
+  // Issue #752: dialog 內即時預覽 — 跳過 API fetch，直接吃 props
+  previewWords?: WordOption[];
+  previewSettings?: {
+    show_image?: boolean;
+    show_option_images?: boolean;
+    play_audio?: boolean;
+    target_proficiency?: number;
+    time_limit_per_question?: number | null;
+  };
 }
 
 const OPTION_COLORS = [
@@ -113,12 +122,15 @@ export default function WordSelectionActivity({
   initialPracticeMode = false,
   showAnswer = false,
   onComplete,
+  previewWords,
+  previewSettings,
 }: WordSelectionActivityProps) {
+  const isLivePreview = !!previewWords;
   const { t } = useTranslation();
   // Note: Using apiClient which auto-detects token (student or teacher)
 
-  // State
-  const [loading, setLoading] = useState(true);
+  // State — 預覽模式 items 從 props 來，不需要 loading
+  const [loading, setLoading] = useState(!isLivePreview);
   const [words, setWords] = useState<WordOption[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [sessionId, setSessionId] = useState<number | null>(null);
@@ -198,13 +210,13 @@ export default function WordSelectionActivity({
 
   // Computed: 顯示用的熟練度（預覽模式和 demo 模式用本地計算，學生模式用 API 回傳）
   const displayProficiency =
-    isPreviewMode || isDemoMode
+    isPreviewMode || isDemoMode || isLivePreview
       ? previewProficiency
       : proficiency.current_mastery;
 
   // Computed: tier counts shown in UI (live = API, preview/demo = local).
   const displayTierCounts = useMemo(() => {
-    if (isPreviewMode || isDemoMode) {
+    if (isPreviewMode || isDemoMode || isLivePreview) {
       return previewTierCounts;
     }
     const master = proficiency.words_master ?? proficiency.words_mastered ?? 0;
@@ -223,7 +235,7 @@ export default function WordSelectionActivity({
       very_unfamiliar,
       total: proficiency.total_words,
     };
-  }, [isPreviewMode, isDemoMode, previewTierCounts, proficiency]);
+  }, [isPreviewMode, isDemoMode, isLivePreview, previewTierCounts, proficiency]);
 
   // Computed: 顯示用的已熟練單字數（同等於 master tier 數）
   const displayWordsMastered = displayTierCounts.master;
@@ -343,7 +355,7 @@ export default function WordSelectionActivity({
       setShowResult(false);
 
       // (#379) Preview/demo 模式：累積已練習的單字 ID，避免下一輪重複
-      if (isPreviewMode || isDemoMode) {
+      if (isPreviewMode || isDemoMode || isLivePreview) {
         const newWordIds = (data.words || []).map(
           (w: WordOption) => w.content_item_id,
         );
@@ -375,7 +387,7 @@ export default function WordSelectionActivity({
   // Fetch current proficiency
   const fetchProficiency = useCallback(async () => {
     // Skip in preview mode and demo mode - no proficiency tracking
-    if (isPreviewMode || isDemoMode) return;
+    if (isPreviewMode || isDemoMode || isLivePreview) return;
 
     try {
       const data = await apiClient.get<ProficiencyStatus>(
@@ -391,8 +403,31 @@ export default function WordSelectionActivity({
   }, [assignmentId, isPreviewMode, isDemoMode]);
 
   useEffect(() => {
+    if (isLivePreview && previewWords) {
+      setWords(previewWords);
+      setSessionId(null);
+      setIsPracticeMode(false);
+      setShowImage(previewSettings?.show_image ?? true);
+      setShowOptionImages(previewSettings?.show_option_images ?? false);
+      setPlayAudio(previewSettings?.play_audio ?? false);
+      setTimeLimit(previewSettings?.time_limit_per_question ?? null);
+      setTimeRemaining(previewSettings?.time_limit_per_question ?? null);
+      setProficiency({
+        current_mastery: 0,
+        target_mastery: previewSettings?.target_proficiency ?? 80,
+        achieved: false,
+        words_mastered: 0,
+        total_words: previewWords.length,
+      });
+      setCurrentIndex(0);
+      setRoundCompleted(false);
+      setSelectedAnswer(null);
+      setShowResult(false);
+      setLoading(false);
+      return;
+    }
     startPractice();
-  }, [startPractice]);
+  }, [startPractice, isLivePreview, previewWords, previewSettings]);
 
   useEffect(() => {
     return () => {
@@ -503,7 +538,7 @@ export default function WordSelectionActivity({
 
     // Skip API call in preview/demo mode, but track local counts so the
     // local tier breakdown matches what students would see.
-    if (isPreviewMode || isDemoMode) {
+    if (isPreviewMode || isDemoMode || isLivePreview) {
       recordPreviewAnswer(currentWord.content_item_id, false);
       setSubmitting(false);
       return;
@@ -554,7 +589,7 @@ export default function WordSelectionActivity({
 
     // Skip API call in preview/demo mode, but track local counts so the
     // local tier breakdown matches what students would see.
-    if (isPreviewMode || isDemoMode) {
+    if (isPreviewMode || isDemoMode || isLivePreview) {
       recordPreviewAnswer(currentWord.content_item_id, correct);
       setSubmitting(false);
       return;
@@ -614,7 +649,7 @@ export default function WordSelectionActivity({
 
   const handleSubmitAssignment = async () => {
     // 預覽模式和 demo 模式不需要呼叫 API
-    if (isPreviewMode || isDemoMode) {
+    if (isPreviewMode || isDemoMode || isLivePreview) {
       toast.success(
         t("wordSelection.toast.completed") || "Assignment completed!",
       );

--- a/frontend/src/components/activities/WordSelectionPreview.tsx
+++ b/frontend/src/components/activities/WordSelectionPreview.tsx
@@ -4,6 +4,8 @@
  * 從指定的公開 content_id 抓單字，前端組成 4 選項（正解 + 3 干擾項），
  * 餵給 WordSelectionActivity 的 previewWords / previewSettings 路徑，
  * 不打 student/preview/demo 任何 API。
+ *
+ * ⚠️ 改動前必讀：docs/design/preview-architecture.md
  */
 import { useEffect, useMemo, useState } from "react";
 import WordSelectionActivity from "./WordSelectionActivity";

--- a/frontend/src/components/activities/WordSelectionPreview.tsx
+++ b/frontend/src/components/activities/WordSelectionPreview.tsx
@@ -82,6 +82,8 @@ function buildOptions(
   return allOptions;
 }
 
+const MIN_PREVIEW_WORDS = 4;
+
 export default function WordSelectionPreview({
   contentId,
   settings,
@@ -138,6 +140,25 @@ export default function WordSelectionPreview({
     }));
   }, [items, settings.show_image]);
 
+  // 穩定的 previewSettings reference — 否則 WordSelectionActivity 的 useEffect
+  // 會在 AssignmentDialog 每次表單按鍵時重觸發，把預覽 reset 回第 1 題
+  const previewSettings = useMemo(
+    () => ({
+      show_image: settings.show_image,
+      show_option_images: settings.show_option_images,
+      play_audio: settings.play_audio,
+      target_proficiency: settings.target_proficiency,
+      time_limit_per_question: settings.time_limit_per_question ?? null,
+    }),
+    [
+      settings.show_image,
+      settings.show_option_images,
+      settings.play_audio,
+      settings.target_proficiency,
+      settings.time_limit_per_question,
+    ],
+  );
+
   if (!token) {
     return (
       <div className="p-4 text-sm text-gray-500">
@@ -153,6 +174,13 @@ export default function WordSelectionPreview({
       <div className="p-4 text-sm text-red-600">Preview error: {error}</div>
     );
   }
+  if (items.length < MIN_PREVIEW_WORDS) {
+    return (
+      <div className="p-4 text-sm text-gray-500 border border-dashed border-gray-200 rounded">
+        預覽至少需要 {MIN_PREVIEW_WORDS} 個單字（此教材僅 {items.length} 個）
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-2">
@@ -164,13 +192,7 @@ export default function WordSelectionPreview({
       <WordSelectionActivity
         assignmentId={0}
         previewWords={previewWords}
-        previewSettings={{
-          show_image: settings.show_image,
-          show_option_images: settings.show_option_images,
-          play_audio: settings.play_audio,
-          target_proficiency: settings.target_proficiency,
-          time_limit_per_question: settings.time_limit_per_question ?? null,
-        }}
+        previewSettings={previewSettings}
       />
     </div>
   );

--- a/frontend/src/components/activities/WordSelectionPreview.tsx
+++ b/frontend/src/components/activities/WordSelectionPreview.tsx
@@ -1,0 +1,172 @@
+/**
+ * WordSelectionPreview — 派發 sheet 內的 word_selection 即時預覽
+ *
+ * 從指定的公開 content_id 抓單字，前端組成 4 選項（正解 + 3 干擾項），
+ * 餵給 WordSelectionActivity 的 previewWords / previewSettings 路徑，
+ * 不打 student/preview/demo 任何 API。
+ */
+import { useEffect, useMemo, useState } from "react";
+import WordSelectionActivity from "./WordSelectionActivity";
+import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
+
+interface WordSelectionPreviewProps {
+  contentId: number;
+  settings: {
+    show_image?: boolean;
+    show_option_images?: boolean;
+    play_audio?: boolean;
+    target_proficiency?: number;
+    time_limit_per_question?: number;
+    shuffle_questions?: boolean;
+  };
+}
+
+interface ContentItem {
+  id: number;
+  text: string;
+  translation?: string;
+  audio_url?: string;
+  image_url?: string;
+}
+
+interface OptionEntry {
+  text: string;
+  image_url?: string | null;
+}
+
+interface WordOption {
+  content_item_id: number;
+  text: string;
+  translation: string;
+  correct_text?: string;
+  audio_url?: string;
+  image_url?: string;
+  memory_strength: number;
+  options: OptionEntry[];
+}
+
+function buildOptions(
+  current: ContentItem,
+  pool: ContentItem[],
+  showImage: boolean,
+): OptionEntry[] {
+  // showImage=true 時，題目顯示英文，選項是翻譯；反之亦然
+  const correctText = showImage ? current.translation || "" : current.text;
+  const distractorPool = pool
+    .filter((p) => p.id !== current.id)
+    .map((p) => ({
+      text: showImage ? p.translation || "" : p.text,
+      image_url: p.image_url ?? null,
+    }))
+    .filter((o) => o.text);
+
+  // 隨機抽 3 個干擾項
+  const shuffled = [...distractorPool];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  const distractors = shuffled.slice(0, 3);
+
+  // 正解 + 干擾項一起再洗一次
+  const allOptions: OptionEntry[] = [
+    { text: correctText, image_url: current.image_url ?? null },
+    ...distractors,
+  ];
+  for (let i = allOptions.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [allOptions[i], allOptions[j]] = [allOptions[j], allOptions[i]];
+  }
+  return allOptions;
+}
+
+export default function WordSelectionPreview({
+  contentId,
+  settings,
+}: WordSelectionPreviewProps) {
+  const { token } = useTeacherAuthStore();
+  const [items, setItems] = useState<ContentItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchContent() {
+      setLoading(true);
+      setError(null);
+      try {
+        const apiUrl = import.meta.env.VITE_API_URL || "";
+        const resp = await fetch(`${apiUrl}/api/teachers/contents/${contentId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        if (!cancelled) {
+          setItems(data.items || []);
+          setLoading(false);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "Failed to load preview");
+          setLoading(false);
+        }
+      }
+    }
+    if (token) fetchContent();
+    return () => {
+      cancelled = true;
+    };
+  }, [contentId, token]);
+
+  // 組成 WordOption[]（含選項）— 只在 items 或 show_image 變動時重組
+  const previewWords = useMemo<WordOption[]>(() => {
+    const showImage = settings.show_image ?? true;
+    return items.map((item) => ({
+      content_item_id: item.id,
+      text: item.text,
+      translation: item.translation || "",
+      correct_text: showImage ? item.translation || "" : item.text,
+      audio_url: item.audio_url,
+      image_url: item.image_url,
+      memory_strength: 0,
+      options: buildOptions(item, items, showImage),
+    }));
+  }, [items, settings.show_image]);
+
+  if (!token) {
+    return (
+      <div className="p-4 text-sm text-gray-500">
+        Preview unavailable (no teacher token)
+      </div>
+    );
+  }
+  if (loading) {
+    return <div className="p-4 text-sm text-gray-500">Loading preview…</div>;
+  }
+  if (error) {
+    return (
+      <div className="p-4 text-sm text-red-600">Preview error: {error}</div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {settings.shuffle_questions && (
+        <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-1.5">
+          🔀 學生實際作答時題目順序會被打亂（預覽固定按原順序顯示）
+        </div>
+      )}
+      <WordSelectionActivity
+        assignmentId={0}
+        previewWords={previewWords}
+        previewSettings={{
+          show_image: settings.show_image,
+          show_option_images: settings.show_option_images,
+          play_audio: settings.play_audio,
+          target_proficiency: settings.target_proficiency,
+          time_limit_per_question: settings.time_limit_per_question ?? null,
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/activities/WordSelectionPreview.tsx
+++ b/frontend/src/components/activities/WordSelectionPreview.tsx
@@ -98,9 +98,12 @@ export default function WordSelectionPreview({
       setError(null);
       try {
         const apiUrl = import.meta.env.VITE_API_URL || "";
-        const resp = await fetch(`${apiUrl}/api/teachers/contents/${contentId}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const resp = await fetch(
+          `${apiUrl}/api/teachers/contents/${contentId}`,
+          {
+            headers: { Authorization: `Bearer ${token}` },
+          },
+        );
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         const data = await resp.json();
         if (!cancelled) {

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -8,6 +8,9 @@
  * - Incorrect → retry button (same word stays).
  * - When the round is complete, show stats + "Start Next Round" or
  *   "Submit Assignment" once target proficiency is reached.
+ *
+ * ⚠️ 此元件同時被學生作答頁與派發 sheet 預覽共用。
+ *    改動前必讀：docs/design/preview-architecture.md
  */
 
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -223,7 +223,13 @@ export default function WordSpellingActivity({
       very_unfamiliar,
       total: proficiency.total_words,
     };
-  }, [isPreviewMode, isDemoMode, isLivePreview, previewTierCounts, proficiency]);
+  }, [
+    isPreviewMode,
+    isDemoMode,
+    isLivePreview,
+    previewTierCounts,
+    proficiency,
+  ]);
 
   const displayWordsMastered = displayTierCounts.master;
 

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -89,6 +89,16 @@ interface WordSpellingActivityProps {
   isDemoMode?: boolean;
   initialPracticeMode?: boolean;
   onComplete?: () => void;
+  // Issue #752: dialog 內即時預覽
+  previewWords?: SpellingWord[];
+  previewSettings?: {
+    show_translation?: boolean;
+    show_image?: boolean;
+    play_audio?: boolean;
+    show_answer?: boolean;
+    target_proficiency?: number;
+    time_limit_per_question?: number | null;
+  };
 }
 
 export default function WordSpellingActivity({
@@ -97,15 +107,18 @@ export default function WordSpellingActivity({
   isDemoMode = false,
   initialPracticeMode = false,
   onComplete,
+  previewWords,
+  previewSettings,
 }: WordSpellingActivityProps) {
+  const isLivePreview = !!previewWords;
   const { t } = useTranslation();
   // Issue #716: 觸控裝置（手機 / 平板）改用 VirtualKeyboard，避免系統鍵盤的
   // 「建議選字」讓學生直接點答案。桌機保留實體鍵盤。
   const deviceMode = useInputDeviceMode();
   const useVirtualKeyboard = deviceMode !== "desktop";
 
-  // State
-  const [loading, setLoading] = useState(true);
+  // State — 預覽模式 items 從 props 來，不需要 loading
+  const [loading, setLoading] = useState(!isLivePreview);
   const [words, setWords] = useState<SpellingWord[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [sessionId, setSessionId] = useState<number | null>(null);
@@ -185,12 +198,12 @@ export default function WordSpellingActivity({
   );
 
   const displayProficiency =
-    isPreviewMode || isDemoMode
+    isPreviewMode || isDemoMode || isLivePreview
       ? previewProficiency
       : proficiency.current_mastery;
 
   const displayTierCounts = useMemo(() => {
-    if (isPreviewMode || isDemoMode) return previewTierCounts;
+    if (isPreviewMode || isDemoMode || isLivePreview) return previewTierCounts;
     const master = proficiency.words_master ?? proficiency.words_mastered ?? 0;
     const familiar = proficiency.words_familiar ?? 0;
     const medium = proficiency.words_medium ?? 0;
@@ -207,7 +220,7 @@ export default function WordSpellingActivity({
       very_unfamiliar,
       total: proficiency.total_words,
     };
-  }, [isPreviewMode, isDemoMode, previewTierCounts, proficiency]);
+  }, [isPreviewMode, isDemoMode, isLivePreview, previewTierCounts, proficiency]);
 
   const displayWordsMastered = displayTierCounts.master;
 
@@ -291,7 +304,7 @@ export default function WordSpellingActivity({
       setShowResult(false);
       setCorrectCount(0);
 
-      if (isPreviewMode || isDemoMode) {
+      if (isPreviewMode || isDemoMode || isLivePreview) {
         const newWordIds = (data.words || []).map(
           (w: SpellingWord) => w.content_item_id,
         );
@@ -318,7 +331,7 @@ export default function WordSpellingActivity({
   }, [assignmentId, isPreviewMode, isDemoMode, t]);
 
   const fetchProficiency = useCallback(async () => {
-    if (isPreviewMode || isDemoMode) return;
+    if (isPreviewMode || isDemoMode || isLivePreview) return;
     try {
       const data = await apiClient.get<ProficiencyStatus>(
         `/api/students/assignments/${assignmentId}/vocabulary/spelling/proficiency`,
@@ -330,8 +343,37 @@ export default function WordSpellingActivity({
   }, [assignmentId, isPreviewMode, isDemoMode]);
 
   useEffect(() => {
+    if (isLivePreview && previewWords) {
+      setWords(previewWords);
+      setSessionId(null);
+      setIsPracticeMode(false);
+      setAudioOnlyMode(previewSettings?.play_audio ?? false);
+      setShowTranslation(
+        (previewSettings?.show_translation ?? true) &&
+          !(previewSettings?.play_audio ?? false),
+      );
+      setShowAnswerOnWrong(
+        (previewSettings?.show_answer ?? false) ||
+          (previewSettings?.play_audio ?? false),
+      );
+      setTimeLimit(previewSettings?.time_limit_per_question ?? null);
+      setTimeRemaining(previewSettings?.time_limit_per_question ?? null);
+      setProficiency({
+        current_mastery: 0,
+        target_mastery: previewSettings?.target_proficiency ?? 80,
+        achieved: false,
+        words_mastered: 0,
+        total_words: previewWords.length,
+      });
+      setCurrentIndex(0);
+      setRoundCompleted(false);
+      setTypedAnswer("");
+      setShowResult(false);
+      setLoading(false);
+      return;
+    }
     startPractice();
-  }, [startPractice]);
+  }, [startPractice, isLivePreview, previewWords, previewSettings]);
 
   // Focus input on question switch
   useEffect(() => {
@@ -427,7 +469,7 @@ export default function WordSpellingActivity({
     }
 
     // Preview/demo: track local counts so the tier breakdown matches live mode.
-    if (isPreviewMode || isDemoMode) {
+    if (isPreviewMode || isDemoMode || isLivePreview) {
       recordPreviewAnswer(currentWord.content_item_id, correct);
       setSubmitting(false);
       return;
@@ -528,7 +570,7 @@ export default function WordSpellingActivity({
   };
 
   const handleSubmitAssignment = async () => {
-    if (isPreviewMode || isDemoMode) {
+    if (isPreviewMode || isDemoMode || isLivePreview) {
       toast.success(
         t("wordSpelling.toast.completed") || "Assignment completed!",
       );

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -233,10 +233,6 @@ export default function WordSpellingActivity({
 
   const displayWordsMastered = displayTierCounts.master;
 
-  // Stats (per round) — kept for completeness; current implementation
-  // doesn't display per-round count, but useful for future analytics.
-  const [, setCorrectCount] = useState(0);
-
   // Timer
   const [timeLimit, setTimeLimit] = useState<number | null>(null);
   const [timeRemaining, setTimeRemaining] = useState<number | null>(null);
@@ -311,7 +307,6 @@ export default function WordSpellingActivity({
       setRoundCompleted(false);
       setTypedAnswer("");
       setShowResult(false);
-      setCorrectCount(0);
 
       if (isPreviewMode || isDemoMode || isLivePreview) {
         const newWordIds = (data.words || []).map(
@@ -467,7 +462,6 @@ export default function WordSpellingActivity({
     setSubmitting(true);
 
     if (correct) {
-      setCorrectCount((prev) => prev + 1);
       setLastAttemptWrong(false);
       // Issue #715: 答對 → 翻面（不立刻顯示 ScoreOverlay）→ onFlipped 後才顯示
       setCardFace("front");

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -356,8 +356,8 @@ export default function WordSpellingActivity({
         (previewSettings?.show_answer ?? false) ||
           (previewSettings?.play_audio ?? false),
       );
-      setTimeLimit(previewSettings?.time_limit_per_question ?? null);
-      setTimeRemaining(previewSettings?.time_limit_per_question ?? null);
+      setTimeLimit(previewSettings?.time_limit_per_question || null);
+      setTimeRemaining(previewSettings?.time_limit_per_question || null);
       setProficiency({
         current_mastery: 0,
         target_mastery: previewSettings?.target_proficiency ?? 80,

--- a/frontend/src/components/activities/WordSpellingPreview.tsx
+++ b/frontend/src/components/activities/WordSpellingPreview.tsx
@@ -106,6 +106,27 @@ export default function WordSpellingPreview({
     [items],
   );
 
+  // 穩定的 previewSettings reference — 否則 WordSpellingActivity 的 useEffect
+  // 會在 AssignmentDialog 每次表單按鍵時重觸發，把預覽 reset 回第 1 題
+  const previewSettings = useMemo(
+    () => ({
+      show_translation: settings.show_translation,
+      show_image: settings.show_image,
+      play_audio: settings.play_audio,
+      show_answer: settings.show_answer,
+      target_proficiency: settings.target_proficiency,
+      time_limit_per_question: settings.time_limit_per_question ?? null,
+    }),
+    [
+      settings.show_translation,
+      settings.show_image,
+      settings.play_audio,
+      settings.show_answer,
+      settings.target_proficiency,
+      settings.time_limit_per_question,
+    ],
+  );
+
   if (!token) {
     return (
       <div className="p-4 text-sm text-gray-500">
@@ -132,14 +153,7 @@ export default function WordSpellingPreview({
       <WordSpellingActivity
         assignmentId={0}
         previewWords={previewWords}
-        previewSettings={{
-          show_translation: settings.show_translation,
-          show_image: settings.show_image,
-          play_audio: settings.play_audio,
-          show_answer: settings.show_answer,
-          target_proficiency: settings.target_proficiency,
-          time_limit_per_question: settings.time_limit_per_question ?? null,
-        }}
+        previewSettings={previewSettings}
       />
     </div>
   );

--- a/frontend/src/components/activities/WordSpellingPreview.tsx
+++ b/frontend/src/components/activities/WordSpellingPreview.tsx
@@ -1,0 +1,141 @@
+/**
+ * WordSpellingPreview — 派發 sheet 內的 word_spelling 即時預覽
+ *
+ * 從指定的公開 content_id 抓單字，餵給 WordSpellingActivity 的
+ * previewWords / previewSettings 路徑，不打 student/preview/demo 任何 API。
+ */
+import { useEffect, useMemo, useState } from "react";
+import WordSpellingActivity from "./WordSpellingActivity";
+import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
+
+interface WordSpellingPreviewProps {
+  contentId: number;
+  settings: {
+    show_translation?: boolean;
+    show_image?: boolean;
+    play_audio?: boolean;
+    show_answer?: boolean;
+    target_proficiency?: number;
+    time_limit_per_question?: number;
+    shuffle_questions?: boolean;
+  };
+}
+
+interface ContentItem {
+  id: number;
+  text: string;
+  translation?: string;
+  audio_url?: string;
+  image_url?: string;
+  part_of_speech?: string;
+  example_sentence?: string;
+  example_sentence_translation?: string;
+  example_sentence_audio_url?: string;
+}
+
+interface SpellingWord {
+  content_item_id: number;
+  text: string;
+  translation: string;
+  audio_url?: string;
+  image_url?: string;
+  memory_strength: number;
+  part_of_speech?: string | null;
+  example_sentence?: string | null;
+  example_sentence_translation?: string | null;
+  example_sentence_audio_url?: string | null;
+}
+
+export default function WordSpellingPreview({
+  contentId,
+  settings,
+}: WordSpellingPreviewProps) {
+  const { token } = useTeacherAuthStore();
+  const [items, setItems] = useState<ContentItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchContent() {
+      setLoading(true);
+      setError(null);
+      try {
+        const apiUrl = import.meta.env.VITE_API_URL || "";
+        const resp = await fetch(`${apiUrl}/api/teachers/contents/${contentId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        if (!cancelled) {
+          setItems(data.items || []);
+          setLoading(false);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "Failed to load preview");
+          setLoading(false);
+        }
+      }
+    }
+    if (token) fetchContent();
+    return () => {
+      cancelled = true;
+    };
+  }, [contentId, token]);
+
+  const previewWords = useMemo<SpellingWord[]>(
+    () =>
+      items.map((item) => ({
+        content_item_id: item.id,
+        text: item.text,
+        translation: item.translation || "",
+        audio_url: item.audio_url,
+        image_url: item.image_url,
+        memory_strength: 0,
+        part_of_speech: item.part_of_speech ?? null,
+        example_sentence: item.example_sentence ?? null,
+        example_sentence_translation: item.example_sentence_translation ?? null,
+        example_sentence_audio_url: item.example_sentence_audio_url ?? null,
+      })),
+    [items],
+  );
+
+  if (!token) {
+    return (
+      <div className="p-4 text-sm text-gray-500">
+        Preview unavailable (no teacher token)
+      </div>
+    );
+  }
+  if (loading) {
+    return <div className="p-4 text-sm text-gray-500">Loading preview…</div>;
+  }
+  if (error) {
+    return (
+      <div className="p-4 text-sm text-red-600">Preview error: {error}</div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {settings.shuffle_questions && (
+        <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-1.5">
+          🔀 學生實際作答時題目順序會被打亂（預覽固定按原順序顯示）
+        </div>
+      )}
+      <WordSpellingActivity
+        assignmentId={0}
+        previewWords={previewWords}
+        previewSettings={{
+          show_translation: settings.show_translation,
+          show_image: settings.show_image,
+          play_audio: settings.play_audio,
+          show_answer: settings.show_answer,
+          target_proficiency: settings.target_proficiency,
+          time_limit_per_question: settings.time_limit_per_question ?? null,
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/activities/WordSpellingPreview.tsx
+++ b/frontend/src/components/activities/WordSpellingPreview.tsx
@@ -64,9 +64,12 @@ export default function WordSpellingPreview({
       setError(null);
       try {
         const apiUrl = import.meta.env.VITE_API_URL || "";
-        const resp = await fetch(`${apiUrl}/api/teachers/contents/${contentId}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const resp = await fetch(
+          `${apiUrl}/api/teachers/contents/${contentId}`,
+          {
+            headers: { Authorization: `Bearer ${token}` },
+          },
+        );
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         const data = await resp.json();
         if (!cancelled) {

--- a/frontend/src/components/activities/WordSpellingPreview.tsx
+++ b/frontend/src/components/activities/WordSpellingPreview.tsx
@@ -3,6 +3,8 @@
  *
  * 從指定的公開 content_id 抓單字，餵給 WordSpellingActivity 的
  * previewWords / previewSettings 路徑，不打 student/preview/demo 任何 API。
+ *
+ * ⚠️ 改動前必讀：docs/design/preview-architecture.md
  */
 import { useEffect, useMemo, useState } from "react";
 import WordSpellingActivity from "./WordSpellingActivity";

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1764,6 +1764,12 @@
         "title": "Practice Mode Settings",
         "description": "Select the practice mode and related settings for students",
         "advancedSettings": "Advanced Settings",
+        "scoreCategory": {
+          "speaking": "Speaking",
+          "listening": "Listening",
+          "reading": "Reading",
+          "writing": "Writing"
+        },
         "reading": "Sentence Reading",
         "readingDesc": "Students read sentences aloud, system scores pronunciation",
         "rearrangement": "Sentence Rearrangement",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1780,6 +1780,7 @@
         "default": "Default",
         "shuffleQuestions": "Shuffle Questions",
         "shuffleQuestionsDesc": "Randomize question order for each practice session",
+        "studentPreview": "Student preview (demo content)",
         "showAnswer": "Show Answer",
         "showAnswerDesc": "Show correct answer after completing each question",
         "wordSelectionShowAnswerDesc": "Reveal correct answer when student answers wrong",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1781,6 +1781,7 @@
         "shuffleQuestions": "Shuffle Questions",
         "shuffleQuestionsDesc": "Randomize question order for each practice session",
         "studentPreview": "Student preview (demo content)",
+        "studentPreviewDisclaimer": "Preview uses demo content. For some modes (Reading, Rearrangement) the timing / audio / shuffle settings come from the demo assignment and don't reflect your selections on the left.",
         "showAnswer": "Show Answer",
         "showAnswerDesc": "Show correct answer after completing each question",
         "wordSelectionShowAnswerDesc": "Reveal correct answer when student answers wrong",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -1834,6 +1834,7 @@
         "shuffleQuestions": "隨機題目順序",
         "shuffleQuestionsDesc": "每次練習時隨機排列題目順序",
         "studentPreview": "學生畫面預覽（demo 教材）",
+        "studentPreviewDisclaimer": "預覽使用範例教材，部分模式（例句朗讀、例句重組）的時間／音檔等設定以示範作業為準，不會跟著左側設定變動。",
         "showAnswer": "顯示答案",
         "showAnswerDesc": "答題結束後顯示正確答案",
         "wordSelectionShowAnswerDesc": "學生答錯後揭示正確答案",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -1817,6 +1817,12 @@
         "title": "練習模式設定",
         "description": "選擇學生練習的模式和相關設定",
         "advancedSettings": "進階設定",
+        "scoreCategory": {
+          "speaking": "口說",
+          "listening": "聽力",
+          "reading": "閱讀",
+          "writing": "寫作"
+        },
         "reading": "例句朗讀",
         "readingDesc": "學生朗讀例句，系統評分發音",
         "rearrangement": "例句重組",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -1833,6 +1833,7 @@
         "default": "預設",
         "shuffleQuestions": "隨機題目順序",
         "shuffleQuestionsDesc": "每次練習時隨機排列題目順序",
+        "studentPreview": "學生畫面預覽（demo 教材）",
         "showAnswer": "顯示答案",
         "showAnswerDesc": "答題結束後顯示正確答案",
         "wordSelectionShowAnswerDesc": "學生答錯後揭示正確答案",

--- a/frontend/src/pages/teacher/TeacherAssignmentPreviewPage.tsx
+++ b/frontend/src/pages/teacher/TeacherAssignmentPreviewPage.tsx
@@ -5,7 +5,7 @@
  * 只是從老師 preview API 載入資料，不儲存進度
  */
 
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
@@ -54,11 +54,7 @@ export default function TeacherAssignmentPreviewPage() {
   const [loading, setLoading] = useState(true);
   const [showBanner, setShowBanner] = useState(true);
 
-  useEffect(() => {
-    fetchPreviewData();
-  }, [assignmentId]);
-
-  const fetchPreviewData = async () => {
+  const fetchPreviewData = useCallback(async () => {
     try {
       setLoading(true);
 
@@ -73,7 +69,11 @@ export default function TeacherAssignmentPreviewPage() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [assignmentId, t]);
+
+  useEffect(() => {
+    fetchPreviewData();
+  }, [fetchPreviewData]);
 
   if (loading) {
     return (

--- a/frontend/src/utils/scoreCategory.ts
+++ b/frontend/src/utils/scoreCategory.ts
@@ -1,0 +1,14 @@
+export type ScoreCategory = "speaking" | "listening" | "reading" | "writing";
+
+export function getScoreCategory(
+  practiceMode: string | undefined | null,
+  playAudio: boolean | undefined | null,
+): ScoreCategory {
+  const mode = (practiceMode ?? "").trim().toLowerCase();
+  const audioOn = Boolean(playAudio);
+
+  if (mode === "reading" || mode === "word_reading") return "speaking";
+  if (mode === "word_cloze") return "reading";
+  if (mode === "rearrangement" && !audioOn) return "reading";
+  return audioOn ? "listening" : "writing";
+}


### PR DESCRIPTION
## Summary
- 派發 sheet Step 1 重構為左側 row list + 右側設定面板架構，科目以 badge 顯示
- 各題型（word_reading / word_selection / word_spelling / word_cloze / rearrangement / reading）支援即時預覽
- 練習模式改為橫向 chip 列、響應式排版（mobile 滿版 / 設定區固定 320px / viewport < 1100px 隱藏預覽）
- 時間選項統一（不限/10/20/30/40 秒），word_reading 固定 10 秒，reading 固定 30 秒
- chip emoji 改 lucide icon 與學生端統一，記憶模式加 Brain icon

Closes #752

## Test plan
- [ ] 老師端開啟派發 sheet，確認 Step 1 左 rail + 右 panel 排版
- [ ] 各題型切換即時預覽正常顯示
- [ ] 響應式：mobile / 960px / 1100px 各斷點排版正確
- [ ] chip 列在內容超寬時顯示左右箭頭與邊緣漸層
- [ ] 時間選項統一、shuffle 模式預覽顯示提示字

🤖 Generated with [Claude Code](https://claude.com/claude-code)