### PR TITLE
chore(#632): add cloze_answer column to content_items

### DIFF
--- a/backend/alembic/versions/20260521_1000_add_cloze_answer_to_content_item.py
+++ b/backend/alembic/versions/20260521_1000_add_cloze_answer_to_content_item.py
@@ -1,0 +1,37 @@
+"""add_cloze_answer_to_content_items
+
+Revision ID: 20260521_1000
+Revises: 20260518_1400
+Create Date: 2026-05-21 10:00:00.000000
+
+Issue #632: persist the word-cloze answer (the actual word/phrase form that
+appears in the example sentence) on each vocabulary item. Previously the
+answer was extracted at runtime from the example sentence; persisting it lets
+teachers override it (per assignment copy) and lets the practice endpoint use
+the teacher-confirmed answer. Nullable — existing rows stay NULL and are
+backfilled lazily on next save / via the toast guard (#791).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260521_1000"
+down_revision: Union[str, None] = "20260518_1400"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE content_items
+        ADD COLUMN IF NOT EXISTS cloze_answer TEXT
+        """
+    )
+
+
+def downgrade() -> None:
+    # Additive-only migration policy: do not drop columns on downgrade.
+    pass

--- a/backend/models/program.py
+++ b/backend/models/program.py
@@ -242,6 +242,11 @@ class ContentItem(Base):
     # 儲存格式: ["干擾項1", "干擾項2", "干擾項3"]
     distractors = Column(JSON, nullable=True)
 
+    # 單字克漏字答案（word_cloze 練習用）— 例句中要被挖空的單字/片語的實際變體形式
+    # 例如：base "cup" + 例句 "I have two cups" → cloze_answer = "cups"
+    # 儲存時自動抽取（見 utils/cloze.py），老師可在單字集 / 作業副本中手動覆寫
+    cloze_answer = Column(Text, nullable=True)
+
     item_metadata = Column(JSON, default={})
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(


### PR DESCRIPTION
## Summary
抽出 #632 的 **schema 變更**先行合併到 staging，以解除其他 issue PR 被此 migration 卡住的狀況。

- `content_items` 新增 `cloze_answer TEXT`（idempotent `ADD COLUMN IF NOT EXISTS`，nullable）
- `ContentItem` model 對應欄位
- 純 additive，**無任何行為變更**

讀寫此欄位的功能邏輯（自動抽取、編輯 UI、派發防呆）在 feature PR #792。

## Migration
`backend/alembic/versions/20260521_1000_add_cloze_answer_to_content_item.py`
- `down_revision = 20260518_1400`（目前 staging head）→ 合併後仍為單一 head
- `downgrade()` 不 drop 欄位（additive-only 政策）

## Test plan
- [x] `alembic heads` 確認單一 head（`20260521_1000`）
- [x] model import OK
- [ ] CI seed-database 跑過 migration

## 後續
- Feature PR #792 會 rebase 到含此 migration 的 staging；屆時 #792 內相同的 migration 檔與 model 變更會在 rebase 時自動合一，不會重複。
- Backfill 既有資料另開 #791。

🤖 Generated with [Claude Code](https://claude.com/claude-code)