### PR TITLE
feat(#637): bind referral at registration + stamp verified_at

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -5,7 +5,7 @@ from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 from typing import Optional  # noqa: F401
-from pydantic import BaseModel, EmailStr, field_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator
 from database import get_db
 from models import (
     Teacher,
@@ -63,8 +63,10 @@ class TeacherRegisterRequest(BaseModel):
     password: str
     name: str
     phone: Optional[str] = None
-    # Optional referral code (from ?promo= URL param or input field)
-    promo_code: Optional[str] = None
+    # Optional referral code (from ?promo= URL param or input field).
+    # max_length bounds the input (DB column is VARCHAR(16)) so an oversized
+    # payload is rejected at parse time rather than hitting the logs / DB.
+    promo_code: Optional[str] = Field(None, max_length=32)
 
     @field_validator("password")
     @classmethod
@@ -361,7 +363,12 @@ async def verify_teacher_email(token: str, db: Session = Depends(get_db)):
         mark_referral_verified(db, teacher.id)
     except Exception as e:
         db.rollback()
-        logger.error(f"Marking referral verified failed for teacher {teacher.id}: {e}")
+        # verified_at not persisted. The reward engine falls back to the
+        # teacher's email_verified flag, so this is recoverable; log loudly.
+        logger.error(
+            f"ALERT: mark_referral_verified failed for teacher {teacher.id} "
+            f"— verified_at not stamped: {e}"
+        )
 
     # 不自動登入，只返回驗證成功訊息
     return {

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -63,7 +63,7 @@ class TeacherRegisterRequest(BaseModel):
     password: str
     name: str
     phone: Optional[str] = None
-    # Issue #637: optional referral code (from ?promo= URL param or input field)
+    # Optional referral code (from ?promo= URL param or input field)
     promo_code: Optional[str] = None
 
     @field_validator("password")
@@ -284,17 +284,13 @@ async def teacher_register(
         logger.error(f"Onboarding failed for teacher {new_teacher.id}: {e}")
         # User can still complete registration and login, just without default resources
 
-    # 🎯 Issue #637: 為新老師建立個人推銷碼，並（若有填）綁定推薦關係。
-    # 全程非致命，失敗不影響註冊。
+    # 建立個人推銷碼，並（若有填）綁定推薦關係。全程非致命，失敗不影響註冊。
     try:
         from services.promo_code_service import (
             create_personal_code_for_teacher,
             bind_referral,
         )
-        import logging
 
-        logger = logging.getLogger(__name__)
-        logger.info(f"Creating personal promo code for teacher {new_teacher.id}")
         create_personal_code_for_teacher(db, new_teacher.id)
 
         if register_req.promo_code:
@@ -304,12 +300,13 @@ async def teacher_register(
                     f"Promo code '{register_req.promo_code}' not bound for "
                     f"teacher {new_teacher.id} (invalid/expired/self-referral)"
                 )
+            else:
+                logger.info(
+                    f"Referral {referral.id} bound: teacher {new_teacher.id} "
+                    f"referred by {referral.referrer_teacher_id}"
+                )
     except Exception as e:
-        import logging
-
-        logging.getLogger(__name__).error(
-            f"Promo code handling failed for teacher {new_teacher.id}: {e}"
-        )
+        logger.error(f"Promo code handling failed for teacher {new_teacher.id}: {e}")
 
     # 🎯 發送驗證 email
     email_sent = email_service.send_teacher_verification_email(db, new_teacher)
@@ -349,17 +346,13 @@ async def verify_teacher_email(token: str, db: Session = Depends(get_db)):
             detail="Invalid or expired verification token",
         )
 
-    # 🎯 Issue #637: 標記推薦關係已驗證（非致命）。實際發點留待 PR 3。
+    # 標記推薦關係已驗證（非致命）。實際發點在獎勵引擎處理。
     try:
         from services.promo_code_service import mark_referral_verified
 
         mark_referral_verified(db, teacher.id)
     except Exception as e:
-        import logging
-
-        logging.getLogger(__name__).error(
-            f"Marking referral verified failed for teacher {teacher.id}: {e}"
-        )
+        logger.error(f"Marking referral verified failed for teacher {teacher.id}: {e}")
 
     # 不自動登入，只返回驗證成功訊息
     return {

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -284,16 +284,23 @@ async def teacher_register(
         logger.error(f"Onboarding failed for teacher {new_teacher.id}: {e}")
         # User can still complete registration and login, just without default resources
 
-    # 建立個人推銷碼，並（若有填）綁定推薦關係。全程非致命，失敗不影響註冊。
+    # 建立個人推銷碼（非致命）。獨立 try：即使產碼失敗也不影響後續綁定。
+    # except 內 rollback 避免 session 卡在 PendingRollbackError，後續 email 發送才不會 500。
     try:
-        from services.promo_code_service import (
-            create_personal_code_for_teacher,
-            bind_referral,
-        )
+        from services.promo_code_service import create_personal_code_for_teacher
 
         create_personal_code_for_teacher(db, new_teacher.id)
+    except Exception as e:
+        db.rollback()
+        logger.error(
+            f"Personal promo code creation failed for teacher {new_teacher.id}: {e}"
+        )
 
-        if register_req.promo_code:
+    # 綁定推薦關係（非致命，獨立於個人碼建立）。
+    if register_req.promo_code:
+        try:
+            from services.promo_code_service import bind_referral
+
             referral = bind_referral(db, register_req.promo_code, new_teacher.id)
             if referral is None:
                 logger.info(
@@ -305,8 +312,9 @@ async def teacher_register(
                     f"Referral {referral.id} bound: teacher {new_teacher.id} "
                     f"referred by {referral.referrer_teacher_id}"
                 )
-    except Exception as e:
-        logger.error(f"Promo code handling failed for teacher {new_teacher.id}: {e}")
+        except Exception as e:
+            db.rollback()
+            logger.error(f"Referral binding failed for teacher {new_teacher.id}: {e}")
 
     # 🎯 發送驗證 email
     email_sent = email_service.send_teacher_verification_email(db, new_teacher)
@@ -352,6 +360,7 @@ async def verify_teacher_email(token: str, db: Session = Depends(get_db)):
 
         mark_referral_verified(db, teacher.id)
     except Exception as e:
+        db.rollback()
         logger.error(f"Marking referral verified failed for teacher {teacher.id}: {e}")
 
     # 不自動登入，只返回驗證成功訊息

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -63,6 +63,8 @@ class TeacherRegisterRequest(BaseModel):
     password: str
     name: str
     phone: Optional[str] = None
+    # Issue #637: optional referral code (from ?promo= URL param or input field)
+    promo_code: Optional[str] = None
 
     @field_validator("password")
     @classmethod
@@ -282,20 +284,31 @@ async def teacher_register(
         logger.error(f"Onboarding failed for teacher {new_teacher.id}: {e}")
         # User can still complete registration and login, just without default resources
 
-    # 🎯 Issue #637: 為新老師建立個人推銷碼（非致命，失敗不影響註冊）
+    # 🎯 Issue #637: 為新老師建立個人推銷碼，並（若有填）綁定推薦關係。
+    # 全程非致命，失敗不影響註冊。
     try:
-        from services.promo_code_service import create_personal_code_for_teacher
+        from services.promo_code_service import (
+            create_personal_code_for_teacher,
+            bind_referral,
+        )
         import logging
 
-        logging.getLogger(__name__).info(
-            f"Creating personal promo code for teacher {new_teacher.id}"
-        )
+        logger = logging.getLogger(__name__)
+        logger.info(f"Creating personal promo code for teacher {new_teacher.id}")
         create_personal_code_for_teacher(db, new_teacher.id)
+
+        if register_req.promo_code:
+            referral = bind_referral(db, register_req.promo_code, new_teacher.id)
+            if referral is None:
+                logger.info(
+                    f"Promo code '{register_req.promo_code}' not bound for "
+                    f"teacher {new_teacher.id} (invalid/expired/self-referral)"
+                )
     except Exception as e:
         import logging
 
         logging.getLogger(__name__).error(
-            f"Promo code creation failed for teacher {new_teacher.id}: {e}"
+            f"Promo code handling failed for teacher {new_teacher.id}: {e}"
         )
 
     # 🎯 發送驗證 email
@@ -334,6 +347,18 @@ async def verify_teacher_email(token: str, db: Session = Depends(get_db)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired verification token",
+        )
+
+    # 🎯 Issue #637: 標記推薦關係已驗證（非致命）。實際發點留待 PR 3。
+    try:
+        from services.promo_code_service import mark_referral_verified
+
+        mark_referral_verified(db, teacher.id)
+    except Exception as e:
+        import logging
+
+        logging.getLogger(__name__).error(
+            f"Marking referral verified failed for teacher {teacher.id}: {e}"
         )
 
     # 不自動登入，只返回驗證成功訊息

--- a/backend/services/promo_code_service.py
+++ b/backend/services/promo_code_service.py
@@ -6,9 +6,12 @@ teacher's personal promo code. Reward dispatch lives in a later PR.
 """
 
 import secrets
+from datetime import datetime, timezone
+from typing import Optional
+
 from sqlalchemy.orm import Session
 
-from models import PromoCode
+from models import PromoCode, PromoReferral
 
 # Alphabet excludes ambiguous glyphs (0/O, 1/I/L) so codes read cleanly
 # off a screen or printed page.
@@ -74,3 +77,89 @@ def create_personal_code_for_teacher(db: Session, teacher_id: int) -> PromoCode:
     db.commit()
     db.refresh(code)
     return code
+
+
+def _is_expired(expires_at) -> bool:
+    """NULL expiry means permanent. Tolerate naive datetimes (SQLite) by
+    assuming UTC."""
+    if expires_at is None:
+        return False
+    exp = expires_at
+    if exp.tzinfo is None:
+        exp = exp.replace(tzinfo=timezone.utc)
+    return exp < datetime.now(timezone.utc)
+
+
+def validate_promo_code(db: Session, code: Optional[str]) -> Optional[PromoCode]:
+    """Return an active, non-expired ``PromoCode`` matching ``code`` (case-
+    insensitive), or None. Codes are stored uppercase."""
+    if not code:
+        return None
+    normalized = code.strip().upper()
+    if not normalized:
+        return None
+    pc = (
+        db.query(PromoCode)
+        .filter(PromoCode.code == normalized, PromoCode.is_active.is_(True))
+        .first()
+    )
+    if pc is None or _is_expired(pc.expires_at):
+        return None
+    return pc
+
+
+def bind_referral(
+    db: Session, code: Optional[str], referred_teacher_id: int
+) -> Optional[PromoReferral]:
+    """Bind a newly registered teacher to the owner of ``code``.
+
+    Returns the referral, or None when the binding is disqualified — invalid /
+    expired code, self-referral, or the teacher is already bound (a teacher can
+    only ever be referred once). Idempotent: a second call for an
+    already-bound teacher returns the existing referral. Non-fatal by design
+    so registration never fails because of a bad promo code.
+    """
+    pc = validate_promo_code(db, code)
+    if pc is None:
+        return None
+    if pc.teacher_id == referred_teacher_id:
+        return None  # cannot refer yourself
+
+    existing = (
+        db.query(PromoReferral)
+        .filter(PromoReferral.referred_teacher_id == referred_teacher_id)
+        .first()
+    )
+    if existing is not None:
+        return existing
+
+    referral = PromoReferral(
+        referrer_teacher_id=pc.teacher_id,
+        referred_teacher_id=referred_teacher_id,
+        promo_code=pc.code,
+        promo_code_id=pc.id,
+    )
+    db.add(referral)
+    db.commit()
+    db.refresh(referral)
+    return referral
+
+
+def mark_referral_verified(
+    db: Session, referred_teacher_id: int
+) -> Optional[PromoReferral]:
+    """Stamp ``verified_at`` on the teacher's referral once their email is
+    verified. Idempotent: only sets the timestamp the first time. Returns the
+    referral, or None if the teacher has no referral."""
+    referral = (
+        db.query(PromoReferral)
+        .filter(PromoReferral.referred_teacher_id == referred_teacher_id)
+        .first()
+    )
+    if referral is None:
+        return None
+    if referral.verified_at is None:
+        referral.verified_at = datetime.now(timezone.utc)
+        db.commit()
+        db.refresh(referral)
+    return referral

--- a/backend/tests/test_promo_referral_binding.py
+++ b/backend/tests/test_promo_referral_binding.py
@@ -1,0 +1,176 @@
+"""
+PR 2 (issue #637) — referral binding at registration + verify-time stamping.
+
+Backend only: validates promo code, binds the referral, and stamps
+verified_at on email verification. No point granting here (that lands in
+PR 3); these tests assert binding behaviour and edge cases.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from models import Teacher, PromoCode, PromoReferral
+from services.promo_code_service import (
+    create_personal_code_for_teacher,
+    validate_promo_code,
+    bind_referral,
+    mark_referral_verified,
+)
+
+
+def _make_teacher(db, email):
+    t = Teacher(name="T", email=email, password_hash="x")
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+# ------------------------------------------------------------ validate_promo_code
+
+
+def test_validate_active_code(test_db_session):
+    teacher = _make_teacher(test_db_session, "v1@test.com")
+    code = create_personal_code_for_teacher(test_db_session, teacher.id)
+    found = validate_promo_code(test_db_session, code.code)
+    assert found is not None
+    assert found.id == code.id
+
+
+def test_validate_is_case_insensitive(test_db_session):
+    teacher = _make_teacher(test_db_session, "v2@test.com")
+    code = create_personal_code_for_teacher(test_db_session, teacher.id)
+    assert validate_promo_code(test_db_session, code.code.lower()) is not None
+    assert validate_promo_code(test_db_session, f"  {code.code}  ") is not None
+
+
+def test_validate_none_and_empty(test_db_session):
+    assert validate_promo_code(test_db_session, None) is None
+    assert validate_promo_code(test_db_session, "") is None
+    assert validate_promo_code(test_db_session, "   ") is None
+
+
+def test_validate_unknown_code(test_db_session):
+    assert validate_promo_code(test_db_session, "NOTACODE") is None
+
+
+def test_validate_inactive_code(test_db_session):
+    teacher = _make_teacher(test_db_session, "v3@test.com")
+    code = create_personal_code_for_teacher(test_db_session, teacher.id)
+    code.is_active = False
+    test_db_session.commit()
+    assert validate_promo_code(test_db_session, code.code) is None
+
+
+def test_validate_expired_code(test_db_session):
+    teacher = _make_teacher(test_db_session, "v4@test.com")
+    test_db_session.add(
+        PromoCode(
+            code="EXPIRED2",
+            teacher_id=teacher.id,
+            kind="affiliate",
+            expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+    )
+    test_db_session.commit()
+    assert validate_promo_code(test_db_session, "EXPIRED2") is None
+
+
+def test_validate_future_expiry_is_valid(test_db_session):
+    teacher = _make_teacher(test_db_session, "v5@test.com")
+    test_db_session.add(
+        PromoCode(
+            code="FUTURE22",
+            teacher_id=teacher.id,
+            kind="affiliate",
+            expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+        )
+    )
+    test_db_session.commit()
+    assert validate_promo_code(test_db_session, "FUTURE22") is not None
+
+
+# ------------------------------------------------------------ bind_referral
+
+
+def test_bind_referral_success(test_db_session):
+    referrer = _make_teacher(test_db_session, "ref@test.com")
+    referred = _make_teacher(test_db_session, "new@test.com")
+    code = create_personal_code_for_teacher(test_db_session, referrer.id)
+
+    referral = bind_referral(test_db_session, code.code, referred.id)
+    assert referral is not None
+    assert referral.referrer_teacher_id == referrer.id
+    assert referral.referred_teacher_id == referred.id
+    assert referral.promo_code == code.code
+    assert referral.promo_code_id == code.id
+    assert referral.verified_at is None
+
+
+def test_bind_referral_invalid_code_returns_none(test_db_session):
+    referred = _make_teacher(test_db_session, "n2@test.com")
+    assert bind_referral(test_db_session, "NOPE", referred.id) is None
+    assert bind_referral(test_db_session, None, referred.id) is None
+    # No referral row was created.
+    assert (
+        test_db_session.query(PromoReferral)
+        .filter(PromoReferral.referred_teacher_id == referred.id)
+        .count()
+        == 0
+    )
+
+
+def test_bind_referral_rejects_self_referral(test_db_session):
+    teacher = _make_teacher(test_db_session, "selfref@test.com")
+    code = create_personal_code_for_teacher(test_db_session, teacher.id)
+    assert bind_referral(test_db_session, code.code, teacher.id) is None
+
+
+def test_bind_referral_idempotent_when_already_bound(test_db_session):
+    r1 = _make_teacher(test_db_session, "r1@test.com")
+    r2 = _make_teacher(test_db_session, "r2@test.com")
+    referred = _make_teacher(test_db_session, "bound@test.com")
+    code1 = create_personal_code_for_teacher(test_db_session, r1.id)
+    code2 = create_personal_code_for_teacher(test_db_session, r2.id)
+
+    first = bind_referral(test_db_session, code1.code, referred.id)
+    # A second attempt with a different code must NOT rebind; returns existing.
+    second = bind_referral(test_db_session, code2.code, referred.id)
+    assert first.id == second.id
+    assert second.referrer_teacher_id == r1.id
+    assert (
+        test_db_session.query(PromoReferral)
+        .filter(PromoReferral.referred_teacher_id == referred.id)
+        .count()
+        == 1
+    )
+
+
+# ------------------------------------------------------------ mark_referral_verified
+
+
+def test_mark_referral_verified_sets_timestamp(test_db_session):
+    referrer = _make_teacher(test_db_session, "mv1@test.com")
+    referred = _make_teacher(test_db_session, "mv2@test.com")
+    code = create_personal_code_for_teacher(test_db_session, referrer.id)
+    bind_referral(test_db_session, code.code, referred.id)
+
+    referral = mark_referral_verified(test_db_session, referred.id)
+    assert referral is not None
+    assert referral.verified_at is not None
+
+
+def test_mark_referral_verified_idempotent(test_db_session):
+    referrer = _make_teacher(test_db_session, "mv3@test.com")
+    referred = _make_teacher(test_db_session, "mv4@test.com")
+    code = create_personal_code_for_teacher(test_db_session, referrer.id)
+    bind_referral(test_db_session, code.code, referred.id)
+
+    first = mark_referral_verified(test_db_session, referred.id)
+    first_ts = first.verified_at
+    second = mark_referral_verified(test_db_session, referred.id)
+    assert second.verified_at == first_ts  # unchanged on second call
+
+
+def test_mark_referral_verified_no_referral(test_db_session):
+    teacher = _make_teacher(test_db_session, "noref@test.com")
+    assert mark_referral_verified(test_db_session, teacher.id) is None


### PR DESCRIPTION
## Summary

PR 2 of 4 for the Promo Code referral system (#637). **Backend only** — no point granting (PR 3) and no frontend (separate PR).

- `teacher/register` accepts an optional `promo_code` (from a `?promo=` URL param or input field, both wired by the frontend PR). On success it binds a `promo_referrals` row linking the new teacher to the code owner.
- `verify-teacher` stamps `referral.verified_at` once the email is verified.
- `promo_code_service` gains three functions:
  - `validate_promo_code` — active + non-expired, case-insensitive lookup
  - `bind_referral` — rejects invalid/expired codes and self-referrals; idempotent when the teacher is already bound (one referral per teacher, ever)
  - `mark_referral_verified` — idempotent `verified_at` stamp
- All promo handling in the register/verify paths is **non-fatal**: a bad code never blocks registration or verification (same pattern as onboarding).

## Test plan

- [x] `tests/test_promo_referral_binding.py` — 14 tests (validate: active/case-insensitive/empty/unknown/inactive/expired/future; bind: success/invalid/self/idempotent; verify: stamp/idempotent/no-referral)
- [x] `tests/test_promo_code_model.py` still green (26 total)
- [x] `black` + `flake8` clean
- [x] No new migration (reuses PR 1 tables); single alembic head unchanged
- [ ] CI green on staging

> Endpoint-level tests are deferred: the integration TestClient needs the permission-system bootstrap which isn't available locally. The register/verify changes are thin delegations to the fully unit-tested service functions.

## Out of scope (later PRs)

- Frontend: register page `?promo=` URL param + input field
- PR 3: reward dispatch engine (signup-verified 10pts, referred-bonus 300pts, subscription / credit-package rewards) + admin management UI
- PR 4: teacher dashboard points-usage bar + referral stats

Related to #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)