### PR TITLE
chore(#723): add admin audit columns to credit_packages

### DIFF
--- a/backend/alembic/versions/20260518_1400_add_admin_audit_to_credit_packages.py
+++ b/backend/alembic/versions/20260518_1400_add_admin_audit_to_credit_packages.py
@@ -1,0 +1,106 @@
+"""Add admin audit columns to credit_packages
+
+Revision ID: 20260518_1400
+Revises: 20260518_1000
+Create Date: 2026-05-18 14:00:00
+
+Adds `admin_id`, `admin_reason`, `admin_metadata` to `credit_packages`
+so the upcoming admin CRUD endpoints (edit / refund per-teacher credit
+package instances, issue #723) can record who changed what and why.
+
+Mirrors the audit pattern already present on `subscription_periods`.
+
+Migration is idempotent: safe to re-run.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "20260518_1400"
+down_revision: Union[str, None] = "20260518_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # admin_id: FK to teachers, SET NULL on teacher delete so audit row
+    # outlives a deleted admin account.
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'credit_packages' AND column_name = 'admin_id'
+            ) THEN
+                ALTER TABLE credit_packages ADD COLUMN admin_id INTEGER;
+            END IF;
+        END $$;
+        """
+    )
+
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'fk_credit_packages_admin_id'
+            ) THEN
+                ALTER TABLE credit_packages
+                ADD CONSTRAINT fk_credit_packages_admin_id
+                FOREIGN KEY (admin_id)
+                REFERENCES teachers(id) ON DELETE SET NULL;
+            END IF;
+        END $$;
+        """
+    )
+
+    # Partial index on the FK so admin-audit joins don't seq-scan. Most
+    # rows have NULL admin_id (purchases without admin involvement), so
+    # the partial index stays compact.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_credit_packages_admin_id "
+        "ON credit_packages (admin_id) "
+        "WHERE admin_id IS NOT NULL"
+    )
+
+    # admin_reason: free-text note attached to the most recent admin write
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'credit_packages'
+                AND column_name = 'admin_reason'
+            ) THEN
+                ALTER TABLE credit_packages ADD COLUMN admin_reason TEXT;
+            END IF;
+        END $$;
+        """
+    )
+
+    # admin_metadata: JSONB accumulating full change history. Use JSONB
+    # (not JSON) to match the SubscriptionPeriod pattern and to allow
+    # future indexed lookups inside the JSON.
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'credit_packages'
+                AND column_name = 'admin_metadata'
+            ) THEN
+                ALTER TABLE credit_packages ADD COLUMN admin_metadata JSONB;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Intentional no-op: dropping these columns would lose admin audit
+    # history (the whole reason they exist). If we ever need to rollback,
+    # leaving the columns in place is harmless — downstream code tolerates
+    # NULLs for all three.
+    pass

--- a/backend/models/credit_package.py
+++ b/backend/models/credit_package.py
@@ -9,11 +9,12 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Index,
+    Text,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from database import Base
-from .base import UUID
+from .base import UUID, JSONType
 import uuid
 
 
@@ -69,13 +70,25 @@ class CreditPackage(Base):
         String, nullable=False
     )  # "purchase" / "trial_bonus" / "admin_grant" / "org_purchase"
 
+    # Admin audit (mirrors SubscriptionPeriod pattern). `admin_id` and
+    # `admin_reason` record the most recent admin write (edit or refund);
+    # `admin_metadata` JSONB accumulates the full change history.
+    admin_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="SET NULL"), nullable=True
+    )
+    admin_reason = Column(Text, nullable=True)
+    admin_metadata = Column(JSONType, nullable=True)
+
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
     # Relationships
-    teacher = relationship("Teacher", back_populates="credit_packages")
+    teacher = relationship(
+        "Teacher", foreign_keys=[teacher_id], back_populates="credit_packages"
+    )
     organization = relationship("Organization", back_populates="credit_packages")
+    admin = relationship("Teacher", foreign_keys=[admin_id])
 
     @property
     def points_remaining(self) -> int:


### PR DESCRIPTION
## Summary
Adds `admin_id` / `admin_reason` / `admin_metadata` audit columns to `credit_packages`, plus a partial index on `admin_id`. Mirrors the audit pattern already present on `subscription_periods`.

Prep for the upcoming admin Credit Package instance CRUD endpoints (edit / refund), so admin writes carry "who, what, why" alongside the data change.

## Notes
- All 3 columns are nullable — existing rows (purchases without admin involvement) are unaffected.
- `admin_metadata` is JSONB to allow future indexed lookups inside the JSON (e.g. find all rows changed by admin X).
- Partial index on `admin_id` filters out rows with NULL admin_id (the majority).
- `downgrade()` is a no-op (dropping would lose audit history).

## Why split this out
Mirrors the approach taken for #743 (Plan migration) and #775 (CreditPackageDefinition migration). Landing the schema change alone lets staging apply it in isolation; the follow-up feature PR will be rebased onto staging after this merges.

## Test plan
- [ ] CI green on staging
- [ ] After merge, manually verify `\d credit_packages` shows the 3 new columns + `idx_credit_packages_admin_id` partial index + `fk_credit_packages_admin_id` constraint
- [ ] Open feature PR for `PUT /api/admin/subscription/credit-package/{id}` + cancel endpoint + UI Edit/Delete dialogs

Related to #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)