### PR TITLE
feat(#723): admin CRUD for per-teacher credit package instances

### DIFF
--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -190,6 +190,7 @@ class Teacher(Base):
         "CreditPackage",
         foreign_keys="CreditPackage.teacher_id",
         back_populates="teacher",
+        foreign_keys="CreditPackage.teacher_id",
         cascade="all, delete-orphan",
         order_by="CreditPackage.expires_at.asc()",
     )

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -190,7 +190,6 @@ class Teacher(Base):
         "CreditPackage",
         foreign_keys="CreditPackage.teacher_id",
         back_populates="teacher",
-        foreign_keys="CreditPackage.teacher_id",
         cascade="all, delete-orphan",
         order_by="CreditPackage.expires_at.asc()",
     )

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session, aliased
 from sqlalchemy import func
 from sqlalchemy.orm.attributes import flag_modified
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -70,6 +70,33 @@ class SubscriptionResponse(BaseModel):
     quota_total: int
     quota_used: int
     end_date: str
+    status: str
+
+
+class EditCreditPackageRequest(BaseModel):
+    """編輯點數包請求（每次至少 reason 必填）"""
+
+    points_total: Optional[int] = Field(default=None, ge=0)
+    expires_at: Optional[str] = None  # YYYY-MM-DD
+    reason: str = Field(min_length=1, max_length=500)
+
+
+class CancelCreditPackageRequest(BaseModel):
+    """退款 / 取消點數包請求"""
+
+    reason: str = Field(min_length=1, max_length=500)
+
+
+class CreditPackageResponse(BaseModel):
+    """點數包編輯後回應"""
+
+    id: int
+    package_id: str
+    source: str
+    points_total: int
+    points_used: int
+    points_remaining: int
+    expires_at: str
     status: str
 
 
@@ -395,6 +422,166 @@ async def cancel_subscription(
     }
 
 
+# ============ Credit Package Instance CRUD ============
+def _credit_package_response(pkg: CreditPackage) -> dict:
+    return {
+        "id": pkg.id,
+        "package_id": pkg.package_id,
+        "source": pkg.source,
+        "points_total": pkg.points_total,
+        "points_used": pkg.points_used,
+        "points_remaining": pkg.points_remaining,
+        "expires_at": pkg.expires_at.isoformat() if pkg.expires_at else None,
+        "status": pkg.status,
+    }
+
+
+def _append_admin_operation(pkg: CreditPackage, op: dict) -> None:
+    """Append `op` to pkg.admin_metadata['operations'] and flag the column
+    so SQLAlchemy persists the in-place JSONB mutation."""
+    if pkg.admin_metadata is None:
+        pkg.admin_metadata = {"operations": []}
+    if "operations" not in pkg.admin_metadata:
+        pkg.admin_metadata["operations"] = []
+    pkg.admin_metadata["operations"].append(op)
+    flag_modified(pkg, "admin_metadata")
+
+
+@router.put("/credit-package/{package_id}", response_model=CreditPackageResponse)
+async def edit_credit_package(
+    package_id: int,
+    request: EditCreditPackageRequest,
+    db: Session = Depends(get_db),
+    admin: Teacher = Depends(get_current_admin),
+):
+    """Admin: edit a teacher's CreditPackage row.
+
+    Editable fields: `points_total`, `expires_at`. `reason` is required
+    and recorded in `admin_reason` + accumulated in `admin_metadata`.
+
+    Refused (422) if `points_total < points_used` (would invalidate
+    historical PointUsageLog entries) or if the package is already
+    refunded.
+    """
+    pkg = db.query(CreditPackage).filter(CreditPackage.id == package_id).first()
+    if pkg is None:
+        raise HTTPException(
+            status_code=404, detail=f"Credit package {package_id} not found"
+        )
+
+    if pkg.status == "refunded":
+        raise HTTPException(
+            status_code=422,
+            detail="Cannot edit a refunded credit package",
+        )
+
+    payload = request.model_dump(exclude_unset=True)
+    payload.pop("reason", None)
+    if not payload:
+        raise HTTPException(status_code=400, detail="No editable fields provided")
+
+    changes: dict = {}
+
+    if "points_total" in payload:
+        new_total = payload["points_total"]
+        if new_total < pkg.points_used:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"points_total ({new_total}) cannot be less than "
+                    f"points_used ({pkg.points_used})"
+                ),
+            )
+        if new_total != pkg.points_total:
+            changes["points_total"] = {
+                "from": pkg.points_total,
+                "to": new_total,
+            }
+            pkg.points_total = new_total
+
+    if "expires_at" in payload:
+        try:
+            new_expires = datetime.strptime(payload["expires_at"], "%Y-%m-%d").replace(
+                tzinfo=timezone.utc
+            )
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=422,
+                detail="expires_at must be a date in YYYY-MM-DD format",
+            )
+        old_iso = pkg.expires_at.isoformat() if pkg.expires_at else None
+        new_iso = new_expires.isoformat()
+        if old_iso != new_iso:
+            changes["expires_at"] = {"from": old_iso, "to": new_iso}
+            pkg.expires_at = new_expires
+
+    pkg.admin_id = admin.id
+    pkg.admin_reason = request.reason
+
+    _append_admin_operation(
+        pkg,
+        {
+            "action": "edit",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "admin_id": admin.id,
+            "admin_email": admin.email,
+            "admin_name": admin.name,
+            "reason": request.reason,
+            "changes": changes,
+        },
+    )
+
+    db.commit()
+    db.refresh(pkg)
+    return _credit_package_response(pkg)
+
+
+@router.post("/credit-package/{package_id}/cancel")
+async def cancel_credit_package(
+    package_id: int,
+    request: CancelCreditPackageRequest,
+    db: Session = Depends(get_db),
+    admin: Teacher = Depends(get_current_admin),
+):
+    """Admin: soft-delete a teacher's CreditPackage by setting
+    `status='refunded'`. The row is preserved so PointUsageLog audit
+    trails remain valid; the list endpoint filters refunded packages out
+    of the UI."""
+    pkg = db.query(CreditPackage).filter(CreditPackage.id == package_id).first()
+    if pkg is None:
+        raise HTTPException(
+            status_code=404, detail=f"Credit package {package_id} not found"
+        )
+
+    if pkg.status == "refunded":
+        raise HTTPException(
+            status_code=422,
+            detail="Credit package is already refunded",
+        )
+
+    old_status = pkg.status
+    pkg.status = "refunded"
+    pkg.admin_id = admin.id
+    pkg.admin_reason = request.reason
+
+    _append_admin_operation(
+        pkg,
+        {
+            "action": "cancel",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "admin_id": admin.id,
+            "admin_email": admin.email,
+            "admin_name": admin.name,
+            "reason": request.reason,
+            "changes": {"status": {"from": old_status, "to": "refunded"}},
+        },
+    )
+
+    db.commit()
+    db.refresh(pkg)
+    return _credit_package_response(pkg)
+
+
 @router.get("/all-teachers")
 async def get_all_teachers_subscriptions(
     db: Session = Depends(get_db),
@@ -522,9 +709,14 @@ async def get_teacher_periods(
         )
 
     # 🔥 Approach A: 同時撈取 credit_packages（trial_bonus / admin_grant / 加購）
+    # Refunded packages are hidden from the dashboard list (soft-delete UX);
+    # the row stays in DB so PointUsageLog audit trails remain valid.
     credit_packages = (
         db.query(CreditPackage)
-        .filter(CreditPackage.teacher_id == teacher_id)
+        .filter(
+            CreditPackage.teacher_id == teacher_id,
+            CreditPackage.status != "refunded",
+        )
         .order_by(CreditPackage.purchased_at.desc())
         .all()
     )

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -96,6 +96,7 @@ class CreditPackageResponse(BaseModel):
     points_total: int
     points_used: int
     points_remaining: int
+    # CreditPackage.expires_at is nullable=False so this is always set.
     expires_at: str
     status: str
 
@@ -424,6 +425,8 @@ async def cancel_subscription(
 
 # ============ Credit Package Instance CRUD ============
 def _credit_package_response(pkg: CreditPackage) -> dict:
+    # `CreditPackage.expires_at` is `nullable=False` in the DB schema, so it
+    # is always set in practice — no None guard needed here.
     return {
         "id": pkg.id,
         "package_id": pkg.package_id,
@@ -431,7 +434,7 @@ def _credit_package_response(pkg: CreditPackage) -> dict:
         "points_total": pkg.points_total,
         "points_used": pkg.points_used,
         "points_remaining": pkg.points_remaining,
-        "expires_at": pkg.expires_at.isoformat() if pkg.expires_at else None,
+        "expires_at": pkg.expires_at.isoformat(),
         "status": pkg.status,
     }
 
@@ -536,7 +539,9 @@ async def edit_credit_package(
     return _credit_package_response(pkg)
 
 
-@router.post("/credit-package/{package_id}/cancel")
+@router.post(
+    "/credit-package/{package_id}/cancel", response_model=CreditPackageResponse
+)
 async def cancel_credit_package(
     package_id: int,
     request: CancelCreditPackageRequest,

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -12,7 +12,7 @@ from sqlalchemy import func
 from sqlalchemy.orm.attributes import flag_modified
 from pydantic import BaseModel, EmailStr, Field
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 from database import get_db
 from models import (
@@ -99,6 +99,9 @@ class CreditPackageResponse(BaseModel):
     # CreditPackage.expires_at is nullable=False so this is always set.
     expires_at: str
     status: str
+    # Full audit trail from admin_metadata.operations[] — every edit / cancel
+    # appends one entry. Empty list when no admin has touched the package.
+    admin_operations: List[Dict[str, Any]] = []
 
 
 # ============ Helper Functions ============
@@ -424,6 +427,18 @@ async def cancel_subscription(
 
 
 # ============ Credit Package Instance CRUD ============
+def _admin_operations(pkg: CreditPackage) -> List[Dict[str, Any]]:
+    """Return the operation history from ``pkg.admin_metadata`` as a list.
+
+    `admin_metadata` is a JSONB column shaped like ``{"operations": [...]}``
+    after the first admin write; anything else (None, missing key, wrong
+    type) is treated as no history so the response is always a list."""
+    if not isinstance(pkg.admin_metadata, dict):
+        return []
+    ops = pkg.admin_metadata.get("operations")
+    return ops if isinstance(ops, list) else []
+
+
 def _credit_package_response(pkg: CreditPackage) -> dict:
     # `CreditPackage.expires_at` is `nullable=False` in the DB schema, so it
     # is always set in practice — no None guard needed here.
@@ -436,6 +451,7 @@ def _credit_package_response(pkg: CreditPackage) -> dict:
         "points_remaining": pkg.points_remaining,
         "expires_at": pkg.expires_at.isoformat(),
         "status": pkg.status,
+        "admin_operations": _admin_operations(pkg),
     }
 
 
@@ -743,6 +759,7 @@ async def get_teacher_periods(
                 "expires_at": pkg.expires_at.isoformat() if pkg.expires_at else None,
                 "status": pkg.status,
                 "payment_id": pkg.payment_id,
+                "admin_operations": _admin_operations(pkg),
             }
         )
 

--- a/backend/tests/test_admin_credit_packages.py
+++ b/backend/tests/test_admin_credit_packages.py
@@ -342,6 +342,76 @@ def test_cancel_credit_package_non_admin_forbidden(
     assert response.status_code == 403
 
 
+# ============ admin_operations surfacing ============
+def test_edit_response_includes_admin_operations(
+    active_package, auth_headers_admin, test_client
+):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 1500, "reason": "history surfacing"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "admin_operations" in body
+    assert len(body["admin_operations"]) == 1
+    op = body["admin_operations"][0]
+    assert op["action"] == "edit"
+    assert op["reason"] == "history surfacing"
+    assert "timestamp" in op
+    assert "changes" in op
+
+
+def test_cancel_response_includes_admin_operations(
+    active_package, auth_headers_admin, test_client
+):
+    response = test_client.post(
+        f"/api/admin/subscription/credit-package/{active_package.id}/cancel",
+        headers=auth_headers_admin,
+        json={"reason": "refund test"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    ops = body["admin_operations"]
+    assert len(ops) == 1
+    assert ops[0]["action"] == "cancel"
+
+
+def test_teacher_periods_includes_admin_operations(
+    active_package, auth_headers_admin, regular_teacher, test_client
+):
+    # Generate one edit so the package has history
+    test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 1500, "reason": "seeding history"},
+    )
+
+    response = test_client.get(
+        f"/api/admin/subscription/teacher/{regular_teacher.id}/periods",
+        headers=auth_headers_admin,
+    )
+    assert response.status_code == 200
+    pkg = next(
+        p for p in response.json()["credit_packages"] if p["id"] == active_package.id
+    )
+    assert pkg["admin_operations"]
+    assert pkg["admin_operations"][0]["action"] == "edit"
+
+
+def test_teacher_periods_empty_admin_operations_for_untouched_pkg(
+    active_package, auth_headers_admin, regular_teacher, test_client
+):
+    response = test_client.get(
+        f"/api/admin/subscription/teacher/{regular_teacher.id}/periods",
+        headers=auth_headers_admin,
+    )
+    pkg = next(
+        p for p in response.json()["credit_packages"] if p["id"] == active_package.id
+    )
+    assert pkg["admin_operations"] == []
+
+
 # ============ List filter ============
 def test_teacher_periods_excludes_refunded_packages(
     active_package,

--- a/backend/tests/test_admin_credit_packages.py
+++ b/backend/tests/test_admin_credit_packages.py
@@ -1,0 +1,345 @@
+"""Tests for admin credit package instance CRUD endpoints.
+
+Covers per-teacher CreditPackage row editing and soft-cancellation
+(status -> 'refunded') with audit trail in admin_metadata.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from auth import create_access_token, get_password_hash
+from models import CreditPackage, Teacher
+
+
+# ============ Fixtures ============
+@pytest.fixture
+def admin_teacher(shared_test_session):
+    teacher = Teacher(
+        email="admin-cp@duotopia.com",
+        password_hash=get_password_hash("admin_password"),
+        name="Admin CP",
+        is_active=True,
+        is_admin=True,
+        email_verified=True,
+    )
+    shared_test_session.add(teacher)
+    shared_test_session.commit()
+    shared_test_session.refresh(teacher)
+    return teacher
+
+
+@pytest.fixture
+def regular_teacher(shared_test_session):
+    teacher = Teacher(
+        email="user-cp@duotopia.com",
+        password_hash=get_password_hash("user_password"),
+        name="User CP",
+        is_active=True,
+        is_admin=False,
+        email_verified=True,
+    )
+    shared_test_session.add(teacher)
+    shared_test_session.commit()
+    shared_test_session.refresh(teacher)
+    return teacher
+
+
+@pytest.fixture
+def auth_headers_admin(admin_teacher):
+    token = create_access_token(data={"sub": str(admin_teacher.id), "type": "teacher"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def auth_headers_regular(regular_teacher):
+    token = create_access_token(
+        data={"sub": str(regular_teacher.id), "type": "teacher"}
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def active_package(shared_test_session, regular_teacher):
+    now = datetime.now(timezone.utc)
+    pkg = CreditPackage(
+        teacher_id=regular_teacher.id,
+        package_id="trial-bonus",
+        points_total=2000,
+        points_used=300,
+        price_paid=0,
+        purchased_at=now - timedelta(days=10),
+        expires_at=now + timedelta(days=355),
+        status="active",
+        source="trial_bonus",
+    )
+    shared_test_session.add(pkg)
+    shared_test_session.commit()
+    shared_test_session.refresh(pkg)
+    return pkg
+
+
+@pytest.fixture
+def refunded_package(shared_test_session, regular_teacher):
+    now = datetime.now(timezone.utc)
+    pkg = CreditPackage(
+        teacher_id=regular_teacher.id,
+        package_id="pkg-1000",
+        points_total=1000,
+        points_used=0,
+        price_paid=180,
+        purchased_at=now - timedelta(days=30),
+        expires_at=now + timedelta(days=335),
+        status="refunded",
+        source="purchase",
+    )
+    shared_test_session.add(pkg)
+    shared_test_session.commit()
+    shared_test_session.refresh(pkg)
+    return pkg
+
+
+# ============ PUT /api/admin/subscription/credit-package/{id} ============
+def test_edit_credit_package_happy_path(
+    active_package, admin_teacher, auth_headers_admin, test_client, shared_test_session
+):
+    new_expires = (datetime.now(timezone.utc) + timedelta(days=400)).date().isoformat()
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={
+            "points_total": 1800,
+            "expires_at": new_expires,
+            "reason": "Extending expiry per customer request",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["id"] == active_package.id
+    assert body["points_total"] == 1800
+    assert body["expires_at"].startswith(new_expires)
+
+    shared_test_session.expire_all()
+    row = shared_test_session.query(CreditPackage).get(active_package.id)
+    assert row.points_total == 1800
+    assert row.admin_id == admin_teacher.id
+    assert row.admin_reason == "Extending expiry per customer request"
+    # Audit history accumulated
+    assert row.admin_metadata is not None
+    ops = row.admin_metadata.get("operations", [])
+    assert len(ops) == 1
+    assert ops[0]["action"] == "edit"
+    assert ops[0]["admin_id"] == admin_teacher.id
+    assert ops[0]["reason"] == "Extending expiry per customer request"
+
+
+def test_edit_credit_package_partial_points_only(
+    active_package, auth_headers_admin, test_client, shared_test_session
+):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 1500, "reason": "correction"},
+    )
+    assert response.status_code == 200
+
+    shared_test_session.expire_all()
+    row = shared_test_session.query(CreditPackage).get(active_package.id)
+    assert row.points_total == 1500
+    # expires_at untouched
+    assert row.expires_at == active_package.expires_at
+
+
+def test_edit_credit_package_points_below_used_rejected(
+    active_package, auth_headers_admin, test_client
+):
+    # active_package.points_used == 300, so 200 should be rejected
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 200, "reason": "bad reduce"},
+    )
+    assert response.status_code == 422
+    assert "points_used" in response.json()["detail"].lower()
+
+
+def test_edit_credit_package_negative_points_rejected(
+    active_package, auth_headers_admin, test_client
+):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": -1, "reason": "bad"},
+    )
+    assert response.status_code == 422
+
+
+def test_edit_credit_package_reason_required(
+    active_package, auth_headers_admin, test_client
+):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 1500},
+    )
+    assert response.status_code == 422
+
+
+def test_edit_credit_package_reason_empty_rejected(
+    active_package, auth_headers_admin, test_client
+):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 1500, "reason": ""},
+    )
+    assert response.status_code == 422
+
+
+def test_edit_credit_package_not_found(auth_headers_admin, test_client):
+    response = test_client.put(
+        "/api/admin/subscription/credit-package/999999",
+        headers=auth_headers_admin,
+        json={"points_total": 1000, "reason": "test"},
+    )
+    assert response.status_code == 404
+
+
+def test_edit_credit_package_already_refunded_rejected(
+    refunded_package, auth_headers_admin, test_client
+):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{refunded_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 500, "reason": "should fail"},
+    )
+    assert response.status_code in (409, 422)
+
+
+def test_edit_credit_package_non_admin_forbidden(
+    active_package, auth_headers_regular, test_client
+):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_regular,
+        json={"points_total": 1500, "reason": "should fail"},
+    )
+    assert response.status_code == 403
+
+
+def test_edit_credit_package_unauthenticated(active_package, test_client):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        json={"points_total": 1500, "reason": "test"},
+    )
+    assert response.status_code in (401, 403)
+
+
+def test_edit_credit_package_accumulates_history(
+    active_package, admin_teacher, auth_headers_admin, test_client, shared_test_session
+):
+    """Two consecutive edits should produce two operation entries."""
+    test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 1800, "reason": "first edit"},
+    )
+    test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 1500, "reason": "second edit"},
+    )
+
+    shared_test_session.expire_all()
+    row = shared_test_session.query(CreditPackage).get(active_package.id)
+    ops = row.admin_metadata.get("operations", [])
+    assert len(ops) == 2
+    assert [op["reason"] for op in ops] == ["first edit", "second edit"]
+    # Latest admin_reason reflects last edit
+    assert row.admin_reason == "second edit"
+
+
+# ============ POST /api/admin/subscription/credit-package/{id}/cancel ============
+def test_cancel_credit_package_happy_path(
+    active_package, admin_teacher, auth_headers_admin, test_client, shared_test_session
+):
+    response = test_client.post(
+        f"/api/admin/subscription/credit-package/{active_package.id}/cancel",
+        headers=auth_headers_admin,
+        json={"reason": "Customer refund request"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "refunded"
+
+    shared_test_session.expire_all()
+    row = shared_test_session.query(CreditPackage).get(active_package.id)
+    assert row.status == "refunded"
+    assert row.admin_id == admin_teacher.id
+    assert row.admin_reason == "Customer refund request"
+    ops = row.admin_metadata.get("operations", [])
+    assert len(ops) == 1
+    assert ops[0]["action"] == "cancel"
+
+
+def test_cancel_credit_package_reason_required(
+    active_package, auth_headers_admin, test_client
+):
+    response = test_client.post(
+        f"/api/admin/subscription/credit-package/{active_package.id}/cancel",
+        headers=auth_headers_admin,
+        json={},
+    )
+    assert response.status_code == 422
+
+
+def test_cancel_credit_package_not_found(auth_headers_admin, test_client):
+    response = test_client.post(
+        "/api/admin/subscription/credit-package/999999/cancel",
+        headers=auth_headers_admin,
+        json={"reason": "test"},
+    )
+    assert response.status_code == 404
+
+
+def test_cancel_credit_package_already_refunded_rejected(
+    refunded_package, auth_headers_admin, test_client
+):
+    response = test_client.post(
+        f"/api/admin/subscription/credit-package/{refunded_package.id}/cancel",
+        headers=auth_headers_admin,
+        json={"reason": "double cancel"},
+    )
+    assert response.status_code in (409, 422)
+
+
+def test_cancel_credit_package_non_admin_forbidden(
+    active_package, auth_headers_regular, test_client
+):
+    response = test_client.post(
+        f"/api/admin/subscription/credit-package/{active_package.id}/cancel",
+        headers=auth_headers_regular,
+        json={"reason": "should fail"},
+    )
+    assert response.status_code == 403
+
+
+# ============ List filter ============
+def test_teacher_periods_excludes_refunded_packages(
+    active_package,
+    refunded_package,
+    regular_teacher,
+    auth_headers_admin,
+    test_client,
+):
+    response = test_client.get(
+        f"/api/admin/subscription/teacher/{regular_teacher.id}/periods",
+        headers=auth_headers_admin,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    pkg_ids = [p["id"] for p in body["credit_packages"]]
+    assert active_package.id in pkg_ids
+    assert refunded_package.id not in pkg_ids

--- a/backend/tests/test_admin_credit_packages.py
+++ b/backend/tests/test_admin_credit_packages.py
@@ -121,7 +121,7 @@ def test_edit_credit_package_happy_path(
     assert body["expires_at"].startswith(new_expires)
 
     shared_test_session.expire_all()
-    row = shared_test_session.query(CreditPackage).get(active_package.id)
+    row = shared_test_session.get(CreditPackage, active_package.id)
     assert row.points_total == 1800
     assert row.admin_id == admin_teacher.id
     assert row.admin_reason == "Extending expiry per customer request"
@@ -145,7 +145,7 @@ def test_edit_credit_package_partial_points_only(
     assert response.status_code == 200
 
     shared_test_session.expire_all()
-    row = shared_test_session.query(CreditPackage).get(active_package.id)
+    row = shared_test_session.get(CreditPackage, active_package.id)
     assert row.points_total == 1500
     # expires_at untouched
     assert row.expires_at == active_package.expires_at
@@ -214,7 +214,23 @@ def test_edit_credit_package_already_refunded_rejected(
         headers=auth_headers_admin,
         json={"points_total": 500, "reason": "should fail"},
     )
-    assert response.status_code in (409, 422)
+    assert response.status_code == 422
+
+
+def test_edit_credit_package_points_equal_used_accepted(
+    active_package, auth_headers_admin, test_client, shared_test_session
+):
+    """points_total == points_used is the lower bound and must be accepted."""
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": active_package.points_used, "reason": "exact match"},
+    )
+    assert response.status_code == 200, response.text
+
+    shared_test_session.expire_all()
+    row = shared_test_session.get(CreditPackage, active_package.id)
+    assert row.points_total == active_package.points_used
 
 
 def test_edit_credit_package_non_admin_forbidden(
@@ -252,7 +268,7 @@ def test_edit_credit_package_accumulates_history(
     )
 
     shared_test_session.expire_all()
-    row = shared_test_session.query(CreditPackage).get(active_package.id)
+    row = shared_test_session.get(CreditPackage, active_package.id)
     ops = row.admin_metadata.get("operations", [])
     assert len(ops) == 2
     assert [op["reason"] for op in ops] == ["first edit", "second edit"]
@@ -275,7 +291,7 @@ def test_cancel_credit_package_happy_path(
     assert body["status"] == "refunded"
 
     shared_test_session.expire_all()
-    row = shared_test_session.query(CreditPackage).get(active_package.id)
+    row = shared_test_session.get(CreditPackage, active_package.id)
     assert row.status == "refunded"
     assert row.admin_id == admin_teacher.id
     assert row.admin_reason == "Customer refund request"
@@ -312,7 +328,7 @@ def test_cancel_credit_package_already_refunded_rejected(
         headers=auth_headers_admin,
         json={"reason": "double cancel"},
     )
-    assert response.status_code in (409, 422)
+    assert response.status_code == 422
 
 
 def test_cancel_credit_package_non_admin_forbidden(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -134,6 +134,17 @@ export interface RegisterRequest {
   phone?: string;
 }
 
+interface AdminCreditPackageResult {
+  id: number;
+  package_id: string;
+  source: string;
+  points_total: number;
+  points_used: number;
+  points_remaining: number;
+  expires_at: string;
+  status: string;
+}
+
 class ApiClient {
   private baseUrl: string;
 
@@ -1533,35 +1544,23 @@ class ApiClient {
       reason: string;
     },
   ) {
-    return this.request<{
-      id: number;
-      package_id: string;
-      source: string;
-      points_total: number;
-      points_used: number;
-      points_remaining: number;
-      expires_at: string;
-      status: string;
-    }>(`/api/admin/subscription/credit-package/${packageId}`, {
-      method: "PUT",
-      body: JSON.stringify(data),
-    });
+    return this.request<AdminCreditPackageResult>(
+      `/api/admin/subscription/credit-package/${packageId}`,
+      {
+        method: "PUT",
+        body: JSON.stringify(data),
+      },
+    );
   }
 
   async adminCancelCreditPackage(packageId: number, data: { reason: string }) {
-    return this.request<{
-      id: number;
-      package_id: string;
-      source: string;
-      points_total: number;
-      points_used: number;
-      points_remaining: number;
-      expires_at: string;
-      status: string;
-    }>(`/api/admin/subscription/credit-package/${packageId}/cancel`, {
-      method: "POST",
-      body: JSON.stringify(data),
-    });
+    return this.request<AdminCreditPackageResult>(
+      `/api/admin/subscription/credit-package/${packageId}/cancel`,
+      {
+        method: "POST",
+        body: JSON.stringify(data),
+      },
+    );
   }
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -134,6 +134,19 @@ export interface RegisterRequest {
   phone?: string;
 }
 
+export interface AdminCreditPackageOperation {
+  action: "edit" | "cancel" | string;
+  timestamp: string;
+  admin_id: number;
+  admin_email?: string;
+  admin_name?: string;
+  reason: string;
+  changes: Record<
+    string,
+    { from: unknown; to: unknown } | string | number | boolean
+  >;
+}
+
 interface AdminCreditPackageResult {
   id: number;
   package_id: string;
@@ -143,6 +156,7 @@ interface AdminCreditPackageResult {
   points_remaining: number;
   expires_at: string;
   status: string;
+  admin_operations: AdminCreditPackageOperation[];
 }
 
 class ApiClient {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1523,6 +1523,46 @@ class ApiClient {
       body: JSON.stringify(data),
     });
   }
+
+  // ============ Admin Credit Package Instance Methods ============
+  async adminEditCreditPackage(
+    packageId: number,
+    data: {
+      points_total?: number;
+      expires_at?: string; // YYYY-MM-DD
+      reason: string;
+    },
+  ) {
+    return this.request<{
+      id: number;
+      package_id: string;
+      source: string;
+      points_total: number;
+      points_used: number;
+      points_remaining: number;
+      expires_at: string;
+      status: string;
+    }>(`/api/admin/subscription/credit-package/${packageId}`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    });
+  }
+
+  async adminCancelCreditPackage(packageId: number, data: { reason: string }) {
+    return this.request<{
+      id: number;
+      package_id: string;
+      source: string;
+      points_total: number;
+      points_used: number;
+      points_remaining: number;
+      expires_at: string;
+      status: string;
+    }>(`/api/admin/subscription/credit-package/${packageId}/cancel`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  }
 }
 
 // Export singleton instance

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -51,6 +51,7 @@ import {
   GraduationCap,
   Download,
   RefreshCcw,
+  X,
 } from "lucide-react";
 import { apiClient } from "@/lib/api";
 import {
@@ -105,6 +106,19 @@ interface SubscriptionPeriod {
   amount_paid?: number;
 }
 
+interface CreditPackageOperation {
+  action: string; // "edit" | "cancel"
+  timestamp: string;
+  admin_id: number;
+  admin_email?: string;
+  admin_name?: string;
+  reason: string;
+  changes: Record<
+    string,
+    { from: unknown; to: unknown } | string | number | boolean
+  >;
+}
+
 interface CreditPackageInfo {
   id: number;
   package_id: string;
@@ -117,6 +131,7 @@ interface CreditPackageInfo {
   expires_at: string;
   status: string;
   payment_id?: string;
+  admin_operations?: CreditPackageOperation[];
 }
 
 interface EditHistoryRecord {
@@ -217,6 +232,108 @@ interface LearningAnalytics {
   total_points_used: number;
 }
 
+function formatOperationTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString("zh-TW", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function describeOperationChanges(
+  changes: CreditPackageOperation["changes"],
+): string[] {
+  return Object.entries(changes).map(([field, value]) => {
+    if (
+      value &&
+      typeof value === "object" &&
+      "from" in value &&
+      "to" in value
+    ) {
+      const fromVal = (value as { from: unknown }).from;
+      const toVal = (value as { to: unknown }).to;
+      return `${field}: ${String(fromVal)} → ${String(toVal)}`;
+    }
+    return `${field}: ${String(value)}`;
+  });
+}
+
+function CreditPackageHistory({
+  operations,
+}: {
+  operations: CreditPackageOperation[];
+}) {
+  // Render newest first so admins see the latest change at the top.
+  const ordered = [...operations].sort((a, b) =>
+    a.timestamp < b.timestamp ? 1 : -1,
+  );
+  return (
+    <div className="p-4 pl-12 space-y-2">
+      <div className="text-xs font-semibold text-gray-700">
+        變更歷史 ({operations.length})
+      </div>
+      <div className="space-y-2">
+        {ordered.map((op, idx) => {
+          const isCancel = op.action === "cancel";
+          const badgeClass = isCancel
+            ? "bg-red-100 text-red-700"
+            : "bg-blue-100 text-blue-700";
+          return (
+            <div
+              key={`${op.timestamp}-${idx}`}
+              className="rounded-md border border-gray-200 bg-white p-3 flex gap-3"
+            >
+              <div
+                className={`w-7 h-7 rounded-full flex items-center justify-center flex-shrink-0 ${
+                  isCancel
+                    ? "bg-red-50 text-red-600"
+                    : "bg-blue-50 text-blue-600"
+                }`}
+              >
+                {isCancel ? (
+                  <X className="w-4 h-4" />
+                ) : (
+                  <Edit className="w-4 h-4" />
+                )}
+              </div>
+              <div className="flex-1 min-w-0 space-y-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span
+                    className={`px-2 py-0.5 rounded text-[11px] font-semibold ${badgeClass}`}
+                  >
+                    {op.action}
+                  </span>
+                  {describeOperationChanges(op.changes).map((change, i) => (
+                    <span
+                      key={i}
+                      className="font-mono text-xs text-gray-600 break-all"
+                    >
+                      {change}
+                    </span>
+                  ))}
+                  <span className="ml-auto text-[11px] text-gray-400">
+                    {formatOperationTimestamp(op.timestamp)}
+                  </span>
+                </div>
+                <div className="text-sm text-gray-900 whitespace-pre-wrap break-words">
+                  原因：{op.reason}
+                </div>
+                <div className="text-[11px] text-gray-400">
+                  by {op.admin_email || op.admin_name || `admin#${op.admin_id}`}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export default function AdminSubscriptionDashboard() {
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -292,6 +409,22 @@ export default function AdminSubscriptionDashboard() {
   const [creditPackageCancelReason, setCreditPackageCancelReason] =
     useState("");
   const [creditPackageSubmitting, setCreditPackageSubmitting] = useState(false);
+  // Set of credit package IDs whose history panel is expanded inline.
+  const [expandedCreditPackageIds, setExpandedCreditPackageIds] = useState<
+    Set<number>
+  >(new Set());
+
+  const toggleCreditPackageHistory = (pkgId: number) => {
+    setExpandedCreditPackageIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(pkgId)) {
+        next.delete(pkgId);
+      } else {
+        next.add(pkgId);
+      }
+      return next;
+    });
+  };
 
   useEffect(() => {
     loadDashboardData();
@@ -509,6 +642,7 @@ export default function AdminSubscriptionDashboard() {
                 points_remaining: updated.points_remaining,
                 expires_at: updated.expires_at,
                 status: updated.status,
+                admin_operations: updated.admin_operations,
               }
             : p,
         ),
@@ -1828,94 +1962,159 @@ export default function AdminSubscriptionDashboard() {
                                                   "bg-gray-100 text-gray-700",
                                               };
 
+                                              const isHistoryOpen =
+                                                expandedCreditPackageIds.has(
+                                                  pkg.id,
+                                                );
                                               return (
-                                                <TableRow key={`pkg-${pkg.id}`}>
-                                                  <TableCell>
-                                                    <span
-                                                      className={`px-2 py-1 rounded text-xs font-semibold ${sourceBadge.className}`}
-                                                    >
-                                                      {sourceBadge.label}
-                                                    </span>
-                                                  </TableCell>
-                                                  <TableCell className="font-mono text-xs text-gray-600">
-                                                    {pkg.package_id}
-                                                  </TableCell>
-                                                  <TableCell className="text-sm text-gray-600">
-                                                    {formatDate(
-                                                      pkg.purchased_at,
-                                                    )}{" "}
-                                                    →{" "}
-                                                    {formatDate(pkg.expires_at)}
-                                                  </TableCell>
-                                                  <TableCell>
-                                                    <div className="space-y-1">
-                                                      <div className="text-sm">
-                                                        {pkg.points_used.toLocaleString()}{" "}
-                                                        /{" "}
-                                                        {pkg.points_total.toLocaleString()}
-                                                      </div>
-                                                      <div className="w-full bg-gray-200 rounded-full h-1.5">
-                                                        <div
-                                                          className="bg-purple-500 h-1.5 rounded-full"
-                                                          style={{
-                                                            width: `${Math.min((pkg.points_used / pkg.points_total) * 100 || 0, 100)}%`,
-                                                          }}
-                                                        />
-                                                      </div>
-                                                    </div>
-                                                  </TableCell>
-                                                  <TableCell className="text-sm">
-                                                    {pkg.price_paid > 0
-                                                      ? `NT$ ${pkg.price_paid.toLocaleString()}`
-                                                      : "-"}
-                                                  </TableCell>
-                                                  <TableCell>
-                                                    <span
-                                                      className={`px-2 py-1 rounded text-xs font-semibold ${
-                                                        pkg.status === "active"
-                                                          ? "bg-green-100 text-green-700"
-                                                          : "bg-gray-100 text-gray-600"
-                                                      }`}
-                                                    >
-                                                      {pkg.status}
-                                                    </span>
-                                                  </TableCell>
-                                                  <TableCell
-                                                    onClick={(e) =>
-                                                      e.stopPropagation()
-                                                    }
-                                                  >
-                                                    <div className="flex justify-end gap-1">
-                                                      <Button
-                                                        size="sm"
-                                                        variant="outline"
-                                                        className="h-7 px-2 text-xs"
-                                                        onClick={() =>
-                                                          openEditCreditPackageDialog(
-                                                            teacher.teacher_id,
-                                                            pkg,
-                                                          )
-                                                        }
+                                                <React.Fragment
+                                                  key={`pkg-${pkg.id}`}
+                                                >
+                                                  <TableRow>
+                                                    <TableCell>
+                                                      <span
+                                                        className={`px-2 py-1 rounded text-xs font-semibold ${sourceBadge.className}`}
                                                       >
-                                                        <Edit className="w-3 h-3 mr-1" />
-                                                        編輯
-                                                      </Button>
-                                                      <Button
-                                                        size="sm"
-                                                        variant="outline"
-                                                        className="h-7 px-2 text-xs text-red-600 border-red-300 hover:bg-red-50"
-                                                        onClick={() =>
-                                                          openCancelCreditPackageDialog(
-                                                            teacher.teacher_id,
-                                                            pkg,
-                                                          )
-                                                        }
+                                                        {sourceBadge.label}
+                                                      </span>
+                                                    </TableCell>
+                                                    <TableCell className="font-mono text-xs text-gray-600">
+                                                      {pkg.package_id}
+                                                    </TableCell>
+                                                    <TableCell className="text-sm text-gray-600">
+                                                      {formatDate(
+                                                        pkg.purchased_at,
+                                                      )}{" "}
+                                                      →{" "}
+                                                      {formatDate(
+                                                        pkg.expires_at,
+                                                      )}
+                                                    </TableCell>
+                                                    <TableCell>
+                                                      <div className="space-y-1">
+                                                        <div className="text-sm">
+                                                          {pkg.points_used.toLocaleString()}{" "}
+                                                          /{" "}
+                                                          {pkg.points_total.toLocaleString()}
+                                                        </div>
+                                                        <div className="w-full bg-gray-200 rounded-full h-1.5">
+                                                          <div
+                                                            className="bg-purple-500 h-1.5 rounded-full"
+                                                            style={{
+                                                              width: `${Math.min((pkg.points_used / pkg.points_total) * 100 || 0, 100)}%`,
+                                                            }}
+                                                          />
+                                                        </div>
+                                                      </div>
+                                                    </TableCell>
+                                                    <TableCell className="text-sm">
+                                                      {pkg.price_paid > 0
+                                                        ? `NT$ ${pkg.price_paid.toLocaleString()}`
+                                                        : "-"}
+                                                    </TableCell>
+                                                    <TableCell>
+                                                      <span
+                                                        className={`px-2 py-1 rounded text-xs font-semibold ${
+                                                          pkg.status ===
+                                                          "active"
+                                                            ? "bg-green-100 text-green-700"
+                                                            : "bg-gray-100 text-gray-600"
+                                                        }`}
                                                       >
-                                                        刪除
-                                                      </Button>
-                                                    </div>
-                                                  </TableCell>
-                                                </TableRow>
+                                                        {pkg.status}
+                                                      </span>
+                                                    </TableCell>
+                                                    <TableCell
+                                                      onClick={(e) =>
+                                                        e.stopPropagation()
+                                                      }
+                                                    >
+                                                      <div className="flex justify-end gap-1">
+                                                        <Button
+                                                          size="sm"
+                                                          variant="outline"
+                                                          className="h-7 px-2 text-xs"
+                                                          onClick={() =>
+                                                            toggleCreditPackageHistory(
+                                                              pkg.id,
+                                                            )
+                                                          }
+                                                          disabled={
+                                                            !pkg
+                                                              .admin_operations
+                                                              ?.length
+                                                          }
+                                                          title={
+                                                            pkg.admin_operations
+                                                              ?.length
+                                                              ? `查看 ${pkg.admin_operations.length} 筆變更紀錄`
+                                                              : "尚無變更紀錄"
+                                                          }
+                                                        >
+                                                          {expandedCreditPackageIds.has(
+                                                            pkg.id,
+                                                          ) ? (
+                                                            <ChevronDown className="w-3 h-3 mr-1" />
+                                                          ) : (
+                                                            <ChevronRight className="w-3 h-3 mr-1" />
+                                                          )}
+                                                          紀錄
+                                                          {pkg.admin_operations
+                                                            ?.length
+                                                            ? ` (${pkg.admin_operations.length})`
+                                                            : ""}
+                                                        </Button>
+                                                        <Button
+                                                          size="sm"
+                                                          variant="outline"
+                                                          className="h-7 px-2 text-xs"
+                                                          onClick={() =>
+                                                            openEditCreditPackageDialog(
+                                                              teacher.teacher_id,
+                                                              pkg,
+                                                            )
+                                                          }
+                                                        >
+                                                          <Edit className="w-3 h-3 mr-1" />
+                                                          編輯
+                                                        </Button>
+                                                        <Button
+                                                          size="sm"
+                                                          variant="outline"
+                                                          className="h-7 px-2 text-xs text-red-600 border-red-300 hover:bg-red-50"
+                                                          onClick={() =>
+                                                            openCancelCreditPackageDialog(
+                                                              teacher.teacher_id,
+                                                              pkg,
+                                                            )
+                                                          }
+                                                        >
+                                                          刪除
+                                                        </Button>
+                                                      </div>
+                                                    </TableCell>
+                                                  </TableRow>
+                                                  {isHistoryOpen &&
+                                                    pkg.admin_operations &&
+                                                    pkg.admin_operations
+                                                      .length > 0 && (
+                                                      <TableRow
+                                                        key={`pkg-${pkg.id}-history`}
+                                                        className="bg-gray-50"
+                                                      >
+                                                        <TableCell
+                                                          colSpan={7}
+                                                          className="p-0"
+                                                        >
+                                                          <CreditPackageHistory
+                                                            operations={
+                                                              pkg.admin_operations
+                                                            }
+                                                          />
+                                                        </TableCell>
+                                                      </TableRow>
+                                                    )}
+                                                </React.Fragment>
                                               );
                                             })}
                                           </TableBody>

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -2812,7 +2812,7 @@ export default function AdminSubscriptionDashboard() {
                 disabled={
                   creditPackageSubmitting ||
                   !creditPackageEditForm.reason.trim() ||
-                  !creditPackageEditForm.points_total
+                  creditPackageEditForm.points_total === ""
                 }
               >
                 {creditPackageSubmitting ? (

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -277,6 +277,22 @@ export default function AdminSubscriptionDashboard() {
     expires_days: 365,
   });
 
+  // Credit package instance edit/cancel modal state
+  const [creditPackageEditOpen, setCreditPackageEditOpen] = useState(false);
+  const [creditPackageCancelOpen, setCreditPackageCancelOpen] = useState(false);
+  const [selectedCreditPackage, setSelectedCreditPackage] = useState<{
+    teacherId: number;
+    pkg: CreditPackageInfo;
+  } | null>(null);
+  const [creditPackageEditForm, setCreditPackageEditForm] = useState({
+    points_total: "",
+    expires_at: "", // YYYY-MM-DD
+    reason: "",
+  });
+  const [creditPackageCancelReason, setCreditPackageCancelReason] =
+    useState("");
+  const [creditPackageSubmitting, setCreditPackageSubmitting] = useState(false);
+
   useEffect(() => {
     loadDashboardData();
   }, []);
@@ -414,6 +430,121 @@ export default function AdminSubscriptionDashboard() {
       }
     } finally {
       setLoading(false);
+    }
+  };
+
+  const openEditCreditPackageDialog = (
+    teacherId: number,
+    pkg: CreditPackageInfo,
+  ) => {
+    setSelectedCreditPackage({ teacherId, pkg });
+    setCreditPackageEditForm({
+      points_total: pkg.points_total.toString(),
+      expires_at: pkg.expires_at ? pkg.expires_at.split("T")[0] : "",
+      reason: "",
+    });
+    setCreditPackageEditOpen(true);
+  };
+
+  const openCancelCreditPackageDialog = (
+    teacherId: number,
+    pkg: CreditPackageInfo,
+  ) => {
+    setSelectedCreditPackage({ teacherId, pkg });
+    setCreditPackageCancelReason("");
+    setCreditPackageCancelOpen(true);
+  };
+
+  const handleSubmitEditCreditPackage = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedCreditPackage) return;
+    const { teacherId, pkg } = selectedCreditPackage;
+    const reason = creditPackageEditForm.reason.trim();
+    if (!reason) return;
+
+    const newTotal = Number(creditPackageEditForm.points_total);
+    if (!Number.isInteger(newTotal) || newTotal < 0) {
+      setErrorMessage("總點數必須是 0 或正整數");
+      return;
+    }
+    if (newTotal < pkg.points_used) {
+      setErrorMessage(
+        `總點數 (${newTotal}) 不可小於已使用點數 (${pkg.points_used})`,
+      );
+      return;
+    }
+
+    const payload: {
+      points_total?: number;
+      expires_at?: string;
+      reason: string;
+    } = { reason };
+    if (newTotal !== pkg.points_total) payload.points_total = newTotal;
+    if (
+      creditPackageEditForm.expires_at &&
+      (!pkg.expires_at ||
+        creditPackageEditForm.expires_at !== pkg.expires_at.split("T")[0])
+    ) {
+      payload.expires_at = creditPackageEditForm.expires_at;
+    }
+
+    if (
+      payload.points_total === undefined &&
+      payload.expires_at === undefined
+    ) {
+      setErrorMessage("沒有變更欄位");
+      return;
+    }
+
+    try {
+      setCreditPackageSubmitting(true);
+      const updated = await apiClient.adminEditCreditPackage(pkg.id, payload);
+      setTeacherCreditPackages((prev) => ({
+        ...prev,
+        [teacherId]: (prev[teacherId] || []).map((p) =>
+          p.id === pkg.id
+            ? {
+                ...p,
+                points_total: updated.points_total,
+                points_remaining: updated.points_remaining,
+                expires_at: updated.expires_at,
+                status: updated.status,
+              }
+            : p,
+        ),
+      }));
+      setSuccessMessage(`已更新點數包 ${pkg.package_id}`);
+      setCreditPackageEditOpen(false);
+    } catch (error) {
+      const err = error as { response?: { data?: { detail?: string } } };
+      setErrorMessage(err.response?.data?.detail || "更新點數包失敗");
+    } finally {
+      setCreditPackageSubmitting(false);
+    }
+  };
+
+  const handleSubmitCancelCreditPackage = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedCreditPackage) return;
+    const reason = creditPackageCancelReason.trim();
+    if (!reason) return;
+    const { teacherId, pkg } = selectedCreditPackage;
+
+    try {
+      setCreditPackageSubmitting(true);
+      await apiClient.adminCancelCreditPackage(pkg.id, { reason });
+      // Soft-deleted: remove from local list (backend now filters status='refunded')
+      setTeacherCreditPackages((prev) => ({
+        ...prev,
+        [teacherId]: (prev[teacherId] || []).filter((p) => p.id !== pkg.id),
+      }));
+      setSuccessMessage(`已刪除點數包 ${pkg.package_id}`);
+      setCreditPackageCancelOpen(false);
+    } catch (error) {
+      const err = error as { response?: { data?: { detail?: string } } };
+      setErrorMessage(err.response?.data?.detail || "刪除點數包失敗");
+    } finally {
+      setCreditPackageSubmitting(false);
     }
   };
 
@@ -1646,6 +1777,12 @@ export default function AdminSubscriptionDashboard() {
                                                   "狀態",
                                                 )}
                                               </TableHead>
+                                              <TableHead className="text-right">
+                                                {t(
+                                                  "adminSubscription.creditPackageTable.actions",
+                                                  "操作",
+                                                )}
+                                              </TableHead>
                                             </TableRow>
                                           </TableHeader>
                                           <TableBody>
@@ -1742,6 +1879,41 @@ export default function AdminSubscriptionDashboard() {
                                                     >
                                                       {pkg.status}
                                                     </span>
+                                                  </TableCell>
+                                                  <TableCell
+                                                    onClick={(e) =>
+                                                      e.stopPropagation()
+                                                    }
+                                                  >
+                                                    <div className="flex justify-end gap-1">
+                                                      <Button
+                                                        size="sm"
+                                                        variant="outline"
+                                                        className="h-7 px-2 text-xs"
+                                                        onClick={() =>
+                                                          openEditCreditPackageDialog(
+                                                            teacher.teacher_id,
+                                                            pkg,
+                                                          )
+                                                        }
+                                                      >
+                                                        <Edit className="w-3 h-3 mr-1" />
+                                                        編輯
+                                                      </Button>
+                                                      <Button
+                                                        size="sm"
+                                                        variant="outline"
+                                                        className="h-7 px-2 text-xs text-red-600 border-red-300 hover:bg-red-50"
+                                                        onClick={() =>
+                                                          openCancelCreditPackageDialog(
+                                                            teacher.teacher_id,
+                                                            pkg,
+                                                          )
+                                                        }
+                                                      >
+                                                        刪除
+                                                      </Button>
+                                                    </div>
                                                   </TableCell>
                                                 </TableRow>
                                               );
@@ -2547,6 +2719,175 @@ export default function AdminSubscriptionDashboard() {
                     <Gift className="w-4 h-4 mr-2" />
                     {t("adminSubscription.grant.confirm", "Confirm Grant")}
                   </>
+                )}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Credit Package — Edit */}
+      <Dialog
+        open={creditPackageEditOpen}
+        onOpenChange={setCreditPackageEditOpen}
+      >
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle>編輯點數包</DialogTitle>
+            <DialogDescription>
+              {selectedCreditPackage &&
+                `${selectedCreditPackage.pkg.package_id} · 已使用 ${selectedCreditPackage.pkg.points_used.toLocaleString()} 點`}
+            </DialogDescription>
+          </DialogHeader>
+
+          <form
+            onSubmit={handleSubmitEditCreditPackage}
+            className="space-y-4 mt-4"
+          >
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                總點數 <span className="text-red-500">*</span>
+              </label>
+              <Input
+                type="number"
+                value={creditPackageEditForm.points_total}
+                onChange={(e) =>
+                  setCreditPackageEditForm({
+                    ...creditPackageEditForm,
+                    points_total: e.target.value,
+                  })
+                }
+                min={selectedCreditPackage?.pkg.points_used ?? 0}
+                required
+              />
+              <p className="text-xs text-gray-500">
+                最低為已使用點數 (
+                {selectedCreditPackage?.pkg.points_used.toLocaleString() ?? 0})
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">到期日</label>
+              <Input
+                type="date"
+                value={creditPackageEditForm.expires_at}
+                onChange={(e) =>
+                  setCreditPackageEditForm({
+                    ...creditPackageEditForm,
+                    expires_at: e.target.value,
+                  })
+                }
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                變更原因 <span className="text-red-500">*</span>
+              </label>
+              <Textarea
+                value={creditPackageEditForm.reason}
+                onChange={(e) =>
+                  setCreditPackageEditForm({
+                    ...creditPackageEditForm,
+                    reason: e.target.value,
+                  })
+                }
+                placeholder="請說明此次編輯的原因"
+                required
+                rows={3}
+              />
+            </div>
+
+            <div className="flex gap-2 justify-end pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setCreditPackageEditOpen(false)}
+                disabled={creditPackageSubmitting}
+              >
+                取消
+              </Button>
+              <Button
+                type="submit"
+                disabled={
+                  creditPackageSubmitting ||
+                  !creditPackageEditForm.reason.trim() ||
+                  !creditPackageEditForm.points_total
+                }
+              >
+                {creditPackageSubmitting ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    儲存中
+                  </>
+                ) : (
+                  "儲存"
+                )}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Credit Package — Cancel (soft delete) */}
+      <Dialog
+        open={creditPackageCancelOpen}
+        onOpenChange={setCreditPackageCancelOpen}
+      >
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle>刪除點數包</DialogTitle>
+            <DialogDescription>
+              {selectedCreditPackage &&
+                `${selectedCreditPackage.pkg.package_id} · 總點數 ${selectedCreditPackage.pkg.points_total.toLocaleString()} / 已使用 ${selectedCreditPackage.pkg.points_used.toLocaleString()}`}
+            </DialogDescription>
+          </DialogHeader>
+
+          <form
+            onSubmit={handleSubmitCancelCreditPackage}
+            className="space-y-4 mt-4"
+          >
+            <div className="rounded-md bg-red-50 border border-red-200 p-3 text-sm text-red-800">
+              點數包將標記為 refunded
+              並從清單中隱藏。已使用的點數紀錄會保留作為稽核，請填寫刪除原因。
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                刪除原因 <span className="text-red-500">*</span>
+              </label>
+              <Textarea
+                value={creditPackageCancelReason}
+                onChange={(e) => setCreditPackageCancelReason(e.target.value)}
+                placeholder="請說明此次刪除的原因（例如：使用者要求退費）"
+                required
+                rows={3}
+              />
+            </div>
+
+            <div className="flex gap-2 justify-end pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setCreditPackageCancelOpen(false)}
+                disabled={creditPackageSubmitting}
+              >
+                取消
+              </Button>
+              <Button
+                type="submit"
+                variant="destructive"
+                disabled={
+                  creditPackageSubmitting || !creditPackageCancelReason.trim()
+                }
+              >
+                {creditPackageSubmitting ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    處理中
+                  </>
+                ) : (
+                  "確認刪除"
                 )}
               </Button>
             </div>


### PR DESCRIPTION
## Summary
Admins can now edit or refund (soft-delete) a teacher's individual `CreditPackage` row from the 所有訂閱 dashboard. Builds on the audit columns landed in #778.

- **Edit** — change `points_total` and/or `expires_at`. Validates `points_total >= points_used` (422 otherwise) so historical `PointUsageLog` rows stay valid.
- **Refund (soft-delete)** — flips `status` to `refunded`. Row stays in DB so audit + usage logs remain intact; the dashboard list filters it out.
- Both endpoints require a non-empty `reason` (422 otherwise), record `admin_id` / `admin_reason`, and append a structured entry to `admin_metadata.operations[]` — mirrors the existing `SubscriptionPeriod` audit pattern.

## Endpoints
- `PUT /api/admin/subscription/credit-package/{id}` — edit
- `POST /api/admin/subscription/credit-package/{id}/cancel` — refund / soft-delete

Both gated by `Depends(get_current_admin)`. Editing an already-`refunded` package is refused (422).

## Frontend
- `編輯` / `刪除` buttons added to the existing 點數包紀錄 sub-table row.
- Edit dialog: number + date + required reason; client min = `points_used` and disabled-until-reason-non-empty.
- Cancel dialog: required reason + clear warning that the row stays in DB for audit.
- `apiClient.adminEditCreditPackage` / `adminCancelCreditPackage` added.

## Test plan
- [x] 17 backend pytest cases pass: happy path, partial edits, validation (negative / below-used / empty reason / missing reason), permission (admin / non-admin / unauthenticated), 404, already-refunded rejection, audit history accumulation, list filter
- [x] Frontend: `tsc --noEmit` clean, prettier clean, `npm run build` clean
- [ ] Manual: open 所有訂閱 → expand a teacher with a credit package → 編輯 lowers total above used → success and row updates inline
- [ ] Manual: try to lower total below `points_used` → server rejects, dialog stays open with error
- [ ] Manual: 刪除 with reason → row disappears from list; verify in DB that `status='refunded'` and `admin_metadata.operations` has the cancel entry
- [ ] Manual: empty reason field → save button disabled

## Notes
- Other admin domain feedback from PR #778's review (e.g. `ORG_ALLOWED_PACKAGES` cutover, plan caching) is **not** addressed here — those will land in their own follow-up PRs.

Fixes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)