### PR TITLE
fix(#787): 編輯學生時空白生日導致 500 / Failed to fetch

### DIFF
--- a/backend/routers/teachers/student_ops.py
+++ b/backend/routers/teachers/student_ops.py
@@ -456,9 +456,18 @@ async def update_student(
             )
 
     # Update birthdate (no longer syncs password since default password is join date)
-    if update_data.birthdate is not None:
-        new_birthdate = datetime.strptime(update_data.birthdate, "%Y-%m-%d").date()
-        student.birthdate = new_birthdate
+    # An empty string means "no birthdate provided" — skip it instead of crashing
+    # on strptime("") (Issue #787: surfaced to the browser as "Failed to fetch").
+    if update_data.birthdate:
+        try:
+            student.birthdate = datetime.strptime(
+                update_data.birthdate, "%Y-%m-%d"
+            ).date()
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid birthdate format. Please use YYYY-MM-DD format",
+            )
 
     # Update other fields
     if update_data.name is not None:

--- a/backend/tests/integration/api/test_teachers_students_api.py
+++ b/backend/tests/integration/api/test_teachers_students_api.py
@@ -323,3 +323,74 @@ class TestTeachersStudentsAPI:
 
         # Assert
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_update_student_with_empty_birthdate_does_not_500(
+        self, test_client, demo_teacher, demo_student, test_db_session
+    ):
+        """
+        Regression for Issue #787.
+
+        Given: A student being edited with an empty birthdate string ("")
+        When: Teacher updates the student (e.g. to fix the name)
+        Then: Request succeeds (200), birthdate is left unchanged, not a 500
+              (which surfaced to the browser as "Failed to fetch")
+        """
+        access_token = create_access_token(
+            data={"sub": str(demo_teacher.id), "type": "teacher"}
+        )
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+        response = test_client.put(
+            f"/api/teachers/students/{demo_student.id}",
+            json={"name": "Duncan", "birthdate": ""},
+            headers=headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["name"] == "Duncan"
+
+    def test_update_student_with_invalid_birthdate_returns_400(
+        self, test_client, demo_teacher, demo_student, test_db_session
+    ):
+        """
+        Issue #787: an unparseable birthdate should be a clean 400, not a 500.
+        """
+        access_token = create_access_token(
+            data={"sub": str(demo_teacher.id), "type": "teacher"}
+        )
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+        response = test_client.put(
+            f"/api/teachers/students/{demo_student.id}",
+            json={"birthdate": "not-a-date"},
+            headers=headers,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_update_student_with_valid_birthdate_succeeds(
+        self, test_client, demo_teacher, demo_student, test_db_session
+    ):
+        """
+        Issue #787: a valid birthdate is still parsed and persisted.
+        """
+        access_token = create_access_token(
+            data={"sub": str(demo_teacher.id), "type": "teacher"}
+        )
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+        response = test_client.put(
+            f"/api/teachers/students/{demo_student.id}",
+            json={"birthdate": "2015-03-01"},
+            headers=headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        # Verify it persisted (PUT response doesn't echo birthdate)
+        verify = test_client.get(
+            f"/api/teachers/students/{demo_student.id}",
+            headers=headers,
+        )
+        assert verify.status_code == status.HTTP_200_OK
+        assert verify.json()["birthdate"] == "2015-03-01"


### PR DESCRIPTION
## Summary
- **Root cause (from prod logs 2026-05-20):** `PUT /api/teachers/students/{id}` returned 500 repeatedly while the teacher tried to fix a mis-typed student name. `update_student` ran `datetime.strptime(birthdate, "%Y-%m-%d")` on an empty string (`""`) the frontend sends when a student has no birthdate → unhandled `ValueError`. Because the exception escapes through the CORS middleware, the 500 response has **no `Access-Control-Allow-Origin` header**, so the browser reports it as **"Failed to fetch"** — which the teacher reported as a *delete* failure (the DELETE actually returns 200).
- **Fix:** only parse `birthdate` when non-empty; return `400` on bad format instead of crashing. Mirrors the existing `create_student` behavior.

## Changes
- `backend/routers/teachers/student_ops.py` — guard empty/invalid birthdate in `update_student`
- `backend/tests/integration/api/test_teachers_students_api.py` — 3 regression tests (empty → 200, invalid → 400, valid → persisted)

## Test plan
- [x] `PUT` with `birthdate=""` → 200 (was 500)
- [x] `PUT` with `birthdate="not-a-date"` → 400 (was 500)
- [x] `PUT` with `birthdate="2015-03-01"` → 200, persisted
- [ ] Manual: edit a student with no birthdate in the teacher UI

## Notes
- The shadowed dead module `backend/routers/teachers.py` has the same bug but is never imported (the `teachers/` package takes precedence) — left untouched.
- 3 unrelated pre-existing `student_number` test failures in this file exist on `staging` already (the active module returns `student_id`); out of scope.

Related to #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)