### PR TITLE
fix(#723): resolve Teacher.credit_packages ambiguous FK after admin_id added

### DIFF
--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -188,6 +188,7 @@ class Teacher(Base):
     )
     credit_packages = relationship(
         "CreditPackage",
+        foreign_keys="CreditPackage.teacher_id",
         back_populates="teacher",
         cascade="all, delete-orphan",
         order_by="CreditPackage.expires_at.asc()",


### PR DESCRIPTION
## Summary

- PR #778 (`f86c0806`) added `credit_packages.admin_id` FK → `teachers.id`, creating two FK paths from `credit_packages` to `teachers`.
- `CreditPackage` side specified `foreign_keys=[teacher_id]` / `foreign_keys=[admin_id]` correctly, but `Teacher.credit_packages` did **not** specify `foreign_keys`, so SQLAlchemy could not pick a join path.
- Result: `AmbiguousForeignKeysError` at mapper configure → **`seed-database` step in Per-Issue Deploy CI fails on every run** (e.g. https://github.com/myduotopia/duotopia/actions/runs/26034573530).

## Fix

One-line change in [`backend/models/user.py`](backend/models/user.py): add `foreign_keys="CreditPackage.teacher_id"` to `Teacher.credit_packages` so it pairs with the existing `back_populates="teacher"` on `CreditPackage.teacher`.

## Verification

```
python3 -c "from sqlalchemy.orm import configure_mappers; from models.user import Teacher; from models.credit_package import CreditPackage; configure_mappers()"
✅ Mappers configured OK
```

## Test plan

- [ ] CI green (especially backend tests that load the SQLAlchemy registry)
- [ ] Per-Issue Deploy `seed-database` step succeeds after merge
- [ ] Spot-check Teacher API endpoints still load `credit_packages` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)