### PR TITLE
fix(#813): 例句朗讀成績便利貼顯示 0 — 補 speaking 顯示端 fallback

### DIFF
--- a/backend/routers/assignments/detail.py
+++ b/backend/routers/assignments/detail.py
@@ -154,6 +154,11 @@ def _compute_interim_score(
     # item-level AI scores. Issue #813 — some GRADED rows never got that roll-up
     # (item scores exist, sa.score=NULL) and surfaced as 0. Recompute from items.
     if practice_mode in _SPEAKING_SCORE_MODES:
+        # Don't surface a partial score for a student still working: _is_interim_score
+        # returns False for speaking modes, so the UI would render it as a final score
+        # (misleading). Keep prior behavior — only fall back once past IN_PROGRESS.
+        if sa.status and sa.status.value == "IN_PROGRESS":
+            return None
         # canonical_items is invariant per assignment — callers pass it pre-fetched
         # to avoid re-querying once per student (this runs in per-student loops).
         if canonical_items is None:

--- a/backend/routers/assignments/detail.py
+++ b/backend/routers/assignments/detail.py
@@ -23,6 +23,7 @@ from models import (
     StudentItemProgress,
 )
 from .dependencies import get_current_teacher
+from .utils import compute_speaking_total_score
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,13 @@ AUTO_GRADED_MODES = frozenset(
 # all three accumulate correct/incorrect counts on
 # StudentItemProgress.word_selection_data, which the PG function reads.
 _MASTERY_FUNCTION_MODES = frozenset({"word_selection", "word_spelling", "word_cloze"})
+
+# Speaking modes scored by Azure pronunciation assessment (score_category=speaking).
+# These get their total from batch-grade rolling up item-level scores into
+# StudentAssignment.score. When that roll-up is missing (issue #813: item scores
+# present + status GRADED, but sa.score=NULL), we recompute on read — same pattern
+# as the mastery-mode fallback above. See utils.compute_speaking_total_score.
+_SPEAKING_SCORE_MODES = frozenset({"reading", "word_reading"})
 
 
 def _get_total_item_count(assignment_id: int, db: Session) -> int:
@@ -124,6 +132,27 @@ def _compute_interim_score(sa, assignment, db: Session, total_items: int | None 
         if total_items == 0:
             return None
         return round(sum(valid_scores) / total_items, 1)
+
+    # Speaking modes (例句朗讀 / 單字朗讀): sa.score is the batch-grade roll-up of
+    # item-level AI scores. Issue #813 — some GRADED rows never got that roll-up
+    # (item scores exist, sa.score=NULL) and surfaced as 0. Recompute from items.
+    if practice_mode in _SPEAKING_SCORE_MODES:
+        canonical_items = (
+            db.query(ContentItem)
+            .join(Content, ContentItem.content_id == Content.id)
+            .join(AssignmentContent, AssignmentContent.content_id == Content.id)
+            .filter(AssignmentContent.assignment_id == assignment.id)
+            .all()
+        )
+        if not canonical_items:
+            return None
+        progress_by_item = {
+            p.content_item_id: p
+            for p in db.query(StudentItemProgress)
+            .filter(StudentItemProgress.student_assignment_id == sa.id)
+            .all()
+        }
+        return compute_speaking_total_score(canonical_items, progress_by_item)
 
     return None
 

--- a/backend/routers/assignments/detail.py
+++ b/backend/routers/assignments/detail.py
@@ -152,10 +152,13 @@ def _compute_interim_score(
     # item-level AI scores. Issue #813 — some GRADED rows never got that roll-up
     # (item scores exist, sa.score=NULL) and surfaced as 0. Recompute from items.
     if practice_mode in _SPEAKING_SCORE_MODES:
-        # Don't surface a partial score for a student still working: _is_interim_score
-        # returns False for speaking modes, so the UI would render it as a final score
-        # (misleading). Keep prior behavior — only fall back once past IN_PROGRESS.
-        if sa.status and sa.status.value == "IN_PROGRESS":
+        # Only recompute for a GRADED assignment — that's the #813 state (batch-grade
+        # finalized status=GRADED but never wrote sa.score). For any other status
+        # (SUBMITTED/RESUBMITTED/RETURNED/IN_PROGRESS) a NULL score is expected because
+        # grading hasn't completed; computing a partial item-level average there would
+        # render as a misleading FINAL score (speaking modes aren't in AUTO_GRADED_MODES,
+        # so _is_interim_score is False and the UI shows no "~" marker).
+        if not (sa.status and sa.status.value == "GRADED"):
             return None
         # canonical_items is invariant per assignment — callers pass it pre-fetched
         # to avoid re-querying once per student (this runs in per-student loops).

--- a/backend/routers/assignments/detail.py
+++ b/backend/routers/assignments/detail.py
@@ -59,6 +59,21 @@ def _get_total_item_count(assignment_id: int, db: Session) -> int:
     )
 
 
+def _get_canonical_items(assignment_id: int, db: Session):
+    """The assignment's canonical ContentItem rows (AssignmentContent → Content → ContentItem).
+
+    Invariant per assignment — callers hoist this out of per-student loops and
+    pass it into _compute_interim_score to avoid an N+1 in the speaking fallback.
+    """
+    return (
+        db.query(ContentItem)
+        .join(Content, ContentItem.content_id == Content.id)
+        .join(AssignmentContent, AssignmentContent.content_id == Content.id)
+        .filter(AssignmentContent.assignment_id == assignment_id)
+        .all()
+    )
+
+
 def _is_interim_score(sa, assignment) -> bool:
     """Check if a student assignment should show an interim (provisional) score."""
     return (
@@ -70,7 +85,9 @@ def _is_interim_score(sa, assignment) -> bool:
     )
 
 
-def _compute_interim_score(sa, assignment, db: Session, total_items: int | None = None):
+def _compute_interim_score(
+    sa, assignment, db: Session, total_items: int | None = None, canonical_items=None
+):
     """
     Compute display score for /progress endpoint.
 
@@ -137,13 +154,10 @@ def _compute_interim_score(sa, assignment, db: Session, total_items: int | None 
     # item-level AI scores. Issue #813 — some GRADED rows never got that roll-up
     # (item scores exist, sa.score=NULL) and surfaced as 0. Recompute from items.
     if practice_mode in _SPEAKING_SCORE_MODES:
-        canonical_items = (
-            db.query(ContentItem)
-            .join(Content, ContentItem.content_id == Content.id)
-            .join(AssignmentContent, AssignmentContent.content_id == Content.id)
-            .filter(AssignmentContent.assignment_id == assignment.id)
-            .all()
-        )
+        # canonical_items is invariant per assignment — callers pass it pre-fetched
+        # to avoid re-querying once per student (this runs in per-student loops).
+        if canonical_items is None:
+            canonical_items = _get_canonical_items(assignment.id, db)
         if not canonical_items:
             return None
         progress_by_item = {
@@ -243,6 +257,15 @@ async def get_assignment_detail(
     # Pre-compute total item count once (avoids O(N) redundant queries in the loop)
     total_items = _get_total_item_count(assignment.id, db)
 
+    # Speaking-mode fallback needs the assignment's canonical items; fetch once
+    # here (invariant per assignment) and pass into _compute_interim_score so we
+    # don't re-query per student.
+    speaking_canonical_items = (
+        _get_canonical_items(assignment.id, db)
+        if assignment.practice_mode in _SPEAKING_SCORE_MODES
+        else None
+    )
+
     students_progress = []
     for student in all_students:
         # 檢查這個學生是否已被指派
@@ -299,7 +322,13 @@ async def get_assignment_detail(
                 ),
                 "content_progress": content_progress,
                 "score": (
-                    _compute_interim_score(sa, assignment, db, total_items=total_items)
+                    _compute_interim_score(
+                        sa,
+                        assignment,
+                        db,
+                        total_items=total_items,
+                        canonical_items=speaking_canonical_items,
+                    )
                     if sa
                     else None
                 ),
@@ -396,6 +425,15 @@ async def get_assignment_progress(
     # Pre-compute total item count once (avoids O(N) redundant queries in the loop)
     total_items = _get_total_item_count(assignment.id, db)
 
+    # Speaking-mode fallback needs the assignment's canonical items; fetch once
+    # here (invariant per assignment) and pass into _compute_interim_score so we
+    # don't re-query per student.
+    speaking_canonical_items = (
+        _get_canonical_items(assignment.id, db)
+        if assignment.practice_mode in _SPEAKING_SCORE_MODES
+        else None
+    )
+
     progress_list = []
     for student in all_students:
         # 使用字典快速查找，O(1) 時間複雜度
@@ -417,7 +455,13 @@ async def get_assignment_progress(
                     sa.submitted_at.isoformat() if sa and sa.submitted_at else None
                 ),
                 "score": (
-                    _compute_interim_score(sa, assignment, db, total_items=total_items)
+                    _compute_interim_score(
+                        sa,
+                        assignment,
+                        db,
+                        total_items=total_items,
+                        canonical_items=speaking_canonical_items,
+                    )
                     if sa
                     else None
                 ),

--- a/backend/routers/assignments/detail.py
+++ b/backend/routers/assignments/detail.py
@@ -25,6 +25,11 @@ from models import (
 from .dependencies import get_current_teacher
 from .utils import compute_speaking_total_score
 
+# Single source of truth for speaking-scored modes (Azure pronunciation assessment,
+# score_category=speaking). Imported — not re-declared — so a new speaking mode added
+# in score_category.py can't silently miss the #813 display fallback here.
+from utils.score_category import _SPEAKING_MODES as _SPEAKING_SCORE_MODES
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
@@ -38,13 +43,6 @@ AUTO_GRADED_MODES = frozenset(
 # all three accumulate correct/incorrect counts on
 # StudentItemProgress.word_selection_data, which the PG function reads.
 _MASTERY_FUNCTION_MODES = frozenset({"word_selection", "word_spelling", "word_cloze"})
-
-# Speaking modes scored by Azure pronunciation assessment (score_category=speaking).
-# These get their total from batch-grade rolling up item-level scores into
-# StudentAssignment.score. When that roll-up is missing (issue #813: item scores
-# present + status GRADED, but sa.score=NULL), we recompute on read — same pattern
-# as the mastery-mode fallback above. See utils.compute_speaking_total_score.
-_SPEAKING_SCORE_MODES = frozenset({"reading", "word_reading"})
 
 
 def _get_total_item_count(assignment_id: int, db: Session) -> int:

--- a/backend/routers/assignments/grading.py
+++ b/backend/routers/assignments/grading.py
@@ -37,7 +37,11 @@ from .validators import (
     BatchGradeFinalizeResponse,
 )
 from .dependencies import get_current_teacher
-from .detail import _compute_interim_score
+from .detail import (
+    _compute_interim_score,
+    _get_canonical_items,
+    _SPEAKING_SCORE_MODES,
+)
 from services.analysis_quota import (
     reset_analysis_count_for_assignment,
     reset_analysis_count_for_assignments,
@@ -567,6 +571,15 @@ async def get_student_submission(
             actual_assignment_id,
         )
 
+    # Pre-fetch canonical items for speaking-mode fallback so _compute_interim_score
+    # doesn't re-query them inline (mirrors get_assignment_detail / grade reports).
+    speaking_canonical = (
+        _get_canonical_items(parent_assignment.id, db)
+        if parent_assignment
+        and parent_assignment.practice_mode in _SPEAKING_SCORE_MODES
+        else None
+    )
+
     return {
         "student_id": student.id,
         "student_name": student.name,
@@ -586,7 +599,12 @@ async def get_student_submission(
         # parent_assignment may be None for orphaned StudentAssignment rows;
         # the helper would AttributeError on `assignment.practice_mode`.
         "current_score": (
-            _compute_interim_score(assignment, parent_assignment, db)
+            _compute_interim_score(
+                assignment,
+                parent_assignment,
+                db,
+                canonical_items=speaking_canonical,
+            )
             if parent_assignment
             else assignment.score
         ),

--- a/backend/routers/assignments/utils.py
+++ b/backend/routers/assignments/utils.py
@@ -197,7 +197,6 @@ def compute_speaking_total_score(canonical_items, progress_by_item) -> float | N
             item_scores.append(0.0)
             continue
 
-        any_assessed = True
         ai_feedback_data = {}
         if item.ai_feedback:
             try:
@@ -222,6 +221,28 @@ def compute_speaking_total_score(canonical_items, progress_by_item) -> float | N
             )
             if v > 0
         ]
+
+        # ai_assessed_at can be stamped on a corrupt/partial row (all four score
+        # columns NULL, no ai_feedback). Such a row carries no real score and must
+        # not flip a whole assignment's None into 0.0 — only count it as assessed
+        # when it actually has score data (a legit zero column counts; all-NULL
+        # does not). See #813 PR review.
+        has_score_data = (
+            bool(available)
+            or bool(ai_feedback_data)
+            or any(
+                getattr(item, field) is not None
+                for field in (
+                    "pronunciation_score",
+                    "accuracy_score",
+                    "fluency_score",
+                    "completeness_score",
+                )
+            )
+        )
+        if has_score_data:
+            any_assessed = True
+
         item_scores.append(sum(available) / len(available) if available else 0.0)
 
     if not item_scores or not any_assessed:

--- a/backend/routers/assignments/utils.py
+++ b/backend/routers/assignments/utils.py
@@ -2,6 +2,7 @@
 Utility functions for assignment processing
 """
 
+import json
 from typing import List, Dict, Any
 
 
@@ -187,8 +188,6 @@ def compute_speaking_total_score(canonical_items, progress_by_item) -> float | N
     Returns the rounded total, or None when there is no assessed work to score
     (so callers can leave sa.score-less, not-yet-attempted rows blank).
     """
-    import json
-
     item_scores: list[float] = []
     any_assessed = False
     for ci in canonical_items:
@@ -225,8 +224,9 @@ def compute_speaking_total_score(canonical_items, progress_by_item) -> float | N
         # ai_assessed_at can be stamped on a corrupt/partial row (all four score
         # columns NULL, no ai_feedback). Such a row carries no real score and must
         # not flip a whole assignment's None into 0.0 — only count it as assessed
-        # when it actually has score data (a legit zero column counts; all-NULL
-        # does not). See #813 PR review.
+        # when it actually has score data. `available` holds only >0 values, so a
+        # legitimate zero column (Decimal("0")) drops out of it but is still real
+        # data — the getattr check below catches it; all-NULL does not. (#813 review)
         has_score_data = (
             bool(available)
             or bool(ai_feedback_data)

--- a/backend/routers/assignments/utils.py
+++ b/backend/routers/assignments/utils.py
@@ -152,6 +152,15 @@ def get_score_with_fallback(
         return float(json_score)
 
 
+# The four Azure pronunciation-assessment component columns / ai_feedback keys.
+_SCORE_FIELDS = (
+    "pronunciation_score",
+    "accuracy_score",
+    "fluency_score",
+    "completeness_score",
+)
+
+
 def _read_component_score(
     item_progress, field_name: str, ai_feedback_data: dict
 ) -> float:
@@ -211,34 +220,23 @@ def compute_speaking_total_score(canonical_items, progress_by_item) -> float | N
             v
             for v in (
                 _read_component_score(item, field, ai_feedback_data)
-                for field in (
-                    "pronunciation_score",
-                    "accuracy_score",
-                    "fluency_score",
-                    "completeness_score",
-                )
+                for field in _SCORE_FIELDS
             )
             if v > 0
         ]
 
         # ai_assessed_at can be stamped on a corrupt/partial row (all four score
-        # columns NULL, no ai_feedback). Such a row carries no real score and must
-        # not flip a whole assignment's None into 0.0 — only count it as assessed
-        # when it actually has score data. `available` holds only >0 values, so a
-        # legitimate zero column (Decimal("0")) drops out of it but is still real
-        # data — the getattr check below catches it; all-NULL does not. (#813 review)
+        # columns NULL, ai_feedback holding only non-score JSON like {"error": ...}).
+        # Such a row carries no real score and must not flip a whole assignment's
+        # None into 0.0 — only count it as assessed when an actual score value
+        # exists. `available` holds only >0 values, so a legitimate zero (column or
+        # JSON == 0) drops out of it but is still real data — the per-field
+        # None-checks below catch that; all-NULL / non-score JSON does not.
+        # (#813 review) — note we check the score keys specifically, NOT bool(json).
         has_score_data = (
             bool(available)
-            or bool(ai_feedback_data)
-            or any(
-                getattr(item, field) is not None
-                for field in (
-                    "pronunciation_score",
-                    "accuracy_score",
-                    "fluency_score",
-                    "completeness_score",
-                )
-            )
+            or any(ai_feedback_data.get(field) is not None for field in _SCORE_FIELDS)
+            or any(getattr(item, field) is not None for field in _SCORE_FIELDS)
         )
         if has_score_data:
             any_assessed = True

--- a/backend/routers/assignments/utils.py
+++ b/backend/routers/assignments/utils.py
@@ -151,6 +151,84 @@ def get_score_with_fallback(
         return float(json_score)
 
 
+def _read_component_score(
+    item_progress, field_name: str, ai_feedback_data: dict
+) -> float:
+    """Read one component score read-only (column first, then ai_feedback JSON).
+
+    Mirrors get_score_with_fallback's value resolution but never writes/backfills
+    — safe to call from GET endpoints. Used by compute_speaking_total_score.
+    """
+    score = getattr(item_progress, field_name)
+    if score is not None:
+        return float(score)
+    if ai_feedback_data:
+        json_score = ai_feedback_data.get(field_name)
+        if json_score is not None:
+            try:
+                return float(json_score)
+            except (TypeError, ValueError):
+                return 0.0
+    return 0.0
+
+
+def compute_speaking_total_score(canonical_items, progress_by_item) -> float | None:
+    """Roll up a speaking/reading assignment's total score from item-level AI scores.
+
+    Mirrors batch_grade_assignment's averaging so a displayed fallback equals what a
+    re-grade would produce: per item, average the >0 components
+    (pronunciation/accuracy/fluency/completeness); a missing/un-assessed item scores 0;
+    the total is the mean across all canonical items.
+
+    Args:
+        canonical_items: the assignment's canonical ContentItem rows (the denominator).
+        progress_by_item: dict[content_item_id -> StudentItemProgress].
+
+    Returns the rounded total, or None when there is no assessed work to score
+    (so callers can leave sa.score-less, not-yet-attempted rows blank).
+    """
+    import json
+
+    item_scores: list[float] = []
+    any_assessed = False
+    for ci in canonical_items:
+        item = progress_by_item.get(ci.id)
+        if item is None or not item.recording_url or not item.has_ai_assessment:
+            item_scores.append(0.0)
+            continue
+
+        any_assessed = True
+        ai_feedback_data = {}
+        if item.ai_feedback:
+            try:
+                ai_feedback_data = (
+                    json.loads(item.ai_feedback)
+                    if isinstance(item.ai_feedback, str)
+                    else item.ai_feedback
+                )
+            except (json.JSONDecodeError, TypeError):
+                ai_feedback_data = {}
+
+        available = [
+            v
+            for v in (
+                _read_component_score(item, field, ai_feedback_data)
+                for field in (
+                    "pronunciation_score",
+                    "accuracy_score",
+                    "fluency_score",
+                    "completeness_score",
+                )
+            )
+            if v > 0
+        ]
+        item_scores.append(sum(available) / len(available) if available else 0.0)
+
+    if not item_scores or not any_assessed:
+        return None
+    return round(sum(item_scores) / len(item_scores), 1)
+
+
 def generate_item_comment(
     pronunciation: float,
     accuracy: float,

--- a/backend/routers/teachers/grade_reports.py
+++ b/backend/routers/teachers/grade_reports.py
@@ -48,7 +48,11 @@ from models import (
     StudentAssignment,
     Teacher,
 )
-from routers.assignments.detail import _compute_interim_score
+from routers.assignments.detail import (
+    _compute_interim_score,
+    _get_canonical_items,
+    _SPEAKING_SCORE_MODES,
+)
 from .dependencies import get_current_teacher
 
 logger = logging.getLogger(__name__)
@@ -146,7 +150,26 @@ def _category_key(assignment: Assignment) -> str:
     return key if key in _CATEGORY_ZH else "writing"
 
 
-def _final_score(sa: Optional[StudentAssignment], assignment: Assignment, db: Session):
+def _speaking_canonical_cache(assignments: List[Assignment], db: Session) -> dict:
+    """Pre-fetch canonical items per speaking-mode assignment.
+
+    _compute_interim_score's speaking fallback would otherwise re-query canonical
+    items for every (student, assignment) cell in the report grid (N+1). Build the
+    per-assignment cache once and thread it through _final_score.
+    """
+    return {
+        a.id: _get_canonical_items(a.id, db)
+        for a in assignments
+        if a.practice_mode in _SPEAKING_SCORE_MODES
+    }
+
+
+def _final_score(
+    sa: Optional[StudentAssignment],
+    assignment: Assignment,
+    db: Session,
+    canonical_items=None,
+):
     """Return a numeric score (or ``None``) for one (student, assignment) cell.
 
     Sample reports show integer scores, so we round to the nearest integer.
@@ -155,7 +178,9 @@ def _final_score(sa: Optional[StudentAssignment], assignment: Assignment, db: Se
         return None
     if sa.score is not None:
         return int(round(float(sa.score)))
-    interim = _compute_interim_score(sa, assignment, db)
+    interim = _compute_interim_score(
+        sa, assignment, db, canonical_items=canonical_items
+    )
     return int(round(float(interim))) if interim is not None else None
 
 
@@ -310,6 +335,7 @@ def _build_class_workbook(
     # --- Data rows ---
     all_scores: List[float] = []
     per_assignment_scores: dict[int, List[float]] = {a.id: [] for a in assignments}
+    canonical_cache = _speaking_canonical_cache(assignments, db)
 
     first_data_row = 6
     for student_idx, student in enumerate(students):
@@ -320,7 +346,7 @@ def _build_class_workbook(
 
         for col_idx, (_, a) in enumerate(ordered):
             sa = sa_by_pair.get((student.id, a.id))
-            score = _final_score(sa, a, db)
+            score = _final_score(sa, a, db, canonical_items=canonical_cache.get(a.id))
             if score is not None:
                 student_scores.append(float(score))
                 per_assignment_scores[a.id].append(float(score))
@@ -429,6 +455,7 @@ def _build_single_student_workbook(
     assignments: List[Assignment],
     sa_by_assignment: dict,
     db: Session,
+    canonical_cache: Optional[dict] = None,
 ) -> Workbook:
     """Build a one-sheet workbook for a single student.
 
@@ -485,6 +512,11 @@ def _build_single_student_workbook(
         cell.alignment = Alignment(horizontal="center")
         cell.border = border
 
+    # Built once by the caller across all students; fall back to building it here
+    # so the builder stays correct when called standalone.
+    if canonical_cache is None:
+        canonical_cache = _speaking_canonical_cache(assignments, db)
+
     # Bucket assignments by category, preserving insertion order within bucket.
     groups: dict[str, List[Assignment]] = {k: [] for k in _CATEGORY_ORDER}
     for a in assignments:
@@ -508,7 +540,7 @@ def _build_single_student_workbook(
 
         for a in items:
             sa = sa_by_assignment.get(a.id)
-            score = _final_score(sa, a, db)
+            score = _final_score(sa, a, db, canonical_items=canonical_cache.get(a.id))
             d = a.created_at.date().isoformat() if a.created_at else ""
             ws.cell(row=cur_row, column=1, value=_CATEGORY_ZH[cat])
             ws.cell(row=cur_row, column=2, value=a.title)
@@ -626,11 +658,15 @@ async def student_grade_report(
     sa_by_pair = {(sa.student_id, sa.assignment_id): sa for sa in sa_rows}
 
     today = _today_yyyymmdd()
+    # Build the speaking canonical-items cache once for all students (invariant
+    # per assignment) rather than re-fetching inside each per-student workbook.
+    canonical_cache = _speaking_canonical_cache(assignments, db)
+
     files: List[Tuple[str, bytes]] = []
     for student in students:
         sa_for_student = {a.id: sa_by_pair.get((student.id, a.id)) for a in assignments}
         wb = _build_single_student_workbook(
-            classroom, student, assignments, sa_for_student, db
+            classroom, student, assignments, sa_for_student, db, canonical_cache
         )
         buf = io.BytesIO()
         wb.save(buf)

--- a/backend/tests/unit/test_speaking_score_813.py
+++ b/backend/tests/unit/test_speaking_score_813.py
@@ -217,6 +217,25 @@ class TestComputeSpeakingTotalScore:
         # item 2 recorded but un-assessed → missing (0); (80 + 0) / 2 = 40.0
         assert compute_speaking_total_score(canonical, progress) == pytest.approx(40.0)
 
+    def test_corrupt_item_assessed_flag_but_all_null_returns_none(self):
+        """ai_assessed_at 有值但 4 個分數欄全 NULL、無 ai_feedback（半寫入/壞資料）
+        → 不算 assessed，整份回 None（不顯示 0）。#813 PR review finding 3。"""
+        canonical = _canonical(1)
+        corrupt = _item(
+            1, ai=True, feedback=None, pron=None, acc=None, flu=None, comp=None
+        )
+        assert compute_speaking_total_score(canonical, {1: corrupt}) is None
+
+    def test_legit_zero_scored_item_counts_as_assessed(self):
+        """欄位為實際 0（非 NULL）代表「有評分但得 0」→ 算 assessed，回 0.0（非 None）。"""
+        canonical = _canonical(1)
+        zeroed = _item(
+            1, pron=Decimal("0"), acc=Decimal("0"), flu=Decimal("0"), comp=Decimal("0")
+        )
+        assert compute_speaking_total_score(canonical, {1: zeroed}) == pytest.approx(
+            0.0
+        )
+
 
 # ---------------------------------------------------------------------------
 # 顯示端：_compute_interim_score 的 speaking fallback 分支
@@ -227,6 +246,33 @@ class TestComputeInterimScoreSpeakingFallback:
     def test_speaking_modes_set(self):
         assert "reading" in _SPEAKING_SCORE_MODES
         assert "word_reading" in _SPEAKING_SCORE_MODES
+
+    def test_speaking_modes_match_score_category_source(self):
+        """detail._SPEAKING_SCORE_MODES 必須與 score_category 的 speaking 模式一致，
+        否則未來新增 speaking 模式只改一邊會對新模式重演 #813。#813 PR review finding 4。"""
+        from utils.score_category import _SPEAKING_MODES
+
+        assert _SPEAKING_SCORE_MODES == _SPEAKING_MODES
+
+    @pytest.mark.parametrize("mode", ["reading", "word_reading"])
+    def test_in_progress_returns_none_not_partial_score(self, mode):
+        """IN_PROGRESS 學生即便有部分 item 評分，也不回部分分數（會被當成最終分顯示）。
+        #813 PR review finding 2。"""
+        sa = _sa("IN_PROGRESS", score=None)
+        assignment = _assignment(mode)
+        canonical = _canonical(1, 2)
+        progress = [
+            _item(
+                1,
+                pron=Decimal("80"),
+                acc=Decimal("80"),
+                flu=Decimal("80"),
+                comp=Decimal("80"),
+            ),
+            _item(2, rec=None, ai=False, pron=None, acc=None, flu=None, comp=None),
+        ]
+        db = _mock_db_speaking(canonical, progress)
+        assert _compute_interim_score(sa, assignment, db) is None
 
     @pytest.mark.parametrize("mode", ["reading", "word_reading"])
     def test_graded_null_score_recomputes_from_items(self, mode):

--- a/backend/tests/unit/test_speaking_score_813.py
+++ b/backend/tests/unit/test_speaking_score_813.py
@@ -247,12 +247,13 @@ class TestComputeInterimScoreSpeakingFallback:
         assert "reading" in _SPEAKING_SCORE_MODES
         assert "word_reading" in _SPEAKING_SCORE_MODES
 
-    def test_speaking_modes_match_score_category_source(self):
-        """detail._SPEAKING_SCORE_MODES 必須與 score_category 的 speaking 模式一致，
-        否則未來新增 speaking 模式只改一邊會對新模式重演 #813。#813 PR review finding 4。"""
+    def test_speaking_modes_use_score_category_single_source(self):
+        """detail._SPEAKING_SCORE_MODES 直接 import 自 score_category（同一物件），
+        不再維護第二份常數，避免新增 speaking 模式漂移、對新模式重演 #813。
+        #813 PR review finding 4。"""
         from utils.score_category import _SPEAKING_MODES
 
-        assert _SPEAKING_SCORE_MODES == _SPEAKING_MODES
+        assert _SPEAKING_SCORE_MODES is _SPEAKING_MODES
 
     @pytest.mark.parametrize("mode", ["reading", "word_reading"])
     def test_in_progress_returns_none_not_partial_score(self, mode):

--- a/backend/tests/unit/test_speaking_score_813.py
+++ b/backend/tests/unit/test_speaking_score_813.py
@@ -269,12 +269,14 @@ class TestComputeInterimScoreSpeakingFallback:
 
         assert _SPEAKING_SCORE_MODES is _SPEAKING_MODES
 
-    @pytest.mark.parametrize("mode", ["reading", "word_reading"])
-    def test_in_progress_returns_none_not_partial_score(self, mode):
-        """IN_PROGRESS 學生即便有部分 item 評分，也不回部分分數（會被當成最終分顯示）。
-        #813 PR review finding 2。"""
-        sa = _sa("IN_PROGRESS", score=None)
-        assignment = _assignment(mode)
+    @pytest.mark.parametrize(
+        "status", ["IN_PROGRESS", "SUBMITTED", "RESUBMITTED", "RETURNED", "NOT_STARTED"]
+    )
+    def test_non_graded_status_returns_none_not_partial_score(self, status):
+        """只有 GRADED 才現算。其他狀態（含 SUBMITTED — 尚未批改，NULL 分數屬正常）
+        即便有部分 item 評分也回 None，避免部分分數被當最終分顯示。#813 PR review finding 2。"""
+        sa = _sa(status, score=None)
+        assignment = _assignment("reading")
         canonical = _canonical(1, 2)
         progress = [
             _item(

--- a/backend/tests/unit/test_speaking_score_813.py
+++ b/backend/tests/unit/test_speaking_score_813.py
@@ -226,6 +226,20 @@ class TestComputeSpeakingTotalScore:
         )
         assert compute_speaking_total_score(canonical, {1: corrupt}) is None
 
+    def test_non_score_ai_feedback_does_not_count_as_assessed(self):
+        """ai_feedback 只有非分數欄位（如 {"error": "timeout"}）、分數欄全 NULL
+        → 不算 assessed，回 None（不被 bool(json) 誤判）。#813 PR review。"""
+        canonical = _canonical(1)
+        item = _item(
+            1,
+            feedback='{"error": "timeout", "attempt": 2}',
+            pron=None,
+            acc=None,
+            flu=None,
+            comp=None,
+        )
+        assert compute_speaking_total_score(canonical, {1: item}) is None
+
     def test_legit_zero_scored_item_counts_as_assessed(self):
         """欄位為實際 0（非 NULL）代表「有評分但得 0」→ 算 assessed，回 0.0（非 None）。"""
         canonical = _canonical(1)

--- a/backend/tests/unit/test_speaking_score_813.py
+++ b/backend/tests/unit/test_speaking_score_813.py
@@ -187,6 +187,36 @@ class TestComputeSpeakingTotalScore:
     def test_empty_canonical_returns_none(self):
         assert compute_speaking_total_score([], {}) is None
 
+    def test_uses_real_model_has_ai_assessment_property(self):
+        """Anchor against a real StudentItemProgress so the _item() helper's plain
+        has_ai_assessment attribute can't hide a regression in the model @property
+        (it is backed by `ai_assessed_at is not None`). Review feedback on PR #815.
+        """
+        from datetime import datetime, timezone
+
+        assessed = StudentItemProgress(
+            content_item_id=1,
+            recording_url="https://gcs/a.wav",
+            ai_assessed_at=datetime(2026, 4, 23, tzinfo=timezone.utc),
+            pronunciation_score=Decimal("80"),
+            accuracy_score=Decimal("80"),
+            fluency_score=Decimal("80"),
+            completeness_score=Decimal("80"),
+        )
+        not_assessed = StudentItemProgress(
+            content_item_id=2,
+            recording_url="https://gcs/b.wav",
+            ai_assessed_at=None,
+        )
+        # Property contract: driven purely by ai_assessed_at.
+        assert assessed.has_ai_assessment is True
+        assert not_assessed.has_ai_assessment is False
+
+        canonical = _canonical(1, 2)
+        progress = {1: assessed, 2: not_assessed}
+        # item 2 recorded but un-assessed → missing (0); (80 + 0) / 2 = 40.0
+        assert compute_speaking_total_score(canonical, progress) == pytest.approx(40.0)
+
 
 # ---------------------------------------------------------------------------
 # 顯示端：_compute_interim_score 的 speaking fallback 分支

--- a/backend/tests/unit/test_speaking_score_813.py
+++ b/backend/tests/unit/test_speaking_score_813.py
@@ -1,0 +1,258 @@
+"""
+Issue #813 — 例句朗讀（reading）AI 批次批改後 Progress & Grade 便利貼成績顯示 0。
+
+Root cause（已用 PROD 資料證實，assignment 433）：
+- 學生 item 層級 AI 分數齊全（ai_assessed_at + pronunciation/accuracy/fluency/
+  completeness 都有值），status=GRADED，但 student_assignment.score 沒被 roll-up，
+  停留在 NULL。
+- 顯示端 _compute_interim_score 對 speaking 模式（reading / word_reading）沒有
+  fallback，sa.score=None 直接回 None → 前端 score ?? 0 → 顯示 0.0。
+  （與 #807 的 mastery 模式同類，#807 只補了 mastery，沒補 speaking。）
+
+Fix（比照 #807 顯示端 fallback）：sa.score 為 None 時，用 item 分數即時重算，
+公式與 batch_grade_assignment 完全一致（每題取 >0 的 4 項平均、缺題 0、全題平均）。
+"""
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from models import ContentItem, StudentItemProgress
+from routers.assignments.detail import (
+    _SPEAKING_SCORE_MODES,
+    _compute_interim_score,
+    _is_interim_score,
+)
+from routers.assignments.utils import compute_speaking_total_score
+
+
+def _item(
+    cid,
+    *,
+    rec="https://gcs/a.wav",
+    ai=True,
+    feedback=None,
+    pron=None,
+    acc=None,
+    flu=None,
+    comp=None
+):
+    return SimpleNamespace(
+        content_item_id=cid,
+        recording_url=rec,
+        has_ai_assessment=ai,
+        ai_feedback=feedback,
+        pronunciation_score=pron,
+        accuracy_score=acc,
+        fluency_score=flu,
+        completeness_score=comp,
+    )
+
+
+def _canonical(*cids):
+    return [SimpleNamespace(id=c) for c in cids]
+
+
+def _mock_db_speaking(canonical_items, progress_list):
+    """db where query(ContentItem)->canonical, query(StudentItemProgress)->progress."""
+    db = MagicMock()
+
+    def query_side_effect(model):
+        q = MagicMock()
+        q.join.return_value = q
+        q.filter.return_value = q
+        if model is ContentItem:
+            q.all.return_value = canonical_items
+        elif model is StudentItemProgress:
+            q.all.return_value = progress_list
+        else:
+            q.all.return_value = []
+        return q
+
+    db.query.side_effect = query_side_effect
+    return db
+
+
+def _sa(status_value, score=None, sa_id=1):
+    return SimpleNamespace(
+        id=sa_id, score=score, status=SimpleNamespace(value=status_value)
+    )
+
+
+def _assignment(practice_mode, assignment_id=1):
+    return SimpleNamespace(id=assignment_id, practice_mode=practice_mode)
+
+
+# ---------------------------------------------------------------------------
+# 純函式：compute_speaking_total_score（與 batch-grade 公式對齊）
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSpeakingTotalScore:
+    def test_real_433_sa4534_case(self):
+        """PROD assignment 433, sa_id 4534 的真實三題分數 → 應算出 71.3（非 0）。"""
+        canonical = _canonical(41620, 41621, 41622)
+        progress = {
+            41620: _item(
+                41620,
+                pron=Decimal("64.60"),
+                acc=Decimal("79"),
+                flu=Decimal("52"),
+                comp=Decimal("88"),
+            ),
+            41621: _item(
+                41621,
+                pron=Decimal("61.20"),
+                acc=Decimal("72"),
+                flu=Decimal("51"),
+                comp=Decimal("81"),
+            ),
+            41622: _item(
+                41622,
+                pron=Decimal("73.40"),
+                acc=Decimal("83"),
+                flu=Decimal("67"),
+                comp=Decimal("83"),
+            ),
+        }
+        # 每題平均: 70.9 / 66.3 / 76.6 → 總平均 71.2667 → 71.3
+        assert compute_speaking_total_score(canonical, progress) == pytest.approx(71.3)
+
+    def test_missing_progress_row_counts_as_zero(self):
+        """缺 progress row 的題目算 0 分（缺題），仍計入分母。"""
+        canonical = _canonical(1, 2)
+        progress = {
+            1: _item(
+                1,
+                pron=Decimal("90"),
+                acc=Decimal("90"),
+                flu=Decimal("90"),
+                comp=Decimal("90"),
+            ),
+        }
+        # 題1=90, 題2=0 → (90+0)/2 = 45.0
+        assert compute_speaking_total_score(canonical, progress) == pytest.approx(45.0)
+
+    def test_recorded_but_not_assessed_counts_as_zero(self):
+        """有錄音但沒 AI 評分（has_ai_assessment=False）算缺題 0 分。"""
+        canonical = _canonical(1, 2)
+        progress = {
+            1: _item(
+                1,
+                pron=Decimal("80"),
+                acc=Decimal("80"),
+                flu=Decimal("80"),
+                comp=Decimal("80"),
+            ),
+            2: _item(2, ai=False, pron=None, acc=None, flu=None, comp=None),
+        }
+        assert compute_speaking_total_score(canonical, progress) == pytest.approx(40.0)
+
+    def test_zero_components_excluded_from_average(self):
+        """單題內只平均 >0 的項目（對齊 batch-grade）。"""
+        canonical = _canonical(1)
+        progress = {
+            1: _item(
+                1,
+                pron=Decimal("80"),
+                acc=Decimal("0"),
+                flu=Decimal("0"),
+                comp=Decimal("40"),
+            ),
+        }
+        # 只取 80 與 40 → (80+40)/2 = 60.0
+        assert compute_speaking_total_score(canonical, progress) == pytest.approx(60.0)
+
+    def test_no_assessed_work_returns_none(self):
+        """完全沒有任何題目被評分 → 回 None（讓未作答的列維持空白，不顯示 0）。"""
+        canonical = _canonical(1, 2)
+        progress = {}
+        assert compute_speaking_total_score(canonical, progress) is None
+
+    def test_reads_from_ai_feedback_json_when_column_null(self):
+        """欄位為 NULL 但 ai_feedback JSON 有值時，read-only 取 JSON（不回填）。"""
+        canonical = _canonical(1)
+        feedback = (
+            '{"pronunciation_score": 90, "accuracy_score": 90, '
+            '"fluency_score": 90, "completeness_score": 90}'
+        )
+        item = _item(1, feedback=feedback, pron=None, acc=None, flu=None, comp=None)
+        progress = {1: item}
+        assert compute_speaking_total_score(canonical, progress) == pytest.approx(90.0)
+        # 確認 read-only：沒有寫回欄位
+        assert item.pronunciation_score is None
+
+    def test_empty_canonical_returns_none(self):
+        assert compute_speaking_total_score([], {}) is None
+
+
+# ---------------------------------------------------------------------------
+# 顯示端：_compute_interim_score 的 speaking fallback 分支
+# ---------------------------------------------------------------------------
+
+
+class TestComputeInterimScoreSpeakingFallback:
+    def test_speaking_modes_set(self):
+        assert "reading" in _SPEAKING_SCORE_MODES
+        assert "word_reading" in _SPEAKING_SCORE_MODES
+
+    @pytest.mark.parametrize("mode", ["reading", "word_reading"])
+    def test_graded_null_score_recomputes_from_items(self, mode):
+        """核心 case：GRADED 但 sa.score=None → 從 item 分數現算（非 0）。"""
+        sa = _sa("GRADED", score=None)
+        assignment = _assignment(mode)
+        canonical = _canonical(1, 2)
+        progress = [
+            _item(
+                1,
+                pron=Decimal("80"),
+                acc=Decimal("80"),
+                flu=Decimal("80"),
+                comp=Decimal("80"),
+            ),
+            _item(
+                2,
+                pron=Decimal("90"),
+                acc=Decimal("90"),
+                flu=Decimal("90"),
+                comp=Decimal("90"),
+            ),
+        ]
+        db = _mock_db_speaking(canonical, progress)
+        # (80+90)/2 = 85.0
+        assert _compute_interim_score(sa, assignment, db) == pytest.approx(85.0)
+
+    def test_fast_path_existing_score_returned_without_query(self):
+        """sa.score 有值就直接回傳，不去 query item（即使是 0）。"""
+        sa = _sa("GRADED", score=66.3)
+        assignment = _assignment("reading")
+        db = _mock_db_speaking(_canonical(1), [])
+        assert _compute_interim_score(sa, assignment, db) == 66.3
+        db.query.assert_not_called()
+
+    def test_no_canonical_items_returns_none(self):
+        """作業內容關聯查不到題目（如 PROD assignment 415）→ 回 None，不 crash。"""
+        sa = _sa("GRADED", score=None)
+        assignment = _assignment("reading")
+        db = _mock_db_speaking([], [])
+        assert _compute_interim_score(sa, assignment, db) is None
+
+    def test_not_started_no_recordings_returns_none(self):
+        """未作答（item 無錄音/無評分）→ 回 None（不顯示 0）。"""
+        sa = _sa("NOT_STARTED", score=None)
+        assignment = _assignment("reading")
+        canonical = _canonical(1, 2)
+        progress = [
+            _item(1, rec=None, ai=False, pron=None, acc=None, flu=None, comp=None),
+            _item(2, rec=None, ai=False, pron=None, acc=None, flu=None, comp=None),
+        ]
+        db = _mock_db_speaking(canonical, progress)
+        assert _compute_interim_score(sa, assignment, db) is None
+
+    def test_is_interim_score_false_for_graded_speaking(self):
+        """GRADED speaking 即便現算，也不是 interim（不帶 ~ 前綴）。"""
+        sa = _sa("GRADED", score=None)
+        assignment = _assignment("reading")
+        assert _is_interim_score(sa, assignment) is False


### PR DESCRIPTION
## 問題
例句朗讀（`reading`）作業 AI 批次批改完成後，Progress & Grade 便利貼上學生成績全顯示 **0**。

## 根因（已用 PROD 資料證實，assignment 433）
- 學生 item 層級 AI 分數齊全（`ai_assessed_at` + pronunciation/accuracy/fluency/completeness 都有值），作業 `status=GRADED`，但 `student_assignment.score` 從沒被 roll-up，停留在 **NULL**。
- 顯示端 `_compute_interim_score` 對 speaking 模式（`reading`/`word_reading`）**沒有 fallback**，`sa.score=None` 直接回 None → 前端 `score ?? 0` → 顯示 0.0。
- 與 #807（mastery 模式 GRADED 但 score=None）同類，#807 只補了 mastery，沒補 speaking。

## 修法（比照 #807 顯示端 fallback）
- `utils.py`：新增唯讀 `compute_speaking_total_score()`（公式與 `batch_grade_assignment` 一致：每題取 >0 的 4 項平均、缺題 0、全題平均）+ `_read_component_score()` helper（不回填、GET 端安全）。
- `detail.py`：`_compute_interim_score` 對 `reading`/`word_reading` 加 fallback — `sa.score` 為 None 時用 item 分數即時重算。便利貼與作業詳情頁兩處共用。
- 不動資料、不改寫入端（沿用 #807「顯示 fallback、不回填」的決定）。

## 驗證
- 單元測試 38 passed（14 新 + 24 個 #807 regression）；black/flake8 clean。
- PROD assignment 433 實跑：原顯示 0 的學生算出 71.3 / 90.9 / 86.9 / 92.7 等正確分數。

## 已知範圍外
1. 少數學生「有錄音但 AI 從沒評過分」仍會顯示 0（fallback 回 None）— 屬「AI 評分沒跑」的另一個資料問題。
2. 寫入端為何 GRADED 了 `sa.score` 還是 NULL — 建議另開 issue 追根因。

## Test plan
- [ ] CI: backend unit tests 綠
- [ ] 便利貼開啟例句朗讀作業，確認原本顯示 0 的學生顯示出正確分數
- [ ] Regression：mastery 模式（#807）與已有分數的 fast-path 不受影響

Related to #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)