### PR TITLE
chore(#723): add credit_package_definitions table + model

### DIFF
--- a/backend/alembic/versions/20260518_1000_add_credit_package_definitions_table.py
+++ b/backend/alembic/versions/20260518_1000_add_credit_package_definitions_table.py
@@ -50,10 +50,8 @@ def upgrade() -> None:
         """
     )
 
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_credit_package_definitions_package_id "
-        "ON credit_package_definitions (package_id)"
-    )
+    # NOTE: no explicit index on package_id — the UNIQUE constraint above
+    # already creates one. Adding a second would be redundant.
 
     # FK to teachers (admin who last edited). Add after table creation so
     # re-running detects existing constraint.

--- a/backend/alembic/versions/20260518_1000_add_credit_package_definitions_table.py
+++ b/backend/alembic/versions/20260518_1000_add_credit_package_definitions_table.py
@@ -71,6 +71,44 @@ def upgrade() -> None:
         """
     )
 
+    # Index on the FK column. Postgres doesn't auto-index FK columns, so
+    # admin-audit joins (CreditPackageDefinition → Teacher) would otherwise
+    # seq-scan. Partial index keeps it tight given most rows have NULL here.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS "
+        "idx_credit_package_definitions_updated_by_admin_id "
+        "ON credit_package_definitions (updated_by_admin_id) "
+        "WHERE updated_by_admin_id IS NOT NULL"
+    )
+
+    # DB-level trigger to refresh updated_at on every UPDATE, including
+    # raw-SQL writes (e.g. Supabase dashboard) that bypass SQLAlchemy's
+    # ORM-only `onupdate=func.now()`. Function uses CREATE OR REPLACE;
+    # trigger is dropped + re-created so the migration stays idempotent.
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION set_credit_package_definitions_updated_at()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            NEW.updated_at = now();
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_credit_package_definitions_updated_at "
+        "ON credit_package_definitions"
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_credit_package_definitions_updated_at
+        BEFORE UPDATE ON credit_package_definitions
+        FOR EACH ROW
+        EXECUTE FUNCTION set_credit_package_definitions_updated_at();
+        """
+    )
+
     # Seed default packages from config constants. ON CONFLICT keeps
     # existing rows untouched so re-running won't overwrite admin edits.
     # `org_allowed = TRUE` only for pkg-20000 (matches legacy

--- a/backend/alembic/versions/20260518_1000_add_credit_package_definitions_table.py
+++ b/backend/alembic/versions/20260518_1000_add_credit_package_definitions_table.py
@@ -1,0 +1,99 @@
+"""Add credit_package_definitions table for admin-editable overrides
+
+Revision ID: 20260518_1000
+Revises: 20260513_1700
+Create Date: 2026-05-18 10:00:00
+
+Package IDs (pkg-1000 / pkg-2000 / pkg-5000 / pkg-10000 / pkg-20000)
+remain code constants in `backend/config/plans.py::CREDIT_PACKAGES`.
+This table stores per-package overrides for `points`, `bonus`, `price`,
+plus `is_active`, `org_allowed`, and ordering, so admins can adjust
+them from the admin console without a deploy.
+
+`org_allowed` replaces the legacy `ORG_ALLOWED_PACKAGES` constant
+(currently `["pkg-20000"]`); seed accordingly.
+
+Validity period intentionally stays a single global constant
+(`CREDIT_PACKAGE_VALIDITY_DAYS`); per-package validity is out of scope.
+
+Migration is idempotent: safe to re-run.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "20260518_1000"
+down_revision: Union[str, None] = "20260513_1700"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create table (idempotent)
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS credit_package_definitions (
+            id SERIAL PRIMARY KEY,
+            package_id VARCHAR(50) NOT NULL UNIQUE,
+            points INTEGER,
+            bonus INTEGER,
+            price INTEGER,
+            is_active BOOLEAN NOT NULL DEFAULT TRUE,
+            org_allowed BOOLEAN NOT NULL DEFAULT FALSE,
+            display_order INTEGER NOT NULL DEFAULT 0,
+            updated_by_admin_id INTEGER,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_credit_package_definitions_package_id "
+        "ON credit_package_definitions (package_id)"
+    )
+
+    # FK to teachers (admin who last edited). Add after table creation so
+    # re-running detects existing constraint.
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'fk_credit_package_definitions_updated_by_admin'
+            ) THEN
+                ALTER TABLE credit_package_definitions
+                ADD CONSTRAINT fk_credit_package_definitions_updated_by_admin
+                FOREIGN KEY (updated_by_admin_id)
+                REFERENCES teachers(id) ON DELETE SET NULL;
+            END IF;
+        END $$;
+        """
+    )
+
+    # Seed default packages from config constants. ON CONFLICT keeps
+    # existing rows untouched so re-running won't overwrite admin edits.
+    # `org_allowed = TRUE` only for pkg-20000 (matches legacy
+    # ORG_ALLOWED_PACKAGES = ["pkg-20000"]).
+    op.execute(
+        """
+        INSERT INTO credit_package_definitions
+            (package_id, points, bonus, price, is_active, org_allowed, display_order)
+        VALUES
+            ('pkg-1000',   1000,  0,   180,  TRUE, FALSE, 1),
+            ('pkg-2000',   2000,  0,   320,  TRUE, FALSE, 2),
+            ('pkg-5000',   5000,  200, 700,  TRUE, FALSE, 3),
+            ('pkg-10000',  10000, 500, 1200, TRUE, FALSE, 4),
+            ('pkg-20000',  20000, 800, 2000, TRUE, TRUE,  5)
+        ON CONFLICT (package_id) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    # Intentional no-op: dropping the table would lose admin-edited values
+    # and break running services that read overrides via
+    # get_credit_package_config().
+    pass

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -33,6 +33,7 @@ from .subscription import (
 
 # Credit package models
 from .credit_package import CreditPackage
+from .credit_package_definition import CreditPackageDefinition
 
 # Plan models (admin-editable price/quota overrides)
 from .plan import Plan
@@ -106,6 +107,7 @@ __all__ = [
     "InvoiceStatusHistory",
     # Credit packages
     "CreditPackage",
+    "CreditPackageDefinition",
     # Plans
     "Plan",
     # Organizations

--- a/backend/models/credit_package_definition.py
+++ b/backend/models/credit_package_definition.py
@@ -40,7 +40,8 @@ class CreditPackageDefinition(Base):
 
     # Matches the package_id strings used in code constants
     # (pkg-1000, pkg-2000, pkg-5000, pkg-10000, pkg-20000).
-    package_id = Column(String(50), nullable=False, unique=True, index=True)
+    # `unique=True` already creates an index — no need for index=True.
+    package_id = Column(String(50), nullable=False, unique=True)
 
     # Base points granted. NULL means inherit config default.
     points = Column(Integer, nullable=True)
@@ -64,7 +65,10 @@ class CreditPackageDefinition(Base):
 
     # Audit
     updated_at = Column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
     )
     updated_by_admin_id = Column(
         Integer, ForeignKey("teachers.id", ondelete="SET NULL"), nullable=True

--- a/backend/models/credit_package_definition.py
+++ b/backend/models/credit_package_definition.py
@@ -63,7 +63,13 @@ class CreditPackageDefinition(Base):
     # Display order in admin UI / checkout list.
     display_order = Column(Integer, nullable=False, default=0)
 
-    # Audit
+    # Audit (column order matches migration: created_at, updated_at, FK)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    # `onupdate` covers ORM writes. A DB-level BEFORE UPDATE trigger
+    # (set_credit_package_definitions_updated_at) covers raw-SQL writes
+    # such as Supabase-dashboard edits — see the matching migration.
     updated_at = Column(
         DateTime(timezone=True),
         server_default=func.now(),
@@ -72,9 +78,6 @@ class CreditPackageDefinition(Base):
     )
     updated_by_admin_id = Column(
         Integer, ForeignKey("teachers.id", ondelete="SET NULL"), nullable=True
-    )
-    created_at = Column(
-        DateTime(timezone=True), server_default=func.now(), nullable=False
     )
 
     updated_by = relationship("Teacher", foreign_keys=[updated_by_admin_id])

--- a/backend/models/credit_package_definition.py
+++ b/backend/models/credit_package_definition.py
@@ -1,0 +1,83 @@
+"""
+CreditPackageDefinition model - admin-editable price / points / bonus
+overrides for the credit package catalog.
+
+Package IDs are still defined as code constants in
+`backend/config/plans.py::CREDIT_PACKAGES` (consumers reference them by
+string `pkg-1000`, `pkg-5000`, ...). This table only overrides the numeric
+attributes (price, points, bonus), the `is_active` flag, and the
+`org_allowed` boolean (which replaces the legacy `ORG_ALLOWED_PACKAGES`
+list).
+
+The validity period stays a global constant
+(`CREDIT_PACKAGE_VALIDITY_DAYS`); per-package validity is intentionally
+out of scope for this iteration.
+
+Do NOT confuse with `CreditPackage` (purchase history per teacher/org) in
+`models/credit_package.py` — that table records actual purchases, this
+table records the catalog definition.
+"""
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Boolean,
+    DateTime,
+    ForeignKey,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from database import Base
+
+
+class CreditPackageDefinition(Base):
+    """點數包定義 - 由管理員可調整 points / bonus / price / is_active / org_allowed"""
+
+    __tablename__ = "credit_package_definitions"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    # Matches the package_id strings used in code constants
+    # (pkg-1000, pkg-2000, pkg-5000, pkg-10000, pkg-20000).
+    package_id = Column(String(50), nullable=False, unique=True, index=True)
+
+    # Base points granted. NULL means inherit config default.
+    points = Column(Integer, nullable=True)
+
+    # Bonus / free points on top of `points`.
+    bonus = Column(Integer, nullable=True)
+
+    # TWD price. NULL means inherit config default.
+    price = Column(Integer, nullable=True)
+
+    # Soft toggle. When false, package is hidden from the checkout flow
+    # (existing purchases with this package_id continue to work).
+    is_active = Column(Boolean, nullable=False, default=True)
+
+    # Whether organizations can purchase this package. Replaces the legacy
+    # `ORG_ALLOWED_PACKAGES` list constant.
+    org_allowed = Column(Boolean, nullable=False, default=False)
+
+    # Display order in admin UI / checkout list.
+    display_order = Column(Integer, nullable=False, default=0)
+
+    # Audit
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+    updated_by_admin_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    updated_by = relationship("Teacher", foreign_keys=[updated_by_admin_id])
+
+    def __repr__(self):
+        return (
+            f"<CreditPackageDefinition package_id={self.package_id} "
+            f"points={self.points} bonus={self.bonus} price={self.price} "
+            f"active={self.is_active} org_allowed={self.org_allowed}>"
+        )


### PR DESCRIPTION
## Summary
- Adds `credit_package_definitions` table via idempotent Alembic migration (`CREATE TABLE IF NOT EXISTS` + `ON CONFLICT DO NOTHING` seed of the 5 existing `pkg-*` IDs).
- Adds matching `CreditPackageDefinition` SQLAlchemy model with admin-editable fields (`points`, `bonus`, `price`, `is_active`, `org_allowed`, `display_order`, audit columns).
- **Schema only** — no router / API / frontend. Lands the table first so the feature PR for credit-package CRUD (#723) can rebase cleanly on top.

## Notes
- `package_id` stays a code constant; this table only stores numeric overrides + active/org flags.
- `org_allowed` replaces the legacy `ORG_ALLOWED_PACKAGES = ["pkg-20000"]` constant. Seed reflects that exact list.
- Validity period stays a single global constant (`CREDIT_PACKAGE_VALIDITY_DAYS`) — per-package validity intentionally out of scope.
- `downgrade()` is a no-op (dropping the table would lose admin-edited values).

## Why split this out
Mirrors the approach taken for #743 (Plan migration). Landing the migration alone lets staging apply the schema change in isolation; the feature PR will be rebased onto staging after this merges.

## Test plan
- [ ] CI green on staging
- [ ] After merge, manually verify `\d credit_package_definitions` on staging Supabase shows the table with 5 seed rows (pkg-20000 having `org_allowed = TRUE`, others `FALSE`)
- [ ] Open feature PR for `/api/admin/credit-packages` + UI panel

Related to #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)