### PR TITLE
feat(#637): promo code data layer + auto personal code on register

### DIFF
--- a/backend/alembic/versions/20260525_1000_add_promo_code_tables.py
+++ b/backend/alembic/versions/20260525_1000_add_promo_code_tables.py
@@ -1,0 +1,172 @@
+"""Add promo code / referral tables (issue #637)
+
+Revision ID: 20260525_1000
+Revises: 20260522_1000
+Create Date: 2026-05-25 10:00:00
+
+Creates the four data-layer tables for the Promo Code referral system:
+
+- promo_codes          每位老師的推銷碼（個人預設碼 + admin 特約碼）
+- promo_referrals      被推薦人 ↔ 推薦人綁定（一個被推薦人僅一筆）
+- promo_reward_configs admin 可調整的各事件獎勵點數（seed 7 筆預設）
+- promo_reward_events  已發放紀錄，idempotency_key 防重複發放
+
+All statements are idempotent (CREATE ... IF NOT EXISTS / ON CONFLICT)
+so the migration is safe to re-run across develop / staging / production.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "20260525_1000"
+down_revision: Union[str, None] = "20260522_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ---- promo_codes -------------------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS promo_codes (
+            id SERIAL PRIMARY KEY,
+            code VARCHAR(16) NOT NULL,
+            teacher_id INTEGER NOT NULL
+                REFERENCES teachers(id) ON DELETE CASCADE,
+            kind VARCHAR(16) NOT NULL DEFAULT 'personal',
+            expires_at TIMESTAMPTZ,
+            is_active BOOLEAN NOT NULL DEFAULT TRUE,
+            note TEXT,
+            created_at TIMESTAMPTZ DEFAULT now(),
+            updated_at TIMESTAMPTZ,
+            admin_id INTEGER REFERENCES teachers(id) ON DELETE SET NULL,
+            admin_reason TEXT,
+            admin_metadata JSONB
+        )
+        """
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_promo_codes_code " "ON promo_codes (code)"
+    )
+    # One personal code per teacher; affiliate codes are unconstrained.
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_promo_codes_teacher_personal "
+        "ON promo_codes (teacher_id) WHERE kind = 'personal'"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_promo_codes_teacher_id "
+        "ON promo_codes (teacher_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_promo_codes_active_expires "
+        "ON promo_codes (is_active, expires_at)"
+    )
+
+    # ---- promo_referrals ---------------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS promo_referrals (
+            id SERIAL PRIMARY KEY,
+            referrer_teacher_id INTEGER NOT NULL
+                REFERENCES teachers(id) ON DELETE CASCADE,
+            referred_teacher_id INTEGER NOT NULL
+                REFERENCES teachers(id) ON DELETE CASCADE,
+            promo_code VARCHAR(16) NOT NULL,
+            promo_code_id INTEGER
+                REFERENCES promo_codes(id) ON DELETE SET NULL,
+            signup_at TIMESTAMPTZ DEFAULT now(),
+            verified_at TIMESTAMPTZ,
+            first_paid_event_consumed BOOLEAN NOT NULL DEFAULT FALSE,
+            referred_bonus_granted BOOLEAN NOT NULL DEFAULT FALSE,
+            created_at TIMESTAMPTZ DEFAULT now(),
+            updated_at TIMESTAMPTZ,
+            CONSTRAINT uq_promo_referrals_referred_teacher
+                UNIQUE (referred_teacher_id),
+            CONSTRAINT ck_promo_referrals_no_self_referral
+                CHECK (referrer_teacher_id != referred_teacher_id)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_promo_referrals_referrer "
+        "ON promo_referrals (referrer_teacher_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_promo_referrals_promo_code "
+        "ON promo_referrals (promo_code)"
+    )
+
+    # ---- promo_reward_configs ----------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS promo_reward_configs (
+            id SERIAL PRIMARY KEY,
+            reward_key VARCHAR(64) NOT NULL,
+            points INTEGER NOT NULL,
+            recipient VARCHAR(16) NOT NULL DEFAULT 'referrer',
+            is_active BOOLEAN NOT NULL DEFAULT TRUE,
+            updated_at TIMESTAMPTZ DEFAULT now(),
+            updated_by_admin_id INTEGER
+                REFERENCES teachers(id) ON DELETE SET NULL
+        )
+        """
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_promo_reward_configs_reward_key "
+        "ON promo_reward_configs (reward_key)"
+    )
+    # Seed default reward values. ON CONFLICT keeps existing admin edits.
+    op.execute(
+        """
+        INSERT INTO promo_reward_configs (reward_key, points, recipient) VALUES
+            ('signup_verified', 10, 'referrer'),
+            ('subscribe_tutor', 1000, 'referrer'),
+            ('subscribe_school', 2000, 'referrer'),
+            ('package_pkg-5000', 200, 'referrer'),
+            ('package_pkg-10000', 500, 'referrer'),
+            ('package_pkg-20000', 800, 'referrer'),
+            ('referred_signup_bonus', 300, 'referred')
+        ON CONFLICT (reward_key) DO NOTHING
+        """
+    )
+
+    # ---- promo_reward_events -----------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS promo_reward_events (
+            id SERIAL PRIMARY KEY,
+            referral_id INTEGER NOT NULL
+                REFERENCES promo_referrals(id) ON DELETE CASCADE,
+            reward_key VARCHAR(64) NOT NULL,
+            trigger_type VARCHAR(32) NOT NULL,
+            points INTEGER NOT NULL,
+            granted_to_teacher_id INTEGER NOT NULL
+                REFERENCES teachers(id) ON DELETE CASCADE,
+            credit_package_id INTEGER
+                REFERENCES credit_packages(id) ON DELETE SET NULL,
+            idempotency_key VARCHAR(128) NOT NULL,
+            event_payload JSONB,
+            created_at TIMESTAMPTZ DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_promo_reward_events_idempotency_key "
+        "ON promo_reward_events (idempotency_key)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_promo_reward_events_granted_to "
+        "ON promo_reward_events (granted_to_teacher_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_promo_reward_events_referral "
+        "ON promo_reward_events (referral_id)"
+    )
+
+
+def downgrade() -> None:
+    # Intentional no-op: dropping these tables would lose referral history
+    # and granted-reward audit trail. Leaving them in place is harmless.
+    pass

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -38,6 +38,14 @@ from .credit_package_definition import CreditPackageDefinition
 # Plan models (admin-editable price/quota overrides)
 from .plan import Plan
 
+# Promo code / referral models (issue #637)
+from .promo_code import (
+    PromoCode,
+    PromoReferral,
+    PromoRewardConfig,
+    PromoRewardEvent,
+)
+
 # Organization models
 from .organization import (
     Organization,
@@ -110,6 +118,11 @@ __all__ = [
     "CreditPackageDefinition",
     # Plans
     "Plan",
+    # Promo codes / referrals
+    "PromoCode",
+    "PromoReferral",
+    "PromoRewardConfig",
+    "PromoRewardEvent",
     # Organizations
     "Organization",
     "School",

--- a/backend/models/promo_code.py
+++ b/backend/models/promo_code.py
@@ -1,0 +1,210 @@
+"""
+Promo Code models (issue #637) — referral tracking for the 特約合作方案.
+
+Four tables form the data layer:
+
+- ``PromoCode``        每位老師的推銷碼（個人預設碼 + admin 特約碼）
+- ``PromoReferral``    被推薦人 ↔ 推薦人的綁定關係（一個被推薦人僅一筆）
+- ``PromoRewardConfig`` admin 可調整的各事件獎勵點數
+- ``PromoRewardEvent`` 已發放紀錄，靠 idempotency_key 防重複發放
+
+PR 1 只建立 schema + 自動產生個人碼；獎勵發放與 API 在後續 PR。
+"""
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Text,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    CheckConstraint,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from database import Base
+from .base import JSONType
+
+
+class PromoCode(Base):
+    """推銷碼本體。
+
+    ``kind``：
+    - ``personal``  每位老師註冊時自動產生一組，``expires_at`` 為 NULL（永久），
+      一師只會有一筆（partial unique index 保證）。
+    - ``affiliate`` admin 為特約老師額外建立，可設定到期日。
+    """
+
+    __tablename__ = "promo_codes"
+    __table_args__ = (
+        # 一師一個人碼；特約碼不受限。
+        Index(
+            "uq_promo_codes_teacher_personal",
+            "teacher_id",
+            unique=True,
+            sqlite_where=text("kind = 'personal'"),
+            postgresql_where=text("kind = 'personal'"),
+        ),
+        Index("ix_promo_codes_teacher_id", "teacher_id"),
+        Index("ix_promo_codes_active_expires", "is_active", "expires_at"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    code = Column(String(16), nullable=False, unique=True, index=True)
+    teacher_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="CASCADE"), nullable=False
+    )
+
+    kind = Column(String(16), nullable=False, default="personal")
+    # NULL = 永久有效；有值 = 到期日
+    expires_at = Column(DateTime(timezone=True), nullable=True)
+    is_active = Column(Boolean, nullable=False, default=True)
+    note = Column(Text, nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    # Admin audit (mirrors CreditPackage pattern)
+    admin_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="SET NULL"), nullable=True
+    )
+    admin_reason = Column(Text, nullable=True)
+    admin_metadata = Column(JSONType, nullable=True)
+
+    teacher = relationship(
+        "Teacher", foreign_keys=[teacher_id], back_populates="promo_codes"
+    )
+    admin = relationship("Teacher", foreign_keys=[admin_id])
+
+    def __repr__(self):
+        return (
+            f"<PromoCode code={self.code} teacher={self.teacher_id} "
+            f"kind={self.kind} active={self.is_active}>"
+        )
+
+
+class PromoReferral(Base):
+    """被推薦人與推薦人的綁定關係。一個被推薦人最多綁定一次。"""
+
+    __tablename__ = "promo_referrals"
+    __table_args__ = (
+        UniqueConstraint(
+            "referred_teacher_id", name="uq_promo_referrals_referred_teacher"
+        ),
+        CheckConstraint(
+            "referrer_teacher_id != referred_teacher_id",
+            name="ck_promo_referrals_no_self_referral",
+        ),
+        Index("ix_promo_referrals_referrer", "referrer_teacher_id"),
+        Index("ix_promo_referrals_promo_code", "promo_code"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    referrer_teacher_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="CASCADE"), nullable=False
+    )
+    referred_teacher_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="CASCADE"), nullable=False
+    )
+
+    # 註冊當下填入的 code（快照，避免日後 code 改動），加上軟參照。
+    promo_code = Column(String(16), nullable=False)
+    promo_code_id = Column(
+        Integer, ForeignKey("promo_codes.id", ondelete="SET NULL"), nullable=True
+    )
+
+    signup_at = Column(DateTime(timezone=True), server_default=func.now())
+    verified_at = Column(DateTime(timezone=True), nullable=True)
+
+    # 「首次付費」獎勵（訂閱 or 點數包二擇一）是否已發。
+    first_paid_event_consumed = Column(Boolean, nullable=False, default=False)
+    # 被推薦人一次性 bonus 是否已發。
+    referred_bonus_granted = Column(Boolean, nullable=False, default=False)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    referrer = relationship("Teacher", foreign_keys=[referrer_teacher_id])
+    referred = relationship("Teacher", foreign_keys=[referred_teacher_id])
+    promo_code_ref = relationship("PromoCode", foreign_keys=[promo_code_id])
+
+    def __repr__(self):
+        return (
+            f"<PromoReferral referrer={self.referrer_teacher_id} "
+            f"referred={self.referred_teacher_id} code={self.promo_code}>"
+        )
+
+
+class PromoRewardConfig(Base):
+    """admin 可編輯的各事件獎勵點數設定（每個 trigger 一列）。"""
+
+    __tablename__ = "promo_reward_configs"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    reward_key = Column(String(64), nullable=False, unique=True, index=True)
+    points = Column(Integer, nullable=False)
+    recipient = Column(String(16), nullable=False, default="referrer")
+    is_active = Column(Boolean, nullable=False, default=True)
+
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+    updated_by_admin_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="SET NULL"), nullable=True
+    )
+
+    updated_by = relationship("Teacher", foreign_keys=[updated_by_admin_id])
+
+    def __repr__(self):
+        return (
+            f"<PromoRewardConfig key={self.reward_key} points={self.points} "
+            f"recipient={self.recipient}>"
+        )
+
+
+class PromoRewardEvent(Base):
+    """已發放點數紀錄。``idempotency_key`` unique 防止重複發放，也是報表來源。"""
+
+    __tablename__ = "promo_reward_events"
+    __table_args__ = (
+        Index("ix_promo_reward_events_granted_to", "granted_to_teacher_id"),
+        Index("ix_promo_reward_events_referral", "referral_id"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    referral_id = Column(
+        Integer, ForeignKey("promo_referrals.id", ondelete="CASCADE"), nullable=False
+    )
+    reward_key = Column(String(64), nullable=False)
+    # signup / subscription / credit_package
+    trigger_type = Column(String(32), nullable=False)
+    points = Column(Integer, nullable=False)
+    granted_to_teacher_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="CASCADE"), nullable=False
+    )
+    # 發點所建立的 CreditPackage（PR 3 填）
+    credit_package_id = Column(
+        Integer, ForeignKey("credit_packages.id", ondelete="SET NULL"), nullable=True
+    )
+
+    idempotency_key = Column(String(128), nullable=False, unique=True, index=True)
+    event_payload = Column(JSONType, nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    referral = relationship("PromoReferral")
+
+    def __repr__(self):
+        return (
+            f"<PromoRewardEvent key={self.reward_key} points={self.points} "
+            f"to={self.granted_to_teacher_id}>"
+        )

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -199,6 +199,22 @@ class Teacher(Base):
         back_populates="teacher",
         cascade="all, delete-orphan",
     )
+    # Promo code / referral (issue #637)
+    promo_codes = relationship(
+        "PromoCode",
+        foreign_keys="PromoCode.teacher_id",
+        back_populates="teacher",
+        cascade="all, delete-orphan",
+    )
+    referrals_made = relationship(
+        "PromoReferral",
+        foreign_keys="PromoReferral.referrer_teacher_id",
+    )
+    referral_received = relationship(
+        "PromoReferral",
+        foreign_keys="PromoReferral.referred_teacher_id",
+        uselist=False,
+    )
 
     @property
     def current_period(self):

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -282,6 +282,22 @@ async def teacher_register(
         logger.error(f"Onboarding failed for teacher {new_teacher.id}: {e}")
         # User can still complete registration and login, just without default resources
 
+    # 🎯 Issue #637: 為新老師建立個人推銷碼（非致命，失敗不影響註冊）
+    try:
+        from services.promo_code_service import create_personal_code_for_teacher
+        import logging
+
+        logging.getLogger(__name__).info(
+            f"Creating personal promo code for teacher {new_teacher.id}"
+        )
+        create_personal_code_for_teacher(db, new_teacher.id)
+    except Exception as e:
+        import logging
+
+        logging.getLogger(__name__).error(
+            f"Promo code creation failed for teacher {new_teacher.id}: {e}"
+        )
+
     # 🎯 發送驗證 email
     email_sent = email_service.send_teacher_verification_email(db, new_teacher)
 

--- a/backend/services/promo_code_service.py
+++ b/backend/services/promo_code_service.py
@@ -1,0 +1,76 @@
+"""
+Promo code service (issue #637).
+
+PR 1 scope: collision-free code generation and idempotent creation of a
+teacher's personal promo code. Reward dispatch lives in a later PR.
+"""
+
+import secrets
+from sqlalchemy.orm import Session
+
+from models import PromoCode
+
+# Alphabet excludes ambiguous glyphs (0/O, 1/I/L) so codes read cleanly
+# off a screen or printed page.
+CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
+CODE_LENGTH = 8
+_MAX_GENERATION_ATTEMPTS = 10
+
+# Default reward point values, seeded by the migration. `recipient` is who
+# receives the points when the event fires. `package_*` keys map directly to
+# config.plans.CREDIT_PACKAGES keys so the PR 3 dispatcher can look them up.
+DEFAULT_REWARD_CONFIGS = [
+    {"reward_key": "signup_verified", "points": 10, "recipient": "referrer"},
+    {"reward_key": "subscribe_tutor", "points": 1000, "recipient": "referrer"},
+    {"reward_key": "subscribe_school", "points": 2000, "recipient": "referrer"},
+    {"reward_key": "package_pkg-5000", "points": 200, "recipient": "referrer"},
+    {"reward_key": "package_pkg-10000", "points": 500, "recipient": "referrer"},
+    {"reward_key": "package_pkg-20000", "points": 800, "recipient": "referrer"},
+    {"reward_key": "referred_signup_bonus", "points": 300, "recipient": "referred"},
+]
+
+
+def _random_code() -> str:
+    """Return a single random candidate code. Extracted so tests can patch it."""
+    return "".join(secrets.choice(CODE_ALPHABET) for _ in range(CODE_LENGTH))
+
+
+def generate_unique_code(db: Session) -> str:
+    """Generate a code not already present in ``promo_codes``.
+
+    Retries on collision; the keyspace (31^8 ≈ 8.5e11) makes collisions
+    vanishingly rare, so a small attempt cap is plenty.
+    """
+    for _ in range(_MAX_GENERATION_ATTEMPTS):
+        candidate = _random_code()
+        exists = db.query(PromoCode.id).filter(PromoCode.code == candidate).first()
+        if not exists:
+            return candidate
+    raise RuntimeError("Could not generate a unique promo code after retries")
+
+
+def create_personal_code_for_teacher(db: Session, teacher_id: int) -> PromoCode:
+    """Return the teacher's personal promo code, creating it if absent.
+
+    Idempotent: a teacher has at most one ``kind='personal'`` code (enforced
+    by a partial unique index); repeated calls return the existing row.
+    """
+    existing = (
+        db.query(PromoCode)
+        .filter(PromoCode.teacher_id == teacher_id, PromoCode.kind == "personal")
+        .first()
+    )
+    if existing:
+        return existing
+
+    code = PromoCode(
+        code=generate_unique_code(db),
+        teacher_id=teacher_id,
+        kind="personal",
+        expires_at=None,  # permanent
+        is_active=True,
+    )
+    db.add(code)
+    db.commit()
+    db.refresh(code)
+    return code

--- a/backend/tests/test_promo_code_model.py
+++ b/backend/tests/test_promo_code_model.py
@@ -1,0 +1,224 @@
+"""
+PR 1 (issue #637) — Promo Code data-layer tests.
+
+Covers the four new tables and the code-generation service. No reward
+dispatch or API behaviour here (those land in later PRs); this only proves
+the schema, constraints, defaults, and the collision-free code generator.
+"""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from models import (
+    Teacher,
+    PromoCode,
+    PromoReferral,
+    PromoRewardConfig,
+    PromoRewardEvent,
+)
+from services.promo_code_service import (
+    generate_unique_code,
+    create_personal_code_for_teacher,
+    CODE_ALPHABET,
+    CODE_LENGTH,
+)
+
+
+def _make_teacher(db, email):
+    teacher = Teacher(name="T", email=email, password_hash="x")
+    db.add(teacher)
+    db.commit()
+    db.refresh(teacher)
+    return teacher
+
+
+# ---------------------------------------------------------------- generator
+
+
+def test_code_alphabet_excludes_ambiguous_chars():
+    assert CODE_LENGTH == 8
+    for ch in "01OIL":
+        assert ch not in CODE_ALPHABET
+
+
+def test_generate_unique_code_uses_alphabet(test_db_session):
+    code = generate_unique_code(test_db_session)
+    assert len(code) == CODE_LENGTH
+    assert all(c in CODE_ALPHABET for c in code)
+
+
+def test_generate_unique_code_retries_on_collision(test_db_session, monkeypatch):
+    teacher = _make_teacher(test_db_session, "collide@test.com")
+    # Seed an existing code, force the RNG to emit it once, then a fresh one.
+    existing = create_personal_code_for_teacher(test_db_session, teacher.id)
+
+    seq = iter([existing.code, "AAAA2222"])
+    monkeypatch.setattr("services.promo_code_service._random_code", lambda: next(seq))
+    new_code = generate_unique_code(test_db_session)
+    assert new_code == "AAAA2222"
+
+
+# ---------------------------------------------------------------- PromoCode
+
+
+def test_create_personal_code_is_idempotent(test_db_session):
+    teacher = _make_teacher(test_db_session, "idem@test.com")
+    first = create_personal_code_for_teacher(test_db_session, teacher.id)
+    second = create_personal_code_for_teacher(test_db_session, teacher.id)
+    assert first.id == second.id
+    codes = (
+        test_db_session.query(PromoCode)
+        .filter(PromoCode.teacher_id == teacher.id, PromoCode.kind == "personal")
+        .all()
+    )
+    assert len(codes) == 1
+
+
+def test_personal_code_defaults(test_db_session):
+    teacher = _make_teacher(test_db_session, "defaults@test.com")
+    code = create_personal_code_for_teacher(test_db_session, teacher.id)
+    assert code.kind == "personal"
+    assert code.expires_at is None  # NULL = permanent
+    assert code.is_active is True
+
+
+def test_promo_code_unique_code(test_db_session):
+    t1 = _make_teacher(test_db_session, "u1@test.com")
+    t2 = _make_teacher(test_db_session, "u2@test.com")
+    test_db_session.add(PromoCode(code="DUP12345", teacher_id=t1.id, kind="personal"))
+    test_db_session.commit()
+    test_db_session.add(PromoCode(code="DUP12345", teacher_id=t2.id, kind="affiliate"))
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()
+
+
+# ---------------------------------------------------------------- Referral
+
+
+def test_referral_one_per_referred_teacher(test_db_session):
+    referrer = _make_teacher(test_db_session, "ref@test.com")
+    referred = _make_teacher(test_db_session, "new@test.com")
+    test_db_session.add(
+        PromoReferral(
+            referrer_teacher_id=referrer.id,
+            referred_teacher_id=referred.id,
+            promo_code="ABCD2345",
+        )
+    )
+    test_db_session.commit()
+    # Second referral for the same referred teacher must fail.
+    test_db_session.add(
+        PromoReferral(
+            referrer_teacher_id=referrer.id,
+            referred_teacher_id=referred.id,
+            promo_code="WXYZ6789",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()
+
+
+def test_referral_cannot_refer_self(test_db_session):
+    teacher = _make_teacher(test_db_session, "self@test.com")
+    test_db_session.add(
+        PromoReferral(
+            referrer_teacher_id=teacher.id,
+            referred_teacher_id=teacher.id,
+            promo_code="SELF2345",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()
+
+
+def test_referral_flags_default_false(test_db_session):
+    referrer = _make_teacher(test_db_session, "r2@test.com")
+    referred = _make_teacher(test_db_session, "n2@test.com")
+    referral = PromoReferral(
+        referrer_teacher_id=referrer.id,
+        referred_teacher_id=referred.id,
+        promo_code="FLAG2345",
+    )
+    test_db_session.add(referral)
+    test_db_session.commit()
+    test_db_session.refresh(referral)
+    assert referral.first_paid_event_consumed is False
+    assert referral.referred_bonus_granted is False
+    assert referral.verified_at is None
+
+
+# ---------------------------------------------------------------- RewardConfig
+
+
+EXPECTED_DEFAULTS = {
+    "signup_verified": (10, "referrer"),
+    "subscribe_tutor": (1000, "referrer"),
+    "subscribe_school": (2000, "referrer"),
+    "package_pkg-5000": (200, "referrer"),
+    "package_pkg-10000": (500, "referrer"),
+    "package_pkg-20000": (800, "referrer"),
+    "referred_signup_bonus": (300, "referred"),
+}
+
+
+def test_reward_config_seed_defaults():
+    from services.promo_code_service import DEFAULT_REWARD_CONFIGS
+
+    seeded = {
+        c["reward_key"]: (c["points"], c["recipient"]) for c in DEFAULT_REWARD_CONFIGS
+    }
+    assert seeded == EXPECTED_DEFAULTS
+
+
+def test_reward_config_unique_key(test_db_session):
+    test_db_session.add(PromoRewardConfig(reward_key="signup_verified", points=10))
+    test_db_session.commit()
+    test_db_session.add(PromoRewardConfig(reward_key="signup_verified", points=99))
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()
+
+
+# ---------------------------------------------------------------- RewardEvent
+
+
+def test_reward_event_idempotency_key_unique(test_db_session):
+    referrer = _make_teacher(test_db_session, "re@test.com")
+    referred = _make_teacher(test_db_session, "rd@test.com")
+    referral = PromoReferral(
+        referrer_teacher_id=referrer.id,
+        referred_teacher_id=referred.id,
+        promo_code="EVNT2345",
+    )
+    test_db_session.add(referral)
+    test_db_session.commit()
+    test_db_session.refresh(referral)
+
+    key = f"{referral.id}:signup_verified"
+    test_db_session.add(
+        PromoRewardEvent(
+            referral_id=referral.id,
+            reward_key="signup_verified",
+            trigger_type="signup",
+            points=10,
+            granted_to_teacher_id=referrer.id,
+            idempotency_key=key,
+        )
+    )
+    test_db_session.commit()
+    test_db_session.add(
+        PromoRewardEvent(
+            referral_id=referral.id,
+            reward_key="signup_verified",
+            trigger_type="signup",
+            points=10,
+            granted_to_teacher_id=referrer.id,
+            idempotency_key=key,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()


### PR DESCRIPTION
## Summary

PR 1 of 4 for the Promo Code referral system (#637). **Data layer only** — no reward dispatch or API endpoints yet; those land in later PRs.

- **4 new tables**:
  - `promo_codes` — one permanent personal code per teacher (partial unique on `kind='personal'`) + admin-created `affiliate` codes with optional expiry. Admin audit columns mirror the `credit_packages` pattern.
  - `promo_referrals` — one referral per referred teacher (`UNIQUE`), self-referral `CHECK`, plus `first_paid_event_consumed` / `referred_bonus_granted` flags consumed by later PRs.
  - `promo_reward_configs` — 7 admin-editable reward values, seeded by the migration.
  - `promo_reward_events` — `idempotency_key` unique guards against double grants; also the reporting source.
- **Code generator** — collision-free 8-char codes, alphabet excludes ambiguous glyphs `0/O/1/I/L`.
- **Register hook** — teacher registration now creates the personal code (non-fatal on failure, same pattern as onboarding).
- **Idempotent migration** — `CREATE ... IF NOT EXISTS` / `ON CONFLICT`, chained off current staging head `20260522_1000` (single head verified).

### Seeded reward defaults

| reward_key | points | recipient |
|---|---|---|
| `signup_verified` | 10 | referrer |
| `subscribe_tutor` | 1000 | referrer |
| `subscribe_school` | 2000 | referrer |
| `package_pkg-5000` | 200 | referrer |
| `package_pkg-10000` | 500 | referrer |
| `package_pkg-20000` | 800 | referrer |
| `referred_signup_bonus` | 300 | referred |

## Test plan

- [x] `tests/test_promo_code_model.py` — 12 tests pass (schema, constraints, defaults, generator collision-retry, idempotent personal-code creation)
- [x] `black` + `flake8` clean
- [x] Single alembic head confirmed (`20260525_1000`)
- [ ] CI green on staging

## Out of scope (later PRs)

- PR 2: registration `?promo=` URL param + form field, referral binding, signup-verified reward
- PR 3: reward dispatch engine (subscription / credit-package webhooks) + admin management UI
- PR 4: teacher dashboard points-usage bar + referral stats

Related to #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)