### PR TITLE
feat(#748): 即刻練習-拔河隊戰新增例句克漏字題型

### DIFF
--- a/backend/performance_monitoring.py
+++ b/backend/performance_monitoring.py
@@ -5,6 +5,7 @@
 2. 在函數內部使用 with start_span("操作名稱") 記錄子步驟
 """
 
+import os
 import time
 import logging
 from functools import wraps
@@ -21,13 +22,21 @@ from opentelemetry.sdk.resources import Resource
 # Google Cloud Logging
 from google.cloud import logging as cloud_logging
 
-# 初始化 GCP Logging
-try:
-    client = cloud_logging.Client()
-    client.setup_logging()
-    logger = logging.getLogger(__name__)
-except Exception as e:
-    print(f"⚠️  Warning: Failed to initialize GCP logging: {e}")
+# Only attach Cloud Logging handler when running on GCP (Cloud Run sets K_SERVICE).
+# Locally the SSL handshake to logging.googleapis.com fails and each log call hangs
+# for the full 60s retry window, blocking the request handler.
+_IS_GCP_RUNTIME = bool(os.getenv("K_SERVICE"))
+
+if _IS_GCP_RUNTIME:
+    try:
+        client = cloud_logging.Client()
+        client.setup_logging()
+        logger = logging.getLogger(__name__)
+    except Exception as e:
+        print(f"⚠️  Warning: Failed to initialize GCP logging: {e}")
+        logging.basicConfig(level=logging.INFO)
+        logger = logging.getLogger(__name__)
+else:
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
 

--- a/backend/routers/demo.py
+++ b/backend/routers/demo.py
@@ -342,7 +342,7 @@ async def demo_word_selection_start(
 ):
     """Demo mode: Start word selection practice."""
     assignment = get_demo_assignment(assignment_id, db)
-    return get_word_selection_start(assignment, db, exclude_ids)
+    return await get_word_selection_start(assignment, db, exclude_ids)
 
 
 @router.get("/assignments/{assignment_id}/preview/word-spelling-start")

--- a/backend/routers/teachers/assignment_ops.py
+++ b/backend/routers/teachers/assignment_ops.py
@@ -273,7 +273,7 @@ async def preview_word_selection_start(
 ):
     """Preview mode: Get word selection practice data."""
     assignment = _get_teacher_assignment(assignment_id, current_teacher, db)
-    return get_word_selection_start(assignment, db, exclude_ids)
+    return await get_word_selection_start(assignment, db, exclude_ids)
 
 
 @router.get("/assignments/{assignment_id}/preview/word-spelling-start")

--- a/backend/services/preview_service.py
+++ b/backend/services/preview_service.py
@@ -553,6 +553,8 @@ def get_word_selection_start(
                 "correct_text": correct_answer,
                 "audio_url": item.audio_url,
                 "image_url": item.image_url,
+                "example_sentence": item.example_sentence or "",
+                "example_sentence_translation": item.example_sentence_translation or "",
                 "memory_strength": 0,
                 "options": options,
             }

--- a/backend/services/preview_service.py
+++ b/backend/services/preview_service.py
@@ -489,9 +489,7 @@ async def get_word_selection_start(
 
     # Backfill missing example_sentence_audio_url so tug_of_war cloze mode
     # always has audio (TTS-generated on demand if needed).
-    sentence_audio_by_id = await ensure_example_sentence_audio(
-        list(content_items), db
-    )
+    sentence_audio_by_id = await ensure_example_sentence_audio(list(content_items), db)
 
     total_words_in_assignment = len(content_items)
 

--- a/backend/services/preview_service.py
+++ b/backend/services/preview_service.py
@@ -460,7 +460,7 @@ def _parse_exclude_ids(exclude_ids: str) -> set:
     return result
 
 
-def get_word_selection_start(
+async def get_word_selection_start(
     assignment: Assignment,
     db: Session,
     exclude_ids: str = "",
@@ -486,6 +486,12 @@ def get_word_selection_start(
             status_code=404,
             detail="No vocabulary items found for this assignment",
         )
+
+    # Backfill missing example_sentence_audio_url so tug_of_war cloze mode
+    # always has audio (TTS-generated on demand if needed).
+    sentence_audio_by_id = await ensure_example_sentence_audio(
+        list(content_items), db
+    )
 
     total_words_in_assignment = len(content_items)
 
@@ -555,6 +561,11 @@ def get_word_selection_start(
                 "image_url": item.image_url,
                 "example_sentence": item.example_sentence or "",
                 "example_sentence_translation": item.example_sentence_translation or "",
+                "example_sentence_audio_url": (
+                    sentence_audio_by_id.get(item.id)
+                    or item.example_sentence_audio_url
+                    or ""
+                ),
                 "memory_strength": 0,
                 "options": options,
             }

--- a/backend/services/preview_service.py
+++ b/backend/services/preview_service.py
@@ -487,10 +487,6 @@ async def get_word_selection_start(
             detail="No vocabulary items found for this assignment",
         )
 
-    # Backfill missing example_sentence_audio_url so tug_of_war cloze mode
-    # always has audio (TTS-generated on demand if needed).
-    sentence_audio_by_id = await ensure_example_sentence_audio(list(content_items), db)
-
     total_words_in_assignment = len(content_items)
 
     # (#379) Exclude already-practiced words
@@ -510,6 +506,11 @@ async def get_word_selection_start(
         if assignment.shuffle_questions:
             random.shuffle(remaining_items)
         content_items = remaining_items[:10]
+
+    # Backfill missing example_sentence_audio_url so tug_of_war cloze mode
+    # always has audio (TTS-generated on demand if needed). Runs after
+    # exclude filtering so we don't generate TTS for discarded words.
+    sentence_audio_by_id = await ensure_example_sentence_audio(list(content_items), db)
 
     # Build response — Issue #631: options 升級為 list[{text, image_url}]
     # show_image 模式：選項用英文（item.text），題目隱藏英文，避免答案太明顯。

--- a/frontend/src/components/activities/TugOfWarGame.tsx
+++ b/frontend/src/components/activities/TugOfWarGame.tsx
@@ -42,6 +42,8 @@ interface WordOptionResponse {
   translation: string;
   audio_url?: string;
   image_url?: string;
+  example_sentence?: string;
+  example_sentence_translation?: string;
 }
 
 const QUESTION_MODES: { value: QuestionMode; labelKey: string }[] = [
@@ -50,6 +52,7 @@ const QUESTION_MODES: { value: QuestionMode; labelKey: string }[] = [
   { value: "english_to_chinese", labelKey: "tugOfWar.modes.englishToChinese" },
   { value: "chinese_to_english", labelKey: "tugOfWar.modes.chineseToEnglish" },
   { value: "image_to_english", labelKey: "tugOfWar.modes.imageToEnglish" },
+  { value: "cloze_to_english", labelKey: "tugOfWar.modes.clozeToEnglish" },
 ];
 
 export function TugOfWarGame({
@@ -129,6 +132,8 @@ export function TugOfWarGame({
           translation: w.translation,
           audio_url: w.audio_url,
           image_url: w.image_url,
+          example_sentence: w.example_sentence,
+          example_sentence_translation: w.example_sentence_translation,
         }));
 
         setVocabItems(items);
@@ -154,9 +159,13 @@ export function TugOfWarGame({
     startGame,
     changeMode,
     handleAnswer,
+    toggleSentenceTranslation,
   } = useGameLogic(vocabItems);
 
   const hasEnoughImages = vocabItems.filter((v) => !!v.image_url).length >= 4;
+  const hasEnoughSentences =
+    vocabItems.filter((v) => !!v.example_sentence).length >= 4;
+  const isClozeMode = gameState.questionMode === "cloze_to_english";
 
   // Auto-start when vocab loads
   useEffect(() => {
@@ -316,7 +325,20 @@ export function TugOfWarGame({
           <DropdownMenuContent className="bg-white dark:bg-gray-900 border shadow-lg">
             {QUESTION_MODES.map((mode) => {
               const isDisabled =
-                mode.value === "image_to_english" && !hasEnoughImages;
+                (mode.value === "image_to_english" && !hasEnoughImages) ||
+                (mode.value === "cloze_to_english" && !hasEnoughSentences);
+              const disabledTitle =
+                mode.value === "image_to_english"
+                  ? t(
+                      "tugOfWar.imagesModeRequirement",
+                      "需要至少 4 個單字有圖片",
+                    )
+                  : mode.value === "cloze_to_english"
+                    ? t(
+                        "tugOfWar.clozeModeRequirement",
+                        "需要至少 4 個單字有例句",
+                      )
+                    : undefined;
               return (
                 <DropdownMenuItem
                   key={mode.value}
@@ -329,14 +351,7 @@ export function TugOfWarGame({
                         ? "opacity-40 cursor-not-allowed"
                         : ""
                   }
-                  title={
-                    isDisabled
-                      ? t(
-                          "tugOfWar.imagesModeRequirement",
-                          "需要至少 4 個單字有圖片",
-                        )
-                      : undefined
-                  }
+                  title={isDisabled ? disabledTitle : undefined}
                 >
                   {t(mode.labelKey)}
                 </DropdownMenuItem>
@@ -346,17 +361,29 @@ export function TugOfWarGame({
         </DropdownMenu>
 
         <label
-          className={`flex items-center gap-1.5 text-sm text-gray-600 cursor-pointer select-none ${isImageMode ? "opacity-40 pointer-events-none" : ""}`}
+          className={`flex items-center gap-1.5 text-sm text-gray-600 cursor-pointer select-none ${isImageMode || isClozeMode ? "opacity-40 pointer-events-none" : ""}`}
         >
           <input
             type="checkbox"
             checked={showImages}
             onChange={(e) => setShowImages(e.target.checked)}
-            disabled={isImageMode}
+            disabled={isImageMode || isClozeMode}
             className="rounded border-gray-300"
           />
           {t("tugOfWar.showImages")}
         </label>
+
+        {isClozeMode && (
+          <label className="flex items-center gap-1.5 text-sm text-gray-600 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={gameState.showSentenceTranslation}
+              onChange={toggleSentenceTranslation}
+              className="rounded border-gray-300"
+            />
+            {t("tugOfWar.showSentenceTranslation", "顯示例句翻譯")}
+          </label>
+        )}
 
         <div className="pixel-font text-sm text-gray-500">
           {progress} / {totalQuestions}
@@ -411,7 +438,8 @@ export function TugOfWarGame({
               useHandwriteFont={
                 gameState.questionMode === "audio_to_english" ||
                 gameState.questionMode === "chinese_to_english" ||
-                gameState.questionMode === "image_to_english"
+                gameState.questionMode === "image_to_english" ||
+                gameState.questionMode === "cloze_to_english"
               }
             />
           ) : winner && answerHistory.length > 0 ? (
@@ -451,6 +479,7 @@ export function TugOfWarGame({
               <QuestionDisplay
                 question={currentQuestion}
                 showPrompt={!isAnswered}
+                showSentenceTranslation={gameState.showSentenceTranslation}
               />
             </div>
           )}
@@ -487,7 +516,8 @@ export function TugOfWarGame({
               useHandwriteFont={
                 gameState.questionMode === "audio_to_english" ||
                 gameState.questionMode === "chinese_to_english" ||
-                gameState.questionMode === "image_to_english"
+                gameState.questionMode === "image_to_english" ||
+                gameState.questionMode === "cloze_to_english"
               }
             />
           ) : winner && answerHistory.length > 0 ? (

--- a/frontend/src/components/activities/TugOfWarGame.tsx
+++ b/frontend/src/components/activities/TugOfWarGame.tsx
@@ -162,6 +162,7 @@ export function TugOfWarGame({
     changeMode,
     handleAnswer,
     toggleSentenceTranslation,
+    toggleAudioMute,
   } = useGameLogic(vocabItems);
 
   const hasEnoughImages = vocabItems.filter((v) => !!v.image_url).length >= 4;
@@ -496,6 +497,8 @@ export function TugOfWarGame({
               <QuestionDisplay
                 question={currentQuestion}
                 showPrompt={!isAnswered}
+                audioMuted={gameState.audioMuted}
+                onToggleMute={toggleAudioMute}
               />
             </div>
           )}

--- a/frontend/src/components/activities/TugOfWarGame.tsx
+++ b/frontend/src/components/activities/TugOfWarGame.tsx
@@ -44,6 +44,7 @@ interface WordOptionResponse {
   image_url?: string;
   example_sentence?: string;
   example_sentence_translation?: string;
+  example_sentence_audio_url?: string;
 }
 
 const QUESTION_MODES: { value: QuestionMode; labelKey: string }[] = [
@@ -134,6 +135,7 @@ export function TugOfWarGame({
           image_url: w.image_url,
           example_sentence: w.example_sentence,
           example_sentence_translation: w.example_sentence_translation,
+          example_sentence_audio_url: w.example_sentence_audio_url,
         }));
 
         setVocabItems(items);
@@ -420,6 +422,21 @@ export function TugOfWarGame({
         </div>
       </div>
 
+      {/* Cloze sentence banner — only shown in cloze mode, sits between score row and game area */}
+      {isClozeMode && currentQuestion && currentQuestion.hasCloze && (
+        <div className="flex flex-col items-center gap-1 px-4 py-2">
+          <span className="text-2xl md:text-3xl font-semibold leading-snug text-gray-800 text-center">
+            {currentQuestion.clozeSentence}
+          </span>
+          {gameState.showSentenceTranslation &&
+            currentQuestion.clozeTranslation && (
+              <span className="text-base md:text-lg text-gray-600 text-center">
+                {currentQuestion.clozeTranslation}
+              </span>
+            )}
+        </div>
+      )}
+
       {/* Game area: three-column layout, fills remaining parent space */}
       <div className="flex gap-3 items-stretch flex-1 min-h-0">
         {/* Team A — left */}
@@ -479,7 +496,6 @@ export function TugOfWarGame({
               <QuestionDisplay
                 question={currentQuestion}
                 showPrompt={!isAnswered}
-                showSentenceTranslation={gameState.showSentenceTranslation}
               />
             </div>
           )}

--- a/frontend/src/components/activities/tug-of-war/QuestionDisplay.tsx
+++ b/frontend/src/components/activities/tug-of-war/QuestionDisplay.tsx
@@ -12,11 +12,13 @@ import type { Question } from "./types";
 interface QuestionDisplayProps {
   question: Question;
   showPrompt: boolean; // false when question is answered
+  showSentenceTranslation?: boolean; // For cloze mode only
 }
 
 export function QuestionDisplay({
   question,
   showPrompt,
+  showSentenceTranslation = false,
 }: QuestionDisplayProps) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const loopTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -110,19 +112,38 @@ export function QuestionDisplay({
   // Fixed height for image mode to prevent container from jumping
   const imageContainerClass =
     "text-center py-2 h-72 flex items-center justify-center";
+  const clozeContainerClass =
+    "text-center py-2 h-28 flex flex-col items-center justify-center gap-1 px-4";
   const defaultContainerClass =
     "text-center py-2 h-16 flex items-end justify-center pb-4";
 
+  const answeredContainerClass = question.hasImage
+    ? imageContainerClass
+    : question.hasCloze
+      ? clozeContainerClass
+      : defaultContainerClass;
+
   if (!showPrompt) {
     return (
-      <div
-        className={
-          question.hasImage ? imageContainerClass : defaultContainerClass
-        }
-      >
+      <div className={answeredContainerClass}>
         <span className="text-4xl font-bold text-green-600 handwrite-font">
           {question.correctAnswer}
         </span>
+      </div>
+    );
+  }
+
+  if (question.hasCloze) {
+    return (
+      <div className={clozeContainerClass}>
+        <span className="text-2xl md:text-3xl font-semibold leading-snug">
+          {question.clozeSentence}
+        </span>
+        {showSentenceTranslation && question.clozeTranslation && (
+          <span className="text-base md:text-lg text-gray-600">
+            {question.clozeTranslation}
+          </span>
+        )}
       </div>
     );
   }

--- a/frontend/src/components/activities/tug-of-war/QuestionDisplay.tsx
+++ b/frontend/src/components/activities/tug-of-war/QuestionDisplay.tsx
@@ -12,11 +12,15 @@ import type { Question } from "./types";
 interface QuestionDisplayProps {
   question: Question;
   showPrompt: boolean; // false when question is answered
+  audioMuted?: boolean;
+  onToggleMute?: () => void;
 }
 
 export function QuestionDisplay({
   question,
   showPrompt,
+  audioMuted = false,
+  onToggleMute,
 }: QuestionDisplayProps) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const loopTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -101,11 +105,13 @@ export function QuestionDisplay({
     playAndSchedule();
   }, [playOnce, stopLoop]);
 
-  // Auto-play loop for audio questions — only on question change
+  // Auto-play loop for audio questions — skipped when user has muted
   useEffect(() => {
     isMountedRef.current = true;
-    if (question.hasAudio && showPrompt) {
+    if (question.hasAudio && showPrompt && !audioMuted) {
       startLoop();
+    } else {
+      stopLoop();
     }
     return () => {
       isMountedRef.current = false;
@@ -116,6 +122,7 @@ export function QuestionDisplay({
     question.vocabItem.id,
     showPrompt,
     question.hasAudio,
+    audioMuted,
     startLoop,
     stopLoop,
   ]);
@@ -164,7 +171,9 @@ export function QuestionDisplay({
       <div className="text-center py-2 h-16 flex items-center justify-center">
         <button
           onClick={() => {
-            if (isPlaying) {
+            if (onToggleMute) {
+              onToggleMute();
+            } else if (isPlaying) {
               stopLoop();
             } else {
               startLoop();
@@ -172,7 +181,7 @@ export function QuestionDisplay({
           }}
           className="p-3 rounded-full hover:bg-white/30 transition-colors cursor-pointer"
         >
-          {isPlaying ? (
+          {audioMuted ? (
             <VolumeOff className="h-10 w-10 text-gray-400" strokeWidth={2.5} />
           ) : (
             <Volume2 className="h-10 w-10 text-gray-700" strokeWidth={2.5} />

--- a/frontend/src/components/activities/tug-of-war/QuestionDisplay.tsx
+++ b/frontend/src/components/activities/tug-of-war/QuestionDisplay.tsx
@@ -12,13 +12,11 @@ import type { Question } from "./types";
 interface QuestionDisplayProps {
   question: Question;
   showPrompt: boolean; // false when question is answered
-  showSentenceTranslation?: boolean; // For cloze mode only
 }
 
 export function QuestionDisplay({
   question,
   showPrompt,
-  showSentenceTranslation = false,
 }: QuestionDisplayProps) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const loopTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -41,9 +39,16 @@ export function QuestionDisplay({
   }, []);
 
   const playOnce = useCallback(() => {
-    const url = question.vocabItem.audio_url;
+    const isCloze = question.hasCloze;
+    const url = isCloze
+      ? question.vocabItem.example_sentence_audio_url
+      : question.vocabItem.audio_url;
+    const ttsText = isCloze
+      ? question.vocabItem.example_sentence || ""
+      : question.vocabItem.text;
+
     if (!url) {
-      const utterance = new SpeechSynthesisUtterance(question.vocabItem.text);
+      const utterance = new SpeechSynthesisUtterance(ttsText);
       utterance.lang = "en-US";
       utterance.rate = 0.9;
       speechSynthesis.speak(utterance);
@@ -56,13 +61,19 @@ export function QuestionDisplay({
     const audio = new Audio(url);
     audioRef.current = audio;
     audio.play().catch(() => {
-      const utterance = new SpeechSynthesisUtterance(question.vocabItem.text);
+      const utterance = new SpeechSynthesisUtterance(ttsText);
       utterance.lang = "en-US";
       utterance.rate = 0.9;
       speechSynthesis.speak(utterance);
     });
     return audio;
-  }, [question.vocabItem.audio_url, question.vocabItem.text]);
+  }, [
+    question.hasCloze,
+    question.vocabItem.audio_url,
+    question.vocabItem.example_sentence_audio_url,
+    question.vocabItem.example_sentence,
+    question.vocabItem.text,
+  ]);
 
   const startLoop = useCallback(() => {
     if (!isMountedRef.current) return;
@@ -112,38 +123,19 @@ export function QuestionDisplay({
   // Fixed height for image mode to prevent container from jumping
   const imageContainerClass =
     "text-center py-2 h-72 flex items-center justify-center";
-  const clozeContainerClass =
-    "text-center py-2 h-28 flex flex-col items-center justify-center gap-1 px-4";
   const defaultContainerClass =
     "text-center py-2 h-16 flex items-end justify-center pb-4";
 
-  const answeredContainerClass = question.hasImage
-    ? imageContainerClass
-    : question.hasCloze
-      ? clozeContainerClass
-      : defaultContainerClass;
-
   if (!showPrompt) {
     return (
-      <div className={answeredContainerClass}>
+      <div
+        className={
+          question.hasImage ? imageContainerClass : defaultContainerClass
+        }
+      >
         <span className="text-4xl font-bold text-green-600 handwrite-font">
           {question.correctAnswer}
         </span>
-      </div>
-    );
-  }
-
-  if (question.hasCloze) {
-    return (
-      <div className={clozeContainerClass}>
-        <span className="text-2xl md:text-3xl font-semibold leading-snug">
-          {question.clozeSentence}
-        </span>
-        {showSentenceTranslation && question.clozeTranslation && (
-          <span className="text-base md:text-lg text-gray-600">
-            {question.clozeTranslation}
-          </span>
-        )}
       </div>
     );
   }

--- a/frontend/src/components/activities/tug-of-war/types.ts
+++ b/frontend/src/components/activities/tug-of-war/types.ts
@@ -55,6 +55,7 @@ export interface GameState {
   teamBCooldown: boolean;
   questionMode: QuestionMode;
   showSentenceTranslation: boolean; // For cloze mode — default false
+  audioMuted: boolean; // Persistent mute toggle across audio-mode questions
   gameStatus: GameStatus;
   scores: { a: number; b: number };
   answeredBy: Team | null; // Who answered the current question

--- a/frontend/src/components/activities/tug-of-war/types.ts
+++ b/frontend/src/components/activities/tug-of-war/types.ts
@@ -25,6 +25,7 @@ export interface VocabItem {
   part_of_speech?: string;
   example_sentence?: string;
   example_sentence_translation?: string;
+  example_sentence_audio_url?: string;
 }
 
 export interface Question {

--- a/frontend/src/components/activities/tug-of-war/types.ts
+++ b/frontend/src/components/activities/tug-of-war/types.ts
@@ -9,7 +9,8 @@ export type QuestionMode =
   | "audio_to_chinese" // 音檔播放 → 選中文
   | "english_to_chinese" // 英文 → 選中文
   | "chinese_to_english" // 中文 → 選英文
-  | "image_to_english"; // 看圖 → 選英文
+  | "image_to_english" // 看圖 → 選英文
+  | "cloze_to_english"; // 例句克漏字 → 選英文
 
 export type Team = "a" | "b";
 
@@ -22,6 +23,8 @@ export interface VocabItem {
   audio_url?: string;
   image_url?: string;
   part_of_speech?: string;
+  example_sentence?: string;
+  example_sentence_translation?: string;
 }
 
 export interface Question {
@@ -33,6 +36,9 @@ export interface Question {
   optionsB: string[]; // Shuffled differently for Team B
   hasAudio: boolean; // Whether this question uses audio playback
   hasImage: boolean; // Whether this question uses image as prompt
+  hasCloze: boolean; // Whether this question shows a cloze sentence as prompt
+  clozeSentence?: string; // Sentence with target word blanked
+  clozeTranslation?: string; // Optional translation of the sentence
 }
 
 export interface AnswerRecord {
@@ -47,6 +53,7 @@ export interface GameState {
   teamACooldown: boolean;
   teamBCooldown: boolean;
   questionMode: QuestionMode;
+  showSentenceTranslation: boolean; // For cloze mode — default false
   gameStatus: GameStatus;
   scores: { a: number; b: number };
   answeredBy: Team | null; // Who answered the current question

--- a/frontend/src/components/activities/tug-of-war/useGameLogic.ts
+++ b/frontend/src/components/activities/tug-of-war/useGameLogic.ts
@@ -61,8 +61,6 @@ function generateQuestions(
     const withSentence = items.filter((i) => i.example_sentence);
     if (withSentence.length >= 4) {
       items = withSentence;
-    } else {
-      items = withSentence;
     }
   }
 

--- a/frontend/src/components/activities/tug-of-war/useGameLogic.ts
+++ b/frontend/src/components/activities/tug-of-war/useGameLogic.ts
@@ -160,6 +160,7 @@ export function useGameLogic(
     teamBCooldown: false,
     questionMode: "audio_to_english",
     showSentenceTranslation: false,
+    audioMuted: false,
     gameStatus: "waiting",
     scores: { a: 0, b: 0 },
     answeredBy: null,
@@ -191,6 +192,7 @@ export function useGameLogic(
         teamBCooldown: false,
         questionMode: mode,
         showSentenceTranslation: prev.showSentenceTranslation,
+        audioMuted: prev.audioMuted,
         gameStatus: "playing",
         scores: { a: 0, b: 0 },
         answeredBy: null,
@@ -213,6 +215,7 @@ export function useGameLogic(
         teamBCooldown: false,
         questionMode: mode,
         showSentenceTranslation: prev.showSentenceTranslation,
+        audioMuted: prev.audioMuted,
         gameStatus: "playing",
         scores: { a: 0, b: 0 },
         answeredBy: null,
@@ -228,6 +231,10 @@ export function useGameLogic(
       ...prev,
       showSentenceTranslation: !prev.showSentenceTranslation,
     }));
+  }, []);
+
+  const toggleAudioMute = useCallback(() => {
+    setGameState((prev) => ({ ...prev, audioMuted: !prev.audioMuted }));
   }, []);
 
   const handleAnswer = useCallback(
@@ -372,5 +379,6 @@ export function useGameLogic(
     changeMode,
     handleAnswer,
     toggleSentenceTranslation,
+    toggleAudioMute,
   };
 }

--- a/frontend/src/components/activities/tug-of-war/useGameLogic.ts
+++ b/frontend/src/components/activities/tug-of-war/useGameLogic.ts
@@ -25,6 +25,23 @@ function shuffleArray<T>(arr: T[]): T[] {
   return shuffled;
 }
 
+const CLOZE_BLANK = "_____";
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function makeCloze(sentence: string, target: string): string {
+  if (!sentence) return CLOZE_BLANK;
+  if (!target) return sentence;
+  const re = new RegExp(`\\b${escapeRegex(target)}\\b`, "gi");
+  if (re.test(sentence)) {
+    return sentence.replace(re, CLOZE_BLANK);
+  }
+  // Fallback: append a blank at the end so question still works
+  return `${sentence} ${CLOZE_BLANK}`;
+}
+
 function generateQuestions(
   vocabItems: VocabItem[],
   mode: QuestionMode,
@@ -39,12 +56,25 @@ function generateQuestions(
     }
   }
 
+  // Cloze mode: require example_sentence (fallback to all if < 4)
+  if (mode === "cloze_to_english") {
+    const withSentence = items.filter((i) => i.example_sentence);
+    if (withSentence.length >= 4) {
+      items = withSentence;
+    } else {
+      items = withSentence;
+    }
+  }
+
   return items.map((item) => {
     // Determine correct answer and prompt based on mode
     let correctAnswer: string;
     let prompt: string;
     let hasAudio = false;
     let hasImage = false;
+    let hasCloze = false;
+    let clozeSentence: string | undefined;
+    let clozeTranslation: string | undefined;
 
     switch (mode) {
       case "audio_to_english":
@@ -70,13 +100,21 @@ function generateQuestions(
         prompt = "";
         hasImage = true;
         break;
+      case "cloze_to_english":
+        correctAnswer = item.text;
+        prompt = "";
+        hasCloze = true;
+        clozeSentence = makeCloze(item.example_sentence || "", item.text);
+        clozeTranslation = item.example_sentence_translation || undefined;
+        break;
     }
 
     // Generate distractors from other vocab items
     const isAnswerEnglish =
       mode === "audio_to_english" ||
       mode === "chinese_to_english" ||
-      mode === "image_to_english";
+      mode === "image_to_english" ||
+      mode === "cloze_to_english";
     const pool = vocabItems
       .filter((v) => v.id !== item.id)
       .map((v) => (isAnswerEnglish ? v.text : v.translation))
@@ -102,6 +140,9 @@ function generateQuestions(
       optionsB,
       hasAudio,
       hasImage,
+      hasCloze,
+      clozeSentence,
+      clozeTranslation,
     };
   });
 }
@@ -117,6 +158,7 @@ export function useGameLogic(
     teamACooldown: false,
     teamBCooldown: false,
     questionMode: "audio_to_english",
+    showSentenceTranslation: false,
     gameStatus: "waiting",
     scores: { a: 0, b: 0 },
     answeredBy: null,
@@ -140,19 +182,20 @@ export function useGameLogic(
   const startGame = useCallback(
     (mode: QuestionMode = "audio_to_english") => {
       const questions = generateQuestions(vocabItems, mode);
-      setGameState({
+      setGameState((prev) => ({
         questions,
         currentIndex: 0,
         ropePosition: 0,
         teamACooldown: false,
         teamBCooldown: false,
         questionMode: mode,
+        showSentenceTranslation: prev.showSentenceTranslation,
         gameStatus: "playing",
         scores: { a: 0, b: 0 },
         answeredBy: null,
         lastCorrectTeam: null,
         answerHistory: [],
-      });
+      }));
     },
     [vocabItems],
   );
@@ -161,22 +204,30 @@ export function useGameLogic(
     (mode: QuestionMode) => {
       // Regenerate questions with new mode, reset game
       const questions = generateQuestions(vocabItems, mode);
-      setGameState({
+      setGameState((prev) => ({
         questions,
         currentIndex: 0,
         ropePosition: 0,
         teamACooldown: false,
         teamBCooldown: false,
         questionMode: mode,
+        showSentenceTranslation: prev.showSentenceTranslation,
         gameStatus: "playing",
         scores: { a: 0, b: 0 },
         answeredBy: null,
         lastCorrectTeam: null,
         answerHistory: [],
-      });
+      }));
     },
     [vocabItems],
   );
+
+  const toggleSentenceTranslation = useCallback(() => {
+    setGameState((prev) => ({
+      ...prev,
+      showSentenceTranslation: !prev.showSentenceTranslation,
+    }));
+  }, []);
 
   const handleAnswer = useCallback(
     (team: Team, selectedAnswer: string) => {
@@ -319,5 +370,6 @@ export function useGameLogic(
     startGame,
     changeMode,
     handleAnswer,
+    toggleSentenceTranslation,
   };
 }

--- a/frontend/src/components/activities/tug-of-war/useGameLogic.ts
+++ b/frontend/src/components/activities/tug-of-war/useGameLogic.ts
@@ -104,6 +104,7 @@ function generateQuestions(
         correctAnswer = item.text;
         prompt = "";
         hasCloze = true;
+        hasAudio = true;
         clozeSentence = makeCloze(item.example_sentence || "", item.text);
         clozeTranslation = item.example_sentence_translation || undefined;
         break;

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -5087,12 +5087,15 @@
       "audioToChinese": "Audio → Translation",
       "englishToChinese": "English → Translation",
       "chineseToEnglish": "Translation → English",
-      "imageToEnglish": "Image → English"
+      "imageToEnglish": "Image → English",
+      "clozeToEnglish": "Cloze Sentence → English"
     },
     "rotateDevice": "Please rotate your device",
     "rotateDeviceHint": "This game is best played in landscape mode",
     "continueAnyway": "Continue anyway",
     "imagesModeRequirement": "Requires at least 4 words with images",
+    "clozeModeRequirement": "Requires at least 4 words with example sentences",
+    "showSentenceTranslation": "Show sentence translation",
     "error": {
       "loadFailed": "Failed to load vocabulary",
       "notEnoughWords": "Not enough words (minimum 4 required)"

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -5136,12 +5136,15 @@
       "audioToChinese": "聽音選翻譯/解釋",
       "englishToChinese": "英文選翻譯/解釋",
       "chineseToEnglish": "翻譯/解釋選英文",
-      "imageToEnglish": "看圖選英文"
+      "imageToEnglish": "看圖選英文",
+      "clozeToEnglish": "例句克漏字選英文"
     },
     "rotateDevice": "請將手機轉為橫向",
     "rotateDeviceHint": "此遊戲適合橫向遊玩",
     "continueAnyway": "繼續遊玩",
     "imagesModeRequirement": "需要至少 4 個單字有圖片",
+    "clozeModeRequirement": "需要至少 4 個單字有例句",
+    "showSentenceTranslation": "顯示例句翻譯",
     "error": {
       "loadFailed": "載入單字失敗",
       "notEnoughWords": "單字數量不足（至少需要 4 個）"


### PR DESCRIPTION
## Summary
- 拔河隊戰新增「例句克漏字」題型
- 例句搬到藍框外、自動補例句音檔
- 拔河遊戲靜音狀態跨題保留

Closes #748

## Test plan
- [ ] 進入拔河隊戰，確認例句克漏字題型可正常出題與作答
- [ ] 例句顯示在藍框外、音檔自動播放
- [ ] 在題目中切換靜音，下一題仍維持靜音

🤖 Generated with [Claude Code](https://claude.com/claude-code)