### PR TITLE
Release: staging → main

### DIFF
--- a/backend/alembic/versions/20260521_1000_add_cloze_answer_to_content_item.py
+++ b/backend/alembic/versions/20260521_1000_add_cloze_answer_to_content_item.py
@@ -1,0 +1,37 @@
+"""add_cloze_answer_to_content_items
+
+Revision ID: 20260521_1000
+Revises: 20260518_1400
+Create Date: 2026-05-21 10:00:00.000000
+
+Issue #632: persist the word-cloze answer (the actual word/phrase form that
+appears in the example sentence) on each vocabulary item. Previously the
+answer was extracted at runtime from the example sentence; persisting it lets
+teachers override it (per assignment copy) and lets the practice endpoint use
+the teacher-confirmed answer. Nullable — existing rows stay NULL and are
+backfilled lazily on next save / via the toast guard (#791).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260521_1000"
+down_revision: Union[str, None] = "20260518_1400"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE content_items
+        ADD COLUMN IF NOT EXISTS cloze_answer TEXT
+        """
+    )
+
+
+def downgrade() -> None:
+    # Additive-only migration policy: do not drop columns on downgrade.
+    pass

--- a/backend/alembic/versions/20260522_0900_add_rls_to_credit_package_definitions.py
+++ b/backend/alembic/versions/20260522_0900_add_rls_to_credit_package_definitions.py
@@ -1,0 +1,68 @@
+"""add_rls_to_credit_package_definitions
+
+Revision ID: 20260522_0900
+Revises: 20260521_1000
+Create Date: 2026-05-22 09:00:00
+
+The credit_package_definitions table (added in 20260518_1000) shipped
+without Row Level Security. The backend deploy workflow's RLS gate
+(.github/workflows/deploy-backend.yml) rejects any public table without
+RLS, which blocked every staging backend deploy after the table merged —
+freezing the backend image and surfacing as 404s on the #708 grade-report
+endpoints (frontend deployed independently and called routes the stale
+backend never had).
+
+Like the other JWT-auth business tables, RLS here is enabled with no
+policies: the backend connects as the table owner and bypasses RLS, while
+the anon/authenticated Supabase roles get no access. This mirrors
+20260203_1600_add_rls_to_organization_points_log.
+
+Idempotent — safe to re-run.
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260522_0900"
+down_revision = "20260521_1000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_name = 'credit_package_definitions'
+                  AND table_schema = 'public'
+            ) THEN
+                IF NOT (
+                    SELECT relrowsecurity
+                    FROM pg_class
+                    WHERE relname = 'credit_package_definitions'
+                      AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+                ) THEN
+                    ALTER TABLE credit_package_definitions ENABLE ROW LEVEL SECURITY;
+                END IF;
+            END IF;
+        END $$;
+    """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_name = 'credit_package_definitions'
+                  AND table_schema = 'public'
+            ) THEN
+                ALTER TABLE credit_package_definitions DISABLE ROW LEVEL SECURITY;
+            END IF;
+        END $$;
+    """
+    )

--- a/backend/models/program.py
+++ b/backend/models/program.py
@@ -242,6 +242,11 @@ class ContentItem(Base):
     # 儲存格式: ["干擾項1", "干擾項2", "干擾項3"]
     distractors = Column(JSON, nullable=True)
 
+    # 單字克漏字答案（word_cloze 練習用）— 例句中要被挖空的單字/片語的實際變體形式
+    # 例如：base "cup" + 例句 "I have two cups" → cloze_answer = "cups"
+    # 儲存時自動抽取（見 utils/cloze.py），老師可在單字集 / 作業副本中手動覆寫
+    cloze_answer = Column(Text, nullable=True)
+
     item_metadata = Column(JSON, default={})
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -46,6 +46,9 @@ pydub==0.25.1
 # Retry and Rate Limiting
 tenacity==8.2.3
 
+# Excel export (issue #708 — class & student grade reports)
+openpyxl==3.1.5
+
 # =============================================
 # Development Dependencies
 # =============================================

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -10,9 +10,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session, aliased
 from sqlalchemy import func
 from sqlalchemy.orm.attributes import flag_modified
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 from database import get_db
 from models import (
@@ -71,6 +71,37 @@ class SubscriptionResponse(BaseModel):
     quota_used: int
     end_date: str
     status: str
+
+
+class EditCreditPackageRequest(BaseModel):
+    """編輯點數包請求（每次至少 reason 必填）"""
+
+    points_total: Optional[int] = Field(default=None, ge=0)
+    expires_at: Optional[str] = None  # YYYY-MM-DD
+    reason: str = Field(min_length=1, max_length=500)
+
+
+class CancelCreditPackageRequest(BaseModel):
+    """退款 / 取消點數包請求"""
+
+    reason: str = Field(min_length=1, max_length=500)
+
+
+class CreditPackageResponse(BaseModel):
+    """點數包編輯後回應"""
+
+    id: int
+    package_id: str
+    source: str
+    points_total: int
+    points_used: int
+    points_remaining: int
+    # CreditPackage.expires_at is nullable=False so this is always set.
+    expires_at: str
+    status: str
+    # Full audit trail from admin_metadata.operations[] — every edit / cancel
+    # appends one entry. Empty list when no admin has touched the package.
+    admin_operations: List[Dict[str, Any]] = []
 
 
 # ============ Helper Functions ============
@@ -395,6 +426,183 @@ async def cancel_subscription(
     }
 
 
+# ============ Credit Package Instance CRUD ============
+def _admin_operations(pkg: CreditPackage) -> List[Dict[str, Any]]:
+    """Return the operation history from ``pkg.admin_metadata`` as a list.
+
+    `admin_metadata` is a JSONB column shaped like ``{"operations": [...]}``
+    after the first admin write; anything else (None, missing key, wrong
+    type) is treated as no history so the response is always a list."""
+    if not isinstance(pkg.admin_metadata, dict):
+        return []
+    ops = pkg.admin_metadata.get("operations")
+    return ops if isinstance(ops, list) else []
+
+
+def _credit_package_response(pkg: CreditPackage) -> dict:
+    # `CreditPackage.expires_at` is `nullable=False` in the DB schema, so it
+    # is always set in practice — no None guard needed here.
+    return {
+        "id": pkg.id,
+        "package_id": pkg.package_id,
+        "source": pkg.source,
+        "points_total": pkg.points_total,
+        "points_used": pkg.points_used,
+        "points_remaining": pkg.points_remaining,
+        "expires_at": pkg.expires_at.isoformat(),
+        "status": pkg.status,
+        "admin_operations": _admin_operations(pkg),
+    }
+
+
+def _append_admin_operation(pkg: CreditPackage, op: dict) -> None:
+    """Append `op` to pkg.admin_metadata['operations'] and flag the column
+    so SQLAlchemy persists the in-place JSONB mutation."""
+    if pkg.admin_metadata is None:
+        pkg.admin_metadata = {"operations": []}
+    if "operations" not in pkg.admin_metadata:
+        pkg.admin_metadata["operations"] = []
+    pkg.admin_metadata["operations"].append(op)
+    flag_modified(pkg, "admin_metadata")
+
+
+@router.put("/credit-package/{package_id}", response_model=CreditPackageResponse)
+async def edit_credit_package(
+    package_id: int,
+    request: EditCreditPackageRequest,
+    db: Session = Depends(get_db),
+    admin: Teacher = Depends(get_current_admin),
+):
+    """Admin: edit a teacher's CreditPackage row.
+
+    Editable fields: `points_total`, `expires_at`. `reason` is required
+    and recorded in `admin_reason` + accumulated in `admin_metadata`.
+
+    Refused (422) if `points_total < points_used` (would invalidate
+    historical PointUsageLog entries) or if the package is already
+    refunded.
+    """
+    pkg = db.query(CreditPackage).filter(CreditPackage.id == package_id).first()
+    if pkg is None:
+        raise HTTPException(
+            status_code=404, detail=f"Credit package {package_id} not found"
+        )
+
+    if pkg.status == "refunded":
+        raise HTTPException(
+            status_code=422,
+            detail="Cannot edit a refunded credit package",
+        )
+
+    payload = request.model_dump(exclude_unset=True)
+    payload.pop("reason", None)
+    if not payload:
+        raise HTTPException(status_code=400, detail="No editable fields provided")
+
+    changes: dict = {}
+
+    if "points_total" in payload:
+        new_total = payload["points_total"]
+        if new_total < pkg.points_used:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"points_total ({new_total}) cannot be less than "
+                    f"points_used ({pkg.points_used})"
+                ),
+            )
+        if new_total != pkg.points_total:
+            changes["points_total"] = {
+                "from": pkg.points_total,
+                "to": new_total,
+            }
+            pkg.points_total = new_total
+
+    if "expires_at" in payload:
+        try:
+            new_expires = datetime.strptime(payload["expires_at"], "%Y-%m-%d").replace(
+                tzinfo=timezone.utc
+            )
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=422,
+                detail="expires_at must be a date in YYYY-MM-DD format",
+            )
+        old_iso = pkg.expires_at.isoformat() if pkg.expires_at else None
+        new_iso = new_expires.isoformat()
+        if old_iso != new_iso:
+            changes["expires_at"] = {"from": old_iso, "to": new_iso}
+            pkg.expires_at = new_expires
+
+    pkg.admin_id = admin.id
+    pkg.admin_reason = request.reason
+
+    _append_admin_operation(
+        pkg,
+        {
+            "action": "edit",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "admin_id": admin.id,
+            "admin_email": admin.email,
+            "admin_name": admin.name,
+            "reason": request.reason,
+            "changes": changes,
+        },
+    )
+
+    db.commit()
+    db.refresh(pkg)
+    return _credit_package_response(pkg)
+
+
+@router.post(
+    "/credit-package/{package_id}/cancel", response_model=CreditPackageResponse
+)
+async def cancel_credit_package(
+    package_id: int,
+    request: CancelCreditPackageRequest,
+    db: Session = Depends(get_db),
+    admin: Teacher = Depends(get_current_admin),
+):
+    """Admin: soft-delete a teacher's CreditPackage by setting
+    `status='refunded'`. The row is preserved so PointUsageLog audit
+    trails remain valid; the list endpoint filters refunded packages out
+    of the UI."""
+    pkg = db.query(CreditPackage).filter(CreditPackage.id == package_id).first()
+    if pkg is None:
+        raise HTTPException(
+            status_code=404, detail=f"Credit package {package_id} not found"
+        )
+
+    if pkg.status == "refunded":
+        raise HTTPException(
+            status_code=422,
+            detail="Credit package is already refunded",
+        )
+
+    old_status = pkg.status
+    pkg.status = "refunded"
+    pkg.admin_id = admin.id
+    pkg.admin_reason = request.reason
+
+    _append_admin_operation(
+        pkg,
+        {
+            "action": "cancel",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "admin_id": admin.id,
+            "admin_email": admin.email,
+            "admin_name": admin.name,
+            "reason": request.reason,
+            "changes": {"status": {"from": old_status, "to": "refunded"}},
+        },
+    )
+
+    db.commit()
+    db.refresh(pkg)
+    return _credit_package_response(pkg)
+
+
 @router.get("/all-teachers")
 async def get_all_teachers_subscriptions(
     db: Session = Depends(get_db),
@@ -522,9 +730,14 @@ async def get_teacher_periods(
         )
 
     # 🔥 Approach A: 同時撈取 credit_packages（trial_bonus / admin_grant / 加購）
+    # Refunded packages are hidden from the dashboard list (soft-delete UX);
+    # the row stays in DB so PointUsageLog audit trails remain valid.
     credit_packages = (
         db.query(CreditPackage)
-        .filter(CreditPackage.teacher_id == teacher_id)
+        .filter(
+            CreditPackage.teacher_id == teacher_id,
+            CreditPackage.status != "refunded",
+        )
         .order_by(CreditPackage.purchased_at.desc())
         .all()
     )
@@ -546,6 +759,7 @@ async def get_teacher_periods(
                 "expires_at": pkg.expires_at.isoformat() if pkg.expires_at else None,
                 "status": pkg.status,
                 "payment_id": pkg.payment_id,
+                "admin_operations": _admin_operations(pkg),
             }
         )
 

--- a/backend/routers/assignments/detail.py
+++ b/backend/routers/assignments/detail.py
@@ -26,7 +26,14 @@ from .dependencies import get_current_teacher
 router = APIRouter()
 
 # Auto-graded practice modes (matching students/assignments.py)
-AUTO_GRADED_MODES = frozenset({"rearrangement", "word_selection"})
+AUTO_GRADED_MODES = frozenset(
+    {"rearrangement", "word_selection", "word_spelling", "word_cloze"}
+)
+
+# Modes that derive interim mastery from calculate_assignment_mastery() —
+# all three accumulate correct/incorrect counts on
+# StudentItemProgress.word_selection_data, which the PG function reads.
+_MASTERY_FUNCTION_MODES = frozenset({"word_selection", "word_spelling", "word_cloze"})
 
 
 def _get_total_item_count(assignment_id: int, db: Session) -> int:
@@ -57,7 +64,8 @@ def _compute_interim_score(sa, assignment, db: Session, total_items: int | None 
     Compute interim score for IN_PROGRESS auto-graded assignments.
     - GRADED/RETURNED: return sa.score (already finalized)
     - IN_PROGRESS + rearrangement: sum(expected_scores) / total_items
-    - IN_PROGRESS + word_selection: calculate_assignment_mastery DB function
+    - IN_PROGRESS + word_selection / word_spelling / word_cloze:
+      calculate_assignment_mastery DB function
 
     Args:
         total_items: Pre-computed total item count to avoid redundant DB queries.
@@ -90,7 +98,7 @@ def _compute_interim_score(sa, assignment, db: Session, total_items: int | None 
             return None
         return round(sum(valid_scores) / total_items, 1)
 
-    elif practice_mode == "word_selection":
+    elif practice_mode in _MASTERY_FUNCTION_MODES:
         try:
             result = db.execute(
                 text("SELECT * FROM calculate_assignment_mastery(:sa_id)"),

--- a/backend/routers/organization_programs.py
+++ b/backend/routers/organization_programs.py
@@ -235,8 +235,12 @@ def deep_copy_program(
         db.flush()  # Get new_lesson.id
 
         # Deep copy contents using canonical helper (includes all Phase 2 fields)
+        # Skip assignment copies: they're created per-assignment and must not be
+        # propagated into classroom copies of the template.
         for content in lesson.contents:
             if hasattr(content, "is_active") and not content.is_active:
+                continue
+            if getattr(content, "is_assignment_copy", False):
                 continue
             _copy_content_with_items(content, new_lesson.id, db)
 
@@ -306,6 +310,8 @@ async def list_organization_materials(
             lesson_data.contents = []
             for content in lesson.contents:
                 if hasattr(content, "is_active") and not content.is_active:
+                    continue
+                if getattr(content, "is_assignment_copy", False):
                     continue
                 content_data = ContentResponse.model_validate(content)
 
@@ -383,6 +389,8 @@ async def get_organization_material_details(
 
         for content in lesson.contents:
             if hasattr(content, "is_active") and not content.is_active:
+                continue
+            if getattr(content, "is_assignment_copy", False):
                 continue
             content_data = ContentResponse.model_validate(content)
             content_data.items = [
@@ -720,6 +728,8 @@ async def copy_material_to_classroom(
 
         for content in lesson.contents:
             if hasattr(content, "is_active") and not content.is_active:
+                continue
+            if getattr(content, "is_assignment_copy", False):
                 continue
             content_data = ContentResponse.model_validate(content)
             content_data.items = [

--- a/backend/routers/teachers/__init__.py
+++ b/backend/routers/teachers/__init__.py
@@ -21,6 +21,7 @@ from . import (
     instant_practice,
     teacher_organizations,
     one_campus_ops,
+    grade_reports,
 )
 
 # Create main router with prefix and tags
@@ -41,6 +42,7 @@ router.include_router(assignment_ops.router, tags=["teachers-assignments"])
 router.include_router(instant_practice.router, tags=["teachers-instant-practice"])
 router.include_router(teacher_organizations.router, tags=["teachers-organizations"])
 router.include_router(one_campus_ops.router, tags=["teachers-one-campus"])
+router.include_router(grade_reports.router, tags=["teachers-grade-reports"])
 
 # Re-export router and dependencies for backward compatibility
 from .dependencies import get_current_teacher  # noqa: E402

--- a/backend/routers/teachers/grade_reports.py
+++ b/backend/routers/teachers/grade_reports.py
@@ -1,0 +1,648 @@
+"""Grade-report Excel downloads for teachers.
+
+Issue #708.
+
+Two endpoints, both scoped to a classroom the requesting teacher owns and
+both keyed off the same list of selected assignments (intended for use on
+the archived-assignments view):
+
+- ``POST /classrooms/{classroom_id}/grade-report``
+    Body: ``{"assignment_ids": [int]}``
+    Returns an ``.xlsx`` summarising scores across the selected assignments.
+    Assignments are grouped by ``score_category`` (聽力 / 閱讀 / 寫作 / 口說)
+    matching the sample on the issue.
+
+- ``POST /classrooms/{classroom_id}/student-grade-report``
+    Body: ``{"assignment_ids": [int]}``
+    Returns a ``.zip`` containing one ``.xlsx`` per enrolled student. Each
+    inner workbook covers the same selected assignments grouped by
+    category, ending with that student's 總平均.
+
+The category for each assignment is read from ``assignment.score_category``
+which is auto-resolved by ``utils.score_category.resolve_score_category``
+(see issue #708 PR-1).
+"""
+from __future__ import annotations
+
+import io
+import logging
+import zipfile
+from datetime import datetime, timezone
+from typing import List, Optional, Tuple
+from urllib.parse import quote
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import Response
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
+from openpyxl.utils import get_column_letter
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import (
+    Assignment,
+    Classroom,
+    ClassroomStudent,
+    Student,
+    StudentAssignment,
+    Teacher,
+)
+from routers.assignments.detail import _compute_interim_score
+from .dependencies import get_current_teacher
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# Category display order on the class report (matches sample on the issue).
+# Keys are score_category values stored in the DB.
+_CATEGORY_ORDER: Tuple[str, ...] = ("listening", "reading", "writing", "speaking")
+_CATEGORY_ZH = {
+    "listening": "聽力",
+    "reading": "閱讀",
+    "writing": "寫作",
+    "speaking": "口說",
+}
+
+
+# ---------------------------------------------------------------------------
+# Request schemas
+# ---------------------------------------------------------------------------
+
+
+class _AssignmentSelectionRequest(BaseModel):
+    """Shared request shape for both reports.
+
+    Both endpoints take the same input — the list of assignment IDs the
+    teacher picked on the archived-assignments view. The student report
+    additionally fans out across every enrolled student, but that's a
+    backend concern; the contract surface is identical.
+    """
+
+    assignment_ids: List[int] = Field(..., min_length=1)
+
+    @field_validator("assignment_ids")
+    @classmethod
+    def _unique(cls, v: List[int]) -> List[int]:
+        if len(set(v)) != len(v):
+            raise ValueError("assignment_ids must not contain duplicates")
+        return v
+
+
+# Kept as separate names so OpenAPI / docs distinguish the two endpoints.
+ClassGradeReportRequest = _AssignmentSelectionRequest
+StudentGradeReportRequest = _AssignmentSelectionRequest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _verify_classroom_ownership(
+    classroom_id: int, teacher_id: int, db: Session
+) -> Classroom:
+    classroom = (
+        db.query(Classroom)
+        .filter(
+            Classroom.id == classroom_id,
+            Classroom.teacher_id == teacher_id,
+            Classroom.is_active.is_(True),
+        )
+        .first()
+    )
+    if not classroom:
+        raise HTTPException(
+            status_code=404,
+            detail="Classroom not found or you don't have permission",
+        )
+    return classroom
+
+
+def _classroom_students(classroom_id: int, db: Session) -> List[Student]:
+    return (
+        db.query(Student)
+        .join(ClassroomStudent, Student.id == ClassroomStudent.student_id)
+        .filter(
+            ClassroomStudent.classroom_id == classroom_id,
+            ClassroomStudent.is_active.is_(True),
+            Student.is_active.is_(True),
+        )
+        .order_by(Student.student_number.asc().nullslast(), Student.id.asc())
+        .all()
+    )
+
+
+def _category_key(assignment: Assignment) -> str:
+    """Return the category bucket key for an assignment.
+
+    Falls back to ``"writing"`` when the assignment has no category. After
+    PR-1 (#744, #746) every row has a value, but this keeps the report
+    robust against any future row that slipped through.
+    """
+    key = (assignment.score_category or "").strip().lower()
+    return key if key in _CATEGORY_ZH else "writing"
+
+
+def _final_score(sa: Optional[StudentAssignment], assignment: Assignment, db: Session):
+    """Return a numeric score (or ``None``) for one (student, assignment) cell.
+
+    Sample reports show integer scores, so we round to the nearest integer.
+    """
+    if sa is None:
+        return None
+    if sa.score is not None:
+        return int(round(float(sa.score)))
+    interim = _compute_interim_score(sa, assignment, db)
+    return int(round(float(interim))) if interim is not None else None
+
+
+def _avg(scores: List[float]) -> Optional[float]:
+    return round(sum(scores) / len(scores), 1) if scores else None
+
+
+def _today_yyyymmdd() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d")
+
+
+def _xlsx_response(wb: Workbook, filename: str) -> Response:
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    # RFC 5987: filename* lets us send a UTF-8 filename with full fidelity,
+    # while filename= provides a safe ASCII fallback for older browsers.
+    ascii_fallback = filename.encode("ascii", errors="ignore").decode() or "report.xlsx"
+    disposition = (
+        f'attachment; filename="{ascii_fallback}"; '
+        f"filename*=UTF-8''{quote(filename)}"
+    )
+    return Response(
+        content=buf.getvalue(),
+        media_type=(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        ),
+        headers={"Content-Disposition": disposition},
+    )
+
+
+def _sanitize_sheet_title(raw: str) -> str:
+    """openpyxl rejects ``[]:*?/\\`` and titles longer than 31 chars."""
+    bad = set("[]:*?/\\")
+    cleaned = "".join(ch for ch in raw if ch not in bad).strip() or "Sheet"
+    return cleaned[:31]
+
+
+# ---------------------------------------------------------------------------
+# Class grade report (班級成績單)
+# ---------------------------------------------------------------------------
+
+
+def _build_class_workbook(
+    classroom: Classroom,
+    assignments: List[Assignment],
+    students: List[Student],
+    db: Session,
+) -> Workbook:
+    """Build the class grade report workbook.
+
+    Layout matches the sample on issue #708:
+
+    ::
+
+        Row 1: <ClassName> 班成績總覽           (merged across all columns)
+        Row 2: 下載日期：YYYY-MM-DD             (merged across all columns)
+        Row 3: 座號|姓名|個人平均|<category banner cells>|班級平均
+        Row 4: (blank x3)|<assignment title cells>|(blank)
+        Row 5: (blank x3)|<assignment date cells>|(blank)
+        Row 6+: per-student score rows
+        Last:  class-average row
+    """
+    # Group assignments by category, preserving stable order within a group.
+    groups: dict[str, List[Assignment]] = {k: [] for k in _CATEGORY_ORDER}
+    for a in assignments:
+        groups[_category_key(a)].append(a)
+
+    # Drop empty groups so we don't leave dead columns.
+    non_empty = [
+        (cat, items) for cat in _CATEGORY_ORDER for items in (groups[cat],) if items
+    ]
+
+    # Flat ordered list of assignments, paired with their category, plus the
+    # starting column index for each category group (used for merging).
+    ordered: List[Tuple[str, Assignment]] = []
+    cat_spans: List[Tuple[str, int, int]] = []  # (category, start_col, end_col)
+    col = 4  # 座號(1), 姓名(2), 個人平均(3), then assignments from col 4
+    for cat, items in non_empty:
+        start = col
+        for a in items:
+            ordered.append((cat, a))
+            col += 1
+        cat_spans.append((cat, start, col - 1))
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = _sanitize_sheet_title(f"{classroom.name}成績總覽")
+
+    total_cols = col - 1  # last assignment column
+
+    # --- Row 1: title ---
+    ws.cell(row=1, column=1, value=f"{classroom.name} 班成績總覽")
+    ws.merge_cells(start_row=1, start_column=1, end_row=1, end_column=total_cols)
+    ws.cell(row=1, column=1).font = Font(bold=True, size=14)
+    ws.cell(row=1, column=1).alignment = Alignment(horizontal="center")
+
+    # --- Row 2: download date ---
+    today_iso = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    ws.cell(row=2, column=1, value=f"下載日期：{today_iso}")
+    ws.merge_cells(start_row=2, start_column=1, end_row=2, end_column=total_cols)
+    ws.cell(row=2, column=1).alignment = Alignment(horizontal="left")
+
+    # --- Row 3: top header (with category banners merged) ---
+    headers_row3 = ["座號", "姓名", "個人平均"]
+    ws.cell(row=3, column=1, value=headers_row3[0])
+    ws.cell(row=3, column=2, value=headers_row3[1])
+    ws.cell(row=3, column=3, value=headers_row3[2])
+    for cat, start, end in cat_spans:
+        ws.cell(row=3, column=start, value=_CATEGORY_ZH[cat])
+        if start != end:
+            ws.merge_cells(start_row=3, start_column=start, end_row=3, end_column=end)
+        ws.cell(row=3, column=start).alignment = Alignment(horizontal="center")
+    # Vertically merge the static columns (座號/姓名/個人平均) over
+    # rows 3..5 so they read as a single header cell.
+    for static_col in (1, 2, 3):
+        ws.merge_cells(
+            start_row=3,
+            start_column=static_col,
+            end_row=5,
+            end_column=static_col,
+        )
+        ws.cell(row=3, column=static_col).alignment = Alignment(
+            horizontal="center", vertical="center"
+        )
+
+    # --- Row 4: assignment titles ---
+    for idx, (_, a) in enumerate(ordered):
+        ws.cell(row=4, column=4 + idx, value=a.title)
+        ws.cell(row=4, column=4 + idx).alignment = Alignment(
+            horizontal="center", wrap_text=True
+        )
+
+    # --- Row 5: assignment dates (created_at, treated as 派發日期) ---
+    for idx, (_, a) in enumerate(ordered):
+        d = a.created_at.date().isoformat() if a.created_at else ""
+        ws.cell(row=5, column=4 + idx, value=d)
+        ws.cell(row=5, column=4 + idx).alignment = Alignment(horizontal="center")
+
+    # --- Pre-load student assignments to avoid N+1 ---
+    assignment_ids = [a.id for a in assignments]
+    sa_rows = (
+        db.query(StudentAssignment)
+        .filter(
+            StudentAssignment.assignment_id.in_(assignment_ids),
+            StudentAssignment.is_active.is_(True),
+        )
+        .all()
+    )
+    sa_by_pair = {(sa.student_id, sa.assignment_id): sa for sa in sa_rows}
+
+    # --- Data rows ---
+    all_scores: List[float] = []
+    per_assignment_scores: dict[int, List[float]] = {a.id: [] for a in assignments}
+
+    first_data_row = 6
+    for student_idx, student in enumerate(students):
+        row = first_data_row + student_idx
+        ws.cell(row=row, column=1, value=student.student_number or "")
+        ws.cell(row=row, column=2, value=student.name or "")
+        student_scores: List[float] = []
+
+        for col_idx, (_, a) in enumerate(ordered):
+            sa = sa_by_pair.get((student.id, a.id))
+            score = _final_score(sa, a, db)
+            if score is not None:
+                student_scores.append(float(score))
+                per_assignment_scores[a.id].append(float(score))
+                all_scores.append(float(score))
+                ws.cell(row=row, column=4 + col_idx, value=score)
+            # else: leave blank (per user spec)
+            ws.cell(row=row, column=4 + col_idx).alignment = Alignment(
+                horizontal="center"
+            )
+
+        personal_avg = _avg(student_scores)
+        if personal_avg is not None:
+            ws.cell(row=row, column=3, value=personal_avg)
+        ws.cell(row=row, column=3).alignment = Alignment(horizontal="center")
+
+    # --- Footer row: 班級平均 ---
+    footer_row = first_data_row + len(students)
+    ws.cell(row=footer_row, column=1, value="班級平均")
+    ws.merge_cells(
+        start_row=footer_row, start_column=1, end_row=footer_row, end_column=2
+    )
+    ws.cell(row=footer_row, column=1).font = Font(bold=True)
+    ws.cell(row=footer_row, column=1).alignment = Alignment(horizontal="center")
+
+    overall_avg = _avg(all_scores)
+    if overall_avg is not None:
+        ws.cell(row=footer_row, column=3, value=overall_avg)
+    for col_idx, (_, a) in enumerate(ordered):
+        per_a = _avg(per_assignment_scores[a.id])
+        if per_a is not None:
+            ws.cell(row=footer_row, column=4 + col_idx, value=per_a)
+        ws.cell(row=footer_row, column=4 + col_idx).alignment = Alignment(
+            horizontal="center"
+        )
+    ws.cell(row=footer_row, column=3).alignment = Alignment(horizontal="center")
+
+    # --- Light styling: header background + borders ---
+    header_fill = PatternFill("solid", fgColor="F2F2F2")
+    thin = Side(style="thin", color="BFBFBF")
+    border = Border(left=thin, right=thin, top=thin, bottom=thin)
+    for header_row in (3, 4, 5):
+        for c in range(1, total_cols + 1):
+            cell = ws.cell(row=header_row, column=c)
+            cell.fill = header_fill
+            cell.font = cell.font.copy(bold=True)
+            cell.border = border
+    for r in range(first_data_row, footer_row + 1):
+        for c in range(1, total_cols + 1):
+            ws.cell(row=r, column=c).border = border
+
+    # --- Column widths ---
+    ws.column_dimensions["A"].width = 8
+    ws.column_dimensions["B"].width = 12
+    ws.column_dimensions["C"].width = 10
+    for c in range(4, total_cols + 1):
+        ws.column_dimensions[get_column_letter(c)].width = 16
+    ws.row_dimensions[1].height = 24
+    ws.row_dimensions[4].height = 30
+
+    return wb
+
+
+@router.post("/classrooms/{classroom_id}/grade-report")
+async def class_grade_report(
+    classroom_id: int,
+    request: ClassGradeReportRequest,
+    db: Session = Depends(get_db),
+    current_teacher: Teacher = Depends(get_current_teacher),
+):
+    classroom = _verify_classroom_ownership(classroom_id, current_teacher.id, db)
+
+    assignments = (
+        db.query(Assignment)
+        .filter(
+            Assignment.id.in_(request.assignment_ids),
+            Assignment.classroom_id == classroom_id,
+            Assignment.teacher_id == current_teacher.id,
+            Assignment.is_active.is_(True),
+        )
+        .order_by(Assignment.created_at.asc(), Assignment.id.asc())
+        .all()
+    )
+    if len(assignments) != len(request.assignment_ids):
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                "Some assignments were not found in this classroom or are "
+                "inaccessible"
+            ),
+        )
+
+    students = _classroom_students(classroom_id, db)
+    wb = _build_class_workbook(classroom, assignments, students, db)
+    filename = f"{classroom.name}_成績總覽_{_today_yyyymmdd()}.xlsx"
+    return _xlsx_response(wb, filename)
+
+
+# ---------------------------------------------------------------------------
+# Student grade report (學生成績單)
+# ---------------------------------------------------------------------------
+
+
+def _build_single_student_workbook(
+    classroom: Classroom,
+    student: Student,
+    assignments: List[Assignment],
+    sa_by_assignment: dict,
+    db: Session,
+) -> Workbook:
+    """Build a one-sheet workbook for a single student.
+
+    Layout (matches the sample on issue #708):
+
+    ::
+
+        Row 1: 學生成績單　<class> 班　<num> 號　<name>
+        Row 2: 下載日期：YYYY-MM-DD
+        Row 3: 類別 | 作業名稱 | 派發日期 | 分數
+        Then for each non-empty category:
+            Row:  ▌ <category>
+            Rows: <category> | <title> | <date> | <score>
+        Last: 總平均 | | | <avg>
+
+    ``sa_by_assignment`` is the caller-supplied lookup ``{assignment_id: sa}``
+    for this student — done once in the parent so the per-student loop
+    doesn't re-query the DB N times.
+    """
+    wb = Workbook()
+    ws = wb.active
+    ws.title = _sanitize_sheet_title(
+        f"{classroom.name}_{student.student_number or ''}_{student.name or ''}"
+    )
+
+    today_iso = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    thin = Side(style="thin", color="BFBFBF")
+    border = Border(left=thin, right=thin, top=thin, bottom=thin)
+    header_fill = PatternFill("solid", fgColor="F2F2F2")
+    banner_fill = PatternFill("solid", fgColor="E8EEF7")
+
+    # Row 1: header
+    ws.cell(
+        row=1,
+        column=1,
+        value=(
+            f"學生成績單　{classroom.name} 班　"
+            f"{student.student_number or ''} 號　{student.name or ''}"
+        ),
+    )
+    ws.merge_cells(start_row=1, start_column=1, end_row=1, end_column=4)
+    ws.cell(row=1, column=1).font = Font(bold=True, size=13)
+    ws.cell(row=1, column=1).alignment = Alignment(horizontal="left")
+
+    # Row 2: download date
+    ws.cell(row=2, column=1, value=f"下載日期：{today_iso}")
+    ws.merge_cells(start_row=2, start_column=1, end_row=2, end_column=4)
+
+    # Row 3: column headers
+    for c, h in enumerate(("類別", "作業名稱", "派發日期", "分數"), start=1):
+        cell = ws.cell(row=3, column=c, value=h)
+        cell.fill = header_fill
+        cell.font = Font(bold=True)
+        cell.alignment = Alignment(horizontal="center")
+        cell.border = border
+
+    # Bucket assignments by category, preserving insertion order within bucket.
+    groups: dict[str, List[Assignment]] = {k: [] for k in _CATEGORY_ORDER}
+    for a in assignments:
+        groups[_category_key(a)].append(a)
+
+    cur_row = 4
+    scores: List[float] = []
+    for cat in _CATEGORY_ORDER:
+        items = groups[cat]
+        if not items:
+            continue
+        # Banner row
+        banner = ws.cell(row=cur_row, column=1, value=f"▌ {_CATEGORY_ZH[cat]}")
+        ws.merge_cells(start_row=cur_row, start_column=1, end_row=cur_row, end_column=4)
+        banner.font = Font(bold=True)
+        banner.fill = banner_fill
+        banner.alignment = Alignment(horizontal="left")
+        for c in range(1, 5):
+            ws.cell(row=cur_row, column=c).border = border
+        cur_row += 1
+
+        for a in items:
+            sa = sa_by_assignment.get(a.id)
+            score = _final_score(sa, a, db)
+            d = a.created_at.date().isoformat() if a.created_at else ""
+            ws.cell(row=cur_row, column=1, value=_CATEGORY_ZH[cat])
+            ws.cell(row=cur_row, column=2, value=a.title)
+            ws.cell(row=cur_row, column=3, value=d)
+            if score is not None:
+                ws.cell(row=cur_row, column=4, value=score)
+                scores.append(float(score))
+            # else: leave blank (per user spec)
+            for c in range(1, 5):
+                cell = ws.cell(row=cur_row, column=c)
+                cell.border = border
+                if c >= 3:
+                    cell.alignment = Alignment(horizontal="center")
+            cur_row += 1
+
+    # Footer: 總平均
+    avg = _avg(scores)
+    ws.cell(row=cur_row, column=1, value="總平均")
+    ws.merge_cells(start_row=cur_row, start_column=1, end_row=cur_row, end_column=3)
+    ws.cell(row=cur_row, column=1).font = Font(bold=True)
+    ws.cell(row=cur_row, column=1).alignment = Alignment(horizontal="center")
+    if avg is not None:
+        ws.cell(row=cur_row, column=4, value=avg)
+    ws.cell(row=cur_row, column=4).alignment = Alignment(horizontal="center")
+    for c in range(1, 5):
+        ws.cell(row=cur_row, column=c).border = border
+
+    # Column widths
+    ws.column_dimensions["A"].width = 14
+    ws.column_dimensions["B"].width = 28
+    ws.column_dimensions["C"].width = 14
+    ws.column_dimensions["D"].width = 10
+
+    return wb
+
+
+def _zip_response(files: List[Tuple[str, bytes]], zip_filename: str) -> Response:
+    """Pack the (inner_filename, content) tuples into a single zip Response."""
+    buf = io.BytesIO()
+    # ZIP_DEFLATED keeps xlsx (already compressed) roughly the same size but
+    # at least makes the archive itself well-formed for every client.
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in files:
+            zf.writestr(name, data)
+    buf.seek(0)
+    ascii_fallback = (
+        zip_filename.encode("ascii", errors="ignore").decode() or "report.zip"
+    )
+    disposition = (
+        f'attachment; filename="{ascii_fallback}"; '
+        f"filename*=UTF-8''{quote(zip_filename)}"
+    )
+    return Response(
+        content=buf.getvalue(),
+        media_type="application/zip",
+        headers={"Content-Disposition": disposition},
+    )
+
+
+@router.post("/classrooms/{classroom_id}/student-grade-report")
+async def student_grade_report(
+    classroom_id: int,
+    request: StudentGradeReportRequest,
+    db: Session = Depends(get_db),
+    current_teacher: Teacher = Depends(get_current_teacher),
+):
+    """Per-student grade report for the selected assignments, packed as ZIP.
+
+    One ``.xlsx`` per enrolled student is generated and bundled into a
+    single ``.zip``. Even when the classroom only has one student, the
+    response is still a ZIP containing one file, so the frontend can use a
+    single code path.
+    """
+    classroom = _verify_classroom_ownership(classroom_id, current_teacher.id, db)
+
+    assignments = (
+        db.query(Assignment)
+        .filter(
+            Assignment.id.in_(request.assignment_ids),
+            Assignment.classroom_id == classroom_id,
+            Assignment.teacher_id == current_teacher.id,
+            Assignment.is_active.is_(True),
+        )
+        .order_by(Assignment.created_at.asc(), Assignment.id.asc())
+        .all()
+    )
+    if len(assignments) != len(request.assignment_ids):
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                "Some assignments were not found in this classroom or are "
+                "inaccessible"
+            ),
+        )
+
+    students = _classroom_students(classroom_id, db)
+    if not students:
+        raise HTTPException(
+            status_code=404, detail="Classroom has no enrolled students"
+        )
+
+    # Pre-load all StudentAssignments for these (students, assignments) so the
+    # per-student workbook builder doesn't re-query the DB N times.
+    assignment_ids = [a.id for a in assignments]
+    student_ids = [s.id for s in students]
+    sa_rows = (
+        db.query(StudentAssignment)
+        .filter(
+            StudentAssignment.assignment_id.in_(assignment_ids),
+            StudentAssignment.student_id.in_(student_ids),
+            StudentAssignment.is_active.is_(True),
+        )
+        .all()
+    )
+    sa_by_pair = {(sa.student_id, sa.assignment_id): sa for sa in sa_rows}
+
+    today = _today_yyyymmdd()
+    files: List[Tuple[str, bytes]] = []
+    for student in students:
+        sa_for_student = {a.id: sa_by_pair.get((student.id, a.id)) for a in assignments}
+        wb = _build_single_student_workbook(
+            classroom, student, assignments, sa_for_student, db
+        )
+        buf = io.BytesIO()
+        wb.save(buf)
+        inner_name = (
+            f"{classroom.name}_{student.student_number or ''}_"
+            f"{student.name or ''}_{today}.xlsx"
+        )
+        files.append((inner_name, buf.getvalue()))
+
+    zip_filename = f"{classroom.name}_學生成績單_{today}.zip"
+    return _zip_response(files, zip_filename)
+
+
+# Re-export so the package can register this router.
+__all__ = ["router"]

--- a/backend/tests/integration/api/test_grade_reports.py
+++ b/backend/tests/integration/api/test_grade_reports.py
@@ -1,0 +1,551 @@
+"""Integration tests for the grade-report endpoints (issue #708)."""
+from __future__ import annotations
+
+import io
+import zipfile
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from openpyxl import load_workbook
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+from auth import get_password_hash
+from database import Base, get_db
+from main import app
+from models import (
+    Assignment,
+    Classroom,
+    ClassroomStudent,
+    Student,
+    StudentAssignment,
+    SubscriptionPeriod,
+    Teacher,
+)
+
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test_grade_reports.db"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    pool_pre_ping=True,
+)
+
+
+@event.listens_for(engine, "connect")
+def _enable_fk(dbapi_conn, _record):
+    cur = dbapi_conn.cursor()
+    cur.execute("PRAGMA foreign_keys=ON")
+    cur.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = _override_get_db
+client = TestClient(app)
+
+
+@pytest.fixture(scope="function")
+def fresh_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+def _login(email: str = "t1@test.com", password: str = "pw") -> dict:
+    res = client.post(
+        "/api/auth/teacher/login",
+        json={"email": email, "password": password},
+    )
+    assert res.status_code == 200, res.text
+    return {"Authorization": f"Bearer {res.json()['access_token']}"}
+
+
+@pytest.fixture
+def seeded(fresh_db):
+    """Seed: teacher T1 with classroom C1 containing two students and three
+    assignments across categories. T2 owns a separate classroom for the
+    permission test."""
+    db = TestingSessionLocal()
+    now = datetime.now(timezone.utc)
+
+    # Two teachers, each with a subscription period so they can call the API.
+    for tid, email in [(1, "t1@test.com"), (2, "t2@test.com")]:
+        db.add(
+            Teacher(
+                id=tid,
+                name=f"Teacher {tid}",
+                email=email,
+                password_hash=get_password_hash("pw"),
+                email_verified=True,
+                is_active=True,
+            )
+        )
+    db.commit()
+    for tid in (1, 2):
+        db.add(
+            SubscriptionPeriod(
+                teacher_id=tid,
+                plan_name="Tutor Teachers",
+                amount_paid=299,
+                quota_total=2000,
+                quota_used=0,
+                start_date=now,
+                end_date=now + timedelta(days=30),
+                payment_method="credit_card",
+            )
+        )
+    db.commit()
+
+    # Classrooms
+    db.add(Classroom(id=1, name="301", teacher_id=1, is_active=True))
+    db.add(Classroom(id=2, name="OtherClass", teacher_id=2, is_active=True))
+    db.commit()
+
+    # Students in C1 (T1's classroom): 01 王小明, 02 林小花
+    db.add(
+        Student(
+            id=11,
+            name="王小明",
+            student_number="01",
+            email="s11@test.com",
+            password_hash=get_password_hash("pw"),
+            is_active=True,
+        )
+    )
+    db.add(
+        Student(
+            id=12,
+            name="林小花",
+            student_number="02",
+            email="s12@test.com",
+            password_hash=get_password_hash("pw"),
+            is_active=True,
+        )
+    )
+    db.commit()
+    db.add(ClassroomStudent(classroom_id=1, student_id=11, is_active=True))
+    db.add(ClassroomStudent(classroom_id=1, student_id=12, is_active=True))
+    db.commit()
+
+    # Three assignments owned by T1 in C1 across categories.
+    # Dates: 30 days ago, 20 days ago, 10 days ago — used in date-range test.
+    base = now - timedelta(days=30)
+    a_listening = Assignment(
+        id=101,
+        title="Unit 1 Listening Quiz",
+        classroom_id=1,
+        teacher_id=1,
+        practice_mode="rearrangement",
+        play_audio=True,
+        score_category="listening",
+        is_active=True,
+        created_at=base,
+    )
+    a_reading = Assignment(
+        id=102,
+        title="Chapter 1 Reading",
+        classroom_id=1,
+        teacher_id=1,
+        practice_mode="word_cloze",
+        play_audio=False,
+        score_category="reading",
+        is_active=True,
+        created_at=base + timedelta(days=10),
+    )
+    a_speaking = Assignment(
+        id=103,
+        title="Self-Introduction",
+        classroom_id=1,
+        teacher_id=1,
+        practice_mode="word_reading",
+        play_audio=False,
+        score_category="speaking",
+        is_active=True,
+        created_at=base + timedelta(days=20),
+    )
+    for a in (a_listening, a_reading, a_speaking):
+        db.add(a)
+    db.commit()
+
+    # StudentAssignment scores. 王小明 has all three; 林小花 only has two.
+    db.add(
+        StudentAssignment(
+            assignment_id=101,
+            student_id=11,
+            teacher_id=1,
+            classroom_id=1,
+            title="Unit 1 Listening Quiz",
+            score=88,
+            is_active=True,
+        )
+    )
+    db.add(
+        StudentAssignment(
+            assignment_id=102,
+            student_id=11,
+            teacher_id=1,
+            classroom_id=1,
+            title="Chapter 1 Reading",
+            score=76,
+            is_active=True,
+        )
+    )
+    db.add(
+        StudentAssignment(
+            assignment_id=103,
+            student_id=11,
+            teacher_id=1,
+            classroom_id=1,
+            title="Self-Introduction",
+            score=95,
+            is_active=True,
+        )
+    )
+    db.add(
+        StudentAssignment(
+            assignment_id=101,
+            student_id=12,
+            teacher_id=1,
+            classroom_id=1,
+            title="Unit 1 Listening Quiz",
+            score=75,
+            is_active=True,
+        )
+    )
+    # 林小花 has no row for assignment 102 (intentional — leave blank).
+    db.add(
+        StudentAssignment(
+            assignment_id=103,
+            student_id=12,
+            teacher_id=1,
+            classroom_id=1,
+            title="Self-Introduction",
+            score=88,
+            is_active=True,
+        )
+    )
+    db.commit()
+    db.close()
+    return {
+        "classroom_id": 1,
+        "other_classroom_id": 2,
+        "assignment_ids": [101, 102, 103],
+        "student_ids": [11, 12],
+        "assignment_listening_id": 101,
+        "assignment_reading_id": 102,
+        "assignment_speaking_id": 103,
+    }
+
+
+def _load(content: bytes):
+    return load_workbook(io.BytesIO(content), data_only=True)
+
+
+# ---------------------------------------------------------------------------
+# Class grade report
+# ---------------------------------------------------------------------------
+
+
+def test_class_grade_report_happy_path(seeded):
+    headers = _login()
+    res = client.post(
+        f"/api/teachers/classrooms/{seeded['classroom_id']}/grade-report",
+        headers=headers,
+        json={"assignment_ids": seeded["assignment_ids"]},
+    )
+    assert res.status_code == 200, res.text
+    assert "spreadsheetml" in res.headers["content-type"]
+    assert "Content-Disposition" in res.headers
+    assert "filename*=UTF-8''" in res.headers["Content-Disposition"]
+
+    wb = _load(res.content)
+    ws = wb.active
+    # Title row mentions class name.
+    assert "301" in str(ws.cell(row=1, column=1).value)
+    # Static headers
+    assert ws.cell(row=3, column=1).value == "座號"
+    assert ws.cell(row=3, column=2).value == "姓名"
+    assert ws.cell(row=3, column=3).value == "個人平均"
+    # Categories appear in 聽力 → 閱讀 → 寫作 → 口說 order
+    banner_cells = [
+        str(c.value) for c in ws[3] if c.value and c.value not in ("座號", "姓名", "個人平均")
+    ]
+    assert banner_cells == ["聽力", "閱讀", "口說"]
+    # The rightmost 班級平均 column was removed (issue #708 follow-up):
+    # the rightmost header cell must be the last assignment's category banner
+    # or an assignment cell — never "班級平均".
+    row3_values = [c.value for c in ws[3] if c.value]
+    assert "班級平均" not in row3_values
+    # 王小明 row: student_number 01, has scores 88 / 76 / 95
+    student_rows = [r for r in ws.iter_rows(min_row=6, max_row=7, values_only=True)]
+    names = [r[1] for r in student_rows]
+    assert "王小明" in names
+    assert "林小花" in names
+    # Footer: 班級平均 label still anchors the bottom row in cols 1-2,
+    # and the rightmost footer cell is now a per-assignment average (or
+    # blank), never the duplicated overall average.
+    last_row = list(ws.iter_rows(values_only=True))[-1]
+    assert last_row[0] == "班級平均"
+
+
+def test_class_grade_report_rejects_assignments_in_other_classroom(seeded):
+    """T1 cannot include an ID that belongs to T2's classroom."""
+    # Seed an extra assignment owned by T2 in their classroom.
+    db = TestingSessionLocal()
+    db.add(
+        Assignment(
+            id=999,
+            title="Other classroom assignment",
+            classroom_id=seeded["other_classroom_id"],
+            teacher_id=2,
+            practice_mode="reading",
+            play_audio=False,
+            score_category="speaking",
+            is_active=True,
+        )
+    )
+    db.commit()
+    db.close()
+
+    headers = _login()
+    res = client.post(
+        f"/api/teachers/classrooms/{seeded['classroom_id']}/grade-report",
+        headers=headers,
+        json={"assignment_ids": [seeded["assignment_listening_id"], 999]},
+    )
+    assert res.status_code == 404
+
+
+def test_class_grade_report_404_for_classroom_not_owned(seeded):
+    headers = _login()  # T1
+    res = client.post(
+        f"/api/teachers/classrooms/{seeded['other_classroom_id']}/grade-report",
+        headers=headers,
+        json={"assignment_ids": [seeded["assignment_listening_id"]]},
+    )
+    assert res.status_code == 404
+
+
+def test_class_grade_report_rejects_empty_selection(seeded):
+    headers = _login()
+    res = client.post(
+        f"/api/teachers/classrooms/{seeded['classroom_id']}/grade-report",
+        headers=headers,
+        json={"assignment_ids": []},
+    )
+    assert res.status_code == 422
+
+
+def test_class_grade_report_unauthenticated_returns_401(seeded):
+    res = client.post(
+        f"/api/teachers/classrooms/{seeded['classroom_id']}/grade-report",
+        json={"assignment_ids": seeded["assignment_ids"]},
+    )
+    assert res.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Student grade report (ZIP-of-xlsx contract, issue #708 follow-up)
+# ---------------------------------------------------------------------------
+
+
+def _open_zip(content: bytes) -> zipfile.ZipFile:
+    return zipfile.ZipFile(io.BytesIO(content))
+
+
+def test_student_grade_report_happy_path_returns_zip_per_enrolled_student(seeded):
+    """Selecting all three assignments produces a zip with one xlsx per
+    enrolled student (2 in this fixture), each containing only the selected
+    assignments and the right 總平均."""
+    headers = _login()
+    res = client.post(
+        f"/api/teachers/classrooms/{seeded['classroom_id']}/student-grade-report",
+        headers=headers,
+        json={"assignment_ids": seeded["assignment_ids"]},
+    )
+    assert res.status_code == 200, res.text
+    assert res.headers["content-type"] == "application/zip"
+    assert "Content-Disposition" in res.headers
+    assert "filename*=UTF-8''" in res.headers["Content-Disposition"]
+    # Zip filename pattern: <class>_學生成績單_<YYYYMMDD>.zip
+    assert "301_%E5%AD%B8%E7%94%9F" in res.headers["Content-Disposition"]
+    assert res.headers["Content-Disposition"].endswith(".zip")
+
+    zf = _open_zip(res.content)
+    names = zf.namelist()
+    assert len(names) == 2  # 王小明 + 林小花
+    assert any("王小明" in n for n in names)
+    assert any("林小花" in n for n in names)
+    # Inner files end in .xlsx
+    assert all(n.endswith(".xlsx") for n in names)
+
+    # 王小明: 88 / 76 / 95 → 總平均 86.3
+    wang_name = next(n for n in names if "王小明" in n)
+    wb = load_workbook(io.BytesIO(zf.read(wang_name)), data_only=True)
+    ws = wb.active
+    headers_row = [ws.cell(row=3, column=c).value for c in range(1, 5)]
+    assert headers_row == ["類別", "作業名稱", "派發日期", "分數"]
+    rows = list(ws.iter_rows(values_only=True))
+    assert rows[-1][0] == "總平均"
+    assert rows[-1][3] == pytest.approx(86.3)
+
+
+def test_student_grade_report_subset_of_assignments_changes_average(seeded):
+    """Selecting only the reading assignment (王小明 scored 76) should make
+    that student's 總平均 == 76 — proves the per-student xlsx really is scoped
+    to the selection rather than always covering every assignment."""
+    headers = _login()
+    res = client.post(
+        f"/api/teachers/classrooms/{seeded['classroom_id']}/student-grade-report",
+        headers=headers,
+        json={"assignment_ids": [seeded["assignment_reading_id"]]},
+    )
+    assert res.status_code == 200, res.text
+
+    zf = _open_zip(res.content)
+    wang_name = next(n for n in zf.namelist() if "王小明" in n)
+    ws = load_workbook(io.BytesIO(zf.read(wang_name)), data_only=True).active
+    all_text = " ".join(str(c.value) for row in ws.iter_rows() for c in row if c.value)
+    assert "▌ 閱讀" in all_text
+    assert "▌ 聽力" not in all_text
+    assert "▌ 口說" not in all_text
+    rows = list(ws.iter_rows(values_only=True))
+    assert rows[-1][0] == "總平均"
+    assert rows[-1][3] == pytest.approx(76)
+
+
+def test_student_grade_report_one_student_classroom_still_returns_zip(fresh_db):
+    """A classroom with exactly one student should still come back as a ZIP
+    containing one file — frontend treats every response as a ZIP."""
+    db = TestingSessionLocal()
+    now = datetime.now(timezone.utc)
+    db.add(
+        Teacher(
+            id=1,
+            name="Solo Teacher",
+            email="solo@test.com",
+            password_hash=get_password_hash("pw"),
+            email_verified=True,
+            is_active=True,
+        )
+    )
+    db.commit()
+    db.add(
+        SubscriptionPeriod(
+            teacher_id=1,
+            plan_name="Tutor Teachers",
+            amount_paid=299,
+            quota_total=2000,
+            quota_used=0,
+            start_date=now,
+            end_date=now + timedelta(days=30),
+            payment_method="credit_card",
+        )
+    )
+    db.add(Classroom(id=10, name="SoloClass", teacher_id=1, is_active=True))
+    db.commit()
+    db.add(
+        Student(
+            id=20,
+            name="OnlyKid",
+            student_number="01",
+            email="only@test.com",
+            password_hash=get_password_hash("pw"),
+            is_active=True,
+        )
+    )
+    db.commit()
+    db.add(ClassroomStudent(classroom_id=10, student_id=20, is_active=True))
+    db.add(
+        Assignment(
+            id=200,
+            title="Only Quiz",
+            classroom_id=10,
+            teacher_id=1,
+            practice_mode="word_reading",
+            play_audio=False,
+            score_category="speaking",
+            is_active=True,
+            created_at=now,
+        )
+    )
+    db.commit()
+    db.close()
+
+    headers = _login(email="solo@test.com")
+    res = client.post(
+        "/api/teachers/classrooms/10/student-grade-report",
+        headers=headers,
+        json={"assignment_ids": [200]},
+    )
+    assert res.status_code == 200, res.text
+    assert res.headers["content-type"] == "application/zip"
+    zf = _open_zip(res.content)
+    assert len(zf.namelist()) == 1
+    assert "OnlyKid" in zf.namelist()[0]
+
+
+def test_student_grade_report_rejects_assignments_in_other_classroom(seeded):
+    """T1 cannot include an assignment id that belongs to T2's classroom."""
+    db = TestingSessionLocal()
+    db.add(
+        Assignment(
+            id=999,
+            title="Other classroom assignment",
+            classroom_id=seeded["other_classroom_id"],
+            teacher_id=2,
+            practice_mode="reading",
+            play_audio=False,
+            score_category="speaking",
+            is_active=True,
+        )
+    )
+    db.commit()
+    db.close()
+
+    headers = _login()
+    res = client.post(
+        f"/api/teachers/classrooms/{seeded['classroom_id']}/student-grade-report",
+        headers=headers,
+        json={"assignment_ids": [seeded["assignment_listening_id"], 999]},
+    )
+    assert res.status_code == 404
+
+
+def test_student_grade_report_404_for_classroom_not_owned(seeded):
+    headers = _login()  # T1
+    res = client.post(
+        f"/api/teachers/classrooms/{seeded['other_classroom_id']}/student-grade-report",
+        headers=headers,
+        json={"assignment_ids": [seeded["assignment_listening_id"]]},
+    )
+    assert res.status_code == 404
+
+
+def test_student_grade_report_rejects_empty_selection(seeded):
+    headers = _login()
+    res = client.post(
+        f"/api/teachers/classrooms/{seeded['classroom_id']}/student-grade-report",
+        headers=headers,
+        json={"assignment_ids": []},
+    )
+    assert res.status_code == 422
+
+
+def test_student_grade_report_unauthenticated_returns_401(seeded):
+    res = client.post(
+        f"/api/teachers/classrooms/{seeded['classroom_id']}/student-grade-report",
+        json={"assignment_ids": seeded["assignment_ids"]},
+    )
+    assert res.status_code == 401

--- a/backend/tests/test_admin_credit_packages.py
+++ b/backend/tests/test_admin_credit_packages.py
@@ -1,0 +1,431 @@
+"""Tests for admin credit package instance CRUD endpoints.
+
+Covers per-teacher CreditPackage row editing and soft-cancellation
+(status -> 'refunded') with audit trail in admin_metadata.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from auth import create_access_token, get_password_hash
+from models import CreditPackage, Teacher
+
+
+# ============ Fixtures ============
+@pytest.fixture
+def admin_teacher(shared_test_session):
+    teacher = Teacher(
+        email="admin-cp@duotopia.com",
+        password_hash=get_password_hash("admin_password"),
+        name="Admin CP",
+        is_active=True,
+        is_admin=True,
+        email_verified=True,
+    )
+    shared_test_session.add(teacher)
+    shared_test_session.commit()
+    shared_test_session.refresh(teacher)
+    return teacher
+
+
+@pytest.fixture
+def regular_teacher(shared_test_session):
+    teacher = Teacher(
+        email="user-cp@duotopia.com",
+        password_hash=get_password_hash("user_password"),
+        name="User CP",
+        is_active=True,
+        is_admin=False,
+        email_verified=True,
+    )
+    shared_test_session.add(teacher)
+    shared_test_session.commit()
+    shared_test_session.refresh(teacher)
+    return teacher
+
+
+@pytest.fixture
+def auth_headers_admin(admin_teacher):
+    token = create_access_token(data={"sub": str(admin_teacher.id), "type": "teacher"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def auth_headers_regular(regular_teacher):
+    token = create_access_token(
+        data={"sub": str(regular_teacher.id), "type": "teacher"}
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def active_package(shared_test_session, regular_teacher):
+    now = datetime.now(timezone.utc)
+    pkg = CreditPackage(
+        teacher_id=regular_teacher.id,
+        package_id="trial-bonus",
+        points_total=2000,
+        points_used=300,
+        price_paid=0,
+        purchased_at=now - timedelta(days=10),
+        expires_at=now + timedelta(days=355),
+        status="active",
+        source="trial_bonus",
+    )
+    shared_test_session.add(pkg)
+    shared_test_session.commit()
+    shared_test_session.refresh(pkg)
+    return pkg
+
+
+@pytest.fixture
+def refunded_package(shared_test_session, regular_teacher):
+    now = datetime.now(timezone.utc)
+    pkg = CreditPackage(
+        teacher_id=regular_teacher.id,
+        package_id="pkg-1000",
+        points_total=1000,
+        points_used=0,
+        price_paid=180,
+        purchased_at=now - timedelta(days=30),
+        expires_at=now + timedelta(days=335),
+        status="refunded",
+        source="purchase",
+    )
+    shared_test_session.add(pkg)
+    shared_test_session.commit()
+    shared_test_session.refresh(pkg)
+    return pkg
+
+
+# ============ PUT /api/admin/subscription/credit-package/{id} ============
+def test_edit_credit_package_happy_path(
+    active_package, admin_teacher, auth_headers_admin, test_client, shared_test_session
+):
+    new_expires = (datetime.now(timezone.utc) + timedelta(days=400)).date().isoformat()
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={
+            "points_total": 1800,
+            "expires_at": new_expires,
+            "reason": "Extending expiry per customer request",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["id"] == active_package.id
+    assert body["points_total"] == 1800
+    assert body["expires_at"].startswith(new_expires)
+
+    shared_test_session.expire_all()
+    row = shared_test_session.get(CreditPackage, active_package.id)
+    assert row.points_total == 1800
+    assert row.admin_id == admin_teacher.id
+    assert row.admin_reason == "Extending expiry per customer request"
+    # Audit history accumulated
+    assert row.admin_metadata is not None
+    ops = row.admin_metadata.get("operations", [])
+    assert len(ops) == 1
+    assert ops[0]["action"] == "edit"
+    assert ops[0]["admin_id"] == admin_teacher.id
+    assert ops[0]["reason"] == "Extending expiry per customer request"
+
+
+def test_edit_credit_package_partial_points_only(
+    active_package, auth_headers_admin, test_client, shared_test_session
+):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 1500, "reason": "correction"},
+    )
+    assert response.status_code == 200
+
+    shared_test_session.expire_all()
+    row = shared_test_session.get(CreditPackage, active_package.id)
+    assert row.points_total == 1500
+    # expires_at untouched
+    assert row.expires_at == active_package.expires_at
+
+
+def test_edit_credit_package_points_below_used_rejected(
+    active_package, auth_headers_admin, test_client
+):
+    # active_package.points_used == 300, so 200 should be rejected
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 200, "reason": "bad reduce"},
+    )
+    assert response.status_code == 422
+    assert "points_used" in response.json()["detail"].lower()
+
+
+def test_edit_credit_package_negative_points_rejected(
+    active_package, auth_headers_admin, test_client
+):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": -1, "reason": "bad"},
+    )
+    assert response.status_code == 422
+
+
+def test_edit_credit_package_reason_required(
+    active_package, auth_headers_admin, test_client
+):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 1500},
+    )
+    assert response.status_code == 422
+
+
+def test_edit_credit_package_reason_empty_rejected(
+    active_package, auth_headers_admin, test_client
+):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 1500, "reason": ""},
+    )
+    assert response.status_code == 422
+
+
+def test_edit_credit_package_not_found(auth_headers_admin, test_client):
+    response = test_client.put(
+        "/api/admin/subscription/credit-package/999999",
+        headers=auth_headers_admin,
+        json={"points_total": 1000, "reason": "test"},
+    )
+    assert response.status_code == 404
+
+
+def test_edit_credit_package_already_refunded_rejected(
+    refunded_package, auth_headers_admin, test_client
+):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{refunded_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 500, "reason": "should fail"},
+    )
+    assert response.status_code == 422
+
+
+def test_edit_credit_package_points_equal_used_accepted(
+    active_package, auth_headers_admin, test_client, shared_test_session
+):
+    """points_total == points_used is the lower bound and must be accepted."""
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": active_package.points_used, "reason": "exact match"},
+    )
+    assert response.status_code == 200, response.text
+
+    shared_test_session.expire_all()
+    row = shared_test_session.get(CreditPackage, active_package.id)
+    assert row.points_total == active_package.points_used
+
+
+def test_edit_credit_package_non_admin_forbidden(
+    active_package, auth_headers_regular, test_client
+):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_regular,
+        json={"points_total": 1500, "reason": "should fail"},
+    )
+    assert response.status_code == 403
+
+
+def test_edit_credit_package_unauthenticated(active_package, test_client):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        json={"points_total": 1500, "reason": "test"},
+    )
+    assert response.status_code in (401, 403)
+
+
+def test_edit_credit_package_accumulates_history(
+    active_package, admin_teacher, auth_headers_admin, test_client, shared_test_session
+):
+    """Two consecutive edits should produce two operation entries."""
+    test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 1800, "reason": "first edit"},
+    )
+    test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 1500, "reason": "second edit"},
+    )
+
+    shared_test_session.expire_all()
+    row = shared_test_session.get(CreditPackage, active_package.id)
+    ops = row.admin_metadata.get("operations", [])
+    assert len(ops) == 2
+    assert [op["reason"] for op in ops] == ["first edit", "second edit"]
+    # Latest admin_reason reflects last edit
+    assert row.admin_reason == "second edit"
+
+
+# ============ POST /api/admin/subscription/credit-package/{id}/cancel ============
+def test_cancel_credit_package_happy_path(
+    active_package, admin_teacher, auth_headers_admin, test_client, shared_test_session
+):
+    response = test_client.post(
+        f"/api/admin/subscription/credit-package/{active_package.id}/cancel",
+        headers=auth_headers_admin,
+        json={"reason": "Customer refund request"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "refunded"
+
+    shared_test_session.expire_all()
+    row = shared_test_session.get(CreditPackage, active_package.id)
+    assert row.status == "refunded"
+    assert row.admin_id == admin_teacher.id
+    assert row.admin_reason == "Customer refund request"
+    ops = row.admin_metadata.get("operations", [])
+    assert len(ops) == 1
+    assert ops[0]["action"] == "cancel"
+
+
+def test_cancel_credit_package_reason_required(
+    active_package, auth_headers_admin, test_client
+):
+    response = test_client.post(
+        f"/api/admin/subscription/credit-package/{active_package.id}/cancel",
+        headers=auth_headers_admin,
+        json={},
+    )
+    assert response.status_code == 422
+
+
+def test_cancel_credit_package_not_found(auth_headers_admin, test_client):
+    response = test_client.post(
+        "/api/admin/subscription/credit-package/999999/cancel",
+        headers=auth_headers_admin,
+        json={"reason": "test"},
+    )
+    assert response.status_code == 404
+
+
+def test_cancel_credit_package_already_refunded_rejected(
+    refunded_package, auth_headers_admin, test_client
+):
+    response = test_client.post(
+        f"/api/admin/subscription/credit-package/{refunded_package.id}/cancel",
+        headers=auth_headers_admin,
+        json={"reason": "double cancel"},
+    )
+    assert response.status_code == 422
+
+
+def test_cancel_credit_package_non_admin_forbidden(
+    active_package, auth_headers_regular, test_client
+):
+    response = test_client.post(
+        f"/api/admin/subscription/credit-package/{active_package.id}/cancel",
+        headers=auth_headers_regular,
+        json={"reason": "should fail"},
+    )
+    assert response.status_code == 403
+
+
+# ============ admin_operations surfacing ============
+def test_edit_response_includes_admin_operations(
+    active_package, auth_headers_admin, test_client
+):
+    response = test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 1500, "reason": "history surfacing"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "admin_operations" in body
+    assert len(body["admin_operations"]) == 1
+    op = body["admin_operations"][0]
+    assert op["action"] == "edit"
+    assert op["reason"] == "history surfacing"
+    assert "timestamp" in op
+    assert "changes" in op
+
+
+def test_cancel_response_includes_admin_operations(
+    active_package, auth_headers_admin, test_client
+):
+    response = test_client.post(
+        f"/api/admin/subscription/credit-package/{active_package.id}/cancel",
+        headers=auth_headers_admin,
+        json={"reason": "refund test"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    ops = body["admin_operations"]
+    assert len(ops) == 1
+    assert ops[0]["action"] == "cancel"
+
+
+def test_teacher_periods_includes_admin_operations(
+    active_package, auth_headers_admin, regular_teacher, test_client
+):
+    # Generate one edit so the package has history
+    test_client.put(
+        f"/api/admin/subscription/credit-package/{active_package.id}",
+        headers=auth_headers_admin,
+        json={"points_total": 1500, "reason": "seeding history"},
+    )
+
+    response = test_client.get(
+        f"/api/admin/subscription/teacher/{regular_teacher.id}/periods",
+        headers=auth_headers_admin,
+    )
+    assert response.status_code == 200
+    pkg = next(
+        p for p in response.json()["credit_packages"] if p["id"] == active_package.id
+    )
+    assert pkg["admin_operations"]
+    assert pkg["admin_operations"][0]["action"] == "edit"
+
+
+def test_teacher_periods_empty_admin_operations_for_untouched_pkg(
+    active_package, auth_headers_admin, regular_teacher, test_client
+):
+    response = test_client.get(
+        f"/api/admin/subscription/teacher/{regular_teacher.id}/periods",
+        headers=auth_headers_admin,
+    )
+    pkg = next(
+        p for p in response.json()["credit_packages"] if p["id"] == active_package.id
+    )
+    assert pkg["admin_operations"] == []
+
+
+# ============ List filter ============
+def test_teacher_periods_excludes_refunded_packages(
+    active_package,
+    refunded_package,
+    regular_teacher,
+    auth_headers_admin,
+    test_client,
+):
+    response = test_client.get(
+        f"/api/admin/subscription/teacher/{regular_teacher.id}/periods",
+        headers=auth_headers_admin,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    pkg_ids = [p["id"] for p in body["credit_packages"]]
+    assert active_package.id in pkg_ids
+    assert refunded_package.id not in pkg_ids

--- a/backend/tests/test_organization_programs.py
+++ b/backend/tests/test_organization_programs.py
@@ -1110,6 +1110,80 @@ class TestCopyToClassroom:
 
 
 # ============================================================================
+# Test Cases: Assignment copies must not appear in org materials (#785)
+# ============================================================================
+
+
+class TestAssignmentCopyExcludedFromOrgMaterials:
+    """Regression for #785: dispatched-assignment Content copies are stored
+    under the same Lesson as the template, but must NOT show up in the
+    organization materials listing or detail response."""
+
+    def _add_assignment_copy(self, test_db: Session, original: Content) -> Content:
+        copy = Content(
+            lesson_id=original.lesson_id,
+            type=original.type,
+            title=original.title,
+            order_index=original.order_index,
+            is_active=True,
+            is_assignment_copy=True,
+            source_content_id=original.id,
+        )
+        test_db.add(copy)
+        test_db.commit()
+        test_db.refresh(copy)
+        return copy
+
+    def test_list_excludes_assignment_copies(
+        self,
+        test_client: TestClient,
+        test_db: Session,
+        test_org: Organization,
+        test_org_with_materials: list,
+        owner_headers: dict,
+    ):
+        for program in test_org_with_materials:
+            for lesson in program.lessons:
+                for content in lesson.contents:
+                    self._add_assignment_copy(test_db, content)
+
+        response = test_client.get(
+            f"/api/organizations/{test_org.id}/programs",
+            headers=owner_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        for program in data:
+            for lesson in program["lessons"]:
+                assert (
+                    len(lesson["contents"]) == 1
+                ), "assignment copies leaked into materials list"
+
+    def test_detail_excludes_assignment_copies(
+        self,
+        test_client: TestClient,
+        test_db: Session,
+        test_org: Organization,
+        test_org_with_materials: list,
+        owner_headers: dict,
+    ):
+        program = test_org_with_materials[0]
+        original_content = program.lessons[0].contents[0]
+        self._add_assignment_copy(test_db, original_content)
+        self._add_assignment_copy(test_db, original_content)
+
+        response = test_client.get(
+            f"/api/organizations/{test_org.id}/programs/{program.id}",
+            headers=owner_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        contents = data["lessons"][0]["contents"]
+        assert len(contents) == 1
+        assert contents[0]["id"] == original_content.id
+
+
+# ============================================================================
 # Summary
 # ============================================================================
 

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -78,8 +78,11 @@ import WordClozeContextPreview from "@/components/activities/WordClozeContextPre
 import RearrangementPreview from "@/components/activities/RearrangementPreview";
 import ReadingPreview from "@/components/activities/ReadingPreview";
 
-// Issue #752 PoC: 預覽固定使用 contact@duotopia.co 的「翰林佳音 第二冊 Unit 1」
-const PREVIEW_VOCAB_CONTENT_ID = 282; // Warm up（單字集）
+// Issue #752 PoC: 預覽固定使用 contact@duotopia.co 的官方公開單字集
+// production 用 id 2212（"RPG" VOCABULARY_SET）；其他環境（staging / develop /
+// per-issue / local）沿用舊預覽教材 id 282（翰林佳音 第二冊 Warm up）
+const PREVIEW_VOCAB_CONTENT_ID =
+  import.meta.env.VITE_ENVIRONMENT === "production" ? 2212 : 282;
 
 interface Student {
   id: number;
@@ -3651,7 +3654,10 @@ export function AssignmentDialog({
                             )}
                           </h4>
                           <WordReadingPreview
-                            contentId={PREVIEW_VOCAB_CONTENT_ID}
+                            contentId={
+                              cartItems[0]?.contentId ??
+                              PREVIEW_VOCAB_CONTENT_ID
+                            }
                             settings={{
                               time_limit_per_question:
                                 formData.time_limit_per_question,
@@ -3669,7 +3675,10 @@ export function AssignmentDialog({
                             )}
                           </h4>
                           <WordSelectionPreview
-                            contentId={PREVIEW_VOCAB_CONTENT_ID}
+                            contentId={
+                              cartItems[0]?.contentId ??
+                              PREVIEW_VOCAB_CONTENT_ID
+                            }
                             settings={{
                               show_image: formData.show_image,
                               show_option_images: formData.show_option_images,
@@ -3689,7 +3698,10 @@ export function AssignmentDialog({
                             )}
                           </h4>
                           <WordSpellingPreview
-                            contentId={PREVIEW_VOCAB_CONTENT_ID}
+                            contentId={
+                              cartItems[0]?.contentId ??
+                              PREVIEW_VOCAB_CONTENT_ID
+                            }
                             settings={{
                               show_translation: formData.show_translation,
                               show_image: formData.show_image,
@@ -3710,7 +3722,10 @@ export function AssignmentDialog({
                             )}
                           </h4>
                           <WordClozeContextPreview
-                            contentId={PREVIEW_VOCAB_CONTENT_ID}
+                            contentId={
+                              cartItems[0]?.contentId ??
+                              PREVIEW_VOCAB_CONTENT_ID
+                            }
                             settings={{
                               show_translation: formData.show_translation,
                               play_audio: formData.play_audio,

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -3745,7 +3745,12 @@ export function AssignmentDialog({
                             )}
                           </h4>
                           <RearrangementPreview
+                            contentId={cartItems[0]?.contentId}
                             shuffleQuestions={formData.shuffle_questions}
+                            timeLimitPerQuestion={
+                              formData.time_limit_per_question
+                            }
+                            playAudio={formData.play_audio}
                           />
                         </Card>
                       ) : formData.practice_mode === "reading" ? (
@@ -3756,7 +3761,11 @@ export function AssignmentDialog({
                             )}
                           </h4>
                           <ReadingPreview
+                            contentId={cartItems[0]?.contentId}
                             shuffleQuestions={formData.shuffle_questions}
+                            timeLimitPerQuestion={
+                              formData.time_limit_per_question
+                            }
                           />
                         </Card>
                       ) : (

--- a/frontend/src/components/activities/ReadingPreview.tsx
+++ b/frontend/src/components/activities/ReadingPreview.tsx
@@ -1,21 +1,201 @@
 /**
  * ReadingPreview — 派發 sheet 內的 reading 即時預覽
  *
- * 直接重用既有的 demo 路徑：抓 /api/demo/config 拿 demo_reading_assignment_id，
- * 再用 demoApi.getPreview() 拿 activities，最後渲染 StudentActivityPageContent
- * （isDemoMode + isPreviewMode 開），與 https://duotopia.co/demo/<id> 同等體驗。
+ * 兩條路徑：
+ * 1. 已知教材（內容卡派發）：傳入 contentId → 走 ByContent 子元件，
+ *    打 /api/teachers/contents/{contentId} 並依 content.type 自組 Activity items。
+ * 2. 未知教材（Assign New Homework 未選 cart）：contentId 為 undefined →
+ *    走 ByDemo 子元件，沿用既有 demoApi.getConfig + getPreview 路徑（保證有句子可預覽）。
  *
- * 取捨：設定（play_audio、time_limit 等）來自 demo assignment 自己存的值，
- * 不是老師當下調整的 formData。reading 模式 score_category 固定為 speaking，
- * 影響不大。
+ * 取材規則（ByContent 分支，與 backend / student 端一致）：
+ * - VOCABULARY_SET → 取 item.example_sentence + example_sentence_audio_url
+ * - EXAMPLE_SENTENCES → 取 item.text + item.audio_url
  *
  * ⚠️ 改動前必讀：docs/design/preview-architecture.md
  */
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { demoApi } from "@/lib/demoApi";
+import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
 import StudentActivityPageContent, {
   type Activity,
 } from "@/pages/student/StudentActivityPageContent";
+
+interface ReadingPreviewProps {
+  /** 已知教材時傳入；未傳則走 demo 預覽 */
+  contentId?: number;
+  shuffleQuestions?: boolean;
+  timeLimitPerQuestion?: number;
+}
+
+export default function ReadingPreview(props: ReadingPreviewProps) {
+  if (props.contentId == null) {
+    return <ReadingPreviewByDemo shuffleQuestions={props.shuffleQuestions} />;
+  }
+  return (
+    <ReadingPreviewByContent
+      contentId={props.contentId}
+      shuffleQuestions={props.shuffleQuestions}
+      timeLimitPerQuestion={props.timeLimitPerQuestion}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ByContent — 已知教材路徑（Phase 2）
+// ---------------------------------------------------------------------------
+
+interface RawContentItem {
+  id: number;
+  text?: string;
+  translation?: string;
+  audio_url?: string;
+  example_sentence?: string;
+  example_sentence_translation?: string;
+  example_sentence_audio_url?: string;
+}
+
+interface ContentResponse {
+  id: number;
+  type: string;
+  title: string;
+  items: RawContentItem[];
+}
+
+const VOCAB_TYPES = new Set(["VOCABULARY_SET", "SENTENCE_MAKING"]);
+
+function ReadingPreviewByContent({
+  contentId,
+  shuffleQuestions,
+  timeLimitPerQuestion,
+}: {
+  contentId: number;
+  shuffleQuestions?: boolean;
+  timeLimitPerQuestion?: number;
+}) {
+  const { token } = useTeacherAuthStore();
+  const [data, setData] = useState<ContentResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const apiUrl = import.meta.env.VITE_API_URL || "";
+        const resp = await fetch(
+          `${apiUrl}/api/teachers/contents/${contentId}`,
+          { headers: { Authorization: `Bearer ${token}` } },
+        );
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const body = (await resp.json()) as ContentResponse;
+        if (!cancelled) {
+          setData(body);
+          setLoading(false);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "Failed to load preview");
+          setLoading(false);
+        }
+      }
+    }
+    if (token) load();
+    return () => {
+      cancelled = true;
+    };
+  }, [contentId, token]);
+
+  const activities = useMemo<Activity[]>(() => {
+    if (!data) return [];
+    const isVocab = VOCAB_TYPES.has(data.type?.toUpperCase());
+    const items = (data.items || [])
+      .map((item) => {
+        const text = isVocab ? item.example_sentence : item.text;
+        if (!text) return null;
+        return {
+          id: item.id,
+          text,
+          translation: isVocab
+            ? item.example_sentence_translation
+            : item.translation,
+          audio_url: isVocab ? item.example_sentence_audio_url : item.audio_url,
+        };
+      })
+      .filter((i): i is NonNullable<typeof i> => i !== null);
+
+    return [
+      {
+        id: 0,
+        content_id: data.id,
+        order: 1,
+        type: isVocab ? "VOCABULARY_SET" : "EXAMPLE_SENTENCES",
+        title: data.title,
+        content: "",
+        target_text: "",
+        duration: 0,
+        points: 100,
+        status: "NOT_STARTED",
+        score: null,
+        completed_at: null,
+        items,
+      },
+    ];
+  }, [data]);
+
+  if (!token) {
+    return (
+      <div className="p-4 text-sm text-gray-500">
+        Preview unavailable (no teacher token)
+      </div>
+    );
+  }
+  if (loading) {
+    return <div className="p-4 text-sm text-gray-500">Loading preview…</div>;
+  }
+  if (error || !data) {
+    return (
+      <div className="p-4 text-sm text-red-600">
+        Preview error: {error || "no data"}
+      </div>
+    );
+  }
+  if (activities[0]?.items?.length === 0) {
+    return (
+      <div className="p-4 text-sm text-gray-500 border border-dashed border-gray-200 rounded">
+        此教材沒有可預覽的例句
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {shuffleQuestions && (
+        <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-1.5">
+          🔀 學生實際作答時題目順序會被打亂（預覽固定按原順序顯示）
+        </div>
+      )}
+      <StudentActivityPageContent
+        activities={activities}
+        assignmentTitle={data.title}
+        assignmentId={0}
+        practiceMode="reading"
+        showAnswer={false}
+        timeLimitPerQuestion={timeLimitPerQuestion ?? 0}
+        isDemoMode={true}
+        isPreviewMode={true}
+        canUseAiAnalysis={false}
+        onBack={() => {}}
+        onSubmit={async () => {}}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ByDemo — 未知教材路徑（Phase 2 之前的程式碼）
+// ---------------------------------------------------------------------------
 
 interface DemoActivityResponse {
   assignment_id: number;
@@ -27,19 +207,11 @@ interface DemoActivityResponse {
   activities: Activity[];
 }
 
-interface ReadingPreviewProps {
-  /**
-   * When true, render the "questions will be shuffled" banner.
-   * Note: this prop controls the banner only — preview content always
-   * follows the demo assignment's own stored shuffle setting. The actual
-   * student-facing shuffle takes effect when the assignment is dispatched.
-   */
-  shuffleQuestions?: boolean;
-}
-
-export default function ReadingPreview({
+function ReadingPreviewByDemo({
   shuffleQuestions,
-}: ReadingPreviewProps = {}) {
+}: {
+  shuffleQuestions?: boolean;
+}) {
   const [data, setData] = useState<DemoActivityResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/frontend/src/components/activities/RearrangementPreview.tsx
+++ b/frontend/src/components/activities/RearrangementPreview.tsx
@@ -1,22 +1,211 @@
 /**
  * RearrangementPreview — 派發 sheet 內的 rearrangement 即時預覽
  *
- * 直接重用既有的 demo 路徑：抓 /api/demo/config 拿
- * demo_rearrangement_assignment_id（=77，Unit 1 Dialogue），用
- * demoApi.getPreview() 拿 activities，渲染 StudentActivityPageContent
- * （isDemoMode + isPreviewMode），與 https://duotopia.co/demo/77 完全
- * 同條 code path。
+ * 兩條路徑：
+ * 1. 已知教材（內容卡派發）：傳入 contentId → 走 ByContent 子元件，
+ *    打 /api/teachers/contents/{contentId} 並 tokenize 成 RearrangementQuestion[]，
+ *    餵 RearrangementActivity.previewQuestions（Issue #752）。
+ * 2. 未知教材（Assign New Homework 未選 cart）：contentId 為 undefined →
+ *    走 ByDemo 子元件，沿用 demoApi.getConfig + getPreview 路徑。
  *
- * 取捨：預覽顯示的設定來自 demo assignment 自己存的值，不會跟著老師
- * 當下調 toggle 變動。
+ * 取材規則（ByContent，與 backend / student 端一致）：
+ * - VOCABULARY_SET → 取 item.example_sentence + example_sentence_audio_url
+ * - EXAMPLE_SENTENCES → 取 item.text + item.audio_url
+ *
+ * Tokenize：以空白切詞並 shuffle；單字數 < 2 的句子會被過濾掉。
  *
  * ⚠️ 改動前必讀：docs/design/preview-architecture.md
  */
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { demoApi } from "@/lib/demoApi";
+import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
+import RearrangementActivity, {
+  type RearrangementQuestion,
+} from "./RearrangementActivity";
 import StudentActivityPageContent, {
   type Activity,
 } from "@/pages/student/StudentActivityPageContent";
+
+interface RearrangementPreviewProps {
+  /** 已知教材時傳入；未傳則走 demo 預覽 */
+  contentId?: number;
+  shuffleQuestions?: boolean;
+  timeLimitPerQuestion?: number;
+  playAudio?: boolean;
+}
+
+export default function RearrangementPreview(props: RearrangementPreviewProps) {
+  if (props.contentId == null) {
+    return (
+      <RearrangementPreviewByDemo shuffleQuestions={props.shuffleQuestions} />
+    );
+  }
+  return (
+    <RearrangementPreviewByContent
+      contentId={props.contentId}
+      shuffleQuestions={props.shuffleQuestions}
+      timeLimitPerQuestion={props.timeLimitPerQuestion}
+      playAudio={props.playAudio}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ByContent — 已知教材路徑（Phase 2）
+// ---------------------------------------------------------------------------
+
+interface RawContentItem {
+  id: number;
+  text?: string;
+  translation?: string;
+  audio_url?: string;
+  example_sentence?: string;
+  example_sentence_translation?: string;
+  example_sentence_audio_url?: string;
+}
+
+interface ContentResponse {
+  id: number;
+  type: string;
+  title: string;
+  items: RawContentItem[];
+}
+
+const VOCAB_TYPES = new Set(["VOCABULARY_SET", "SENTENCE_MAKING"]);
+
+function tokenize(sentence: string): string[] {
+  return sentence
+    .trim()
+    .split(/\s+/)
+    .filter((w) => w.length > 0);
+}
+
+function shuffle<T>(arr: T[]): T[] {
+  const out = [...arr];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+function RearrangementPreviewByContent({
+  contentId,
+  shuffleQuestions,
+  timeLimitPerQuestion,
+  playAudio,
+}: {
+  contentId: number;
+  shuffleQuestions?: boolean;
+  timeLimitPerQuestion?: number;
+  playAudio?: boolean;
+}) {
+  const { token } = useTeacherAuthStore();
+  const [data, setData] = useState<ContentResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const apiUrl = import.meta.env.VITE_API_URL || "";
+        const resp = await fetch(
+          `${apiUrl}/api/teachers/contents/${contentId}`,
+          { headers: { Authorization: `Bearer ${token}` } },
+        );
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const body = (await resp.json()) as ContentResponse;
+        if (!cancelled) {
+          setData(body);
+          setLoading(false);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "Failed to load preview");
+          setLoading(false);
+        }
+      }
+    }
+    if (token) load();
+    return () => {
+      cancelled = true;
+    };
+  }, [contentId, token]);
+
+  const previewQuestions = useMemo<RearrangementQuestion[]>(() => {
+    if (!data) return [];
+    const isVocab = VOCAB_TYPES.has(data.type?.toUpperCase());
+    const limit = timeLimitPerQuestion ?? 0;
+    const out: RearrangementQuestion[] = [];
+    for (const item of data.items || []) {
+      const sentence = isVocab ? item.example_sentence : item.text;
+      if (!sentence) continue;
+      const words = tokenize(sentence);
+      if (words.length < 2) continue;
+      out.push({
+        content_item_id: item.id,
+        shuffled_words: shuffle(words),
+        word_count: words.length,
+        max_errors: Math.max(1, Math.floor(words.length / 2)),
+        time_limit: limit,
+        play_audio: !!playAudio,
+        audio_url: isVocab ? item.example_sentence_audio_url : item.audio_url,
+        translation: isVocab
+          ? item.example_sentence_translation
+          : item.translation,
+        original_text: sentence,
+      });
+    }
+    return out;
+  }, [data, timeLimitPerQuestion, playAudio]);
+
+  if (!token) {
+    return (
+      <div className="p-4 text-sm text-gray-500">
+        Preview unavailable (no teacher token)
+      </div>
+    );
+  }
+  if (loading) {
+    return <div className="p-4 text-sm text-gray-500">Loading preview…</div>;
+  }
+  if (error || !data) {
+    return (
+      <div className="p-4 text-sm text-red-600">
+        Preview error: {error || "no data"}
+      </div>
+    );
+  }
+  if (previewQuestions.length === 0) {
+    return (
+      <div className="p-4 text-sm text-gray-500 border border-dashed border-gray-200 rounded">
+        此教材沒有可預覽的句子（需至少 2 個單字才能重組）
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {shuffleQuestions && (
+        <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-1.5">
+          🔀 學生實際作答時題目順序會被打亂（預覽固定按原順序顯示）
+        </div>
+      )}
+      <RearrangementActivity
+        studentAssignmentId={0}
+        isPreviewMode={true}
+        previewQuestions={previewQuestions}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ByDemo — 未知教材路徑（Phase 2 之前的程式碼）
+// ---------------------------------------------------------------------------
 
 interface DemoActivityResponse {
   assignment_id: number;
@@ -28,19 +217,11 @@ interface DemoActivityResponse {
   activities: Activity[];
 }
 
-interface RearrangementPreviewProps {
-  /**
-   * When true, render the "questions will be shuffled" banner.
-   * Note: this prop controls the banner only — preview content always
-   * follows the demo assignment's own stored shuffle setting. The actual
-   * student-facing shuffle takes effect when the assignment is dispatched.
-   */
-  shuffleQuestions?: boolean;
-}
-
-export default function RearrangementPreview({
+function RearrangementPreviewByDemo({
   shuffleQuestions,
-}: RearrangementPreviewProps = {}) {
+}: {
+  shuffleQuestions?: boolean;
+}) {
   const [data, setData] = useState<DemoActivityResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/frontend/src/components/activities/WordSelectionPreview.tsx
+++ b/frontend/src/components/activities/WordSelectionPreview.tsx
@@ -52,12 +52,13 @@ function buildOptions(
   pool: ContentItem[],
   showImage: boolean,
 ): OptionEntry[] {
-  // showImage=true 時，題目顯示英文，選項是翻譯；反之亦然
-  const correctText = showImage ? current.translation || "" : current.text;
+  // showImage=true 時題目顯示圖片+翻譯，選項用英文（item.text）；反之題目顯示英文、選項用翻譯。
+  // 此規則必須與 backend/utils/distractors.py `text_field_for_show_image` 保持一致。
+  const correctText = showImage ? current.text : current.translation || "";
   const distractorPool = pool
     .filter((p) => p.id !== current.id)
     .map((p) => ({
-      text: showImage ? p.translation || "" : p.text,
+      text: showImage ? p.text : p.translation || "",
       image_url: p.image_url ?? null,
     }))
     .filter((o) => o.text);
@@ -132,7 +133,7 @@ export default function WordSelectionPreview({
       content_item_id: item.id,
       text: item.text,
       translation: item.translation || "",
-      correct_text: showImage ? item.translation || "" : item.text,
+      correct_text: showImage ? item.text : item.translation || "",
       audio_url: item.audio_url,
       image_url: item.image_url,
       memory_strength: 0,

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -2693,6 +2693,10 @@
       "updateFailed": "Update failed, but audio was generated"
     }
   },
+  "classGradeDownload": {
+    "downloadStarted": "Grade report download started",
+    "downloadFailed": "Download failed, please try again"
+  },
   "classroomDetail": {
     "title": "Classroom Detail",
     "messages": {
@@ -2750,6 +2754,8 @@
       "backToList": "Back to Classroom List",
       "backToProgramList": "Back to Program List",
       "addStudent": "Add Student",
+      "downloadStudentGrades": "Download Student Grades",
+      "downloadClassGrades": "Download Grade Report",
       "createProgram": "Create Program",
       "assignNewHomework": "Assign New Homework",
       "batchArchive": "Batch Archive",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -2746,6 +2746,10 @@
       "updateFailed": "更新失敗，但音檔已生成"
     }
   },
+  "classGradeDownload": {
+    "downloadStarted": "成績單已開始下載",
+    "downloadFailed": "下載失敗，請稍後再試"
+  },
   "classroomDetail": {
     "title": "班級詳情",
     "messages": {
@@ -2803,6 +2807,8 @@
       "backToList": "返回班級列表",
       "backToProgramList": "返回模板課程列表",
       "addStudent": "新增學生",
+      "downloadStudentGrades": "下載學生成績",
+      "downloadClassGrades": "下載成績單",
       "createProgram": "建立課程",
       "assignNewHomework": "指派新作業",
       "batchArchive": "批次封存",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -134,6 +134,31 @@ export interface RegisterRequest {
   phone?: string;
 }
 
+export interface AdminCreditPackageOperation {
+  action: "edit" | "cancel" | string;
+  timestamp: string;
+  admin_id: number;
+  admin_email?: string;
+  admin_name?: string;
+  reason: string;
+  changes: Record<
+    string,
+    { from: unknown; to: unknown } | string | number | boolean
+  >;
+}
+
+interface AdminCreditPackageResult {
+  id: number;
+  package_id: string;
+  source: string;
+  points_total: number;
+  points_used: number;
+  points_remaining: number;
+  expires_at: string;
+  status: string;
+  admin_operations: AdminCreditPackageOperation[];
+}
+
 class ApiClient {
   private baseUrl: string;
 
@@ -1522,6 +1547,34 @@ class ApiClient {
       method: "PUT",
       body: JSON.stringify(data),
     });
+  }
+
+  // ============ Admin Credit Package Instance Methods ============
+  async adminEditCreditPackage(
+    packageId: number,
+    data: {
+      points_total?: number;
+      expires_at?: string; // YYYY-MM-DD
+      reason: string;
+    },
+  ) {
+    return this.request<AdminCreditPackageResult>(
+      `/api/admin/subscription/credit-package/${packageId}`,
+      {
+        method: "PUT",
+        body: JSON.stringify(data),
+      },
+    );
+  }
+
+  async adminCancelCreditPackage(packageId: number, data: { reason: string }) {
+    return this.request<AdminCreditPackageResult>(
+      `/api/admin/subscription/credit-package/${packageId}/cancel`,
+      {
+        method: "POST",
+        body: JSON.stringify(data),
+      },
+    );
   }
 }
 

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -51,6 +51,7 @@ import {
   GraduationCap,
   Download,
   RefreshCcw,
+  X,
 } from "lucide-react";
 import { apiClient } from "@/lib/api";
 import {
@@ -105,6 +106,19 @@ interface SubscriptionPeriod {
   amount_paid?: number;
 }
 
+interface CreditPackageOperation {
+  action: string; // "edit" | "cancel"
+  timestamp: string;
+  admin_id: number;
+  admin_email?: string;
+  admin_name?: string;
+  reason: string;
+  changes: Record<
+    string,
+    { from: unknown; to: unknown } | string | number | boolean
+  >;
+}
+
 interface CreditPackageInfo {
   id: number;
   package_id: string;
@@ -117,6 +131,7 @@ interface CreditPackageInfo {
   expires_at: string;
   status: string;
   payment_id?: string;
+  admin_operations?: CreditPackageOperation[];
 }
 
 interface EditHistoryRecord {
@@ -217,6 +232,108 @@ interface LearningAnalytics {
   total_points_used: number;
 }
 
+function formatOperationTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString("zh-TW", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function describeOperationChanges(
+  changes: CreditPackageOperation["changes"],
+): string[] {
+  return Object.entries(changes).map(([field, value]) => {
+    if (
+      value &&
+      typeof value === "object" &&
+      "from" in value &&
+      "to" in value
+    ) {
+      const fromVal = (value as { from: unknown }).from;
+      const toVal = (value as { to: unknown }).to;
+      return `${field}: ${String(fromVal)} → ${String(toVal)}`;
+    }
+    return `${field}: ${String(value)}`;
+  });
+}
+
+function CreditPackageHistory({
+  operations,
+}: {
+  operations: CreditPackageOperation[];
+}) {
+  // Render newest first so admins see the latest change at the top.
+  const ordered = [...operations].sort((a, b) =>
+    a.timestamp < b.timestamp ? 1 : -1,
+  );
+  return (
+    <div className="p-4 pl-12 space-y-2">
+      <div className="text-xs font-semibold text-gray-700">
+        變更歷史 ({operations.length})
+      </div>
+      <div className="space-y-2">
+        {ordered.map((op, idx) => {
+          const isCancel = op.action === "cancel";
+          const badgeClass = isCancel
+            ? "bg-red-100 text-red-700"
+            : "bg-blue-100 text-blue-700";
+          return (
+            <div
+              key={`${op.timestamp}-${idx}`}
+              className="rounded-md border border-gray-200 bg-white p-3 flex gap-3"
+            >
+              <div
+                className={`w-7 h-7 rounded-full flex items-center justify-center flex-shrink-0 ${
+                  isCancel
+                    ? "bg-red-50 text-red-600"
+                    : "bg-blue-50 text-blue-600"
+                }`}
+              >
+                {isCancel ? (
+                  <X className="w-4 h-4" />
+                ) : (
+                  <Edit className="w-4 h-4" />
+                )}
+              </div>
+              <div className="flex-1 min-w-0 space-y-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span
+                    className={`px-2 py-0.5 rounded text-[11px] font-semibold ${badgeClass}`}
+                  >
+                    {op.action}
+                  </span>
+                  {describeOperationChanges(op.changes).map((change, i) => (
+                    <span
+                      key={i}
+                      className="font-mono text-xs text-gray-600 break-all"
+                    >
+                      {change}
+                    </span>
+                  ))}
+                  <span className="ml-auto text-[11px] text-gray-400">
+                    {formatOperationTimestamp(op.timestamp)}
+                  </span>
+                </div>
+                <div className="text-sm text-gray-900 whitespace-pre-wrap break-words">
+                  原因：{op.reason}
+                </div>
+                <div className="text-[11px] text-gray-400">
+                  by {op.admin_email || op.admin_name || `admin#${op.admin_id}`}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export default function AdminSubscriptionDashboard() {
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -276,6 +393,38 @@ export default function AdminSubscriptionDashboard() {
     reason: "",
     expires_days: 365,
   });
+
+  // Credit package instance edit/cancel modal state
+  const [creditPackageEditOpen, setCreditPackageEditOpen] = useState(false);
+  const [creditPackageCancelOpen, setCreditPackageCancelOpen] = useState(false);
+  const [selectedCreditPackage, setSelectedCreditPackage] = useState<{
+    teacherId: number;
+    pkg: CreditPackageInfo;
+  } | null>(null);
+  const [creditPackageEditForm, setCreditPackageEditForm] = useState({
+    points_total: "",
+    expires_at: "", // YYYY-MM-DD
+    reason: "",
+  });
+  const [creditPackageCancelReason, setCreditPackageCancelReason] =
+    useState("");
+  const [creditPackageSubmitting, setCreditPackageSubmitting] = useState(false);
+  // Set of credit package IDs whose history panel is expanded inline.
+  const [expandedCreditPackageIds, setExpandedCreditPackageIds] = useState<
+    Set<number>
+  >(new Set());
+
+  const toggleCreditPackageHistory = (pkgId: number) => {
+    setExpandedCreditPackageIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(pkgId)) {
+        next.delete(pkgId);
+      } else {
+        next.add(pkgId);
+      }
+      return next;
+    });
+  };
 
   useEffect(() => {
     loadDashboardData();
@@ -414,6 +563,122 @@ export default function AdminSubscriptionDashboard() {
       }
     } finally {
       setLoading(false);
+    }
+  };
+
+  const openEditCreditPackageDialog = (
+    teacherId: number,
+    pkg: CreditPackageInfo,
+  ) => {
+    setSelectedCreditPackage({ teacherId, pkg });
+    setCreditPackageEditForm({
+      points_total: pkg.points_total.toString(),
+      expires_at: pkg.expires_at ? pkg.expires_at.split("T")[0] : "",
+      reason: "",
+    });
+    setCreditPackageEditOpen(true);
+  };
+
+  const openCancelCreditPackageDialog = (
+    teacherId: number,
+    pkg: CreditPackageInfo,
+  ) => {
+    setSelectedCreditPackage({ teacherId, pkg });
+    setCreditPackageCancelReason("");
+    setCreditPackageCancelOpen(true);
+  };
+
+  const handleSubmitEditCreditPackage = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedCreditPackage) return;
+    const { teacherId, pkg } = selectedCreditPackage;
+    const reason = creditPackageEditForm.reason.trim();
+    if (!reason) return;
+
+    const newTotal = Number(creditPackageEditForm.points_total);
+    if (!Number.isInteger(newTotal) || newTotal < 0) {
+      setErrorMessage("總點數必須是 0 或正整數");
+      return;
+    }
+    if (newTotal < pkg.points_used) {
+      setErrorMessage(
+        `總點數 (${newTotal}) 不可小於已使用點數 (${pkg.points_used})`,
+      );
+      return;
+    }
+
+    const payload: {
+      points_total?: number;
+      expires_at?: string;
+      reason: string;
+    } = { reason };
+    if (newTotal !== pkg.points_total) payload.points_total = newTotal;
+    if (
+      creditPackageEditForm.expires_at &&
+      (!pkg.expires_at ||
+        creditPackageEditForm.expires_at !== pkg.expires_at.split("T")[0])
+    ) {
+      payload.expires_at = creditPackageEditForm.expires_at;
+    }
+
+    if (
+      payload.points_total === undefined &&
+      payload.expires_at === undefined
+    ) {
+      setErrorMessage("沒有變更欄位");
+      return;
+    }
+
+    try {
+      setCreditPackageSubmitting(true);
+      const updated = await apiClient.adminEditCreditPackage(pkg.id, payload);
+      setTeacherCreditPackages((prev) => ({
+        ...prev,
+        [teacherId]: (prev[teacherId] || []).map((p) =>
+          p.id === pkg.id
+            ? {
+                ...p,
+                points_total: updated.points_total,
+                points_remaining: updated.points_remaining,
+                expires_at: updated.expires_at,
+                status: updated.status,
+                admin_operations: updated.admin_operations,
+              }
+            : p,
+        ),
+      }));
+      setSuccessMessage(`已更新點數包 ${pkg.package_id}`);
+      setCreditPackageEditOpen(false);
+    } catch (error) {
+      const err = error as { response?: { data?: { detail?: string } } };
+      setErrorMessage(err.response?.data?.detail || "更新點數包失敗");
+    } finally {
+      setCreditPackageSubmitting(false);
+    }
+  };
+
+  const handleSubmitCancelCreditPackage = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedCreditPackage) return;
+    const reason = creditPackageCancelReason.trim();
+    if (!reason) return;
+    const { teacherId, pkg } = selectedCreditPackage;
+
+    try {
+      setCreditPackageSubmitting(true);
+      await apiClient.adminCancelCreditPackage(pkg.id, { reason });
+      // Soft-deleted: remove from local list (backend now filters status='refunded')
+      setTeacherCreditPackages((prev) => ({
+        ...prev,
+        [teacherId]: (prev[teacherId] || []).filter((p) => p.id !== pkg.id),
+      }));
+      setSuccessMessage(`已刪除點數包 ${pkg.package_id}`);
+      setCreditPackageCancelOpen(false);
+    } catch (error) {
+      const err = error as { response?: { data?: { detail?: string } } };
+      setErrorMessage(err.response?.data?.detail || "刪除點數包失敗");
+    } finally {
+      setCreditPackageSubmitting(false);
     }
   };
 
@@ -1646,6 +1911,12 @@ export default function AdminSubscriptionDashboard() {
                                                   "狀態",
                                                 )}
                                               </TableHead>
+                                              <TableHead className="text-right">
+                                                {t(
+                                                  "adminSubscription.creditPackageTable.actions",
+                                                  "操作",
+                                                )}
+                                              </TableHead>
                                             </TableRow>
                                           </TableHeader>
                                           <TableBody>
@@ -1691,59 +1962,159 @@ export default function AdminSubscriptionDashboard() {
                                                   "bg-gray-100 text-gray-700",
                                               };
 
+                                              const isHistoryOpen =
+                                                expandedCreditPackageIds.has(
+                                                  pkg.id,
+                                                );
                                               return (
-                                                <TableRow key={`pkg-${pkg.id}`}>
-                                                  <TableCell>
-                                                    <span
-                                                      className={`px-2 py-1 rounded text-xs font-semibold ${sourceBadge.className}`}
-                                                    >
-                                                      {sourceBadge.label}
-                                                    </span>
-                                                  </TableCell>
-                                                  <TableCell className="font-mono text-xs text-gray-600">
-                                                    {pkg.package_id}
-                                                  </TableCell>
-                                                  <TableCell className="text-sm text-gray-600">
-                                                    {formatDate(
-                                                      pkg.purchased_at,
-                                                    )}{" "}
-                                                    →{" "}
-                                                    {formatDate(pkg.expires_at)}
-                                                  </TableCell>
-                                                  <TableCell>
-                                                    <div className="space-y-1">
-                                                      <div className="text-sm">
-                                                        {pkg.points_used.toLocaleString()}{" "}
-                                                        /{" "}
-                                                        {pkg.points_total.toLocaleString()}
+                                                <React.Fragment
+                                                  key={`pkg-${pkg.id}`}
+                                                >
+                                                  <TableRow>
+                                                    <TableCell>
+                                                      <span
+                                                        className={`px-2 py-1 rounded text-xs font-semibold ${sourceBadge.className}`}
+                                                      >
+                                                        {sourceBadge.label}
+                                                      </span>
+                                                    </TableCell>
+                                                    <TableCell className="font-mono text-xs text-gray-600">
+                                                      {pkg.package_id}
+                                                    </TableCell>
+                                                    <TableCell className="text-sm text-gray-600">
+                                                      {formatDate(
+                                                        pkg.purchased_at,
+                                                      )}{" "}
+                                                      →{" "}
+                                                      {formatDate(
+                                                        pkg.expires_at,
+                                                      )}
+                                                    </TableCell>
+                                                    <TableCell>
+                                                      <div className="space-y-1">
+                                                        <div className="text-sm">
+                                                          {pkg.points_used.toLocaleString()}{" "}
+                                                          /{" "}
+                                                          {pkg.points_total.toLocaleString()}
+                                                        </div>
+                                                        <div className="w-full bg-gray-200 rounded-full h-1.5">
+                                                          <div
+                                                            className="bg-purple-500 h-1.5 rounded-full"
+                                                            style={{
+                                                              width: `${Math.min((pkg.points_used / pkg.points_total) * 100 || 0, 100)}%`,
+                                                            }}
+                                                          />
+                                                        </div>
                                                       </div>
-                                                      <div className="w-full bg-gray-200 rounded-full h-1.5">
-                                                        <div
-                                                          className="bg-purple-500 h-1.5 rounded-full"
-                                                          style={{
-                                                            width: `${Math.min((pkg.points_used / pkg.points_total) * 100 || 0, 100)}%`,
-                                                          }}
-                                                        />
-                                                      </div>
-                                                    </div>
-                                                  </TableCell>
-                                                  <TableCell className="text-sm">
-                                                    {pkg.price_paid > 0
-                                                      ? `NT$ ${pkg.price_paid.toLocaleString()}`
-                                                      : "-"}
-                                                  </TableCell>
-                                                  <TableCell>
-                                                    <span
-                                                      className={`px-2 py-1 rounded text-xs font-semibold ${
-                                                        pkg.status === "active"
-                                                          ? "bg-green-100 text-green-700"
-                                                          : "bg-gray-100 text-gray-600"
-                                                      }`}
+                                                    </TableCell>
+                                                    <TableCell className="text-sm">
+                                                      {pkg.price_paid > 0
+                                                        ? `NT$ ${pkg.price_paid.toLocaleString()}`
+                                                        : "-"}
+                                                    </TableCell>
+                                                    <TableCell>
+                                                      <span
+                                                        className={`px-2 py-1 rounded text-xs font-semibold ${
+                                                          pkg.status ===
+                                                          "active"
+                                                            ? "bg-green-100 text-green-700"
+                                                            : "bg-gray-100 text-gray-600"
+                                                        }`}
+                                                      >
+                                                        {pkg.status}
+                                                      </span>
+                                                    </TableCell>
+                                                    <TableCell
+                                                      onClick={(e) =>
+                                                        e.stopPropagation()
+                                                      }
                                                     >
-                                                      {pkg.status}
-                                                    </span>
-                                                  </TableCell>
-                                                </TableRow>
+                                                      <div className="flex justify-end gap-1">
+                                                        <Button
+                                                          size="sm"
+                                                          variant="outline"
+                                                          className="h-7 px-2 text-xs"
+                                                          onClick={() =>
+                                                            toggleCreditPackageHistory(
+                                                              pkg.id,
+                                                            )
+                                                          }
+                                                          disabled={
+                                                            !pkg
+                                                              .admin_operations
+                                                              ?.length
+                                                          }
+                                                          title={
+                                                            pkg.admin_operations
+                                                              ?.length
+                                                              ? `查看 ${pkg.admin_operations.length} 筆變更紀錄`
+                                                              : "尚無變更紀錄"
+                                                          }
+                                                        >
+                                                          {expandedCreditPackageIds.has(
+                                                            pkg.id,
+                                                          ) ? (
+                                                            <ChevronDown className="w-3 h-3 mr-1" />
+                                                          ) : (
+                                                            <ChevronRight className="w-3 h-3 mr-1" />
+                                                          )}
+                                                          紀錄
+                                                          {pkg.admin_operations
+                                                            ?.length
+                                                            ? ` (${pkg.admin_operations.length})`
+                                                            : ""}
+                                                        </Button>
+                                                        <Button
+                                                          size="sm"
+                                                          variant="outline"
+                                                          className="h-7 px-2 text-xs"
+                                                          onClick={() =>
+                                                            openEditCreditPackageDialog(
+                                                              teacher.teacher_id,
+                                                              pkg,
+                                                            )
+                                                          }
+                                                        >
+                                                          <Edit className="w-3 h-3 mr-1" />
+                                                          編輯
+                                                        </Button>
+                                                        <Button
+                                                          size="sm"
+                                                          variant="outline"
+                                                          className="h-7 px-2 text-xs text-red-600 border-red-300 hover:bg-red-50"
+                                                          onClick={() =>
+                                                            openCancelCreditPackageDialog(
+                                                              teacher.teacher_id,
+                                                              pkg,
+                                                            )
+                                                          }
+                                                        >
+                                                          刪除
+                                                        </Button>
+                                                      </div>
+                                                    </TableCell>
+                                                  </TableRow>
+                                                  {isHistoryOpen &&
+                                                    pkg.admin_operations &&
+                                                    pkg.admin_operations
+                                                      .length > 0 && (
+                                                      <TableRow
+                                                        key={`pkg-${pkg.id}-history`}
+                                                        className="bg-gray-50"
+                                                      >
+                                                        <TableCell
+                                                          colSpan={7}
+                                                          className="p-0"
+                                                        >
+                                                          <CreditPackageHistory
+                                                            operations={
+                                                              pkg.admin_operations
+                                                            }
+                                                          />
+                                                        </TableCell>
+                                                      </TableRow>
+                                                    )}
+                                                </React.Fragment>
                                               );
                                             })}
                                           </TableBody>
@@ -2547,6 +2918,175 @@ export default function AdminSubscriptionDashboard() {
                     <Gift className="w-4 h-4 mr-2" />
                     {t("adminSubscription.grant.confirm", "Confirm Grant")}
                   </>
+                )}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Credit Package — Edit */}
+      <Dialog
+        open={creditPackageEditOpen}
+        onOpenChange={setCreditPackageEditOpen}
+      >
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle>編輯點數包</DialogTitle>
+            <DialogDescription>
+              {selectedCreditPackage &&
+                `${selectedCreditPackage.pkg.package_id} · 已使用 ${selectedCreditPackage.pkg.points_used.toLocaleString()} 點`}
+            </DialogDescription>
+          </DialogHeader>
+
+          <form
+            onSubmit={handleSubmitEditCreditPackage}
+            className="space-y-4 mt-4"
+          >
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                總點數 <span className="text-red-500">*</span>
+              </label>
+              <Input
+                type="number"
+                value={creditPackageEditForm.points_total}
+                onChange={(e) =>
+                  setCreditPackageEditForm({
+                    ...creditPackageEditForm,
+                    points_total: e.target.value,
+                  })
+                }
+                min={selectedCreditPackage?.pkg.points_used ?? 0}
+                required
+              />
+              <p className="text-xs text-gray-500">
+                最低為已使用點數 (
+                {selectedCreditPackage?.pkg.points_used.toLocaleString() ?? 0})
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">到期日</label>
+              <Input
+                type="date"
+                value={creditPackageEditForm.expires_at}
+                onChange={(e) =>
+                  setCreditPackageEditForm({
+                    ...creditPackageEditForm,
+                    expires_at: e.target.value,
+                  })
+                }
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                變更原因 <span className="text-red-500">*</span>
+              </label>
+              <Textarea
+                value={creditPackageEditForm.reason}
+                onChange={(e) =>
+                  setCreditPackageEditForm({
+                    ...creditPackageEditForm,
+                    reason: e.target.value,
+                  })
+                }
+                placeholder="請說明此次編輯的原因"
+                required
+                rows={3}
+              />
+            </div>
+
+            <div className="flex gap-2 justify-end pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setCreditPackageEditOpen(false)}
+                disabled={creditPackageSubmitting}
+              >
+                取消
+              </Button>
+              <Button
+                type="submit"
+                disabled={
+                  creditPackageSubmitting ||
+                  !creditPackageEditForm.reason.trim() ||
+                  creditPackageEditForm.points_total === ""
+                }
+              >
+                {creditPackageSubmitting ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    儲存中
+                  </>
+                ) : (
+                  "儲存"
+                )}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Credit Package — Cancel (soft delete) */}
+      <Dialog
+        open={creditPackageCancelOpen}
+        onOpenChange={setCreditPackageCancelOpen}
+      >
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle>刪除點數包</DialogTitle>
+            <DialogDescription>
+              {selectedCreditPackage &&
+                `${selectedCreditPackage.pkg.package_id} · 總點數 ${selectedCreditPackage.pkg.points_total.toLocaleString()} / 已使用 ${selectedCreditPackage.pkg.points_used.toLocaleString()}`}
+            </DialogDescription>
+          </DialogHeader>
+
+          <form
+            onSubmit={handleSubmitCancelCreditPackage}
+            className="space-y-4 mt-4"
+          >
+            <div className="rounded-md bg-red-50 border border-red-200 p-3 text-sm text-red-800">
+              點數包將標記為 refunded
+              並從清單中隱藏。已使用的點數紀錄會保留作為稽核，請填寫刪除原因。
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                刪除原因 <span className="text-red-500">*</span>
+              </label>
+              <Textarea
+                value={creditPackageCancelReason}
+                onChange={(e) => setCreditPackageCancelReason(e.target.value)}
+                placeholder="請說明此次刪除的原因（例如：使用者要求退費）"
+                required
+                rows={3}
+              />
+            </div>
+
+            <div className="flex gap-2 justify-end pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setCreditPackageCancelOpen(false)}
+                disabled={creditPackageSubmitting}
+              >
+                取消
+              </Button>
+              <Button
+                type="submit"
+                variant="destructive"
+                disabled={
+                  creditPackageSubmitting || !creditPackageCancelReason.trim()
+                }
+              >
+                {creditPackageSubmitting ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    處理中
+                  </>
+                ) : (
+                  "確認刪除"
                 )}
               </Button>
             </div>

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -52,11 +52,17 @@ import {
   Search,
   StickyNote,
   Printer,
+  Download,
   ChevronLeft,
   ChevronRight,
   MoreVertical,
   BarChart3,
 } from "lucide-react";
+import {
+  downloadClassGradeReport,
+  downloadStudentGradeReport,
+  GradeReportError,
+} from "@/services/gradeReportService";
 import { getContentTypeIcon } from "@/lib/contentTypeIcon";
 import { apiClient, ApiError } from "@/lib/api";
 import { toast } from "sonner";
@@ -311,12 +317,17 @@ export default function ClassroomDetail({
     open: false,
     assignmentIndex: 0,
   });
-  // Batch selection (shared by batch print and batch archive)
+  // Batch selection (shared by batch print, batch archive, and the two
+  // grade-report downloads available on the archived view).
   const [selectedAssignments, setSelectedAssignments] = useState<Set<number>>(
     new Set(),
   );
   const [batchPrinting, setBatchPrinting] = useState(false);
   const [batchArchiving, setBatchArchiving] = useState(false);
+  // Grade-report (issue #708) — both downloads gated on selectedAssignments
+  // and only shown on the archived assignments view.
+  const [downloadingClassGrade, setDownloadingClassGrade] = useState(false);
+  const [downloadingStudentGrade, setDownloadingStudentGrade] = useState(false);
 
   // Clear selection when switching between active/archived tabs
   useEffect(() => {
@@ -496,6 +507,52 @@ export default function ClassroomDetail({
       toast.error(t("classroomDetail.messages.batchArchiveFailed"));
     } finally {
       setBatchArchiving(false);
+    }
+  };
+
+  // Issue #708: download class grade report for the currently selected
+  // archived assignments. Selection state is shared with the batch
+  // print/archive buttons (the user already picked them via the same
+  // checkboxes on the archived view).
+  const handleDownloadClassGrades = async () => {
+    if (selectedAssignments.size === 0 || !id) return;
+    setDownloadingClassGrade(true);
+    try {
+      await downloadClassGradeReport(
+        Number(id),
+        Array.from(selectedAssignments),
+      );
+      toast.success(t("classGradeDownload.downloadStarted"));
+    } catch (e) {
+      const msg =
+        e instanceof GradeReportError
+          ? e.detail
+          : t("classGradeDownload.downloadFailed");
+      toast.error(msg);
+    } finally {
+      setDownloadingClassGrade(false);
+    }
+  };
+
+  // Issue #708 follow-up: download a ZIP of per-student grade reports for the
+  // selected archived assignments. One xlsx per enrolled student.
+  const handleDownloadStudentGrades = async () => {
+    if (selectedAssignments.size === 0 || !id) return;
+    setDownloadingStudentGrade(true);
+    try {
+      await downloadStudentGradeReport(
+        Number(id),
+        Array.from(selectedAssignments),
+      );
+      toast.success(t("classGradeDownload.downloadStarted"));
+    } catch (e) {
+      const msg =
+        e instanceof GradeReportError
+          ? e.detail
+          : t("classGradeDownload.downloadFailed");
+      toast.error(msg);
+    } finally {
+      setDownloadingStudentGrade(false);
     }
   };
 
@@ -1902,6 +1959,41 @@ export default function ClassroomDetail({
                             ` (${selectedAssignments.size})`}
                         </Button>
                       )}
+                      {/* Issue #708: grade-report downloads are only
+                          available on the archived view — teachers download
+                          the report once a batch of assignments is sealed. */}
+                      {archivedAssignments.length > 0 && showArchived && (
+                        <Button
+                          variant="outline"
+                          onClick={handleDownloadClassGrades}
+                          disabled={
+                            selectedAssignments.size === 0 ||
+                            downloadingClassGrade
+                          }
+                          className="h-10"
+                        >
+                          <Download className="h-4 w-4 mr-2" />
+                          {t("classroomDetail.buttons.downloadClassGrades")}
+                          {selectedAssignments.size > 0 &&
+                            ` (${selectedAssignments.size})`}
+                        </Button>
+                      )}
+                      {archivedAssignments.length > 0 && showArchived && (
+                        <Button
+                          variant="outline"
+                          onClick={handleDownloadStudentGrades}
+                          disabled={
+                            selectedAssignments.size === 0 ||
+                            downloadingStudentGrade
+                          }
+                          className="h-10"
+                        >
+                          <Download className="h-4 w-4 mr-2" />
+                          {t("classroomDetail.buttons.downloadStudentGrades")}
+                          {selectedAssignments.size > 0 &&
+                            ` (${selectedAssignments.size})`}
+                        </Button>
+                      )}
                       {!canAssignHomework && !showArchived && teacherData && (
                         <div className="text-xs sm:text-sm text-gray-600 dark:text-gray-300 bg-yellow-50 dark:bg-yellow-900/20 px-3 py-2 rounded-lg border border-yellow-200 dark:border-yellow-800">
                           <span className="font-medium">
@@ -2274,17 +2366,18 @@ export default function ClassroomDetail({
                               >
                                 {/* Title & AI Batch Grade Button */}
                                 <div className="flex items-start justify-between gap-2">
-                                  {!showArchived && (
-                                    <Checkbox
-                                      checked={selectedAssignments.has(
-                                        assignment.id,
-                                      )}
-                                      onCheckedChange={() =>
-                                        toggleAssignmentSelection(assignment.id)
-                                      }
-                                      className="mt-1"
-                                    />
-                                  )}
+                                  {/* Issue #708: archived view also needs
+                                      selection so teachers can pick which
+                                      assignments to download grade reports for. */}
+                                  <Checkbox
+                                    checked={selectedAssignments.has(
+                                      assignment.id,
+                                    )}
+                                    onCheckedChange={() =>
+                                      toggleAssignmentSelection(assignment.id)
+                                    }
+                                    className="mt-1"
+                                  />
                                   <div className="flex-1 min-w-0">
                                     <h4 className="font-medium text-gray-900 dark:text-gray-100 truncate">
                                       {assignment.title}
@@ -2462,18 +2555,16 @@ export default function ClassroomDetail({
                           <table className="w-full">
                             <thead className="bg-gray-50 dark:bg-gray-700 border-b dark:border-gray-600">
                               <tr>
-                                {!showArchived && (
-                                  <th className="w-10 px-4 py-3">
-                                    <Checkbox
-                                      checked={
-                                        filteredAssignments.length > 0 &&
-                                        selectedAssignments.size ===
-                                          filteredAssignments.length
-                                      }
-                                      onCheckedChange={toggleSelectAll}
-                                    />
-                                  </th>
-                                )}
+                                <th className="w-10 px-4 py-3">
+                                  <Checkbox
+                                    checked={
+                                      filteredAssignments.length > 0 &&
+                                      selectedAssignments.size ===
+                                        filteredAssignments.length
+                                    }
+                                    onCheckedChange={toggleSelectAll}
+                                  />
+                                </th>
                                 <th className="text-left px-4 py-3 text-sm font-medium text-gray-700 dark:text-gray-200">
                                   {t(
                                     "classroomDetail.labels.assignmentInfo",
@@ -2644,20 +2735,18 @@ export default function ClassroomDetail({
                                     key={assignment.id}
                                     className="border-b hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:border-gray-600"
                                   >
-                                    {!showArchived && (
-                                      <td className="w-10 px-4 py-3">
-                                        <Checkbox
-                                          checked={selectedAssignments.has(
+                                    <td className="w-10 px-4 py-3">
+                                      <Checkbox
+                                        checked={selectedAssignments.has(
+                                          assignment.id,
+                                        )}
+                                        onCheckedChange={() =>
+                                          toggleAssignmentSelection(
                                             assignment.id,
-                                          )}
-                                          onCheckedChange={() =>
-                                            toggleAssignmentSelection(
-                                              assignment.id,
-                                            )
-                                          }
-                                        />
-                                      </td>
-                                    )}
+                                          )
+                                        }
+                                      />
+                                    </td>
                                     <td className="px-4 py-3">
                                       <div className="font-medium dark:text-gray-100">
                                         {assignment.title}

--- a/frontend/src/services/gradeReportService.ts
+++ b/frontend/src/services/gradeReportService.ts
@@ -1,0 +1,128 @@
+/**
+ * Grade-report download client (issue #708).
+ *
+ * Both endpoints take the same input — a list of selected (archived)
+ * assignment ids — and stream a binary file back:
+ *  - POST /api/teachers/classrooms/:id/grade-report
+ *      → one xlsx for the whole class (across the selected assignments).
+ *  - POST /api/teachers/classrooms/:id/student-grade-report
+ *      → one zip containing one xlsx per enrolled student. The classroom
+ *        having only one student still produces a zip with one file inside.
+ *
+ * Both responses carry the unicode filename via RFC-5987
+ * `Content-Disposition: filename*=UTF-8''<urlencoded>`; we honour that
+ * and fall through to a sensible default if the header is missing.
+ */
+import { API_URL } from "../config/api";
+import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
+
+export class GradeReportError extends Error {
+  constructor(
+    public status: number,
+    public detail: string,
+  ) {
+    super(detail);
+    this.name = "GradeReportError";
+  }
+}
+
+function authHeader(): Record<string, string> {
+  const token = useTeacherAuthStore.getState().token;
+  if (!token) {
+    throw new GradeReportError(401, "Not signed in");
+  }
+  return { Authorization: `Bearer ${token}` };
+}
+
+/**
+ * Parse the unicode filename from a Content-Disposition header.
+ * Prefers `filename*=UTF-8''<urlencoded>` over the ASCII `filename="..."`.
+ */
+function parseFilename(header: string | null, fallback: string): string {
+  if (!header) return fallback;
+  const star = /filename\*\s*=\s*UTF-8''([^;]+)/i.exec(header);
+  if (star) {
+    try {
+      return decodeURIComponent(star[1]);
+    } catch {
+      // fall through to the plain filename
+    }
+  }
+  const plain = /filename\s*=\s*"?([^";]+)"?/i.exec(header);
+  if (plain) return plain[1];
+  return fallback;
+}
+
+async function downloadBinary(
+  endpoint: string,
+  body: unknown,
+  fallbackFilename: string,
+): Promise<void> {
+  const res = await fetch(`${API_URL}${endpoint}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...authHeader(),
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    let detail = `HTTP ${res.status}`;
+    try {
+      const json = await res.json();
+      if (json && typeof json === "object" && "detail" in json) {
+        detail = String((json as { detail: unknown }).detail);
+      }
+    } catch {
+      // server didn't return JSON; keep the HTTP-status detail
+    }
+    throw new GradeReportError(res.status, detail);
+  }
+
+  const filename = parseFilename(
+    res.headers.get("Content-Disposition"),
+    fallbackFilename,
+  );
+
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  // Defer revocation slightly so Safari/Firefox have time to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+function todayYYYYMMDD(): string {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}${mm}${dd}`;
+}
+
+export async function downloadClassGradeReport(
+  classroomId: number,
+  assignmentIds: number[],
+): Promise<void> {
+  await downloadBinary(
+    `/api/teachers/classrooms/${classroomId}/grade-report`,
+    { assignment_ids: assignmentIds },
+    `成績總覽_${todayYYYYMMDD()}.xlsx`,
+  );
+}
+
+export async function downloadStudentGradeReport(
+  classroomId: number,
+  assignmentIds: number[],
+): Promise<void> {
+  await downloadBinary(
+    `/api/teachers/classrooms/${classroomId}/student-grade-report`,
+    { assignment_ids: assignmentIds },
+    `學生成績單_${todayYYYYMMDD()}.zip`,
+  );
+}


### PR DESCRIPTION
## Summary
Release of accumulated staging changes into main (7 commits).

- fix: enable RLS on credit_package_definitions to unblock staging backend deploy (#799)
- Release: Word Selection 派發預覽 — Show word image during practice 預覽錯誤修正 / feat. 785 (#798, fixes #797)
- chore(#632): add cloze_answer column to content_items (#794)
- feat(#708): class & per-student grade report Excel downloads (#749)
- feat(#723): admin CRUD for per-teacher credit package instances (#781)
- Release: 單字拼寫成績顯示問題修正 (#790, fixes #789)
- Release: 機構教師派發作業導致教材內容多次被複製修正 (#788, fixes #785)

## Test plan
- [ ] CI passes on the release PR
- [ ] Smoke test admin credit package CRUD
- [ ] Verify grade report Excel downloads (class & per-student)
- [ ] Verify word selection practice preview shows word image correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)