### PR TITLE
feat(#800): relax mastery + tier-quota selection + cap vocab sets at 2

### DIFF
--- a/backend/alembic/versions/20260522_1000_relax_mastery_and_tier_quota.py
+++ b/backend/alembic/versions/20260522_1000_relax_mastery_and_tier_quota.py
@@ -1,0 +1,494 @@
+"""Relax mastery threshold + tier-quota word selection (issue #800)
+
+Revision ID: 20260522_1000
+Revises: 20260522_0900
+Create Date: 2026-05-22 10:00:00.000000
+
+Changes (issue #800):
+
+1. calculate_assignment_mastery — new tier rules + new weights
+   - T5 master:           diff >= 3 OR repetition_count >= 3
+   - T4 familiar:         diff >= 2 OR repetition_count >= 2 (not T5)
+   - T3 medium:           diff >= 1 (not T4/T5)
+   - T2 unfamiliar:       practiced but diff <= 0 (not T3+)
+   - T1 very_unfamiliar:  never practiced
+   - diff = correct_count - 0.5 * incorrect_count (answers-wrong only -0.5)
+   - weights: T5=1.0 / T4=0.8 / T3=0.6 / T2=0.4 / T1=0
+     (全 T4 練度 = 80%，剛好達預設達標線)
+
+2. get_words_for_practice — discard phase/interval, use tier quotas
+   - Quotas (limit=10): T4=2 / T3=2 / T2=3 / T1=3
+   - Quotas scale proportionally for other limits (cloze passes 30)
+   - Cascade forward when a tier short of supply: T4→T3→T2→T1
+   - Reverse cascade if T1 still unfilled: T1→T2→T3→T4
+   - T5 (mastered) EXCLUDED from candidate pool — never appears
+   - Final output randomized (each round different order)
+   - When fully mastered (all words T5), returns 0 rows; callers detect
+     empty result and surface "全部精熟" UI.
+
+Pure CREATE OR REPLACE; no schema changes; no row mutations. Idempotent.
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "20260522_1000"
+down_revision = "20260522_0900"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. calculate_assignment_mastery — new tier ladder + B1 weights
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION calculate_assignment_mastery(
+            p_student_assignment_id INTEGER
+        ) RETURNS TABLE (
+            current_mastery DECIMAL,
+            target_mastery DECIMAL,
+            achieved BOOLEAN,
+            words_mastered INTEGER,
+            words_master INTEGER,
+            words_familiar INTEGER,
+            words_medium INTEGER,
+            words_unfamiliar INTEGER,
+            words_very_unfamiliar INTEGER,
+            total_words INTEGER
+        ) AS $$
+        DECLARE
+            v_total_words INTEGER;
+            v_t5 INTEGER;
+            v_t4 INTEGER;
+            v_t3 INTEGER;
+            v_t2 INTEGER;
+            v_t1 INTEGER;
+            v_current_mastery DECIMAL;
+            v_target DECIMAL;
+            v_target_proficiency INTEGER;
+        BEGIN
+            SELECT COALESCE(a.target_proficiency, 80) INTO v_target_proficiency
+            FROM student_assignments sa
+            JOIN assignments a ON a.id = sa.assignment_id
+            WHERE sa.id = p_student_assignment_id;
+
+            IF v_target_proficiency IS NULL THEN
+                v_target_proficiency := 80;
+            END IF;
+            v_target := v_target_proficiency / 100.0;
+
+            SELECT COUNT(DISTINCT ci.id) INTO v_total_words
+            FROM student_assignments sa
+            JOIN student_content_progress scp ON scp.student_assignment_id = sa.id
+            JOIN content_items ci ON ci.content_id = scp.content_id
+            WHERE sa.id = p_student_assignment_id;
+
+            IF v_total_words IS NULL OR v_total_words = 0 THEN
+                RETURN QUERY SELECT
+                    0::DECIMAL, v_target, FALSE,
+                    0, 0, 0, 0, 0, 0, 0;
+                RETURN;
+            END IF;
+
+            -- Tier judgement (high tier wins; T5/T4 use OR rule with repetition_count)
+            --   diff = correct_count - 0.5 * incorrect_count
+            SELECT
+                COUNT(*) FILTER (
+                    WHERE (correct_count - 0.5 * incorrect_count) >= 3
+                       OR repetition_count >= 3
+                ),
+                COUNT(*) FILTER (
+                    WHERE NOT (
+                        (correct_count - 0.5 * incorrect_count) >= 3
+                        OR repetition_count >= 3
+                    )
+                    AND (
+                        (correct_count - 0.5 * incorrect_count) >= 2
+                        OR repetition_count >= 2
+                    )
+                ),
+                COUNT(*) FILTER (
+                    WHERE NOT (
+                        (correct_count - 0.5 * incorrect_count) >= 2
+                        OR repetition_count >= 2
+                    )
+                    AND (correct_count - 0.5 * incorrect_count) >= 1
+                ),
+                COUNT(*) FILTER (
+                    WHERE NOT (
+                        (correct_count - 0.5 * incorrect_count) >= 1
+                        OR repetition_count >= 2
+                    )
+                    AND total_attempts > 0
+                )
+            INTO v_t5, v_t4, v_t3, v_t2
+            FROM user_word_progress
+            WHERE student_assignment_id = p_student_assignment_id;
+
+            v_t5 := COALESCE(v_t5, 0);
+            v_t4 := COALESCE(v_t4, 0);
+            v_t3 := COALESCE(v_t3, 0);
+            v_t2 := COALESCE(v_t2, 0);
+            -- T1 = never practiced; compute by subtraction so totals always match
+            v_t1 := v_total_words - v_t5 - v_t4 - v_t3 - v_t2;
+            IF v_t1 < 0 THEN
+                v_t1 := 0;
+            END IF;
+
+            -- B1 weights: T5=1.0 / T4=0.8 / T3=0.6 / T2=0.4 / T1=0
+            -- (全 T4 = 80%，剛好過預設達標)
+            v_current_mastery := (
+                v_t5::DECIMAL
+                + 0.8 * v_t4::DECIMAL
+                + 0.6 * v_t3::DECIMAL
+                + 0.4 * v_t2::DECIMAL
+            ) / GREATEST(v_total_words, 1);
+
+            RETURN QUERY SELECT
+                v_current_mastery,
+                v_target,
+                v_current_mastery >= v_target,
+                v_t5,        -- words_mastered (legacy alias)
+                v_t5,        -- words_master
+                v_t4,        -- words_familiar
+                v_t3,        -- words_medium
+                v_t2,        -- words_unfamiliar
+                v_t1,        -- words_very_unfamiliar
+                v_total_words;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # 2. get_words_for_practice — tier-quota selection + cascade + exclude T5
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION get_words_for_practice(
+            p_student_assignment_id INTEGER,
+            p_limit_count INTEGER DEFAULT 10
+        ) RETURNS TABLE (
+            content_item_id INTEGER,
+            text TEXT,
+            translation TEXT,
+            example_sentence TEXT,
+            example_sentence_translation TEXT,
+            audio_url TEXT,
+            image_url TEXT,
+            memory_strength DECIMAL,
+            priority_score DECIMAL
+        ) AS $$
+        -- Tell PL/pgSQL to prefer table columns over OUT-parameter names
+        -- (RETURNS TABLE declares content_item_id etc. as ambient variables,
+        -- which would otherwise shadow column references in subqueries.)
+        #variable_conflict use_column
+        DECLARE
+            -- Quotas scale to p_limit_count; defaults (limit=10): 2/2/3/3
+            v_q4 INTEGER;
+            v_q3 INTEGER;
+            v_q2 INTEGER;
+            v_q1 INTEGER;
+            v_taken INTEGER;
+            v_unfilled INTEGER;
+        BEGIN
+            -- Compute quotas (ratios 0.2 / 0.2 / 0.3 / 0.3)
+            v_q4 := GREATEST(1, ROUND(p_limit_count::numeric * 0.2)::INTEGER);
+            v_q3 := GREATEST(1, ROUND(p_limit_count::numeric * 0.2)::INTEGER);
+            v_q2 := GREATEST(1, ROUND(p_limit_count::numeric * 0.3)::INTEGER);
+            v_q1 := p_limit_count - v_q4 - v_q3 - v_q2;
+            IF v_q1 < 1 THEN
+                v_q1 := 1;
+                v_q2 := p_limit_count - v_q4 - v_q3 - v_q1;
+                IF v_q2 < 0 THEN v_q2 := 0; END IF;
+            END IF;
+
+            -- Drop temp tables if already exist (re-entrance safety)
+            DROP TABLE IF EXISTS _gwfp_pool;
+            DROP TABLE IF EXISTS _gwfp_picked;
+
+            -- Build candidate pool tagged with tier; EXCLUDE T5 (mastered)
+            CREATE TEMP TABLE _gwfp_pool ON COMMIT DROP AS
+            SELECT
+                ci.id AS content_item_id,
+                ci.text,
+                ci.translation,
+                ci.example_sentence,
+                ci.example_sentence_translation,
+                ci.audio_url,
+                ci.image_url,
+                COALESCE(uwp.memory_strength, 0)::DECIMAL AS memory_strength,
+                CASE
+                    WHEN (COALESCE(uwp.correct_count, 0)
+                          - 0.5 * COALESCE(uwp.incorrect_count, 0)) >= 2
+                      OR COALESCE(uwp.repetition_count, 0) >= 2 THEN 4
+                    WHEN (COALESCE(uwp.correct_count, 0)
+                          - 0.5 * COALESCE(uwp.incorrect_count, 0)) >= 1 THEN 3
+                    WHEN uwp.id IS NOT NULL
+                         AND COALESCE(uwp.total_attempts, 0) > 0 THEN 2
+                    ELSE 1
+                END AS tier
+            FROM student_assignments sa
+            JOIN student_content_progress scp
+                ON scp.student_assignment_id = sa.id
+            JOIN content_items ci
+                ON ci.content_id = scp.content_id
+            LEFT JOIN user_word_progress uwp
+                ON uwp.student_assignment_id = p_student_assignment_id
+                AND uwp.content_item_id = ci.id
+            WHERE sa.id = p_student_assignment_id
+              -- Exclude T5 (mastered): never appears
+              AND NOT (
+                  (COALESCE(uwp.correct_count, 0)
+                   - 0.5 * COALESCE(uwp.incorrect_count, 0)) >= 3
+                  OR COALESCE(uwp.repetition_count, 0) >= 3
+              );
+
+            CREATE TEMP TABLE _gwfp_picked (
+                content_item_id INTEGER PRIMARY KEY
+            ) ON COMMIT DROP;
+
+            -- ===== Forward cascade T4 → T3 → T2 → T1 =====
+            INSERT INTO _gwfp_picked
+            SELECT p.content_item_id FROM _gwfp_pool p
+            WHERE p.tier = 4
+            ORDER BY RANDOM()
+            LIMIT v_q4;
+            GET DIAGNOSTICS v_taken = ROW_COUNT;
+            v_q3 := v_q3 + (v_q4 - v_taken);
+
+            INSERT INTO _gwfp_picked
+            SELECT p.content_item_id FROM _gwfp_pool p
+            WHERE p.tier = 3
+              AND p.content_item_id NOT IN (SELECT content_item_id FROM _gwfp_picked)
+            ORDER BY RANDOM()
+            LIMIT v_q3;
+            GET DIAGNOSTICS v_taken = ROW_COUNT;
+            v_q2 := v_q2 + (v_q3 - v_taken);
+
+            INSERT INTO _gwfp_picked
+            SELECT p.content_item_id FROM _gwfp_pool p
+            WHERE p.tier = 2
+              AND p.content_item_id NOT IN (SELECT content_item_id FROM _gwfp_picked)
+            ORDER BY RANDOM()
+            LIMIT v_q2;
+            GET DIAGNOSTICS v_taken = ROW_COUNT;
+            v_q1 := v_q1 + (v_q2 - v_taken);
+
+            INSERT INTO _gwfp_picked
+            SELECT p.content_item_id FROM _gwfp_pool p
+            WHERE p.tier = 1
+              AND p.content_item_id NOT IN (SELECT content_item_id FROM _gwfp_picked)
+            ORDER BY RANDOM()
+            LIMIT v_q1;
+            GET DIAGNOSTICS v_taken = ROW_COUNT;
+            v_unfilled := v_q1 - v_taken;
+
+            -- ===== Reverse cascade T1 → T2 → T3 → T4 (only if still unfilled) =====
+            IF v_unfilled > 0 THEN
+                INSERT INTO _gwfp_picked
+                SELECT p.content_item_id FROM _gwfp_pool p
+                WHERE p.tier = 2
+                  AND p.content_item_id NOT IN (SELECT content_item_id FROM _gwfp_picked)
+                ORDER BY RANDOM()
+                LIMIT v_unfilled;
+                GET DIAGNOSTICS v_taken = ROW_COUNT;
+                v_unfilled := v_unfilled - v_taken;
+            END IF;
+            IF v_unfilled > 0 THEN
+                INSERT INTO _gwfp_picked
+                SELECT p.content_item_id FROM _gwfp_pool p
+                WHERE p.tier = 3
+                  AND p.content_item_id NOT IN (SELECT content_item_id FROM _gwfp_picked)
+                ORDER BY RANDOM()
+                LIMIT v_unfilled;
+                GET DIAGNOSTICS v_taken = ROW_COUNT;
+                v_unfilled := v_unfilled - v_taken;
+            END IF;
+            IF v_unfilled > 0 THEN
+                INSERT INTO _gwfp_picked
+                SELECT p.content_item_id FROM _gwfp_pool p
+                WHERE p.tier = 4
+                  AND p.content_item_id NOT IN (SELECT content_item_id FROM _gwfp_picked)
+                ORDER BY RANDOM()
+                LIMIT v_unfilled;
+            END IF;
+
+            -- ===== Return picked words in randomized order =====
+            RETURN QUERY
+            SELECT
+                p.content_item_id,
+                p.text,
+                p.translation,
+                p.example_sentence,
+                p.example_sentence_translation,
+                p.audio_url,
+                p.image_url,
+                p.memory_strength,
+                -- priority_score: kept for API back-compat (lower tier = higher score)
+                CASE p.tier
+                    WHEN 4 THEN 30::DECIMAL
+                    WHEN 3 THEN 50::DECIMAL
+                    WHEN 2 THEN 70::DECIMAL
+                    ELSE 100::DECIMAL
+                END AS priority_score
+            FROM _gwfp_pool p
+            JOIN _gwfp_picked pk ON pk.content_item_id = p.content_item_id
+            ORDER BY RANDOM();
+
+            DROP TABLE IF EXISTS _gwfp_picked;
+            DROP TABLE IF EXISTS _gwfp_pool;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Restore diff-based ladder (20260509_1300) for calculate_assignment_mastery
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION calculate_assignment_mastery(
+            p_student_assignment_id INTEGER
+        ) RETURNS TABLE (
+            current_mastery DECIMAL,
+            target_mastery DECIMAL,
+            achieved BOOLEAN,
+            words_mastered INTEGER,
+            words_master INTEGER,
+            words_familiar INTEGER,
+            words_medium INTEGER,
+            words_unfamiliar INTEGER,
+            words_very_unfamiliar INTEGER,
+            total_words INTEGER
+        ) AS $$
+        DECLARE
+            v_total_words INTEGER;
+            v_t5 INTEGER;
+            v_t4 INTEGER;
+            v_t3 INTEGER;
+            v_t2 INTEGER;
+            v_t1 INTEGER;
+            v_current_mastery DECIMAL;
+            v_target DECIMAL;
+            v_target_proficiency INTEGER;
+        BEGIN
+            SELECT COALESCE(a.target_proficiency, 80) INTO v_target_proficiency
+            FROM student_assignments sa
+            JOIN assignments a ON a.id = sa.assignment_id
+            WHERE sa.id = p_student_assignment_id;
+            IF v_target_proficiency IS NULL THEN
+                v_target_proficiency := 80;
+            END IF;
+            v_target := v_target_proficiency / 100.0;
+            SELECT COUNT(DISTINCT ci.id) INTO v_total_words
+            FROM student_assignments sa
+            JOIN student_content_progress scp ON scp.student_assignment_id = sa.id
+            JOIN content_items ci ON ci.content_id = scp.content_id
+            WHERE sa.id = p_student_assignment_id;
+            IF v_total_words IS NULL OR v_total_words = 0 THEN
+                RETURN QUERY SELECT 0::DECIMAL, v_target, FALSE, 0, 0, 0, 0, 0, 0, 0;
+                RETURN;
+            END IF;
+            SELECT
+                COUNT(*) FILTER (WHERE (correct_count - incorrect_count) >= 4),
+                COUNT(*) FILTER (WHERE (correct_count - incorrect_count) = 3),
+                COUNT(*) FILTER (WHERE (correct_count - incorrect_count) = 2),
+                COUNT(*) FILTER (WHERE (correct_count - incorrect_count) = 1)
+            INTO v_t5, v_t4, v_t3, v_t2
+            FROM user_word_progress
+            WHERE student_assignment_id = p_student_assignment_id;
+            v_t5 := COALESCE(v_t5, 0);
+            v_t4 := COALESCE(v_t4, 0);
+            v_t3 := COALESCE(v_t3, 0);
+            v_t2 := COALESCE(v_t2, 0);
+            v_t1 := v_total_words - v_t5 - v_t4 - v_t3 - v_t2;
+            IF v_t1 < 0 THEN v_t1 := 0; END IF;
+            v_current_mastery := (
+                v_t5::DECIMAL
+                + 0.75 * v_t4::DECIMAL
+                + 0.5  * v_t3::DECIMAL
+                + 0.25 * v_t2::DECIMAL
+            ) / GREATEST(v_total_words, 1);
+            RETURN QUERY SELECT
+                v_current_mastery, v_target, v_current_mastery >= v_target,
+                v_t5, v_t5, v_t4, v_t3, v_t2, v_t1, v_total_words;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+    # Restore phase-based get_words_for_practice (20260303_1000)
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION get_words_for_practice(
+            p_student_assignment_id INTEGER,
+            p_limit_count INTEGER DEFAULT 10
+        ) RETURNS TABLE (
+            content_item_id INTEGER,
+            text TEXT,
+            translation TEXT,
+            example_sentence TEXT,
+            example_sentence_translation TEXT,
+            audio_url TEXT,
+            image_url TEXT,
+            memory_strength DECIMAL,
+            priority_score DECIMAL
+        ) AS $$
+        BEGIN
+            RETURN QUERY
+            WITH assignment_words AS (
+                SELECT DISTINCT ci.id as content_item_id
+                FROM student_assignments sa
+                JOIN student_content_progress scp
+                    ON scp.student_assignment_id = sa.id
+                JOIN content_items ci
+                    ON ci.content_id = scp.content_id
+                WHERE sa.id = p_student_assignment_id
+            ),
+            categorized AS (
+                SELECT
+                    ci.id,
+                    ci.text,
+                    ci.translation,
+                    ci.example_sentence,
+                    ci.example_sentence_translation,
+                    ci.audio_url,
+                    ci.image_url,
+                    COALESCE(uwp.memory_strength, 0) as memory_strength,
+                    CASE
+                        WHEN uwp.id IS NULL THEN 1
+                        WHEN uwp.next_review_at IS NULL THEN 1
+                        WHEN uwp.next_review_at <= NOW() THEN 2
+                        ELSE 3
+                    END as phase
+                FROM assignment_words aw
+                JOIN content_items ci ON ci.id = aw.content_item_id
+                LEFT JOIN user_word_progress uwp ON
+                    uwp.student_assignment_id = p_student_assignment_id
+                    AND uwp.content_item_id = ci.id
+            )
+            SELECT
+                c.id,
+                c.text,
+                c.translation,
+                c.example_sentence,
+                c.example_sentence_translation,
+                c.audio_url,
+                c.image_url,
+                c.memory_strength,
+                CASE c.phase
+                    WHEN 1 THEN 100::DECIMAL
+                    WHEN 2 THEN (50 + (1 - c.memory_strength) * 50)::DECIMAL
+                    ELSE ((1 - c.memory_strength) * 30)::DECIMAL
+                END as priority_score
+            FROM categorized c
+            ORDER BY c.phase ASC, c.memory_strength ASC, RANDOM()
+            LIMIT p_limit_count;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )

--- a/backend/alembic/versions/20260522_1000_relax_mastery_and_tier_quota.py
+++ b/backend/alembic/versions/20260522_1000_relax_mastery_and_tier_quota.py
@@ -118,6 +118,11 @@ def upgrade() -> None:
                     AND (correct_count - 0.5 * incorrect_count) >= 1
                 ),
                 COUNT(*) FILTER (
+                    -- T2 = practiced but didn't qualify for T3/T4/T5.
+                    -- repetition_count >= 2 is excluded here because it
+                    -- already lifts a word to T4 via the OR rule above —
+                    -- without this exclusion a rep=2/diff=0 word would
+                    -- be double-counted in both T4 and T2.
                     WHERE NOT (
                         (correct_count - 0.5 * incorrect_count) >= 1
                         OR repetition_count >= 2
@@ -337,7 +342,13 @@ def upgrade() -> None:
                 END AS priority_score
             FROM _gwfp_pool p
             JOIN _gwfp_picked pk ON pk.content_item_id = p.content_item_id
-            ORDER BY RANDOM();
+            ORDER BY RANDOM()
+            -- Safety cap: GREATEST(1, ...) floor on per-tier quotas can in
+            -- theory sum to slightly more than p_limit_count for tiny
+            -- limits (e.g. p_limit_count = 2). Known callers pass 10 / 30
+            -- so this never fires in practice, but the explicit LIMIT
+            -- keeps the contract honest for future callers.
+            LIMIT p_limit_count;
 
             DROP TABLE IF EXISTS _gwfp_picked;
             DROP TABLE IF EXISTS _gwfp_pool;

--- a/backend/routers/assignments/crud.py
+++ b/backend/routers/assignments/crud.py
@@ -257,6 +257,23 @@ async def create_assignment(
     if len(contents) != len(request.content_ids):
         raise HTTPException(status_code=404, detail="Some contents not found")
 
+    # Issue #800: cap vocabulary sets per assignment (defence-in-depth;
+    # the UI already disables further selections once the limit is hit).
+    # Two sets is roomy for a week-long assignment; more makes the
+    # practice pool feel endless. SENTENCE_MAKING is the legacy alias
+    # for VOCABULARY_SET — count both.
+    vocab_count = sum(
+        1
+        for c in contents
+        if c.type
+        in (ContentType.VOCABULARY_SET, ContentType.SENTENCE_MAKING)
+    )
+    if vocab_count > 2:
+        raise HTTPException(
+            status_code=400,
+            detail=f"At most 2 vocabulary sets per assignment (got {vocab_count})",
+        )
+
     # Issue #673 / #757: block reading / rearrangement / word_cloze on vocab
     # contents whose items don't carry example_sentence + translation, and
     # additionally block the listening-flavoured modes when example sentence

--- a/backend/routers/assignments/crud.py
+++ b/backend/routers/assignments/crud.py
@@ -265,8 +265,7 @@ async def create_assignment(
     vocab_count = sum(
         1
         for c in contents
-        if c.type
-        in (ContentType.VOCABULARY_SET, ContentType.SENTENCE_MAKING)
+        if c.type in (ContentType.VOCABULARY_SET, ContentType.SENTENCE_MAKING)
     )
     if vocab_count > 2:
         raise HTTPException(

--- a/backend/routers/students/assignments.py
+++ b/backend/routers/students/assignments.py
@@ -1503,7 +1503,7 @@ async def start_word_selection_practice(
     # excluded from the candidate pool by get_words_for_practice. Frontend
     # uses this to show the "全部精熟" celebration instead of an empty state.
     all_mastered = (
-        total_words_in_assignment > 0 and words_mastered >= total_words_in_assignment
+        total_words_in_assignment > 0 and words_mastered == total_words_in_assignment
     )
 
     return {
@@ -2106,7 +2106,7 @@ async def start_word_spelling_practice(
 
     # Issue #800: see selection endpoint for all_mastered rationale.
     all_mastered = (
-        total_words_in_assignment > 0 and words_mastered >= total_words_in_assignment
+        total_words_in_assignment > 0 and words_mastered == total_words_in_assignment
     )
 
     return {
@@ -2807,7 +2807,7 @@ async def start_word_cloze_practice(
     # contains the target word — that's a different empty state, handled by
     # the existing "no cloze questions available" UI.
     all_mastered = (
-        total_words_in_assignment > 0 and words_mastered >= total_words_in_assignment
+        total_words_in_assignment > 0 and words_mastered == total_words_in_assignment
     )
 
     return {

--- a/backend/routers/students/assignments.py
+++ b/backend/routers/students/assignments.py
@@ -1499,6 +1499,14 @@ async def start_word_selection_practice(
     # Issue #460: Tell frontend if this is practice-only mode (already submitted)
     is_practice_mode = student_assignment.status == AssignmentStatus.GRADED
 
+    # Issue #800: all_mastered means every word reached T5 and is therefore
+    # excluded from the candidate pool by get_words_for_practice. Frontend
+    # uses this to show the "全部精熟" celebration instead of an empty state.
+    all_mastered = (
+        total_words_in_assignment > 0
+        and words_mastered >= total_words_in_assignment
+    )
+
     return {
         "session_id": practice_session.id,
         "words": words_with_options,
@@ -1508,6 +1516,7 @@ async def start_word_selection_practice(
         "words_mastered": words_mastered,
         **tier_counts,
         "achieved": achieved,
+        "all_mastered": all_mastered,
         "is_practice_mode": is_practice_mode,
         "show_word": assignment.show_word if assignment else True,
         "show_image": assignment.show_image if assignment else True,
@@ -2096,6 +2105,12 @@ async def start_word_spelling_practice(
     tier_counts = _tier_counts(mastery_result)
     is_practice_mode = student_assignment.status == AssignmentStatus.GRADED
 
+    # Issue #800: see selection endpoint for all_mastered rationale.
+    all_mastered = (
+        total_words_in_assignment > 0
+        and words_mastered >= total_words_in_assignment
+    )
+
     return {
         "session_id": practice_session.id,
         "words": words_data,
@@ -2105,6 +2120,7 @@ async def start_word_spelling_practice(
         "words_mastered": words_mastered,
         **tier_counts,
         "achieved": achieved,
+        "all_mastered": all_mastered,
         "is_practice_mode": is_practice_mode,
         "show_translation": (assignment.show_translation if assignment else True),
         "show_image": assignment.show_image if assignment else True,
@@ -2788,6 +2804,15 @@ async def start_word_cloze_practice(
     tier_counts = _tier_counts(mastery_result)
     is_practice_mode = student_assignment.status == AssignmentStatus.GRADED
 
+    # Issue #800: see selection endpoint for all_mastered rationale.
+    # Note: cloze may also return empty `questions` when no example sentence
+    # contains the target word — that's a different empty state, handled by
+    # the existing "no cloze questions available" UI.
+    all_mastered = (
+        total_words_in_assignment > 0
+        and words_mastered >= total_words_in_assignment
+    )
+
     return {
         "session_id": practice_session.id,
         "questions": questions,
@@ -2797,6 +2822,7 @@ async def start_word_cloze_practice(
         "words_mastered": words_mastered,
         **tier_counts,
         "achieved": achieved,
+        "all_mastered": all_mastered,
         "is_practice_mode": is_practice_mode,
         "show_translation": (assignment.show_translation if assignment else True),
         "play_audio": assignment.play_audio if assignment else False,

--- a/backend/routers/students/assignments.py
+++ b/backend/routers/students/assignments.py
@@ -1503,8 +1503,7 @@ async def start_word_selection_practice(
     # excluded from the candidate pool by get_words_for_practice. Frontend
     # uses this to show the "全部精熟" celebration instead of an empty state.
     all_mastered = (
-        total_words_in_assignment > 0
-        and words_mastered >= total_words_in_assignment
+        total_words_in_assignment > 0 and words_mastered >= total_words_in_assignment
     )
 
     return {
@@ -2107,8 +2106,7 @@ async def start_word_spelling_practice(
 
     # Issue #800: see selection endpoint for all_mastered rationale.
     all_mastered = (
-        total_words_in_assignment > 0
-        and words_mastered >= total_words_in_assignment
+        total_words_in_assignment > 0 and words_mastered >= total_words_in_assignment
     )
 
     return {
@@ -2809,8 +2807,7 @@ async def start_word_cloze_practice(
     # contains the target word — that's a different empty state, handled by
     # the existing "no cloze questions available" UI.
     all_mastered = (
-        total_words_in_assignment > 0
-        and words_mastered >= total_words_in_assignment
+        total_words_in_assignment > 0 and words_mastered >= total_words_in_assignment
     )
 
     return {

--- a/backend/tests/unit/test_word_familiarity_tier_711.py
+++ b/backend/tests/unit/test_word_familiarity_tier_711.py
@@ -134,6 +134,12 @@ class TestClassifyTierRepetitionPath:
     def test_repetition_two_qualifies_t4(self):
         assert classify_tier(2, 0, 2) == "familiar"
 
+    def test_repetition_two_qualifies_t4_even_with_low_diff(self):
+        # diff = 1 - 0.5 = 0.5 → would be T3 by diff alone.
+        # rep=2 short-circuits the OR rule and lifts to T4.
+        # Isolates the repetition-only path from the diff path.
+        assert classify_tier(1, 1, 2) == "familiar"
+
     def test_repetition_one_does_not_lift_to_t4(self):
         # rep=1 doesn't trigger the OR. Falls through to diff path.
         # 1 correct + 0 wrong + rep=1 → diff=1 → T3.

--- a/backend/tests/unit/test_word_familiarity_tier_711.py
+++ b/backend/tests/unit/test_word_familiarity_tier_711.py
@@ -1,29 +1,36 @@
 """
-Tests for issue #711: diff-based 5-tier familiarity classification.
+Tests for issue #800: relaxed tier classification with repetition-count
+fallback and half-weight error penalty.
 
-The new ``calculate_assignment_mastery`` SQL function classifies each word in
-a vocabulary assignment into one of five tiers based on the *net* number of
-correct answers. Errors directly cancel out previous correct answers:
+Replaces the diff-based rules from issue #711. Each word is still classified
+into one of five tiers, but the rules now look at *two* fields and use a
+softer "diff" (errors only -0.5):
 
-    diff = correct_count - incorrect_count
+    diff = correct_count - 0.5 * incorrect_count
 
-    master           (精熟)    diff >= 4   weight 1.00
-    familiar         (熟悉)    diff == 3   weight 0.75
-    medium           (普通)    diff == 2   weight 0.50
-    unfamiliar       (不熟悉)  diff == 1   weight 0.25
-    very_unfamiliar  (非常不熟) diff <= 0   weight 0.00 (incl. unpracticed)
+    T5 master           diff >= 3  OR  repetition_count >= 3   weight 1.0
+    T4 familiar         diff >= 2  OR  repetition_count >= 2   weight 0.8   (not T5)
+    T3 medium           diff >= 1                              weight 0.6   (not T4/T5)
+    T2 unfamiliar       practiced (total_attempts > 0)         weight 0.4   (not T3+)
+    T1 very_unfamiliar  never practiced                        weight 0.0
 
     current_mastery =
-        (master + 0.75*familiar + 0.5*medium + 0.25*unfamiliar) / total_words
+        (T5 + 0.8*T4 + 0.6*T3 + 0.4*T2) / total_words
 
-So one master word raises mastery by exactly 1/total_words; one familiar
-by 0.75/total_words; etc. current_mastery == 1.0 still strictly requires
-every word at master tier (other tiers contribute at most 0.75 each).
+Why the change (from issue #800):
+- Old "diff >= 4 -> master" required 4 consecutive corrects with no errors;
+  teachers/students reported targets were unreachable in a 5-day window.
+- 0.5 penalty for errors lets one mistake cost only half a step, not a
+  whole one — students who recover are not permanently penalised.
+- The OR-on-repetition_count short-circuit means "answered correctly 3
+  times in a row, regardless of past mistakes" is enough to count as
+  master. This is the intuitive teacher mental model.
+- New weights mean "every word at T4 (連對 2 次)" reaches 80%, which is
+  the default target proficiency. The previous 0.75 weight at T4 fell
+  short of the default threshold.
 
 These tests replicate the SQL logic in pure Python so they run without a
-database. They cover every spec point and the dogfood scenario where a 6-word
-assignment with N rounds of all-correct lands every word in the matching
-tier (1 round → unfamiliar 25%, 2 → medium 50%, 3 → familiar 75%, 4 → master 100%).
+database.
 """
 
 from typing import List, Tuple
@@ -31,43 +38,54 @@ from typing import List, Tuple
 
 TIER_WEIGHTS = {
     "master": 1.0,
-    "familiar": 0.75,
-    "medium": 0.5,
-    "unfamiliar": 0.25,
+    "familiar": 0.8,
+    "medium": 0.6,
+    "unfamiliar": 0.4,
     "very_unfamiliar": 0.0,
 }
 
 
-def classify_tier(correct: int, incorrect: int) -> str:
-    """Pure-Python replica of the SQL diff-based classification."""
-    diff = correct - incorrect
-    if diff >= 4:
+def classify_tier(correct: int, incorrect: int, repetition: int) -> str:
+    """Pure-Python replica of the SQL tier classification (issue #800).
+
+    diff = correct - 0.5 * incorrect
+    """
+    diff = correct - 0.5 * incorrect
+    # T5 / T4 use OR with repetition_count
+    if diff >= 3 or repetition >= 3:
         return "master"
-    if diff == 3:
+    if diff >= 2 or repetition >= 2:
         return "familiar"
-    if diff == 2:
+    if diff >= 1:
         return "medium"
-    if diff == 1:
+    if correct + incorrect > 0:
         return "unfamiliar"
     return "very_unfamiliar"
 
 
-def assignment_mastery(words: List[Tuple[int, int]], total_words: int) -> dict:
+def assignment_mastery(
+    words: List[Tuple[int, int, int]], total_words: int
+) -> dict:
     """Replica of ``calculate_assignment_mastery`` aggregation.
 
-    ``words`` is a list of (correct_count, incorrect_count) tuples — one per
-    practiced word. Words without a row are absent; ``total_words`` includes
-    them and they fall into ``very_unfamiliar``.
+    ``words`` is a list of (correct_count, incorrect_count, repetition_count)
+    tuples — one per practiced word. Words without a row fall into
+    ``very_unfamiliar`` by subtraction.
     """
     counts = {tier: 0 for tier in TIER_WEIGHTS}
-    for c, i in words:
-        counts[classify_tier(c, i)] += 1
-    accounted = sum(counts[t] for t in ("master", "familiar", "medium", "unfamiliar"))
+    for c, i, r in words:
+        counts[classify_tier(c, i, r)] += 1
+    accounted = sum(
+        counts[t] for t in ("master", "familiar", "medium", "unfamiliar")
+    )
     counts["very_unfamiliar"] = max(0, total_words - accounted)
     if total_words == 0:
         current = 0.0
     else:
-        current = sum(TIER_WEIGHTS[t] * counts[t] for t in TIER_WEIGHTS) / total_words
+        current = (
+            sum(TIER_WEIGHTS[t] * counts[t] for t in TIER_WEIGHTS)
+            / total_words
+        )
     return {
         "current_mastery": current,
         **counts,
@@ -75,127 +93,120 @@ def assignment_mastery(words: List[Tuple[int, int]], total_words: int) -> dict:
     }
 
 
-# ---------------------------------------------------------------------------
-# Per-row classification: every diff value
-# ---------------------------------------------------------------------------
-
-
-class TestClassifyTier:
+class TestClassifyTierDiffPath:
     def test_no_practice_is_very_unfamiliar(self):
-        # diff = 0 - 0 = 0 → T1.
-        assert classify_tier(0, 0) == "very_unfamiliar"
+        assert classify_tier(0, 0, 0) == "very_unfamiliar"
 
-    def test_only_wrong_answers_is_very_unfamiliar(self):
-        # Companion to #452: a word the student has only ever answered
-        # wrong is treated the same as never-practiced.
-        assert classify_tier(0, 5) == "very_unfamiliar"
+    def test_practiced_only_wrong_is_unfamiliar_not_very(self):
+        assert classify_tier(0, 5, 0) == "unfamiliar"
 
-    def test_diff_zero_with_practice_is_very_unfamiliar(self):
-        # 5 right + 5 wrong → diff = 0. Practice quantity does not save
-        # the tier — only the *net* matters.
-        assert classify_tier(5, 5) == "very_unfamiliar"
+    def test_diff_one_is_medium(self):
+        assert classify_tier(1, 0, 1) == "medium"
+        assert classify_tier(3, 4, 0) == "medium"  # 3 - 2.0 = 1.0
 
-    def test_diff_one_is_unfamiliar(self):
-        assert classify_tier(1, 0) == "unfamiliar"
-        assert classify_tier(2, 1) == "unfamiliar"
-        assert classify_tier(10, 9) == "unfamiliar"
+    def test_diff_two_is_familiar(self):
+        assert classify_tier(2, 0, 2) == "familiar"
+        assert classify_tier(3, 2, 0) == "familiar"  # 3 - 1.0 = 2.0
 
-    def test_diff_two_is_medium(self):
-        assert classify_tier(2, 0) == "medium"
-        assert classify_tier(3, 1) == "medium"
+    def test_diff_three_is_master(self):
+        assert classify_tier(3, 0, 3) == "master"
+        assert classify_tier(5, 4, 0) == "master"  # 5 - 2.0 = 3.0
 
-    def test_diff_three_is_familiar(self):
-        assert classify_tier(3, 0) == "familiar"
-        assert classify_tier(4, 1) == "familiar"
+    def test_higher_diff_stays_master(self):
+        assert classify_tier(10, 0, 10) == "master"
+        assert classify_tier(20, 30, 0) == "master"  # 20 - 15 = 5
 
-    def test_diff_four_is_master(self):
-        assert classify_tier(4, 0) == "master"
+    def test_half_penalty_keeps_word_at_t4(self):
+        # 3 correct + 1 wrong: diff = 2.5 → T4 familiar
+        # (Old #711 diff=2 → T3 medium; new is more forgiving.)
+        assert classify_tier(3, 1, 0) == "familiar"
 
-    def test_diff_above_four_stays_master(self):
-        assert classify_tier(5, 0) == "master"
-        assert classify_tier(10, 6) == "master"  # diff=4 even with 6 errors
-
-    def test_negative_diff_is_very_unfamiliar(self):
-        # More wrong than right ⇒ effectively no progress.
-        assert classify_tier(2, 5) == "very_unfamiliar"
+    def test_one_slip_after_three_corrects_stays_master(self):
+        # 4 correct + 1 wrong: diff = 3.5 → T5 master
+        # (Old #711: diff=3 → T4; new keeps the master label.)
+        assert classify_tier(4, 1, 0) == "master"
 
 
-# ---------------------------------------------------------------------------
-# Aggregate / mastery formula
-# ---------------------------------------------------------------------------
+class TestClassifyTierRepetitionPath:
+    def test_three_consecutive_correct_qualifies_master(self):
+        # 4 correct, 2 wrong, rep=3 — diff = 4 - 1 = 3 also qualifies,
+        # but the OR short-circuit means rep alone would be enough.
+        assert classify_tier(4, 2, 3) == "master"
+
+    def test_repetition_can_lift_above_diff_tier(self):
+        # diff = 3 - 0.5 = 2.5 → would be T4 by diff alone.
+        # rep>=3 short-circuits to T5.
+        assert classify_tier(3, 1, 3) == "master"
+
+    def test_repetition_two_qualifies_t4(self):
+        assert classify_tier(2, 0, 2) == "familiar"
+
+    def test_repetition_one_does_not_lift_to_t4(self):
+        # rep=1 doesn't trigger the OR. Falls through to diff path.
+        # 1 correct + 0 wrong + rep=1 → diff=1 → T3.
+        assert classify_tier(1, 0, 1) == "medium"
+
+    def test_lost_repetition_after_error_falls_back_to_diff(self):
+        # 4 correct, 1 wrong, rep=0 (error was last).
+        # diff = 4 - 0.5 = 3.5 → T5 still (via diff path).
+        assert classify_tier(4, 1, 0) == "master"
 
 
 class TestAssignmentMastery:
-    def test_unpracticed_assignment_has_zero_mastery_and_all_very_unfamiliar(self):
+    def test_unpracticed_assignment_has_zero_mastery(self):
         result = assignment_mastery([], total_words=10)
         assert result["current_mastery"] == 0.0
         assert result["very_unfamiliar"] == 10
 
-    def test_six_words_one_round_correct_is_25_percent(self):
-        # diff = 1 → T2 → weight 0.25 → 0.25 * 6 / 6 = 0.25
-        result = assignment_mastery([(1, 0)] * 6, total_words=6)
-        assert result["unfamiliar"] == 6
-        assert abs(result["current_mastery"] - 0.25) < 1e-9
+    def test_all_t4_reaches_default_target_proficiency(self):
+        # Key behaviour: every word T4 = mastery 0.8 = default 80% target.
+        result = assignment_mastery([(2, 0, 2)] * 10, total_words=10)
+        assert result["familiar"] == 10
+        assert abs(result["current_mastery"] - 0.8) < 1e-9
 
-    def test_six_words_two_rounds_correct_is_50_percent(self):
-        # diff = 2 → T3 → 0.5 * 6 / 6 = 0.5
-        result = assignment_mastery([(2, 0)] * 6, total_words=6)
-        assert result["medium"] == 6
-        assert abs(result["current_mastery"] - 0.5) < 1e-9
-
-    def test_six_words_three_rounds_correct_is_75_percent(self):
-        # diff = 3 → T4 → 0.75 * 6 / 6 = 0.75
-        result = assignment_mastery([(3, 0)] * 6, total_words=6)
-        assert result["familiar"] == 6
-        assert abs(result["current_mastery"] - 0.75) < 1e-9
-
-    def test_six_words_four_rounds_correct_is_full_mastery(self):
-        # diff = 4 → T5 → 1.0
-        result = assignment_mastery([(4, 0)] * 6, total_words=6)
+    def test_all_t5_gives_full_mastery(self):
+        result = assignment_mastery([(3, 0, 3)] * 6, total_words=6)
         assert result["master"] == 6
         assert result["current_mastery"] == 1.0
 
-    def test_one_master_raises_mastery_by_one_over_total(self):
-        result = assignment_mastery([(4, 0)], total_words=6)
-        assert result["master"] == 1
-        assert abs(result["current_mastery"] - 1 / 6) < 1e-9
-
     def test_mixed_distribution_weights_correctly(self):
-        # diff: 4 → T5, 3 → T4, 2 → T3, 1 → T2, 0 → T1
-        # mastery = (1 + 0.75 + 0.5 + 0.25 + 0) / 5 = 0.5
+        # 1 T5 + 1 T4 + 1 T3 + 1 T2 + 1 T1
+        # = (1 + 0.8 + 0.6 + 0.4 + 0) / 5 = 2.8 / 5 = 0.56
         result = assignment_mastery(
-            [(4, 0), (3, 0), (2, 0), (1, 0)],
-            total_words=5,
+            [
+                (3, 0, 3),  # T5
+                (2, 0, 2),  # T4
+                (1, 0, 1),  # T3
+                (1, 2, 0),  # T2 (practiced, diff=0)
+            ],
+            total_words=5,  # 5th word never practiced → T1
         )
         assert result["master"] == 1
         assert result["familiar"] == 1
         assert result["medium"] == 1
         assert result["unfamiliar"] == 1
         assert result["very_unfamiliar"] == 1
-        assert abs(result["current_mastery"] - 0.5) < 1e-9
+        assert abs(result["current_mastery"] - 0.56) < 1e-9
 
-    def test_full_mastery_strictly_requires_every_word_at_master(self):
-        # All-familiar tops out at 0.75 — diff=3 isn't enough.
-        result = assignment_mastery([(3, 0)] * 4, total_words=4)
-        assert result["familiar"] == 4
-        assert abs(result["current_mastery"] - 0.75) < 1e-9
+    def test_one_master_raises_mastery_by_one_over_total(self):
+        result = assignment_mastery([(3, 0, 3)], total_words=6)
+        assert result["master"] == 1
+        assert abs(result["current_mastery"] - 1 / 6) < 1e-9
 
-    def test_high_practice_with_balanced_errors_collapses_to_very_unfamiliar(self):
-        # Diff-based ladder is unforgiving when errors keep up with corrects:
-        # 10 right + 10 wrong ⇒ diff=0 ⇒ T1.
-        result = assignment_mastery([(10, 10)] * 6, total_words=6)
-        assert result["very_unfamiliar"] == 6
-        assert result["current_mastery"] == 0.0
-
-
-# ---------------------------------------------------------------------------
-# Regression companion for #452
-# ---------------------------------------------------------------------------
+    def test_recovered_student_reaches_t5_via_repetition(self):
+        # 3 right, 2 wrong, then 3 in a row right (rep=3).
+        # diff = 3 - 1 = 2 → T4 by diff alone, but rep>=3 → T5.
+        result = assignment_mastery([(3, 2, 3)] * 4, total_words=4)
+        assert result["master"] == 4
+        assert result["current_mastery"] == 1.0
 
 
-class TestRegressionCompanionToBug452:
-    def test_first_wrong_answer_does_not_increase_mastery(self):
-        before = assignment_mastery([], total_words=5)
-        after = assignment_mastery([(0, 1)], total_words=5)
-        assert after["current_mastery"] == before["current_mastery"]
-        assert classify_tier(0, 1) == "very_unfamiliar"
+class TestHalfPenaltyMakesProgressEasier:
+    def test_equal_corrects_and_errors_no_longer_zero_tier(self):
+        # Old #711: 4 right + 4 wrong = diff=0 = T1.
+        # New #800: diff = 4 - 2 = 2 = T4. Practice quantity matters again.
+        assert classify_tier(4, 4, 0) == "familiar"
+
+    def test_two_errors_still_recoverable_to_master(self):
+        # 5 correct, 2 wrong, rep=0: diff = 5 - 1 = 4 → T5.
+        assert classify_tier(5, 2, 0) == "master"

--- a/backend/tests/unit/test_word_familiarity_tier_711.py
+++ b/backend/tests/unit/test_word_familiarity_tier_711.py
@@ -63,9 +63,7 @@ def classify_tier(correct: int, incorrect: int, repetition: int) -> str:
     return "very_unfamiliar"
 
 
-def assignment_mastery(
-    words: List[Tuple[int, int, int]], total_words: int
-) -> dict:
+def assignment_mastery(words: List[Tuple[int, int, int]], total_words: int) -> dict:
     """Replica of ``calculate_assignment_mastery`` aggregation.
 
     ``words`` is a list of (correct_count, incorrect_count, repetition_count)
@@ -75,17 +73,12 @@ def assignment_mastery(
     counts = {tier: 0 for tier in TIER_WEIGHTS}
     for c, i, r in words:
         counts[classify_tier(c, i, r)] += 1
-    accounted = sum(
-        counts[t] for t in ("master", "familiar", "medium", "unfamiliar")
-    )
+    accounted = sum(counts[t] for t in ("master", "familiar", "medium", "unfamiliar"))
     counts["very_unfamiliar"] = max(0, total_words - accounted)
     if total_words == 0:
         current = 0.0
     else:
-        current = (
-            sum(TIER_WEIGHTS[t] * counts[t] for t in TIER_WEIGHTS)
-            / total_words
-        )
+        current = sum(TIER_WEIGHTS[t] * counts[t] for t in TIER_WEIGHTS) / total_words
     return {
         "current_mastery": current,
         **counts,

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -184,6 +184,13 @@ const isVocabularySetType = (type: string): boolean => {
   return ["SENTENCE_MAKING", "VOCABULARY_SET"].includes(normalizedType);
 };
 
+// Issue #800: cap vocabulary sets per assignment so students don't end up
+// with practice pools that feel endless. Two sets is roomy enough for a
+// week-long assignment and aligns with what teachers actually plan. The
+// limit is enforced both in the UI (proactive disable + toast) and in
+// the backend create endpoint as defence-in-depth.
+const MAX_VOCAB_SETS_PER_ASSIGNMENT = 2;
+
 // Issue #757: 聽力派發前置檢查，例句音檔對應的欄位依 content type 不同：
 //   VOCABULARY_SET → example_sentence_audio_url
 //   EXAMPLE_SENTENCES → audio_url（例句集的 audio_url 本身就是例句音檔）
@@ -971,6 +978,16 @@ export function AssignmentDialog({
     return true;
   };
 
+  // Issue #800: count currently-selected vocabulary sets so we can cap at
+  // MAX_VOCAB_SETS_PER_ASSIGNMENT. Computed inline (not memoised) — cart
+  // length is small (<10) so the filter is cheap and avoids stale-closure
+  // bugs in the toggle handler.
+  const selectedVocabSetCount = cartItems.filter((item) =>
+    isVocabularySetType(item.contentType),
+  ).length;
+  const isVocabLimitReached =
+    selectedVocabSetCount >= MAX_VOCAB_SETS_PER_ASSIGNMENT;
+
   // 添加/移除內容到購物車
   const toggleContent = (
     contentId: number,
@@ -986,6 +1003,18 @@ export function AssignmentDialog({
         t("dialogs.assignmentDialog.errors.mixedContentType", {
           type: t("dialogs.assignmentDialog.contentTypes.VOCABULARY_SET"),
         }),
+      );
+      return;
+    }
+    // Issue #800: block adding a 3rd vocab set even if mode allows it.
+    if (
+      !exists &&
+      isVocabularySetType(content.type) &&
+      isVocabLimitReached
+    ) {
+      toast.warning(
+        t("dialogs.assignmentDialog.errors.maxVocabSetsReached") ||
+          `為避免單次練習量過大，最多選 ${MAX_VOCAB_SETS_PER_ASSIGNMENT} 個單字集`,
       );
       return;
     }
@@ -1976,11 +2005,19 @@ export function AssignmentDialog({
                                                         item.contentId ===
                                                         content.id,
                                                     );
+                                                  // Issue #800: also disable
+                                                  // un-selected vocab sets
+                                                  // once the per-assignment
+                                                  // cap is reached.
                                                   const isDisabled =
                                                     !isSelected &&
-                                                    !isContentSelectable(
+                                                    (!isContentSelectable(
                                                       content.type,
-                                                    );
+                                                    ) ||
+                                                      (isVocabLimitReached &&
+                                                        isVocabularySetType(
+                                                          content.type,
+                                                        )));
                                                   return (
                                                     <button
                                                       key={content.id}
@@ -2227,11 +2264,16 @@ export function AssignmentDialog({
                                                           item.contentId ===
                                                           content.id,
                                                       );
+                                                    // Issue #800: cap vocab sets.
                                                     const isDisabled =
                                                       !isSelected &&
-                                                      !isContentSelectable(
+                                                      (!isContentSelectable(
                                                         content.type,
-                                                      );
+                                                      ) ||
+                                                        (isVocabLimitReached &&
+                                                          isVocabularySetType(
+                                                            content.type,
+                                                          )));
                                                     return (
                                                       <button
                                                         key={content.id}
@@ -2480,11 +2522,19 @@ export function AssignmentDialog({
                                                         item.contentId ===
                                                         content.id,
                                                     );
+                                                  // Issue #800: also disable
+                                                  // un-selected vocab sets
+                                                  // once the per-assignment
+                                                  // cap is reached.
                                                   const isDisabled =
                                                     !isSelected &&
-                                                    !isContentSelectable(
+                                                    (!isContentSelectable(
                                                       content.type,
-                                                    );
+                                                    ) ||
+                                                      (isVocabLimitReached &&
+                                                        isVocabularySetType(
+                                                          content.type,
+                                                        )));
                                                   return (
                                                     <button
                                                       key={content.id}
@@ -2565,12 +2615,29 @@ export function AssignmentDialog({
                     <ShoppingCart className="h-5 w-5 text-blue-600" />
                     <h3 className="font-semibold">已選擇的內容</h3>
                   </div>
-                  <Badge
-                    variant="secondary"
-                    className="bg-blue-50 text-blue-700"
-                  >
-                    {cartItems.length}
-                  </Badge>
+                  <div className="flex items-center gap-2">
+                    {/* Issue #800: surface vocab-set count so teachers
+                        understand why the 3rd vocab set was disabled. */}
+                    {selectedVocabSetCount > 0 && (
+                      <Badge
+                        variant="secondary"
+                        className={
+                          isVocabLimitReached
+                            ? "bg-amber-50 text-amber-700"
+                            : "bg-gray-100 text-gray-600"
+                        }
+                      >
+                        單字集 {selectedVocabSetCount} /{" "}
+                        {MAX_VOCAB_SETS_PER_ASSIGNMENT}
+                      </Badge>
+                    )}
+                    <Badge
+                      variant="secondary"
+                      className="bg-blue-50 text-blue-700"
+                    >
+                      {cartItems.length}
+                    </Badge>
+                  </div>
                 </div>
 
                 <ScrollArea className="flex-1 p-3 max-h-[50vh] sm:max-h-none">

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -1007,11 +1007,7 @@ export function AssignmentDialog({
       return;
     }
     // Issue #800: block adding a 3rd vocab set even if mode allows it.
-    if (
-      !exists &&
-      isVocabularySetType(content.type) &&
-      isVocabLimitReached
-    ) {
+    if (!exists && isVocabularySetType(content.type) && isVocabLimitReached) {
       toast.warning(
         t("dialogs.assignmentDialog.errors.maxVocabSetsReached") ||
           `為避免單次練習量過大，最多選 ${MAX_VOCAB_SETS_PER_ASSIGNMENT} 個單字集`,

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -89,6 +89,8 @@ interface ProficiencyStatus {
   words_unfamiliar?: number;
   words_very_unfamiliar?: number;
   total_words: number;
+  // Issue #800: every word reached T5 and was excluded from the pool.
+  all_mastered?: boolean;
 }
 
 interface WordClozeActivityProps {
@@ -260,6 +262,7 @@ export default function WordClozeActivity({
         words_medium?: number;
         words_unfamiliar?: number;
         words_very_unfamiliar?: number;
+        all_mastered?: boolean;
         achieved: boolean;
         is_practice_mode?: boolean;
         show_translation: boolean;
@@ -292,6 +295,7 @@ export default function WordClozeActivity({
         words_medium: data.words_medium ?? 0,
         words_unfamiliar: data.words_unfamiliar ?? 0,
         words_very_unfamiliar: data.words_very_unfamiliar ?? 0,
+        all_mastered: data.all_mastered ?? false,
         total_words: data.total_questions || 0,
       });
       setCurrentIndex(0);
@@ -626,6 +630,42 @@ export default function WordClozeActivity({
   }
 
   if (questions.length === 0) {
+    // Issue #800: distinguish "全部精熟" (all words T5) from "no usable
+    // example sentence" empty state. The latter retains the explanatory
+    // message about example sentences.
+    if (proficiency.all_mastered) {
+      return (
+        <Card className="p-8">
+          <CardContent className="text-center space-y-4">
+            <div className="flex justify-center">
+              <Trophy className="h-16 w-16 text-yellow-500" />
+            </div>
+            <h2 className="text-2xl font-bold text-gray-800">
+              {t("wordCloze.allMastered") || "全部精熟！"}
+            </h2>
+            <p className="text-gray-600">
+              {t("wordCloze.allMasteredHint") ||
+                "這份作業的單字你已經全部精熟，不需再練。"}
+            </p>
+            {!isPracticeMode && (
+              <div className="flex justify-center">
+                <Button
+                  onClick={handleSubmitAssignment}
+                  disabled={completing}
+                >
+                  {completing ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : (
+                    <Send className="h-4 w-4 mr-2" />
+                  )}
+                  {t("wordCloze.submitAssignment") || "Submit Assignment"}
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      );
+    }
     return (
       <Card className="p-8">
         <CardContent className="text-center">

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -649,10 +649,7 @@ export default function WordClozeActivity({
             </p>
             {!isPracticeMode && (
               <div className="flex justify-center">
-                <Button
-                  onClick={handleSubmitAssignment}
-                  disabled={completing}
-                >
+                <Button onClick={handleSubmitAssignment} disabled={completing}>
                   {completing ? (
                     <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                   ) : (

--- a/frontend/src/components/activities/WordSelectionActivity.tsx
+++ b/frontend/src/components/activities/WordSelectionActivity.tsx
@@ -334,6 +334,7 @@ export default function WordSelectionActivity({
         words_medium?: number;
         words_unfamiliar?: number;
         words_very_unfamiliar?: number;
+        all_mastered?: boolean;
         achieved: boolean;
         is_practice_mode?: boolean;
         show_image: boolean;

--- a/frontend/src/components/activities/WordSelectionActivity.tsx
+++ b/frontend/src/components/activities/WordSelectionActivity.tsx
@@ -744,10 +744,7 @@ export default function WordSelectionActivity({
             </p>
             {!isPracticeMode && (
               <div className="flex justify-center">
-                <Button
-                  onClick={handleSubmitAssignment}
-                  disabled={completing}
-                >
+                <Button onClick={handleSubmitAssignment} disabled={completing}>
                   {completing ? (
                     <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                   ) : (

--- a/frontend/src/components/activities/WordSelectionActivity.tsx
+++ b/frontend/src/components/activities/WordSelectionActivity.tsx
@@ -88,6 +88,10 @@ interface ProficiencyStatus {
   words_unfamiliar?: number;
   words_very_unfamiliar?: number;
   total_words: number;
+  // Issue #800: backend signals every word reached T5 and was therefore
+  // excluded from the candidate pool. Frontend shows the "全部精熟" panel
+  // instead of the generic "no items" empty state.
+  all_mastered?: boolean;
 }
 
 interface WordSelectionActivityProps {
@@ -357,6 +361,7 @@ export default function WordSelectionActivity({
         words_unfamiliar: data.words_unfamiliar ?? 0,
         words_very_unfamiliar: data.words_very_unfamiliar ?? 0,
         total_words: data.total_words || 0,
+        all_mastered: data.all_mastered ?? false,
       });
       setCurrentIndex(0);
       setRoundCompleted(false);
@@ -721,6 +726,41 @@ export default function WordSelectionActivity({
 
   // No words
   if (words.length === 0) {
+    // Issue #800: distinguish "全部精熟" (every word reached T5, none to
+    // practice) from a genuinely empty assignment.
+    if (proficiency.all_mastered) {
+      return (
+        <Card className="p-8">
+          <CardContent className="text-center space-y-4">
+            <div className="flex justify-center">
+              <Trophy className="h-16 w-16 text-yellow-500" />
+            </div>
+            <h2 className="text-2xl font-bold text-gray-800">
+              {t("wordSelection.allMastered") || "全部精熟！"}
+            </h2>
+            <p className="text-gray-600">
+              {t("wordSelection.allMasteredHint") ||
+                "這份作業的單字你已經全部精熟，不需再練。"}
+            </p>
+            {!isPracticeMode && (
+              <div className="flex justify-center">
+                <Button
+                  onClick={handleSubmitAssignment}
+                  disabled={completing}
+                >
+                  {completing ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : (
+                    <Send className="h-4 w-4 mr-2" />
+                  )}
+                  {t("wordSelection.submitAssignment") || "Submit Assignment"}
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      );
+    }
     return (
       <Card className="p-8">
         <CardContent className="text-center">

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -85,6 +85,8 @@ interface ProficiencyStatus {
   words_unfamiliar?: number;
   words_very_unfamiliar?: number;
   total_words: number;
+  // Issue #800: every word reached T5 and was excluded from the pool.
+  all_mastered?: boolean;
 }
 
 interface WordSpellingActivityProps {
@@ -269,6 +271,7 @@ export default function WordSpellingActivity({
         words_medium?: number;
         words_unfamiliar?: number;
         words_very_unfamiliar?: number;
+        all_mastered?: boolean;
         achieved: boolean;
         is_practice_mode?: boolean;
         show_translation: boolean;
@@ -302,6 +305,7 @@ export default function WordSpellingActivity({
         words_medium: data.words_medium ?? 0,
         words_unfamiliar: data.words_unfamiliar ?? 0,
         words_very_unfamiliar: data.words_very_unfamiliar ?? 0,
+        all_mastered: data.all_mastered ?? false,
         total_words: data.total_words || 0,
       });
       setCurrentIndex(0);
@@ -627,6 +631,40 @@ export default function WordSpellingActivity({
   }
 
   if (words.length === 0) {
+    // Issue #800: distinguish "全部精熟" from a genuinely empty assignment.
+    if (proficiency.all_mastered) {
+      return (
+        <Card className="p-8">
+          <CardContent className="text-center space-y-4">
+            <div className="flex justify-center">
+              <Trophy className="h-16 w-16 text-yellow-500" />
+            </div>
+            <h2 className="text-2xl font-bold text-gray-800">
+              {t("wordSpelling.allMastered") || "全部精熟！"}
+            </h2>
+            <p className="text-gray-600">
+              {t("wordSpelling.allMasteredHint") ||
+                "這份作業的單字你已經全部精熟，不需再練。"}
+            </p>
+            {!isPracticeMode && (
+              <div className="flex justify-center">
+                <Button
+                  onClick={handleSubmitAssignment}
+                  disabled={completing}
+                >
+                  {completing ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : (
+                    <Send className="h-4 w-4 mr-2" />
+                  )}
+                  {t("wordSpelling.submitAssignment") || "Submit Assignment"}
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      );
+    }
     return (
       <Card className="p-8">
         <CardContent className="text-center">

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -648,10 +648,7 @@ export default function WordSpellingActivity({
             </p>
             {!isPracticeMode && (
               <div className="flex justify-center">
-                <Button
-                  onClick={handleSubmitAssignment}
-                  disabled={completing}
-                >
+                <Button onClick={handleSubmitAssignment} disabled={completing}>
                   {completing ? (
                     <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                   ) : (


### PR DESCRIPTION
## Summary

實作 #800 三項相關改動，目的是把「永遠做不完」「熟練度永遠到不了」的學生挫折感拿掉：

1. **放寬熟練度判定**（`calculate_assignment_mastery`）— T5/T4 改為「diff 或 repetition_count 任一達標」，diff 改用半懲罰（`correct - 0.5 × incorrect`），權重改為 1.0 / 0.8 / 0.6 / 0.4 / 0，全 T4 = 80% 剛好達預設達標線。
2. **Tier 配額選字**（`get_words_for_practice`）— 廢除 phase/時間間隔，改用 T4=2 / T3=2 / T2=3 / T1=3 配額；正向 + 反向 cascade；T5 已 master 的字**永不被抽到**；輸出隨機打散。
3. **限制單字集數量** — 一份作業最多 2 個單字集，UI 達到上限時其他單字集會 disable（cart 顯示「單字集 X / 2」徽章）；後端 create 端點驗證 ≤ 2。

學生端 3 個練習模式（選字 / 拼寫 / 克漏字）start endpoint 在全字精熟時回 `all_mastered: true`，前端顯示 Trophy + 「全部精熟！」恭喜畫面，而非通用 empty state。

## 主要決策（討論過程的結論）

| 議題 | 結論 |
|------|------|
| 熟練度過嚴 | T5 從 diff ≥ 4 放寬到 diff ≥ 3，並加入 rep ≥ 3 的 OR 短路 |
| 答錯懲罰過重 | 採 D-a 半懲罰（diff = correct − 0.5 × incorrect），不改寫資料 |
| 時間間隔無效 | SM-2 的 `next_review_at` 在選字邏輯內整個拋棄（5 天作業根本到不了 6 天複習）|
| 全 mastered 後 | 永不再選；前端顯示「全部精熟」UI |
| 選字順序 | 整輪 10 題最終 RANDOM 打散 |
| 單字集過多疲勞感 | 派發時最多 2 個單字集；UI 達標 disable |
| 舊資料 | 不動 row；新規則直接套用全站（mastery 顯示會即時上升，預期行為）|
| Preview / Demo | 本次不動（用 `preview_service.py` 獨立邏輯，未來可另開 issue 同步套用）|

詳細試算與規格見 issue #800 描述。

## Migration

- `20260522_1000_relax_mastery_and_tier_quota.py` — 純 `CREATE OR REPLACE FUNCTION`，無 schema 變更，符合 idempotent 鐵則。downgrade 還原舊版函式。
- 本地 develop DB 已套並 downgrade/upgrade 來回測試 ✓

## Test plan

- [ ] 跑現有 `test_word_familiarity_tier_711.py`（已重寫，涵蓋新 tier 規則）
- [ ] 學生：開單字選擇作業 → 連對 3 次同一字 → 該字之後不再出現
- [ ] 學生：全字精熟 → 看到「全部精熟」恭喜畫面而非「No items」
- [ ] 學生：每輪 10 題出題順序每次不同
- [ ] 老師（我的班級派發）：選 2 個單字集 → 第 3 個變灰色不可選
- [ ] 老師（機構教材派發）：同上驗證
- [ ] 老師：取消其中 1 個 → 第 3 個變回可選
- [ ] Cart panel：顯示「單字集 X / 2」徽章，達上限變琥珀色
- [ ] 後端：強塞 3 個 vocab 給 create endpoint → 回 400
- [ ] 已派發 3+ 個 vocab 的舊作業：可正常編輯與被學生練習（grandfathered）

🤖 Generated with [Claude Code](https://claude.com/claude-code)