### PR TITLE
chore(#768): org/school/plan schema + student_status_history (Phase 1)

### DIFF
--- a/backend/alembic/versions/20260527_1000_org_plan_optimization.py
+++ b/backend/alembic/versions/20260527_1000_org_plan_optimization.py
@@ -106,9 +106,7 @@ def upgrade() -> None:
         END $$;
         """
     )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_schools_plan_id ON schools (plan_id)"
-    )
+    op.execute("CREATE INDEX IF NOT EXISTS ix_schools_plan_id ON schools (plan_id)")
 
     # ------------------------------------------------------------------
     # 3. plans: teacher_seats + annual_fee (PER-TEACHER) + topup_discount

--- a/backend/alembic/versions/20260527_1000_org_plan_optimization.py
+++ b/backend/alembic/versions/20260527_1000_org_plan_optimization.py
@@ -101,11 +101,17 @@ def upgrade() -> None:
         END $$;
         """
     )
+    # pg_constraint is global — scope by table OID so a same-named constraint
+    # on another table can't silently skip this FK. See incident in
+    # 20260422_1200_fix_students_identity_fk.py.
     op.execute(
         """
         DO $$ BEGIN
             IF NOT EXISTS (
-                SELECT 1 FROM pg_constraint WHERE conname = 'fk_schools_plan_id'
+                SELECT 1 FROM pg_constraint c
+                JOIN pg_class cls ON c.conrelid = cls.oid
+                WHERE c.conname = 'fk_schools_plan_id'
+                  AND cls.relname = 'schools'
             ) THEN
                 ALTER TABLE schools
                 ADD CONSTRAINT fk_schools_plan_id
@@ -207,12 +213,16 @@ def upgrade() -> None:
         )
         """
     )
+    # All three FK guards scope by table OID (see note above on
+    # fk_schools_plan_id).
     op.execute(
         """
         DO $$ BEGIN
             IF NOT EXISTS (
-                SELECT 1 FROM pg_constraint
-                WHERE conname = 'fk_student_status_history_student'
+                SELECT 1 FROM pg_constraint c
+                JOIN pg_class cls ON c.conrelid = cls.oid
+                WHERE c.conname = 'fk_student_status_history_student'
+                  AND cls.relname = 'student_status_history'
             ) THEN
                 ALTER TABLE student_status_history
                 ADD CONSTRAINT fk_student_status_history_student
@@ -226,8 +236,10 @@ def upgrade() -> None:
         """
         DO $$ BEGIN
             IF NOT EXISTS (
-                SELECT 1 FROM pg_constraint
-                WHERE conname = 'fk_student_status_history_school'
+                SELECT 1 FROM pg_constraint c
+                JOIN pg_class cls ON c.conrelid = cls.oid
+                WHERE c.conname = 'fk_student_status_history_school'
+                  AND cls.relname = 'student_status_history'
             ) THEN
                 ALTER TABLE student_status_history
                 ADD CONSTRAINT fk_student_status_history_school
@@ -241,8 +253,10 @@ def upgrade() -> None:
         """
         DO $$ BEGIN
             IF NOT EXISTS (
-                SELECT 1 FROM pg_constraint
-                WHERE conname = 'fk_student_status_history_changed_by'
+                SELECT 1 FROM pg_constraint c
+                JOIN pg_class cls ON c.conrelid = cls.oid
+                WHERE c.conname = 'fk_student_status_history_changed_by'
+                  AND cls.relname = 'student_status_history'
             ) THEN
                 ALTER TABLE student_status_history
                 ADD CONSTRAINT fk_student_status_history_changed_by

--- a/backend/alembic/versions/20260527_1000_org_plan_optimization.py
+++ b/backend/alembic/versions/20260527_1000_org_plan_optimization.py
@@ -1,0 +1,255 @@
+"""Org plan optimization: group-buy + institution per-student billing (issue #768)
+
+Revision ID: 20260527_1000
+Revises: 20260525_1000
+Create Date: 2026-05-27 10:00:00
+
+Phase 1 (DB only) of issue #768. Adds:
+  - organizations.org_type, organizations.per_student_price
+  - schools.plan_id (FK->plans), schools.teacher_seat_limit  (group-buy only)
+  - plans.teacher_seats, plans.annual_fee (PER-TEACHER), plans.topup_discount
+    + seeds 3 group-buy plans
+  - new table student_status_history (per-head monthly billing trail)
+
+Backend logic (topup discount recompute, group-buy open API, monthly billing
+query) and the institution per-student-price frontend page are out of scope
+here and land in follow-up PRs.
+
+Migration is idempotent: safe to re-run.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "20260527_1000"
+down_revision: Union[str, None] = "20260525_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. organizations: org_type + per_student_price
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'organizations' AND column_name = 'org_type'
+            ) THEN
+                ALTER TABLE organizations
+                ADD COLUMN org_type VARCHAR(20) NOT NULL DEFAULT 'institution';
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'organizations'
+                  AND column_name = 'per_student_price'
+            ) THEN
+                ALTER TABLE organizations ADD COLUMN per_student_price INTEGER;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        "COMMENT ON COLUMN organizations.per_student_price IS "
+        "'Institution-only: monthly fee (NT$) charged per active student.'"
+    )
+
+    # ------------------------------------------------------------------
+    # 2. schools: plan_id (FK->plans) + teacher_seat_limit (group-buy only)
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'schools' AND column_name = 'plan_id'
+            ) THEN
+                ALTER TABLE schools ADD COLUMN plan_id INTEGER;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'schools'
+                  AND column_name = 'teacher_seat_limit'
+            ) THEN
+                ALTER TABLE schools ADD COLUMN teacher_seat_limit INTEGER;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint WHERE conname = 'fk_schools_plan_id'
+            ) THEN
+                ALTER TABLE schools
+                ADD CONSTRAINT fk_schools_plan_id
+                FOREIGN KEY (plan_id)
+                REFERENCES plans(id) ON DELETE SET NULL;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_schools_plan_id ON schools (plan_id)"
+    )
+
+    # ------------------------------------------------------------------
+    # 3. plans: teacher_seats + annual_fee (PER-TEACHER) + topup_discount
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'plans' AND column_name = 'teacher_seats'
+            ) THEN
+                ALTER TABLE plans ADD COLUMN teacher_seats INTEGER;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'plans' AND column_name = 'annual_fee'
+            ) THEN
+                ALTER TABLE plans ADD COLUMN annual_fee INTEGER;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        "COMMENT ON COLUMN plans.annual_fee IS "
+        "'Group-buy plans: annual fee PER TEACHER (NT$), not the team total. "
+        "Team total = annual_fee * teacher_seats, computed at checkout.'"
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'plans' AND column_name = 'topup_discount'
+            ) THEN
+                ALTER TABLE plans ADD COLUMN topup_discount NUMERIC(3,2);
+            END IF;
+        END $$;
+        """
+    )
+
+    # Seed group-buy plans. ON CONFLICT keeps existing rows untouched.
+    op.execute(
+        """
+        INSERT INTO plans
+            (name, price, quota, teacher_seats, annual_fee, topup_discount,
+             display_order, is_active)
+        VALUES
+            ('團購-10席', NULL, 1000, 10, 1500, 0.95, 10, TRUE),
+            ('團購-30席', NULL, 1000, 30, 1300, 0.90, 11, TRUE),
+            ('團購-50席', NULL, 1000, 50, 1000, 0.85, 12, TRUE)
+        ON CONFLICT (name) DO NOTHING
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # 4. student_status_history: per-head monthly billing trail
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS student_status_history (
+            id SERIAL PRIMARY KEY,
+            student_id INTEGER NOT NULL,
+            school_id UUID,
+            status VARCHAR(20) NOT NULL,
+            changed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            changed_by INTEGER,
+            note TEXT
+        )
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'fk_student_status_history_student'
+            ) THEN
+                ALTER TABLE student_status_history
+                ADD CONSTRAINT fk_student_status_history_student
+                FOREIGN KEY (student_id)
+                REFERENCES students(id) ON DELETE CASCADE;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'fk_student_status_history_school'
+            ) THEN
+                ALTER TABLE student_status_history
+                ADD CONSTRAINT fk_student_status_history_school
+                FOREIGN KEY (school_id)
+                REFERENCES schools(id) ON DELETE CASCADE;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'fk_student_status_history_changed_by'
+            ) THEN
+                ALTER TABLE student_status_history
+                ADD CONSTRAINT fk_student_status_history_changed_by
+                FOREIGN KEY (changed_by)
+                REFERENCES teachers(id) ON DELETE SET NULL;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_student_status_history_student "
+        "ON student_status_history (student_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_student_status_history_school "
+        "ON student_status_history (school_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_student_status_history_changed_at "
+        "ON student_status_history (changed_at)"
+    )
+    # Composite index for monthly billing-period headcount queries.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_student_status_history_student_changed "
+        "ON student_status_history (student_id, changed_at)"
+    )
+
+
+def downgrade() -> None:
+    # Intentional no-op: dropping columns/tables would lose data and break
+    # services reading these fields across shared environments.
+    pass

--- a/backend/alembic/versions/20260527_1000_org_plan_optimization.py
+++ b/backend/alembic/versions/20260527_1000_org_plan_optimization.py
@@ -15,7 +15,9 @@ Backend logic (topup discount recompute, group-buy open API, monthly billing
 query) and the institution per-student-price frontend page are out of scope
 here and land in follow-up PRs.
 
-Migration is idempotent: safe to re-run.
+Migration is idempotent: safe to re-run. All information_schema lookups are
+scoped to schema 'public' so columns in other Supabase schemas (auth, storage,
+extensions, ...) cannot mask the existence guard.
 """
 
 from typing import Sequence, Union
@@ -38,10 +40,13 @@ def upgrade() -> None:
         DO $$ BEGIN
             IF NOT EXISTS (
                 SELECT 1 FROM information_schema.columns
-                WHERE table_name = 'organizations' AND column_name = 'org_type'
+                WHERE table_schema = 'public'
+                  AND table_name = 'organizations'
+                  AND column_name = 'org_type'
             ) THEN
                 ALTER TABLE organizations
-                ADD COLUMN org_type VARCHAR(20) NOT NULL DEFAULT 'institution';
+                ADD COLUMN org_type VARCHAR(20) NOT NULL DEFAULT 'institution'
+                CHECK (org_type IN ('institution', 'group_buy'));
             END IF;
         END $$;
         """
@@ -51,17 +56,18 @@ def upgrade() -> None:
         DO $$ BEGIN
             IF NOT EXISTS (
                 SELECT 1 FROM information_schema.columns
-                WHERE table_name = 'organizations'
+                WHERE table_schema = 'public'
+                  AND table_name = 'organizations'
                   AND column_name = 'per_student_price'
             ) THEN
-                ALTER TABLE organizations ADD COLUMN per_student_price INTEGER;
+                ALTER TABLE organizations
+                ADD COLUMN per_student_price INTEGER
+                CHECK (per_student_price > 0);
+                COMMENT ON COLUMN organizations.per_student_price IS
+                    'Institution-only: monthly fee (NT$) charged per active student.';
             END IF;
         END $$;
         """
-    )
-    op.execute(
-        "COMMENT ON COLUMN organizations.per_student_price IS "
-        "'Institution-only: monthly fee (NT$) charged per active student.'"
     )
 
     # ------------------------------------------------------------------
@@ -72,7 +78,9 @@ def upgrade() -> None:
         DO $$ BEGIN
             IF NOT EXISTS (
                 SELECT 1 FROM information_schema.columns
-                WHERE table_name = 'schools' AND column_name = 'plan_id'
+                WHERE table_schema = 'public'
+                  AND table_name = 'schools'
+                  AND column_name = 'plan_id'
             ) THEN
                 ALTER TABLE schools ADD COLUMN plan_id INTEGER;
             END IF;
@@ -84,7 +92,8 @@ def upgrade() -> None:
         DO $$ BEGIN
             IF NOT EXISTS (
                 SELECT 1 FROM information_schema.columns
-                WHERE table_name = 'schools'
+                WHERE table_schema = 'public'
+                  AND table_name = 'schools'
                   AND column_name = 'teacher_seat_limit'
             ) THEN
                 ALTER TABLE schools ADD COLUMN teacher_seat_limit INTEGER;
@@ -116,9 +125,13 @@ def upgrade() -> None:
         DO $$ BEGIN
             IF NOT EXISTS (
                 SELECT 1 FROM information_schema.columns
-                WHERE table_name = 'plans' AND column_name = 'teacher_seats'
+                WHERE table_schema = 'public'
+                  AND table_name = 'plans'
+                  AND column_name = 'teacher_seats'
             ) THEN
-                ALTER TABLE plans ADD COLUMN teacher_seats INTEGER;
+                ALTER TABLE plans
+                ADD COLUMN teacher_seats INTEGER
+                CHECK (teacher_seats > 0);
             END IF;
         END $$;
         """
@@ -128,26 +141,32 @@ def upgrade() -> None:
         DO $$ BEGIN
             IF NOT EXISTS (
                 SELECT 1 FROM information_schema.columns
-                WHERE table_name = 'plans' AND column_name = 'annual_fee'
+                WHERE table_schema = 'public'
+                  AND table_name = 'plans'
+                  AND column_name = 'annual_fee'
             ) THEN
-                ALTER TABLE plans ADD COLUMN annual_fee INTEGER;
+                ALTER TABLE plans
+                ADD COLUMN annual_fee INTEGER
+                CHECK (annual_fee > 0);
+                COMMENT ON COLUMN plans.annual_fee IS
+                    'Group-buy plans: annual fee PER TEACHER (NT$), not the team total. '
+                    'Team total = annual_fee * teacher_seats, computed at checkout.';
             END IF;
         END $$;
         """
-    )
-    op.execute(
-        "COMMENT ON COLUMN plans.annual_fee IS "
-        "'Group-buy plans: annual fee PER TEACHER (NT$), not the team total. "
-        "Team total = annual_fee * teacher_seats, computed at checkout.'"
     )
     op.execute(
         """
         DO $$ BEGIN
             IF NOT EXISTS (
                 SELECT 1 FROM information_schema.columns
-                WHERE table_name = 'plans' AND column_name = 'topup_discount'
+                WHERE table_schema = 'public'
+                  AND table_name = 'plans'
+                  AND column_name = 'topup_discount'
             ) THEN
-                ALTER TABLE plans ADD COLUMN topup_discount NUMERIC(3,2);
+                ALTER TABLE plans
+                ADD COLUMN topup_discount NUMERIC(3,2)
+                CHECK (topup_discount BETWEEN 0 AND 1);
             END IF;
         END $$;
         """
@@ -169,6 +188,10 @@ def upgrade() -> None:
 
     # ------------------------------------------------------------------
     # 4. student_status_history: per-head monthly billing trail
+    #
+    # FK on school_id uses ON DELETE SET NULL (NOT CASCADE) so a school
+    # delete cannot wipe billing-audit rows. student_id stays NOT NULL
+    # so the per-student trail survives — only the school context is lost.
     # ------------------------------------------------------------------
     op.execute(
         """
@@ -176,7 +199,8 @@ def upgrade() -> None:
             id SERIAL PRIMARY KEY,
             student_id INTEGER NOT NULL,
             school_id UUID,
-            status VARCHAR(20) NOT NULL,
+            status VARCHAR(20) NOT NULL
+                CHECK (status IN ('active', 'inactive')),
             changed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
             changed_by INTEGER,
             note TEXT
@@ -208,7 +232,7 @@ def upgrade() -> None:
                 ALTER TABLE student_status_history
                 ADD CONSTRAINT fk_student_status_history_school
                 FOREIGN KEY (school_id)
-                REFERENCES schools(id) ON DELETE CASCADE;
+                REFERENCES schools(id) ON DELETE SET NULL;
             END IF;
         END $$;
         """

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -57,6 +57,9 @@ from .organization import (
     StudentSchool,
 )
 
+# Student status history (issue #768 — per-head billing trail)
+from .student_status_history import StudentStatusHistory
+
 # Classroom models
 from .classroom import Classroom, ClassroomStudent
 
@@ -130,6 +133,8 @@ __all__ = [
     "TeacherSchool",
     "ClassroomSchool",
     "StudentSchool",
+    # Student status history
+    "StudentStatusHistory",
     # Classrooms
     "Classroom",
     "ClassroomStudent",

--- a/backend/models/organization.py
+++ b/backend/models/organization.py
@@ -52,6 +52,13 @@ class Organization(Base):
     # 狀態
     is_active = Column(Boolean, nullable=False, default=True, index=True)
 
+    # 機構類型：'institution'（機構，依學生人數計費）/ 'group_buy'（團購）
+    org_type = Column(
+        String(20), nullable=False, server_default="institution"
+    )
+    # 機構專用：單位學生月費（NT$）。團購機構為 NULL。
+    per_student_price = Column(Integer, nullable=True)
+
     # 授權限制
     teacher_limit = Column(Integer, nullable=True)  # 教師授權數上限（NULL = 無限制）
 
@@ -123,6 +130,13 @@ class School(Base):
     # 狀態
     is_active = Column(Boolean, nullable=False, default=True, index=True)
 
+    # 團購方案專用：綁定的方案（10/30/50 席）。機構底下 schools 為 NULL。
+    plan_id = Column(
+        Integer, ForeignKey("plans.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    # 團購方案專用：該團教師上限。機構底下 schools 為 NULL。
+    teacher_seat_limit = Column(Integer, nullable=True)
+
     # 設定
     settings = Column(JSONType, nullable=True)  # 學校層級設定
 
@@ -134,6 +148,7 @@ class School(Base):
 
     # Relationships
     organization = relationship("Organization", back_populates="schools")
+    plan = relationship("Plan", foreign_keys=[plan_id])
     teacher_schools = relationship(
         "TeacherSchool", back_populates="school", cascade="all, delete-orphan"
     )

--- a/backend/models/organization.py
+++ b/backend/models/organization.py
@@ -146,7 +146,7 @@ class School(Base):
 
     # Relationships
     organization = relationship("Organization", back_populates="schools")
-    plan = relationship("Plan", foreign_keys=[plan_id])
+    plan = relationship("Plan", foreign_keys=[plan_id], back_populates="schools")
     teacher_schools = relationship(
         "TeacherSchool", back_populates="school", cascade="all, delete-orphan"
     )

--- a/backend/models/organization.py
+++ b/backend/models/organization.py
@@ -53,9 +53,7 @@ class Organization(Base):
     is_active = Column(Boolean, nullable=False, default=True, index=True)
 
     # 機構類型：'institution'（機構，依學生人數計費）/ 'group_buy'（團購）
-    org_type = Column(
-        String(20), nullable=False, server_default="institution"
-    )
+    org_type = Column(String(20), nullable=False, server_default="institution")
     # 機構專用：單位學生月費（NT$）。團購機構為 NULL。
     per_student_price = Column(Integer, nullable=True)
 

--- a/backend/models/plan.py
+++ b/backend/models/plan.py
@@ -60,6 +60,10 @@ class Plan(Base):
     )
 
     updated_by = relationship("Teacher", foreign_keys=[updated_by_admin_id])
+    # Group-buy: schools bound to this plan (empty for individual plans).
+    schools = relationship(
+        "School", foreign_keys="School.plan_id", back_populates="plan"
+    )
 
     def __repr__(self):
         return (

--- a/backend/models/plan.py
+++ b/backend/models/plan.py
@@ -10,7 +10,7 @@ Use `config.plans.get_plan_price(name)` and `get_plan_quota(name)` to read —
 those helpers prefer the DB row and fall back to the config constants.
 """
 
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey, Numeric
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from database import Base
@@ -31,6 +31,15 @@ class Plan(Base):
 
     # Monthly quota of points granted on subscription start.
     quota = Column(Integer, nullable=True)
+
+    # --- Group-buy plan fields (NULL for individual plans) ---
+    # Number of teacher seats in the group (10 / 30 / 50).
+    teacher_seats = Column(Integer, nullable=True)
+    # Annual fee PER TEACHER (NT$), not the team total.
+    # Team total = annual_fee * teacher_seats, computed at checkout.
+    annual_fee = Column(Integer, nullable=True)
+    # Top-up discount applied when buying point packages (e.g. 0.95 / 0.90 / 0.85).
+    topup_discount = Column(Numeric(3, 2), nullable=True)
 
     # Display order in admin UI / checkout list.
     display_order = Column(Integer, nullable=False, default=0)

--- a/backend/models/student_status_history.py
+++ b/backend/models/student_status_history.py
@@ -1,0 +1,56 @@
+"""Student status-change history (issue #768).
+
+Records every active/inactive transition for a student so institution
+per-student monthly billing can compute headcount over a billing period
+(active days per student x organizations.per_student_price).
+
+Append-only audit trail — never mutated in place.
+"""
+
+from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, Index
+from sqlalchemy.sql import func
+from database import Base
+from .base import UUID
+
+
+class StudentStatusHistory(Base):
+    __tablename__ = "student_status_history"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    student_id = Column(
+        Integer,
+        ForeignKey("students.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    school_id = Column(
+        UUID,
+        ForeignKey("schools.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+
+    # 'active' / 'inactive'
+    status = Column(String(20), nullable=False)
+
+    changed_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+    changed_by = Column(
+        Integer, ForeignKey("teachers.id", ondelete="SET NULL"), nullable=True
+    )
+    note = Column(Text, nullable=True)
+
+    __table_args__ = (
+        Index(
+            "ix_student_status_history_student_changed",
+            "student_id",
+            "changed_at",
+        ),
+    )
+
+    def __repr__(self):
+        return (
+            f"<StudentStatusHistory(student={self.student_id}, "
+            f"status={self.status}, at={self.changed_at})>"
+        )

--- a/backend/models/student_status_history.py
+++ b/backend/models/student_status_history.py
@@ -23,9 +23,10 @@ class StudentStatusHistory(Base):
         nullable=False,
         index=True,
     )
+    # SET NULL (not CASCADE): a school delete must not wipe billing-audit rows.
     school_id = Column(
         UUID,
-        ForeignKey("schools.id", ondelete="CASCADE"),
+        ForeignKey("schools.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
     )


### PR DESCRIPTION
## Summary
Phase 1 of 5 for issue #768「機構方案優化」— DB schema only, no behavior changes. Lays the foundation for both new product models:
- **團購 (group-buy)** teacher plans — adds plan binding + per-teacher annual fee + topup discount
- **機構 (institution)** per-student billing — adds per-student price + append-only headcount history

Backend logic and the admin frontend page land in follow-up PRs (see roadmap below).

## Changes
- `organizations` +2 cols: `org_type` (`'institution'` default / `'group_buy'`), `per_student_price` (institution-only NT$/student/month)
- `schools` +2 cols (group-buy only, NULL for institution schools): `plan_id` FK→`plans` `ON DELETE SET NULL`, `teacher_seat_limit`
- `plans` +3 cols + 3 seed rows:
  - `teacher_seats` (10 / 30 / 50)
  - `annual_fee` — **per-teacher** (resolves the issue's "考慮要算總團購總金額或團購中個別老師收費基準" — documented in a `COMMENT ON COLUMN`)
  - `topup_discount` `NUMERIC(3,2)` (0.95 / 0.90 / 0.85)
  - Seeds: 團購-10席 / 團購-30席 / 團購-50席 via `ON CONFLICT (name) DO NOTHING`
- **New table** `student_status_history` (resolves the issue's "方案待定" on students soft-delete history): append-only audit trail with composite index `(student_id, changed_at)` for monthly billing-period queries
- SQLAlchemy models updated to match; `StudentStatusHistory` registered in `models/__init__.py`

## Migration safety
Migration `20260527_1000_org_plan_optimization.py` is fully idempotent per project rule:
- `ALTER TABLE ... ADD COLUMN` wrapped in `DO $$ ... information_schema` checks
- `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`
- Constraints (3 FKs on the new table + 1 FK on `schools.plan_id`) wrapped in `pg_constraint` checks
- Seeds use `ON CONFLICT (name) DO NOTHING`
- No DROP / RENAME / ALTER TYPE; new columns are nullable or have DEFAULT
- `down_revision = "20260525_1000"`, single head

## Test plan
- [x] Models import + `Base.metadata.create_all` clean on SQLite (all 4 new cols + new table present)
- [x] `alembic heads` → single `20260527_1000`, chains from `20260525_1000`
- [x] `tests/test_admin_plans.py` + `tests/test_admin_organizations.py` — **37/37 passing**
- [ ] CI runs migration twice on per-issue Postgres env (idempotency exercised end-to-end there)

## Out of scope (follow-up PRs)
Phases 2–5 from the planning comment on the issue:
- Phase 2: 團購加購折扣後端重算（不信任前端價格）
- Phase 3: 團購開團 API + 月配發 1000 點
- Phase 4: 機構月度計費查詢（依 `student_status_history` × `per_student_price`）
- Phase 5: 機構單位學生費前端設定頁

Related to #768 (will not auto-close; #768 closes when Phase 5 ships)

🤖 Generated with [Claude Code](https://claude.com/claude-code)