### PR TITLE
fix(#787): 班級詳情頁 Students tab 補上刪除學生按鈕

### DIFF
--- a/backend/routers/teachers/classroom_ops.py
+++ b/backend/routers/teachers/classroom_ops.py
@@ -154,7 +154,13 @@ async def get_teacher_classrooms(
                 "name": classroom.name,
                 "description": classroom.description,
                 "level": classroom.level.value if classroom.level else "A1",
-                "student_count": len([s for s in classroom.students if s.is_active]),
+                "student_count": len(
+                    [
+                        cs
+                        for cs in classroom.students
+                        if cs.is_active and cs.student.is_active
+                    ]
+                ),
                 "program_count": program_count_map.get(
                     classroom.id, 0
                 ),  # Efficient lookup
@@ -197,7 +203,7 @@ async def get_teacher_classrooms(
                         ),
                     }
                     for cs in classroom.students
-                    if cs.is_active
+                    if cs.is_active and cs.student.is_active
                 ],
             }
         )
@@ -306,7 +312,7 @@ async def get_classroom_students(
             ),
         }
         for cs in classroom.students
-        if cs.is_active
+        if cs.is_active and cs.student.is_active
     ]
 
 

--- a/frontend/src/components/StudentTable.tsx
+++ b/frontend/src/components/StudentTable.tsx
@@ -421,7 +421,7 @@ export default function StudentTable({
                           </span>
                         ) : (
                           <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
-                            {t("studentTable.unassigned")}
+                            {t("studentTable.classroom.unassigned")}
                           </span>
                         )}
                       </div>
@@ -536,7 +536,7 @@ export default function StudentTable({
                       <Button
                         variant="ghost"
                         size="sm"
-                        title={t("studentTable.view")}
+                        title={t("studentTable.actions.view")}
                         onClick={() => onViewStudent(student)}
                       >
                         <Eye className="h-4 w-4" />
@@ -549,7 +549,7 @@ export default function StudentTable({
                         title={
                           disableActions
                             ? disableReason
-                            : t("studentTable.edit")
+                            : t("studentTable.actions.edit")
                         }
                         onClick={() => onEditStudent(student)}
                         disabled={disableActions}
@@ -564,12 +564,12 @@ export default function StudentTable({
                         title={
                           disableActions
                             ? disableReason
-                            : t("studentTable.delete")
+                            : t("studentTable.actions.delete")
                         }
                         onClick={() => {
                           if (
                             confirm(
-                              t("studentTable.confirmDelete", {
+                              t("studentTable.actions.deleteConfirm", {
                                 name: student.name,
                               }),
                             )

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -1135,10 +1135,7 @@ export default function ClassroomDetail({
       toast.success(
         t("teacherStudents.messages.studentDeleted", { name: student.name }),
       );
-      await Promise.all([
-        fetchStudents(),
-        fetchClassroomDetail(false),
-      ]);
+      await Promise.all([fetchStudents(), fetchClassroomDetail(false)]);
     } catch (error) {
       console.error("Failed to delete student:", error);
       toast.error(t("teacherStudents.messages.deleteStudentFailed"));

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -1129,6 +1129,22 @@ export default function ClassroomDetail({
     ]);
   };
 
+  const handleDeleteStudentRow = async (student: Student) => {
+    try {
+      await apiClient.deleteStudent(student.id);
+      toast.success(
+        t("teacherStudents.messages.studentDeleted", { name: student.name }),
+      );
+      await Promise.all([
+        fetchStudents(),
+        fetchClassroomDetail(false),
+      ]);
+    } catch (error) {
+      console.error("Failed to delete student:", error);
+      toast.error(t("teacherStudents.messages.deleteStudentFailed"));
+    }
+  };
+
   const handleCloseDialog = () => {
     setSelectedStudent(null);
     setDialogType(null);
@@ -1756,6 +1772,7 @@ export default function ClassroomDetail({
                     onViewStudent={handleViewStudent}
                     onEditStudent={handleEditStudent}
                     onResetPassword={handleResetPassword}
+                    onDeleteStudent={handleDeleteStudentRow}
                     emptyMessage={t("classroomDetail.messages.noStudents")}
                     disableActions={isOrgMode}
                     disableReason={t(


### PR DESCRIPTION
## Summary
三個並行的修正，全部源自 issue #787 衍生問題：

1. **班級詳情頁加上刪除學生按鈕** — `/teacher/classroom/:id` Students tab 之前 `<StudentTable>` 未傳 `onDeleteStudent`，垃圾桶按鈕不會渲染。新增 `handleDeleteStudentRow(student)`（呼叫 `apiClient.deleteStudent` → toast → 同步刷新學生列表與班級統計），對齊 `/teacher/students` 全列表頁行為。
2. **修正 confirm popup 顯示 i18n key 字面值** — `StudentTable` 桌機表格使用了不存在的 i18n key（`studentTable.view` / `edit` / `delete` / `confirmDelete` / `unassigned`），導致 popup 與 tooltip 顯示原始 key 字串。對齊 mobile 卡片視圖改用 `studentTable.actions.*` 與 `studentTable.classroom.unassigned`。
3. **修正軟刪除學生後班級列表仍顯示** — `classroom.students` 是 `ClassroomStudent` enrollment join table，刪除學生只設 `student.is_active=False`，enrollment 仍 active。在 `get_teacher_classrooms` / `get_classroom_students` read 端同時過濾 `cs.is_active and cs.student.is_active`，一併解決歷史資料中已軟刪但仍顯示的學生，不需 data migration。

## Why two delete handlers in ClassroomDetail
| Caller | Signature | Responsibility |
|---|---|---|
| `<StudentDialogs onDelete>`（保留原本的 `handleDeleteStudent`） | `() => Promise<void>` | dialog 內部 delete 完後的 refresh callback |
| `<StudentTable onDeleteStudent>`（新增 `handleDeleteStudentRow`） | `(student) => void` | 由表格列直接呼叫 API + toast + refresh |

## Files Changed
- `frontend/src/pages/teacher/ClassroomDetail.tsx` — 新增 `handleDeleteStudentRow` + 在 `<StudentTable>` 加 `onDeleteStudent` prop
- `frontend/src/components/StudentTable.tsx` — 桌機表格 5 處 i18n key 路徑修正
- `backend/routers/teachers/classroom_ops.py` — 3 處過濾條件加上 `cs.student.is_active`

## Test Plan
- [ ] 打開 `/teacher/classroom/:id` → Students tab，每列出現垃圾桶 icon。
- [ ] 點垃圾桶 → confirm 對話框顯示「確定要刪除學生「XXX」嗎？」（不是 raw i18n key）。
- [ ] 確認後學生被軟刪除 → 列即時消失、班級學生數同步減少。
- [ ] 重新整理頁面 → 已刪學生不再出現。
- [ ] Cancel confirm → 列維持不變、無 API 呼叫。
- [ ] 組織管理（org mode）班級 → 垃圾桶按鈕 disabled，tooltip 顯示「manageStudentsFromSchool」。
- [ ] `tsc --noEmit` ✅、`eslint` ✅、`black --check` ✅。

Related to #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)