### PR TITLE
feat(#637): referral reward engine + admin promo-code API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -38,6 +38,7 @@ from routers import (
     admin_monitoring,
     admin_billing,
     admin_audio_errors,
+    admin_promo_codes,
     teacher_review,
     subscription,
     payment,
@@ -282,6 +283,7 @@ app.include_router(admin_plans.router)  # Admin 方案 CRUD 路由
 app.include_router(admin_monitoring.router)  # 監控路由（無需認證）
 app.include_router(admin_billing.router)  # Admin 帳單監控路由（Admin only）
 app.include_router(admin_audio_errors.router)  # Admin 錄音錯誤監控路由（Admin only）
+app.include_router(admin_promo_codes.router)  # Admin 推銷碼管理路由（Admin only）
 app.include_router(blog.router)  # Blog 管理路由（Admin only）
 app.include_router(cron.router)  # Cron Job 路由
 app.include_router(debug.router)  # Debug 路由

--- a/backend/routers/admin_promo_codes.py
+++ b/backend/routers/admin_promo_codes.py
@@ -1,0 +1,246 @@
+"""
+Admin Promo Code API (issue #637, PR 3).
+
+Lets admins manage referral promo codes, tune the per-event reward point
+values, and read a referral report. Frontend UI is a separate PR.
+
+All endpoints require admin (`get_current_admin`).
+"""
+
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import func, cast, Integer
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import (
+    Teacher,
+    PromoCode,
+    PromoReferral,
+    PromoRewardConfig,
+    PromoRewardEvent,
+)
+from routers.admin import get_current_admin
+from services.promo_code_service import generate_unique_code
+
+router = APIRouter(prefix="/api/admin/promo-codes", tags=["admin-promo-codes"])
+
+
+# ============ Schemas ============
+class PromoCodeResponse(BaseModel):
+    id: int
+    code: str
+    teacher_id: int
+    kind: str
+    expires_at: Optional[datetime] = None
+    is_active: bool
+    note: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True
+
+
+class AffiliateCodeCreateRequest(BaseModel):
+    teacher_id: int
+    expires_at: Optional[datetime] = None  # None = permanent
+    note: Optional[str] = Field(default=None, max_length=500)
+
+
+class PromoCodeUpdateRequest(BaseModel):
+    is_active: Optional[bool] = None
+    expires_at: Optional[datetime] = None
+    note: Optional[str] = Field(default=None, max_length=500)
+
+
+class RewardConfigResponse(BaseModel):
+    id: int
+    reward_key: str
+    points: int
+    recipient: str
+    is_active: bool
+
+    class Config:
+        from_attributes = True
+
+
+class RewardConfigUpdateRequest(BaseModel):
+    points: Optional[int] = Field(default=None, ge=0)
+    is_active: Optional[bool] = None
+
+
+class ReferralReportRow(BaseModel):
+    referrer_teacher_id: int
+    referral_count: int
+    verified_count: int
+    paid_count: int
+    total_points_awarded: int
+
+
+# ============ Promo code endpoints ============
+@router.get("", response_model=List[PromoCodeResponse])
+async def list_promo_codes(
+    teacher_id: Optional[int] = None,
+    kind: Optional[str] = None,
+    db: Session = Depends(get_db),
+    _: Teacher = Depends(get_current_admin),
+) -> List[PromoCodeResponse]:
+    """List promo codes, newest first. Optional filters by teacher / kind."""
+    query = db.query(PromoCode)
+    if teacher_id is not None:
+        query = query.filter(PromoCode.teacher_id == teacher_id)
+    if kind is not None:
+        query = query.filter(PromoCode.kind == kind)
+    rows = query.order_by(PromoCode.created_at.desc()).all()
+    return [PromoCodeResponse.model_validate(r) for r in rows]
+
+
+@router.post("", response_model=PromoCodeResponse, status_code=201)
+async def create_affiliate_code(
+    request: AffiliateCodeCreateRequest,
+    db: Session = Depends(get_db),
+    admin: Teacher = Depends(get_current_admin),
+) -> PromoCodeResponse:
+    """Create an affiliate promo code for a teacher (optional expiry)."""
+    teacher = db.query(Teacher).filter(Teacher.id == request.teacher_id).first()
+    if teacher is None:
+        raise HTTPException(
+            status_code=404, detail=f"Teacher {request.teacher_id} not found"
+        )
+
+    code = PromoCode(
+        code=generate_unique_code(db),
+        teacher_id=request.teacher_id,
+        kind="affiliate",
+        expires_at=request.expires_at,
+        is_active=True,
+        note=request.note,
+        admin_id=admin.id,
+        admin_reason="affiliate code created",
+    )
+    db.add(code)
+    db.commit()
+    db.refresh(code)
+    return PromoCodeResponse.model_validate(code)
+
+
+@router.patch("/{code_id}", response_model=PromoCodeResponse)
+async def update_promo_code(
+    code_id: int,
+    request: PromoCodeUpdateRequest,
+    db: Session = Depends(get_db),
+    admin: Teacher = Depends(get_current_admin),
+) -> PromoCodeResponse:
+    """Activate / deactivate a code or change its expiry / note."""
+    code = db.query(PromoCode).filter(PromoCode.id == code_id).first()
+    if code is None:
+        raise HTTPException(status_code=404, detail=f"Promo code {code_id} not found")
+
+    payload = request.model_dump(exclude_unset=True)
+    if not payload:
+        raise HTTPException(status_code=400, detail="No fields provided to update")
+
+    for field, value in payload.items():
+        setattr(code, field, value)
+    code.admin_id = admin.id
+    code.admin_reason = "admin update via /admin/promo-codes"
+    db.commit()
+    db.refresh(code)
+    return PromoCodeResponse.model_validate(code)
+
+
+# ============ Reward config endpoints ============
+@router.get("/reward-configs", response_model=List[RewardConfigResponse])
+async def list_reward_configs(
+    db: Session = Depends(get_db),
+    _: Teacher = Depends(get_current_admin),
+) -> List[RewardConfigResponse]:
+    """List the per-event reward point configs."""
+    rows = db.query(PromoRewardConfig).order_by(PromoRewardConfig.id.asc()).all()
+    return [RewardConfigResponse.model_validate(r) for r in rows]
+
+
+@router.patch("/reward-configs/{reward_key}", response_model=RewardConfigResponse)
+async def update_reward_config(
+    reward_key: str,
+    request: RewardConfigUpdateRequest,
+    db: Session = Depends(get_db),
+    admin: Teacher = Depends(get_current_admin),
+) -> RewardConfigResponse:
+    """Update the points / active flag for a reward key."""
+    row = (
+        db.query(PromoRewardConfig)
+        .filter(PromoRewardConfig.reward_key == reward_key)
+        .first()
+    )
+    if row is None:
+        raise HTTPException(
+            status_code=404, detail=f"Reward config '{reward_key}' not found"
+        )
+
+    payload = request.model_dump(exclude_unset=True)
+    if not payload:
+        raise HTTPException(status_code=400, detail="No fields provided to update")
+
+    for field, value in payload.items():
+        setattr(row, field, value)
+    row.updated_by_admin_id = admin.id
+    db.commit()
+    db.refresh(row)
+    return RewardConfigResponse.model_validate(row)
+
+
+# ============ Referral report ============
+def build_referral_report(db: Session) -> List[ReferralReportRow]:
+    """Per-referrer summary. Extracted from the endpoint so it can be unit
+    tested without the admin TestClient (permission-system bootstrap)."""
+    referral_rows = (
+        db.query(
+            PromoReferral.referrer_teacher_id.label("referrer"),
+            func.count(PromoReferral.id).label("referral_count"),
+            func.count(PromoReferral.verified_at).label("verified_count"),
+            func.coalesce(
+                func.sum(cast(PromoReferral.first_paid_event_consumed, Integer)),
+                0,
+            ).label("paid_count"),
+        )
+        .group_by(PromoReferral.referrer_teacher_id)
+        .all()
+    )
+
+    # Points awarded per referrer (referrer is granted_to in referrer-recipient events).
+    points_by_referrer = dict(
+        db.query(
+            PromoReferral.referrer_teacher_id,
+            func.coalesce(func.sum(PromoRewardEvent.points), 0),
+        )
+        .join(PromoRewardEvent, PromoRewardEvent.referral_id == PromoReferral.id)
+        .filter(
+            PromoRewardEvent.granted_to_teacher_id == PromoReferral.referrer_teacher_id
+        )
+        .group_by(PromoReferral.referrer_teacher_id)
+        .all()
+    )
+
+    return [
+        ReferralReportRow(
+            referrer_teacher_id=r.referrer,
+            referral_count=r.referral_count,
+            verified_count=r.verified_count,
+            paid_count=int(r.paid_count or 0),
+            total_points_awarded=int(points_by_referrer.get(r.referrer, 0)),
+        )
+        for r in referral_rows
+    ]
+
+
+@router.get("/report", response_model=List[ReferralReportRow])
+async def referral_report(
+    db: Session = Depends(get_db),
+    _: Teacher = Depends(get_current_admin),
+) -> List[ReferralReportRow]:
+    """Per-referrer summary: referrals, verified, paid-converted, points awarded."""
+    return build_referral_report(db)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -64,9 +64,9 @@ class TeacherRegisterRequest(BaseModel):
     name: str
     phone: Optional[str] = None
     # Optional referral code (from ?promo= URL param or input field).
-    # max_length bounds the input (DB column is VARCHAR(16)) so an oversized
-    # payload is rejected at parse time rather than hitting the logs / DB.
-    promo_code: Optional[str] = Field(None, max_length=32)
+    # max_length matches the DB column (VARCHAR(16)); oversized input is
+    # rejected at parse time rather than hitting the logs / DB.
+    promo_code: Optional[str] = Field(None, max_length=16)
 
     @field_validator("password")
     @classmethod
@@ -294,6 +294,7 @@ async def teacher_register(
         create_personal_code_for_teacher(db, new_teacher.id)
     except Exception as e:
         db.rollback()
+        db.refresh(new_teacher)  # rollback expired the object; make state explicit
         logger.error(
             f"Personal promo code creation failed for teacher {new_teacher.id}: {e}"
         )
@@ -305,8 +306,10 @@ async def teacher_register(
 
             referral = bind_referral(db, register_req.promo_code, new_teacher.id)
             if referral is None:
+                # repr() neutralizes newline/control chars in user input so a
+                # crafted promo_code can't forge log lines.
                 logger.info(
-                    f"Promo code '{register_req.promo_code}' not bound for "
+                    f"Promo code {register_req.promo_code!r} not bound for "
                     f"teacher {new_teacher.id} (invalid/expired/self-referral)"
                 )
             else:
@@ -316,6 +319,7 @@ async def teacher_register(
                 )
         except Exception as e:
             db.rollback()
+            db.refresh(new_teacher)
             logger.error(f"Referral binding failed for teacher {new_teacher.id}: {e}")
 
     # 🎯 發送驗證 email
@@ -356,19 +360,26 @@ async def verify_teacher_email(token: str, db: Session = Depends(get_db)):
             detail="Invalid or expired verification token",
         )
 
-    # 標記推薦關係已驗證（非致命）。實際發點在獎勵引擎處理。
+    # 標記推薦關係已驗證並發放註冊獎勵（非致命）。
     try:
         from services.promo_code_service import mark_referral_verified
 
         mark_referral_verified(db, teacher.id)
     except Exception as e:
         db.rollback()
-        # verified_at not persisted. The reward engine falls back to the
-        # teacher's email_verified flag, so this is recoverable; log loudly.
+        # verified_at not persisted. dispatch_signup_rewards below still keys
+        # off the referral row, so the reward is not lost; log loudly.
         logger.error(
             f"ALERT: mark_referral_verified failed for teacher {teacher.id} "
             f"— verified_at not stamped: {e}"
         )
+
+    try:
+        from services.promo_reward_service import dispatch_signup_rewards
+
+        dispatch_signup_rewards(db, teacher.id)
+    except Exception as e:
+        logger.error(f"dispatch_signup_rewards failed for teacher {teacher.id}: {e}")
 
     # 不自動登入，只返回驗證成功訊息
     return {

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -32,6 +32,17 @@ from core.limiter import limiter
 
 logger = logging.getLogger(__name__)
 
+
+def _safe_refresh(db, obj) -> None:
+    """Best-effort refresh after a rollback. The object was committed earlier,
+    so its PK is still valid; if the DB is momentarily unreachable, swallow the
+    error rather than 500 a request whose primary work already succeeded."""
+    try:
+        db.refresh(obj)
+    except Exception:
+        pass
+
+
 router = APIRouter(prefix="/api/auth", tags=["authentication"])
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/teacher/login")
@@ -294,7 +305,7 @@ async def teacher_register(
         create_personal_code_for_teacher(db, new_teacher.id)
     except Exception as e:
         db.rollback()
-        db.refresh(new_teacher)  # rollback expired the object; make state explicit
+        _safe_refresh(db, new_teacher)
         logger.error(
             f"Personal promo code creation failed for teacher {new_teacher.id}: {e}"
         )
@@ -319,7 +330,7 @@ async def teacher_register(
                 )
         except Exception as e:
             db.rollback()
-            db.refresh(new_teacher)
+            _safe_refresh(db, new_teacher)
             logger.error(f"Referral binding failed for teacher {new_teacher.id}: {e}")
 
     # 🎯 發送驗證 email
@@ -360,20 +371,8 @@ async def verify_teacher_email(token: str, db: Session = Depends(get_db)):
             detail="Invalid or expired verification token",
         )
 
-    # 標記推薦關係已驗證並發放註冊獎勵（非致命）。
-    try:
-        from services.promo_code_service import mark_referral_verified
-
-        mark_referral_verified(db, teacher.id)
-    except Exception as e:
-        db.rollback()
-        # verified_at not persisted. dispatch_signup_rewards below still keys
-        # off the referral row, so the reward is not lost; log loudly.
-        logger.error(
-            f"ALERT: mark_referral_verified failed for teacher {teacher.id} "
-            f"— verified_at not stamped: {e}"
-        )
-
+    # 標記推薦關係已驗證並發放註冊獎勵（非致命）。dispatch_signup_rewards 內部會
+    # 在發點同一交易先 stamp verified_at，避免 report 的 verified_count 與發放結果不一致。
     try:
         from services.promo_reward_service import dispatch_signup_rewards
 

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -329,6 +329,18 @@ async def purchase_credit_package(
             f"pkg={package_id} points={points_total} expires={expires_at.date()}"
         )
 
+        # Issue #637: reward the referrer on the referred teacher's first paid
+        # credit-package purchase (non-fatal — never block the purchase).
+        try:
+            from services.promo_reward_service import dispatch_credit_package_reward
+
+            dispatch_credit_package_reward(db, current_teacher.id, package_id)
+        except Exception as e:
+            logger.error(
+                f"Referral credit-package reward failed for teacher "
+                f"{current_teacher.id}: {e}"
+            )
+
         return CreditPackagePurchaseResponse(
             success=True,
             transaction_id=external_transaction_id,

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -416,6 +416,20 @@ async def process_payment(
             )
             # Continue execution - the important part (subscription update) is done
 
+        # Issue #637: reward the referrer on the referred teacher's first paid
+        # subscription (non-fatal — never block payment).
+        try:
+            from services.promo_reward_service import dispatch_subscription_reward
+
+            dispatch_subscription_reward(
+                db, current_teacher.id, payment_request.plan_name
+            )
+        except Exception as e:
+            logger.error(
+                f"Referral subscription reward failed for teacher "
+                f"{current_teacher.id}: {e}"
+            )
+
         return PaymentResponse(
             success=True,
             transaction_id=external_transaction_id,

--- a/backend/services/promo_code_service.py
+++ b/backend/services/promo_code_service.py
@@ -9,6 +9,7 @@ import secrets
 from datetime import datetime, timezone
 from typing import Optional
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from models import PromoCode, PromoReferral
@@ -140,7 +141,17 @@ def bind_referral(
         promo_code_id=pc.id,
     )
     db.add(referral)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # Concurrent registration won the unique(referred_teacher_id) race.
+        # Harmless: return the row the other request committed.
+        db.rollback()
+        return (
+            db.query(PromoReferral)
+            .filter(PromoReferral.referred_teacher_id == referred_teacher_id)
+            .first()
+        )
     db.refresh(referral)
     return referral
 
@@ -161,5 +172,11 @@ def mark_referral_verified(
     if referral.verified_at is None:
         referral.verified_at = datetime.now(timezone.utc)
         db.commit()
-        db.refresh(referral)
+        # A refresh failure must NOT look like a commit failure to the caller:
+        # verified_at is already durably written, so swallow refresh errors and
+        # return the (correct) in-memory row.
+        try:
+            db.refresh(referral)
+        except Exception:
+            pass
     return referral

--- a/backend/services/promo_reward_service.py
+++ b/backend/services/promo_reward_service.py
@@ -1,0 +1,226 @@
+"""
+Promo referral reward engine (issue #637, PR 3).
+
+Grants points to the referrer (and a one-time bonus to the referred teacher)
+when referral milestones fire:
+
+- email verified         → signup_verified (referrer) + referred_signup_bonus
+- first paid subscription→ subscribe_tutor / subscribe_school (referrer)
+- first paid credit pack → package_pkg-5000 / -10000 / -20000 (referrer)
+
+Subscription and credit-package rewards are mutually exclusive and fire only
+on the referred teacher's FIRST paid action. That "first only" guarantee is
+the ``PromoReferral.first_paid_event_consumed`` flag — whichever paid event
+arrives first consumes it; there is no need to scan prior transactions.
+
+Every grant is idempotent via ``PromoRewardEvent.idempotency_key`` so retries
+and races never double-award. All entry points are non-fatal: a failure here
+must never break payment, registration, or verification.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from config.plans import PLAN_TUTOR, PLAN_SCHOOL, CREDIT_PACKAGE_VALIDITY_DAYS
+from models import (
+    PromoReferral,
+    PromoRewardConfig,
+    PromoRewardEvent,
+    CreditPackage,
+)
+
+logger = logging.getLogger(__name__)
+
+# Plan display name -> reward_key for paid-subscription rewards.
+_PLAN_REWARD_KEYS = {
+    PLAN_TUTOR: "subscribe_tutor",
+    PLAN_SCHOOL: "subscribe_school",
+}
+
+_REWARD_PACKAGE_ID = "referral-reward"
+
+
+def _get_referral(db: Session, referred_teacher_id: int) -> Optional[PromoReferral]:
+    return (
+        db.query(PromoReferral)
+        .filter(PromoReferral.referred_teacher_id == referred_teacher_id)
+        .first()
+    )
+
+
+def _recipient_teacher_id(referral: PromoReferral, recipient: str) -> int:
+    if recipient == "referred":
+        return referral.referred_teacher_id
+    return referral.referrer_teacher_id
+
+
+def _grant_reward(
+    db: Session,
+    referral: PromoReferral,
+    reward_key: str,
+    trigger_type: str,
+    event_payload: Optional[dict] = None,
+) -> Optional[PromoRewardEvent]:
+    """Grant the points configured for ``reward_key`` to the right teacher.
+
+    Idempotent on ``{referral.id}:{reward_key}``: a prior grant (or a
+    concurrent one losing the unique race) returns the existing event without
+    awarding again. Returns None when the reward is unconfigured or inactive.
+    """
+    config = (
+        db.query(PromoRewardConfig)
+        .filter(
+            PromoRewardConfig.reward_key == reward_key,
+            PromoRewardConfig.is_active.is_(True),
+        )
+        .first()
+    )
+    if config is None:
+        return None
+
+    idempotency_key = f"{referral.id}:{reward_key}"
+    existing = (
+        db.query(PromoRewardEvent)
+        .filter(PromoRewardEvent.idempotency_key == idempotency_key)
+        .first()
+    )
+    if existing is not None:
+        return existing
+
+    recipient_id = _recipient_teacher_id(referral, config.recipient)
+    now = datetime.now(timezone.utc)
+
+    credit_package = CreditPackage(
+        teacher_id=recipient_id,
+        package_id=_REWARD_PACKAGE_ID,
+        points_total=config.points,
+        points_used=0,
+        price_paid=0,
+        purchased_at=now,
+        expires_at=now + timedelta(days=CREDIT_PACKAGE_VALIDITY_DAYS),
+        status="active",
+        source="referral_reward",
+        admin_metadata={
+            "reward_key": reward_key,
+            "referral_id": referral.id,
+            "referrer_teacher_id": referral.referrer_teacher_id,
+            "referred_teacher_id": referral.referred_teacher_id,
+        },
+    )
+    db.add(credit_package)
+    db.flush()  # assign credit_package.id without ending the transaction
+
+    event = PromoRewardEvent(
+        referral_id=referral.id,
+        reward_key=reward_key,
+        trigger_type=trigger_type,
+        points=config.points,
+        granted_to_teacher_id=recipient_id,
+        credit_package_id=credit_package.id,
+        idempotency_key=idempotency_key,
+        event_payload=event_payload,
+    )
+    db.add(event)
+    try:
+        db.commit()
+    except IntegrityError:
+        # Concurrent grant won the unique(idempotency_key) race.
+        db.rollback()
+        return (
+            db.query(PromoRewardEvent)
+            .filter(PromoRewardEvent.idempotency_key == idempotency_key)
+            .first()
+        )
+    db.refresh(event)
+    logger.info(
+        f"Referral reward granted: {reward_key} ({config.points} pts) "
+        f"to teacher {recipient_id} (referral {referral.id})"
+    )
+    return event
+
+
+def dispatch_signup_rewards(db: Session, referred_teacher_id: int) -> None:
+    """On email verification: reward the referrer (signup_verified) and the
+    referred teacher (referred_signup_bonus). Non-fatal."""
+    try:
+        referral = _get_referral(db, referred_teacher_id)
+        if referral is None:
+            return
+
+        _grant_reward(db, referral, "signup_verified", "signup")
+
+        bonus = _grant_reward(db, referral, "referred_signup_bonus", "signup")
+        if bonus is not None and not referral.referred_bonus_granted:
+            referral.referred_bonus_granted = True
+            db.commit()
+    except Exception as e:
+        db.rollback()
+        logger.error(
+            f"dispatch_signup_rewards failed for teacher {referred_teacher_id}: {e}"
+        )
+
+
+def dispatch_subscription_reward(db: Session, teacher_id: int, plan_name: str) -> None:
+    """On the referred teacher's first paid subscription: reward the referrer
+    based on the plan tier. Non-fatal; no-op if not their first paid action."""
+    try:
+        reward_key = _PLAN_REWARD_KEYS.get(plan_name)
+        if reward_key is None:
+            return  # free trial / unknown plan: nothing to reward
+        _dispatch_first_paid(
+            db, teacher_id, reward_key, "subscription", {"plan_name": plan_name}
+        )
+    except Exception as e:
+        db.rollback()
+        logger.error(
+            f"dispatch_subscription_reward failed for teacher {teacher_id}: {e}"
+        )
+
+
+def dispatch_credit_package_reward(
+    db: Session, teacher_id: int, package_id: str
+) -> None:
+    """On the referred teacher's first paid credit-package purchase: reward the
+    referrer based on the package. Non-fatal; no-op if not their first paid
+    action or the package has no configured reward."""
+    try:
+        _dispatch_first_paid(
+            db,
+            teacher_id,
+            f"package_{package_id}",
+            "credit_package",
+            {"package_id": package_id},
+        )
+    except Exception as e:
+        db.rollback()
+        logger.error(
+            f"dispatch_credit_package_reward failed for teacher {teacher_id}: {e}"
+        )
+
+
+def _dispatch_first_paid(
+    db: Session,
+    teacher_id: int,
+    reward_key: str,
+    trigger_type: str,
+    payload: dict,
+) -> None:
+    """Shared body for paid-event rewards. Consumes the one-time
+    ``first_paid_event_consumed`` slot so subscription and package rewards are
+    mutually exclusive and fire only once."""
+    referral = _get_referral(db, teacher_id)
+    if referral is None or referral.first_paid_event_consumed:
+        return
+
+    event = _grant_reward(db, referral, reward_key, trigger_type, payload)
+    if event is None:
+        # Reward unconfigured (e.g. pkg-1000/2000) — leave the first-paid slot
+        # unconsumed so a later qualifying purchase can still reward.
+        return
+
+    referral.first_paid_event_consumed = True
+    db.commit()

--- a/backend/services/promo_reward_service.py
+++ b/backend/services/promo_reward_service.py
@@ -174,18 +174,33 @@ def _grant_reward(
 
 
 def dispatch_signup_rewards(db: Session, referred_teacher_id: int) -> None:
-    """On email verification: reward the referrer (signup_verified) and the
-    referred teacher (referred_signup_bonus). Non-fatal."""
+    """On email verification: stamp verified_at, then reward the referrer
+    (signup_verified) and the referred teacher (referred_signup_bonus).
+
+    verified_at is stamped and committed BEFORE granting so it can never end up
+    NULL while a reward exists (which would understate the admin report's
+    verified_count). Non-fatal."""
     try:
         referral = _get_referral(db, referred_teacher_id)
         if referral is None:
             return
 
+        # Stamp verified_at first so verified_count stays consistent with grants.
+        if referral.verified_at is None:
+            referral.verified_at = datetime.now(timezone.utc)
+            db.commit()
+
         _grant_reward(db, referral, "signup_verified", "signup")
 
         bonus = _grant_reward(db, referral, "referred_signup_bonus", "signup")
-        if bonus is not None and not referral.referred_bonus_granted:
-            referral.referred_bonus_granted = True
+        if bonus is not None:
+            # Atomic flag set: concurrent double-verify can't double-write.
+            db.execute(
+                update(PromoReferral)
+                .where(PromoReferral.referred_teacher_id == referred_teacher_id)
+                .where(PromoReferral.referred_bonus_granted.is_(False))
+                .values(referred_bonus_granted=True)
+            )
             db.commit()
     except Exception as e:
         db.rollback()

--- a/backend/services/promo_reward_service.py
+++ b/backend/services/promo_reward_service.py
@@ -26,7 +26,12 @@ from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from config.plans import PLAN_TUTOR, PLAN_SCHOOL, CREDIT_PACKAGE_VALIDITY_DAYS
+from config.plans import (
+    PLAN_TUTOR,
+    PLAN_SCHOOL,
+    PLAN_FREE_TRIAL,
+    CREDIT_PACKAGE_VALIDITY_DAYS,
+)
 from models import (
     PromoReferral,
     PromoRewardConfig,
@@ -59,20 +64,8 @@ def _recipient_teacher_id(referral: PromoReferral, recipient: str) -> int:
     return referral.referrer_teacher_id
 
 
-def _grant_reward(
-    db: Session,
-    referral: PromoReferral,
-    reward_key: str,
-    trigger_type: str,
-    event_payload: Optional[dict] = None,
-) -> Optional[PromoRewardEvent]:
-    """Grant the points configured for ``reward_key`` to the right teacher.
-
-    Idempotent on ``{referral.id}:{reward_key}``: a prior grant (or a
-    concurrent one losing the unique race) returns the existing event without
-    awarding again. Returns None when the reward is unconfigured or inactive.
-    """
-    config = (
+def _get_active_config(db: Session, reward_key: str) -> Optional[PromoRewardConfig]:
+    return (
         db.query(PromoRewardConfig)
         .filter(
             PromoRewardConfig.reward_key == reward_key,
@@ -80,18 +73,21 @@ def _grant_reward(
         )
         .first()
     )
-    if config is None:
-        return None
 
+
+def _build_reward_rows(
+    db: Session,
+    referral: PromoReferral,
+    reward_key: str,
+    trigger_type: str,
+    config: PromoRewardConfig,
+    event_payload: Optional[dict] = None,
+) -> PromoRewardEvent:
+    """Create the CreditPackage + PromoRewardEvent in the CURRENT (uncommitted)
+    transaction and return the event. The caller owns the commit, so the grant
+    can be made atomic with other writes (e.g. the first-paid slot claim).
+    Assumes no prior grant for this key exists (idempotency checked by caller)."""
     idempotency_key = f"{referral.id}:{reward_key}"
-    existing = (
-        db.query(PromoRewardEvent)
-        .filter(PromoRewardEvent.idempotency_key == idempotency_key)
-        .first()
-    )
-    if existing is not None:
-        return existing
-
     recipient_id = _recipient_teacher_id(referral, config.recipient)
     now = datetime.now(timezone.utc)
 
@@ -126,6 +122,39 @@ def _grant_reward(
         event_payload=event_payload,
     )
     db.add(event)
+    return event
+
+
+def _grant_reward(
+    db: Session,
+    referral: PromoReferral,
+    reward_key: str,
+    trigger_type: str,
+    event_payload: Optional[dict] = None,
+) -> Optional[PromoRewardEvent]:
+    """Grant the points configured for ``reward_key`` to the right teacher,
+    committing on its own.
+
+    Idempotent on ``{referral.id}:{reward_key}``: a prior grant (or a
+    concurrent one losing the unique race) returns the existing event without
+    awarding again. Returns None when the reward is unconfigured or inactive.
+    """
+    config = _get_active_config(db, reward_key)
+    if config is None:
+        return None
+
+    idempotency_key = f"{referral.id}:{reward_key}"
+    existing = (
+        db.query(PromoRewardEvent)
+        .filter(PromoRewardEvent.idempotency_key == idempotency_key)
+        .first()
+    )
+    if existing is not None:
+        return existing
+
+    event = _build_reward_rows(
+        db, referral, reward_key, trigger_type, config, event_payload
+    )
     try:
         db.commit()
     except IntegrityError:
@@ -139,7 +168,7 @@ def _grant_reward(
     db.refresh(event)
     logger.info(
         f"Referral reward granted: {reward_key} ({config.points} pts) "
-        f"to teacher {recipient_id} (referral {referral.id})"
+        f"to teacher {event.granted_to_teacher_id} (referral {referral.id})"
     )
     return event
 
@@ -171,7 +200,14 @@ def dispatch_subscription_reward(db: Session, teacher_id: int, plan_name: str) -
     try:
         reward_key = _PLAN_REWARD_KEYS.get(plan_name)
         if reward_key is None:
-            return  # free trial / unknown plan: nothing to reward
+            # Free Trial has no reward (expected). Any OTHER unmapped name is a
+            # surprise (i18n rename / client bug) — log so it's observable.
+            if plan_name not in (PLAN_FREE_TRIAL,):
+                logger.warning(
+                    f"No referral reward mapping for plan_name {plan_name!r} "
+                    f"(teacher {teacher_id})"
+                )
+            return
         _dispatch_first_paid(
             db, teacher_id, reward_key, "subscription", {"plan_name": plan_name}
         )
@@ -212,36 +248,56 @@ def _dispatch_first_paid(
 ) -> None:
     """Shared body for paid-event rewards. Consumes the one-time
     ``first_paid_event_consumed`` slot so subscription and package rewards are
-    mutually exclusive and fire only once."""
+    mutually exclusive and fire only once.
+
+    The slot claim and the reward grant share ONE transaction: if the grant
+    fails the claim is rolled back too (no consume-without-grant), while the
+    conditional UPDATE's row lock serializes concurrent paid events so only one
+    ever grants.
+    """
     referral = _get_referral(db, teacher_id)
     if referral is None or referral.first_paid_event_consumed:
         return
 
     # Skip packages with no active reward (e.g. pkg-1000/2000) BEFORE claiming
-    # the slot, so a later qualifying purchase can still reward.
-    config = (
-        db.query(PromoRewardConfig)
-        .filter(
-            PromoRewardConfig.reward_key == reward_key,
-            PromoRewardConfig.is_active.is_(True),
-        )
-        .first()
-    )
+    # the slot, so a later qualifying purchase can still reward. Pass this
+    # config straight to _build_reward_rows so an admin deactivating it mid-flight
+    # cannot leave the slot consumed with nothing granted.
+    config = _get_active_config(db, reward_key)
     if config is None:
         return
 
-    # Atomically claim the one-time slot. Two concurrent paid events with
-    # different reward keys (subscription + package) would both pass the
-    # in-memory check above; this conditional UPDATE lets only one win, keeping
-    # the rewards mutually exclusive.
-    rows_updated = db.execute(
-        update(PromoReferral)
-        .where(PromoReferral.referred_teacher_id == teacher_id)
-        .where(PromoReferral.first_paid_event_consumed.is_(False))
-        .values(first_paid_event_consumed=True)
-    ).rowcount
-    db.commit()
-    if rows_updated == 0:
-        return  # another paid event already consumed the slot
+    idempotency_key = f"{referral.id}:{reward_key}"
+    if (
+        db.query(PromoRewardEvent)
+        .filter(PromoRewardEvent.idempotency_key == idempotency_key)
+        .first()
+        is not None
+    ):
+        return  # already granted
 
-    _grant_reward(db, referral, reward_key, trigger_type, payload)
+    try:
+        # Atomically claim the one-time slot. Two concurrent paid events with
+        # different reward keys would both pass the in-memory check above; this
+        # conditional UPDATE (row lock) lets only one win.
+        rows_updated = db.execute(
+            update(PromoReferral)
+            .where(PromoReferral.referred_teacher_id == teacher_id)
+            .where(PromoReferral.first_paid_event_consumed.is_(False))
+            .values(first_paid_event_consumed=True)
+        ).rowcount
+        if rows_updated == 0:
+            db.rollback()
+            return  # another paid event already consumed the slot
+
+        # Grant in the SAME transaction so commit persists claim + reward together.
+        _build_reward_rows(db, referral, reward_key, trigger_type, config, payload)
+        db.commit()
+    except IntegrityError:
+        # Lost the idempotency race; rollback reverts the claim too.
+        db.rollback()
+        return
+    logger.info(
+        f"Referral reward granted: {reward_key} ({config.points} pts) "
+        f"(referral {referral.id}, first paid action)"
+    )

--- a/backend/services/promo_reward_service.py
+++ b/backend/services/promo_reward_service.py
@@ -22,6 +22,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
+from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -216,11 +217,31 @@ def _dispatch_first_paid(
     if referral is None or referral.first_paid_event_consumed:
         return
 
-    event = _grant_reward(db, referral, reward_key, trigger_type, payload)
-    if event is None:
-        # Reward unconfigured (e.g. pkg-1000/2000) — leave the first-paid slot
-        # unconsumed so a later qualifying purchase can still reward.
+    # Skip packages with no active reward (e.g. pkg-1000/2000) BEFORE claiming
+    # the slot, so a later qualifying purchase can still reward.
+    config = (
+        db.query(PromoRewardConfig)
+        .filter(
+            PromoRewardConfig.reward_key == reward_key,
+            PromoRewardConfig.is_active.is_(True),
+        )
+        .first()
+    )
+    if config is None:
         return
 
-    referral.first_paid_event_consumed = True
+    # Atomically claim the one-time slot. Two concurrent paid events with
+    # different reward keys (subscription + package) would both pass the
+    # in-memory check above; this conditional UPDATE lets only one win, keeping
+    # the rewards mutually exclusive.
+    rows_updated = db.execute(
+        update(PromoReferral)
+        .where(PromoReferral.referred_teacher_id == teacher_id)
+        .where(PromoReferral.first_paid_event_consumed.is_(False))
+        .values(first_paid_event_consumed=True)
+    ).rowcount
     db.commit()
+    if rows_updated == 0:
+        return  # another paid event already consumed the slot
+
+    _grant_reward(db, referral, reward_key, trigger_type, payload)

--- a/backend/tests/test_promo_reward_engine.py
+++ b/backend/tests/test_promo_reward_engine.py
@@ -1,0 +1,285 @@
+"""
+PR 3 (issue #637) — referral reward engine tests.
+
+Covers grant idempotency, signup rewards, first-paid gating (subscription vs
+credit-package mutual exclusivity), admin-editable point values, and the
+no-reward-configured pass-through. Service-level (runs on SQLite).
+"""
+
+from datetime import datetime, timezone
+
+from config.plans import PLAN_TUTOR, PLAN_SCHOOL
+from models import (
+    Teacher,
+    PromoReferral,
+    PromoRewardConfig,
+    PromoRewardEvent,
+    CreditPackage,
+)
+from services.promo_code_service import create_personal_code_for_teacher, bind_referral
+from services.promo_reward_service import (
+    dispatch_signup_rewards,
+    dispatch_subscription_reward,
+    dispatch_credit_package_reward,
+)
+
+
+def _make_teacher(db, email):
+    t = Teacher(name="T", email=email, password_hash="x")
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+def _seed_reward_configs(db):
+    """conftest builds the schema via Base.metadata.create_all, which does not
+    run the seed migration — seed the configs the engine reads."""
+    defaults = [
+        ("signup_verified", 10, "referrer"),
+        ("subscribe_tutor", 1000, "referrer"),
+        ("subscribe_school", 2000, "referrer"),
+        ("package_pkg-5000", 200, "referrer"),
+        ("package_pkg-10000", 500, "referrer"),
+        ("package_pkg-20000", 800, "referrer"),
+        ("referred_signup_bonus", 300, "referred"),
+    ]
+    for key, points, recipient in defaults:
+        if (
+            db.query(PromoRewardConfig)
+            .filter(PromoRewardConfig.reward_key == key)
+            .first()
+            is None
+        ):
+            db.add(
+                PromoRewardConfig(reward_key=key, points=points, recipient=recipient)
+            )
+    db.commit()
+
+
+def _referral(db, referrer_email, referred_email):
+    referrer = _make_teacher(db, referrer_email)
+    referred = _make_teacher(db, referred_email)
+    code = create_personal_code_for_teacher(db, referrer.id)
+    referral = bind_referral(db, code.code, referred.id)
+    return referrer, referred, referral
+
+
+def _points_to(db, teacher_id):
+    return (
+        db.query(CreditPackage)
+        .filter(
+            CreditPackage.teacher_id == teacher_id,
+            CreditPackage.source == "referral_reward",
+        )
+        .all()
+    )
+
+
+# ---------------------------------------------------------------- signup
+
+
+def test_signup_rewards_grant_both_sides(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, referral = _referral(
+        test_db_session, "s_ref@test.com", "s_new@test.com"
+    )
+
+    dispatch_signup_rewards(test_db_session, referred.id)
+
+    referrer_pkgs = _points_to(test_db_session, referrer.id)
+    referred_pkgs = _points_to(test_db_session, referred.id)
+    assert len(referrer_pkgs) == 1 and referrer_pkgs[0].points_total == 10
+    assert len(referred_pkgs) == 1 and referred_pkgs[0].points_total == 300
+
+    test_db_session.refresh(referral)
+    assert referral.referred_bonus_granted is True
+
+
+def test_signup_rewards_idempotent(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, _ = _referral(
+        test_db_session, "si_ref@test.com", "si_new@test.com"
+    )
+    dispatch_signup_rewards(test_db_session, referred.id)
+    dispatch_signup_rewards(test_db_session, referred.id)  # second call no-ops
+
+    assert len(_points_to(test_db_session, referrer.id)) == 1
+    assert len(_points_to(test_db_session, referred.id)) == 1
+    events = test_db_session.query(PromoRewardEvent).all()
+    assert len(events) == 2  # signup_verified + referred_signup_bonus, once each
+
+
+def test_signup_rewards_no_referral_noop(test_db_session):
+    _seed_reward_configs(test_db_session)
+    lone = _make_teacher(test_db_session, "lone@test.com")
+    dispatch_signup_rewards(test_db_session, lone.id)
+    assert test_db_session.query(PromoRewardEvent).count() == 0
+
+
+# ---------------------------------------------------------------- subscription
+
+
+def test_subscription_reward_tutor(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, referral = _referral(
+        test_db_session, "sub_ref@test.com", "sub_new@test.com"
+    )
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)
+
+    pkgs = _points_to(test_db_session, referrer.id)
+    assert len(pkgs) == 1 and pkgs[0].points_total == 1000
+    test_db_session.refresh(referral)
+    assert referral.first_paid_event_consumed is True
+
+
+def test_subscription_reward_school(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, _ = _referral(
+        test_db_session, "sch_ref@test.com", "sch_new@test.com"
+    )
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_SCHOOL)
+    pkgs = _points_to(test_db_session, referrer.id)
+    assert len(pkgs) == 1 and pkgs[0].points_total == 2000
+
+
+def test_unknown_plan_no_reward(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, referral = _referral(
+        test_db_session, "fp_ref@test.com", "fp_new@test.com"
+    )
+    dispatch_subscription_reward(test_db_session, referred.id, "Free Trial")
+    assert len(_points_to(test_db_session, referrer.id)) == 0
+    test_db_session.refresh(referral)
+    assert referral.first_paid_event_consumed is False  # slot untouched
+
+
+# ---------------------------------------------------------------- credit package
+
+
+def test_credit_package_reward(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, _ = _referral(
+        test_db_session, "cp_ref@test.com", "cp_new@test.com"
+    )
+    dispatch_credit_package_reward(test_db_session, referred.id, "pkg-10000")
+    pkgs = _points_to(test_db_session, referrer.id)
+    assert len(pkgs) == 1 and pkgs[0].points_total == 500
+
+
+def test_credit_package_without_reward_leaves_slot_open(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, referral = _referral(
+        test_db_session, "cpn_ref@test.com", "cpn_new@test.com"
+    )
+    # pkg-1000 has no configured reward.
+    dispatch_credit_package_reward(test_db_session, referred.id, "pkg-1000")
+    assert len(_points_to(test_db_session, referrer.id)) == 0
+    test_db_session.refresh(referral)
+    assert referral.first_paid_event_consumed is False
+    # A later qualifying purchase still rewards.
+    dispatch_credit_package_reward(test_db_session, referred.id, "pkg-5000")
+    assert len(_points_to(test_db_session, referrer.id)) == 1
+
+
+# ---------------------------------------------------------------- first-paid gate
+
+
+def test_first_paid_is_mutually_exclusive(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, _ = _referral(
+        test_db_session, "me_ref@test.com", "me_new@test.com"
+    )
+    # First paid action = subscription (1000). A later package purchase must
+    # NOT reward again.
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)
+    dispatch_credit_package_reward(test_db_session, referred.id, "pkg-20000")
+
+    pkgs = _points_to(test_db_session, referrer.id)
+    assert len(pkgs) == 1 and pkgs[0].points_total == 1000
+
+
+def test_admin_edited_points_are_used(test_db_session):
+    _seed_reward_configs(test_db_session)
+    config = (
+        test_db_session.query(PromoRewardConfig)
+        .filter(PromoRewardConfig.reward_key == "subscribe_tutor")
+        .first()
+    )
+    config.points = 1234  # admin override
+    test_db_session.commit()
+
+    referrer, referred, _ = _referral(
+        test_db_session, "ae_ref@test.com", "ae_new@test.com"
+    )
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)
+    pkgs = _points_to(test_db_session, referrer.id)
+    assert len(pkgs) == 1 and pkgs[0].points_total == 1234
+
+
+def test_inactive_config_skips_reward(test_db_session):
+    _seed_reward_configs(test_db_session)
+    config = (
+        test_db_session.query(PromoRewardConfig)
+        .filter(PromoRewardConfig.reward_key == "subscribe_tutor")
+        .first()
+    )
+    config.is_active = False
+    test_db_session.commit()
+
+    referrer, referred, referral = _referral(
+        test_db_session, "ia_ref@test.com", "ia_new@test.com"
+    )
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)
+    assert len(_points_to(test_db_session, referrer.id)) == 0
+    # No reward granted, so the first-paid slot stays open.
+    test_db_session.refresh(referral)
+    assert referral.first_paid_event_consumed is False
+
+
+def test_reward_credit_package_has_one_year_expiry(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, _ = _referral(
+        test_db_session, "ex_ref@test.com", "ex_new@test.com"
+    )
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)
+    pkg = _points_to(test_db_session, referrer.id)[0]
+    delta_days = (pkg.expires_at - pkg.purchased_at).days
+    assert 364 <= delta_days <= 366
+
+
+# ---------------------------------------------------------------- admin report
+
+
+def test_referral_report_aggregates(test_db_session):
+    from routers.admin_promo_codes import build_referral_report
+
+    _seed_reward_configs(test_db_session)
+    referrer, referred, _ = _referral(
+        test_db_session, "rep_ref@test.com", "rep_new@test.com"
+    )
+    # second referred teacher for the same referrer, verified + paid
+    referred2 = _make_teacher(test_db_session, "rep_new2@test.com")
+    code = (
+        test_db_session.query(PromoReferral)
+        .filter(PromoReferral.referrer_teacher_id == referrer.id)
+        .first()
+        .promo_code
+    )
+    bind_referral(test_db_session, code, referred2.id)
+
+    # Mirror the real verify flow: stamp verified_at, then grant signup rewards.
+    from services.promo_code_service import mark_referral_verified
+
+    mark_referral_verified(test_db_session, referred.id)
+    dispatch_signup_rewards(test_db_session, referred.id)  # +10pts
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)  # +1000
+
+    rows = build_referral_report(test_db_session)
+    by_ref = {r.referrer_teacher_id: r for r in rows}
+    row = by_ref[referrer.id]
+    assert row.referral_count == 2
+    assert row.verified_count == 1
+    assert row.paid_count == 1
+    # referrer received 10 (signup) + 1000 (subscription) = 1010
+    assert row.total_points_awarded == 1010

--- a/backend/tests/test_promo_reward_engine.py
+++ b/backend/tests/test_promo_reward_engine.py
@@ -94,6 +94,9 @@ def test_signup_rewards_grant_both_sides(test_db_session):
 
     test_db_session.refresh(referral)
     assert referral.referred_bonus_granted is True
+    # dispatch stamps verified_at so the admin report's verified_count stays
+    # consistent with granted rewards.
+    assert referral.verified_at is not None
 
 
 def test_signup_rewards_idempotent(test_db_session):

--- a/backend/tests/test_promo_reward_engine.py
+++ b/backend/tests/test_promo_reward_engine.py
@@ -248,6 +248,34 @@ def test_reward_credit_package_has_one_year_expiry(test_db_session):
     assert 364 <= delta_days <= 366
 
 
+def test_grant_failure_does_not_consume_first_paid_slot(test_db_session, monkeypatch):
+    """If the grant raises, the slot claim must roll back so a retry can still
+    reward (no consume-without-grant)."""
+    _seed_reward_configs(test_db_session)
+    referrer, referred, referral = _referral(
+        test_db_session, "gf_ref@test.com", "gf_new@test.com"
+    )
+
+    import services.promo_reward_service as svc
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated grant failure")
+
+    monkeypatch.setattr(svc, "_build_reward_rows", _boom)
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)
+
+    test_db_session.refresh(referral)
+    assert referral.first_paid_event_consumed is False  # slot rolled back
+    assert len(_points_to(test_db_session, referrer.id)) == 0
+
+    # Retry after the transient failure clears: reward is granted, slot consumed.
+    monkeypatch.undo()
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)
+    test_db_session.refresh(referral)
+    assert referral.first_paid_event_consumed is True
+    assert len(_points_to(test_db_session, referrer.id)) == 1
+
+
 # ---------------------------------------------------------------- admin report
 
 


### PR DESCRIPTION
## Summary

PR 3 of 4 for the Promo Code system (#637). **Backend only** — admin UI is a separate frontend PR.

### Reward engine (`services/promo_reward_service.py`)
- `dispatch_signup_rewards` — on email verify: `signup_verified` (10→referrer) + `referred_signup_bonus` (300→referred)
- `dispatch_subscription_reward` — on first paid subscription: `subscribe_tutor` (1000) / `subscribe_school` (2000) by plan tier
- `dispatch_credit_package_reward` — on first paid package: `package_pkg-5000` (200) / `-10000` (500) / `-20000` (800)
- **First-paid rewards are mutually exclusive & once-only** via `PromoReferral.first_paid_event_consumed`; whichever paid event lands first consumes the slot.
- Every grant is **idempotent** on `PromoRewardEvent.idempotency_key` (`{referral_id}:{reward_key}`), with `IntegrityError` race handling.
- Points are read **live** from `promo_reward_configs`, so admin edits take effect immediately.
- Rewards paid as `CreditPackage(source="referral_reward")`, 1-year expiry.

### Hooks (all non-fatal — never block payment / registration / verification)
- [payment.py](backend/routers/payment.py) `process_payment` after txn commit
- [credit_packages.py](backend/routers/credit_packages.py) `purchase_credit_package` after commit
- [auth.py](backend/routers/auth.py) `verify-teacher` after verification

### Admin API (`/api/admin/promo-codes`, admin-only)
- list codes, create affiliate code, activate/deactivate/set-expiry
- list + patch reward configs (admin-editable point values)
- per-referrer referral report (referrals / verified / paid-converted / points awarded)

### Folds in PR #810 r3 review cleanups
- `promo_code` `max_length=16` (match column); `repr()` log to block log injection
- `bind_referral` catches concurrent-race `IntegrityError`, returns existing
- `mark_referral_verified` tolerates a refresh failure after a successful commit
- `db.refresh(new_teacher)` after rollback in register error paths

## Test plan
- [x] `tests/test_promo_reward_engine.py` — 13 tests (signup both-sides, idempotency, subscription tutor/school, unknown plan, package, no-config pass-through, first-paid mutual exclusivity, admin-edited points, inactive config, 1-yr expiry, report aggregation)
- [x] 39 promo tests total green (`reward_engine` + `referral_binding` + `code_model`)
- [x] `black` + `flake8` clean; full app imports
- [ ] CI green on staging

> Admin endpoints can't run under the local TestClient (permission-system bootstrap, same as `test_admin_plans`); the non-trivial report query is unit-tested via an extracted `build_referral_report()`.

## Out of scope (separate frontend PR)
- `/admin/promo-codes` React page, teacher dashboard points bar, register `?promo=` integration

Related to #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)