### PR TITLE
Release: staging → main (2026-05-29)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -301,6 +301,10 @@ jobs:
               'oauth_identities',
               'blog_posts', 'blog_categories', 'blog_post_categories',
               'assignment_analysis_reports',
+              -- Promo code 推薦獎勵系統
+              'promo_codes', 'promo_referrals', 'promo_reward_configs', 'promo_reward_events',
+              -- 組織方案：學生狀態歷史
+              'student_status_history',
               -- n8n 系統表（外部服務，不適用 RLS）
               'annotation_tag_entity', 'auth_identity', 'auth_provider_sync_history', 'binary_data',
               'chat_hub_agents', 'chat_hub_messages', 'chat_hub_sessions', 'credentials_entity',

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,10 +123,14 @@ op.execute("""
 """)
 
 # 新增欄位 - 使用 IF NOT EXISTS + nullable 或 DEFAULT
+# 重要：information_schema 必須加 table_schema = 'public'，
+# 否則 Supabase 其他 schema（auth, storage, ...）同名欄位會讓守衛誤判
 op.execute("""
     DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                      WHERE table_name = 'users' AND column_name = 'new_field') THEN
+                      WHERE table_schema = 'public'
+                        AND table_name = 'users'
+                        AND column_name = 'new_field') THEN
             ALTER TABLE users ADD COLUMN new_field VARCHAR(50) DEFAULT 'default_value';
         END IF;
     END $$;
@@ -136,10 +140,42 @@ op.execute("""
 op.execute("CREATE INDEX IF NOT EXISTS idx_name ON table_name (column)")
 
 # 新增 Constraint - 檢查後再建立
+# 重要：pg_constraint 是全域 catalog，constraint 名稱只在「同一個 table 內」唯一。
+# 必須 JOIN pg_class 用 conrelid + relname 鎖定 table，否則其他 table 的同名
+# constraint 會讓守衛誤判（已發生 prod 事故：20260422_1200_fix_students_identity_fk.py）
 op.execute("""
     DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'uq_table_column') THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint c
+            JOIN pg_class cls ON c.conrelid = cls.oid
+            WHERE c.conname = 'uq_table_column'
+              AND cls.relname = 'table_name'
+        ) THEN
             ALTER TABLE table_name ADD CONSTRAINT uq_table_column UNIQUE (column);
+        END IF;
+    END $$;
+""")
+
+# 對既有欄位加 CHECK 約束 — 拆兩段守衛
+# 1) 欄位存在守衛 (information_schema, scoped to public)
+# 2) 約束存在守衛 (pg_constraint, scoped by table OID + 命名 constraint)
+# 這樣即使欄位曾被手動加入但漏了 CHECK，再跑 migration 也能補上
+op.execute("""
+    DO $$ BEGIN
+        IF EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'schools'
+              AND column_name = 'teacher_seat_limit'
+        ) AND NOT EXISTS (
+            SELECT 1 FROM pg_constraint c
+            JOIN pg_class cls ON c.conrelid = cls.oid
+            WHERE c.conname = 'ck_schools_teacher_seat_limit_positive'
+              AND cls.relname = 'schools'
+        ) THEN
+            ALTER TABLE schools
+            ADD CONSTRAINT ck_schools_teacher_seat_limit_positive
+            CHECK (teacher_seat_limit > 0);
         END IF;
     END $$;
 """)

--- a/backend/alembic/versions/20260525_1000_add_promo_code_tables.py
+++ b/backend/alembic/versions/20260525_1000_add_promo_code_tables.py
@@ -1,0 +1,172 @@
+"""Add promo code / referral tables (issue #637)
+
+Revision ID: 20260525_1000
+Revises: 20260522_1000
+Create Date: 2026-05-25 10:00:00
+
+Creates the four data-layer tables for the Promo Code referral system:
+
+- promo_codes          每位老師的推銷碼（個人預設碼 + admin 特約碼）
+- promo_referrals      被推薦人 ↔ 推薦人綁定（一個被推薦人僅一筆）
+- promo_reward_configs admin 可調整的各事件獎勵點數（seed 7 筆預設）
+- promo_reward_events  已發放紀錄，idempotency_key 防重複發放
+
+All statements are idempotent (CREATE ... IF NOT EXISTS / ON CONFLICT)
+so the migration is safe to re-run across develop / staging / production.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "20260525_1000"
+down_revision: Union[str, None] = "20260522_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ---- promo_codes -------------------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS promo_codes (
+            id SERIAL PRIMARY KEY,
+            code VARCHAR(16) NOT NULL,
+            teacher_id INTEGER NOT NULL
+                REFERENCES teachers(id) ON DELETE CASCADE,
+            kind VARCHAR(16) NOT NULL DEFAULT 'personal',
+            expires_at TIMESTAMPTZ,
+            is_active BOOLEAN NOT NULL DEFAULT TRUE,
+            note TEXT,
+            created_at TIMESTAMPTZ DEFAULT now(),
+            updated_at TIMESTAMPTZ,
+            admin_id INTEGER REFERENCES teachers(id) ON DELETE SET NULL,
+            admin_reason TEXT,
+            admin_metadata JSONB
+        )
+        """
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_promo_codes_code " "ON promo_codes (code)"
+    )
+    # One personal code per teacher; affiliate codes are unconstrained.
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_promo_codes_teacher_personal "
+        "ON promo_codes (teacher_id) WHERE kind = 'personal'"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_promo_codes_teacher_id "
+        "ON promo_codes (teacher_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_promo_codes_active_expires "
+        "ON promo_codes (is_active, expires_at)"
+    )
+
+    # ---- promo_referrals ---------------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS promo_referrals (
+            id SERIAL PRIMARY KEY,
+            referrer_teacher_id INTEGER NOT NULL
+                REFERENCES teachers(id) ON DELETE CASCADE,
+            referred_teacher_id INTEGER NOT NULL
+                REFERENCES teachers(id) ON DELETE CASCADE,
+            promo_code VARCHAR(16) NOT NULL,
+            promo_code_id INTEGER
+                REFERENCES promo_codes(id) ON DELETE SET NULL,
+            signup_at TIMESTAMPTZ DEFAULT now(),
+            verified_at TIMESTAMPTZ,
+            first_paid_event_consumed BOOLEAN NOT NULL DEFAULT FALSE,
+            referred_bonus_granted BOOLEAN NOT NULL DEFAULT FALSE,
+            created_at TIMESTAMPTZ DEFAULT now(),
+            updated_at TIMESTAMPTZ,
+            CONSTRAINT uq_promo_referrals_referred_teacher
+                UNIQUE (referred_teacher_id),
+            CONSTRAINT ck_promo_referrals_no_self_referral
+                CHECK (referrer_teacher_id != referred_teacher_id)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_promo_referrals_referrer "
+        "ON promo_referrals (referrer_teacher_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_promo_referrals_promo_code "
+        "ON promo_referrals (promo_code)"
+    )
+
+    # ---- promo_reward_configs ----------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS promo_reward_configs (
+            id SERIAL PRIMARY KEY,
+            reward_key VARCHAR(64) NOT NULL,
+            points INTEGER NOT NULL,
+            recipient VARCHAR(16) NOT NULL DEFAULT 'referrer',
+            is_active BOOLEAN NOT NULL DEFAULT TRUE,
+            updated_at TIMESTAMPTZ DEFAULT now(),
+            updated_by_admin_id INTEGER
+                REFERENCES teachers(id) ON DELETE SET NULL
+        )
+        """
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_promo_reward_configs_reward_key "
+        "ON promo_reward_configs (reward_key)"
+    )
+    # Seed default reward values. ON CONFLICT keeps existing admin edits.
+    op.execute(
+        """
+        INSERT INTO promo_reward_configs (reward_key, points, recipient) VALUES
+            ('signup_verified', 10, 'referrer'),
+            ('subscribe_tutor', 1000, 'referrer'),
+            ('subscribe_school', 2000, 'referrer'),
+            ('package_pkg-5000', 200, 'referrer'),
+            ('package_pkg-10000', 500, 'referrer'),
+            ('package_pkg-20000', 800, 'referrer'),
+            ('referred_signup_bonus', 300, 'referred')
+        ON CONFLICT (reward_key) DO NOTHING
+        """
+    )
+
+    # ---- promo_reward_events -----------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS promo_reward_events (
+            id SERIAL PRIMARY KEY,
+            referral_id INTEGER NOT NULL
+                REFERENCES promo_referrals(id) ON DELETE CASCADE,
+            reward_key VARCHAR(64) NOT NULL,
+            trigger_type VARCHAR(32) NOT NULL,
+            points INTEGER NOT NULL,
+            granted_to_teacher_id INTEGER NOT NULL
+                REFERENCES teachers(id) ON DELETE CASCADE,
+            credit_package_id INTEGER
+                REFERENCES credit_packages(id) ON DELETE SET NULL,
+            idempotency_key VARCHAR(128) NOT NULL,
+            event_payload JSONB,
+            created_at TIMESTAMPTZ DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_promo_reward_events_idempotency_key "
+        "ON promo_reward_events (idempotency_key)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_promo_reward_events_granted_to "
+        "ON promo_reward_events (granted_to_teacher_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_promo_reward_events_referral "
+        "ON promo_reward_events (referral_id)"
+    )
+
+
+def downgrade() -> None:
+    # Intentional no-op: dropping these tables would lose referral history
+    # and granted-reward audit trail. Leaving them in place is harmless.
+    pass

--- a/backend/alembic/versions/20260527_1000_org_plan_optimization.py
+++ b/backend/alembic/versions/20260527_1000_org_plan_optimization.py
@@ -1,0 +1,291 @@
+"""Org plan optimization: group-buy + institution per-student billing (issue #768)
+
+Revision ID: 20260527_1000
+Revises: 20260525_1000
+Create Date: 2026-05-27 10:00:00
+
+Phase 1 (DB only) of issue #768. Adds:
+  - organizations.org_type, organizations.per_student_price
+  - schools.plan_id (FK->plans), schools.teacher_seat_limit  (group-buy only)
+  - plans.teacher_seats, plans.annual_fee (PER-TEACHER), plans.topup_discount
+    + seeds 3 group-buy plans
+  - new table student_status_history (per-head monthly billing trail)
+
+Backend logic (topup discount recompute, group-buy open API, monthly billing
+query) and the institution per-student-price frontend page are out of scope
+here and land in follow-up PRs.
+
+Migration is idempotent: safe to re-run. All information_schema lookups are
+scoped to schema 'public' so columns in other Supabase schemas (auth, storage,
+extensions, ...) cannot mask the existence guard.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "20260527_1000"
+down_revision: Union[str, None] = "20260525_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. organizations: org_type + per_student_price
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'organizations'
+                  AND column_name = 'org_type'
+            ) THEN
+                ALTER TABLE organizations
+                ADD COLUMN org_type VARCHAR(20) NOT NULL DEFAULT 'institution'
+                CHECK (org_type IN ('institution', 'group_buy'));
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'organizations'
+                  AND column_name = 'per_student_price'
+            ) THEN
+                ALTER TABLE organizations
+                ADD COLUMN per_student_price INTEGER
+                CHECK (per_student_price > 0);
+                COMMENT ON COLUMN organizations.per_student_price IS
+                    'Institution-only: monthly fee (NT$) charged per active student.';
+            END IF;
+        END $$;
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # 2. schools: plan_id (FK->plans) + teacher_seat_limit (group-buy only)
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'schools'
+                  AND column_name = 'plan_id'
+            ) THEN
+                ALTER TABLE schools ADD COLUMN plan_id INTEGER;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'schools'
+                  AND column_name = 'teacher_seat_limit'
+            ) THEN
+                ALTER TABLE schools ADD COLUMN teacher_seat_limit INTEGER;
+            END IF;
+        END $$;
+        """
+    )
+    # pg_constraint is global — scope by table OID so a same-named constraint
+    # on another table can't silently skip this FK. See incident in
+    # 20260422_1200_fix_students_identity_fk.py.
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint c
+                JOIN pg_class cls ON c.conrelid = cls.oid
+                WHERE c.conname = 'fk_schools_plan_id'
+                  AND cls.relname = 'schools'
+            ) THEN
+                ALTER TABLE schools
+                ADD CONSTRAINT fk_schools_plan_id
+                FOREIGN KEY (plan_id)
+                REFERENCES plans(id) ON DELETE SET NULL;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS ix_schools_plan_id ON schools (plan_id)")
+
+    # ------------------------------------------------------------------
+    # 3. plans: teacher_seats + annual_fee (PER-TEACHER) + topup_discount
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'plans'
+                  AND column_name = 'teacher_seats'
+            ) THEN
+                ALTER TABLE plans
+                ADD COLUMN teacher_seats INTEGER
+                CHECK (teacher_seats > 0);
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'plans'
+                  AND column_name = 'annual_fee'
+            ) THEN
+                ALTER TABLE plans
+                ADD COLUMN annual_fee INTEGER
+                CHECK (annual_fee > 0);
+                COMMENT ON COLUMN plans.annual_fee IS
+                    'Group-buy plans: annual fee PER TEACHER (NT$), not the team total. '
+                    'Team total = annual_fee * teacher_seats, computed at checkout.';
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'plans'
+                  AND column_name = 'topup_discount'
+            ) THEN
+                ALTER TABLE plans
+                ADD COLUMN topup_discount NUMERIC(3,2)
+                CHECK (topup_discount BETWEEN 0 AND 1);
+            END IF;
+        END $$;
+        """
+    )
+
+    # Seed group-buy plans. ON CONFLICT keeps existing rows untouched.
+    op.execute(
+        """
+        INSERT INTO plans
+            (name, price, quota, teacher_seats, annual_fee, topup_discount,
+             display_order, is_active)
+        VALUES
+            ('團購-10席', NULL, 1000, 10, 1500, 0.95, 10, TRUE),
+            ('團購-30席', NULL, 1000, 30, 1300, 0.90, 11, TRUE),
+            ('團購-50席', NULL, 1000, 50, 1000, 0.85, 12, TRUE)
+        ON CONFLICT (name) DO NOTHING
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # 4. student_status_history: per-head monthly billing trail
+    #
+    # FK on school_id uses ON DELETE SET NULL (NOT CASCADE) so a school
+    # delete cannot wipe billing-audit rows. student_id stays NOT NULL
+    # so the per-student trail survives — only the school context is lost.
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS student_status_history (
+            id SERIAL PRIMARY KEY,
+            student_id INTEGER NOT NULL,
+            school_id UUID,
+            status VARCHAR(20) NOT NULL
+                CHECK (status IN ('active', 'inactive')),
+            changed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            changed_by INTEGER,
+            note TEXT
+        )
+        """
+    )
+    # All three FK guards scope by table OID (see note above on
+    # fk_schools_plan_id).
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint c
+                JOIN pg_class cls ON c.conrelid = cls.oid
+                WHERE c.conname = 'fk_student_status_history_student'
+                  AND cls.relname = 'student_status_history'
+            ) THEN
+                ALTER TABLE student_status_history
+                ADD CONSTRAINT fk_student_status_history_student
+                FOREIGN KEY (student_id)
+                REFERENCES students(id) ON DELETE CASCADE;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint c
+                JOIN pg_class cls ON c.conrelid = cls.oid
+                WHERE c.conname = 'fk_student_status_history_school'
+                  AND cls.relname = 'student_status_history'
+            ) THEN
+                ALTER TABLE student_status_history
+                ADD CONSTRAINT fk_student_status_history_school
+                FOREIGN KEY (school_id)
+                REFERENCES schools(id) ON DELETE SET NULL;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint c
+                JOIN pg_class cls ON c.conrelid = cls.oid
+                WHERE c.conname = 'fk_student_status_history_changed_by'
+                  AND cls.relname = 'student_status_history'
+            ) THEN
+                ALTER TABLE student_status_history
+                ADD CONSTRAINT fk_student_status_history_changed_by
+                FOREIGN KEY (changed_by)
+                REFERENCES teachers(id) ON DELETE SET NULL;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_student_status_history_student "
+        "ON student_status_history (student_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_student_status_history_school "
+        "ON student_status_history (school_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_student_status_history_changed_at "
+        "ON student_status_history (changed_at)"
+    )
+    # Composite index for monthly billing-period headcount queries.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_student_status_history_student_changed "
+        "ON student_status_history (student_id, changed_at)"
+    )
+
+
+def downgrade() -> None:
+    # Intentional no-op: dropping columns/tables would lose data and break
+    # services reading these fields across shared environments.
+    pass

--- a/backend/alembic/versions/20260528_1000_phase2_constraint_followups.py
+++ b/backend/alembic/versions/20260528_1000_phase2_constraint_followups.py
@@ -1,0 +1,149 @@
+"""Phase 2 constraint follow-ups for issue #768.
+
+Revision ID: 20260528_1000
+Revises: 20260527_1000
+Create Date: 2026-05-28 10:00:00
+
+Adds:
+  1. CHECK on schools.teacher_seat_limit (missing in Phase 1 — sibling
+     plans.teacher_seats had it inline, this one didn't).
+  2. NAMED CHECK constraints for 6 fields that had inline (auto-named)
+     CHECKs in Phase 1. The auto-named ones (e.g. organizations_org_type_check)
+     stay in place; these add named ck_<table>_<col>_<rule> versions that
+     match the ORM CheckConstraint names in the model layer. Redundant in
+     terms of validation rules but ensures the model's claim is also
+     reality in Postgres (otherwise the named constraint only existed in
+     SQLite tests via Base.metadata.create_all).
+
+Uses the split-guard pattern recommended by Round 2 of the Phase 1 review
+(PR #819): column-existence guard (information_schema, scoped to 'public')
+is separate from constraint-existence guard (pg_constraint, scoped by
+table OID + named constraint), so a column added without its CHECK
+elsewhere still gets the CHECK installed on next migration run.
+
+Migration is idempotent: safe to re-run.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "20260528_1000"
+down_revision: Union[str, None] = "20260527_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # schools.teacher_seat_limit: enforce > 0
+    # ------------------------------------------------------------------
+    # Split-guard pattern (issue #768 PR #819 review F4):
+    #   1) Column-existence guard uses information_schema scoped to 'public'.
+    #   2) Constraint-existence guard uses pg_constraint scoped by table OID
+    #      AND a named constraint, so it cannot be masked by a same-named
+    #      constraint on a different table.
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'schools'
+                  AND column_name = 'teacher_seat_limit'
+            ) AND NOT EXISTS (
+                SELECT 1 FROM pg_constraint c
+                JOIN pg_class cls ON c.conrelid = cls.oid
+                WHERE c.conname = 'ck_schools_teacher_seat_limit_positive'
+                  AND cls.relname = 'schools'
+            ) THEN
+                ALTER TABLE schools
+                ADD CONSTRAINT ck_schools_teacher_seat_limit_positive
+                CHECK (teacher_seat_limit IS NULL OR teacher_seat_limit > 0);
+            END IF;
+        END $$;
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # Named-CHECK mirrors for 5 fields that got inline (auto-named) CHECKs
+    # in Phase 1. Adding the named versions so the ORM model layer's
+    # `CheckConstraint(name='ck_...')` claims match reality in Postgres
+    # (the auto-named ones — e.g. organizations_org_type_check — also
+    # remain; predicates are identical so the AND combination is a no-op).
+    # All use the split-guard pattern.
+    # ------------------------------------------------------------------
+    _NAMED_CHECKS = [
+        (
+            "organizations",
+            "org_type",
+            "ck_organizations_org_type_valid",
+            "org_type IN ('institution', 'group_buy')",
+        ),
+        (
+            "organizations",
+            "per_student_price",
+            "ck_organizations_per_student_price_positive",
+            "per_student_price IS NULL OR per_student_price > 0",
+        ),
+        (
+            "plans",
+            "teacher_seats",
+            "ck_plans_teacher_seats_positive",
+            "teacher_seats IS NULL OR teacher_seats > 0",
+        ),
+        (
+            "plans",
+            "annual_fee",
+            "ck_plans_annual_fee_positive",
+            "annual_fee IS NULL OR annual_fee > 0",
+        ),
+        (
+            "plans",
+            "topup_discount",
+            "ck_plans_topup_discount_range",
+            # Reject 0: 100% off → NT$0 charge → TapPay rejects.
+            "topup_discount IS NULL OR (topup_discount > 0 AND topup_discount <= 1)",
+        ),
+        (
+            "student_status_history",
+            "status",
+            "ck_student_status_history_status_valid",
+            "status IN ('active', 'inactive')",
+        ),
+    ]
+    # NOTE: f-string interpolation here is safe because every value in
+    # _NAMED_CHECKS is a hardcoded constant defined in this file. Do NOT
+    # adapt this loop to read table/column/predicate from a config file,
+    # request body, or any user-controllable source — that would become
+    # SQL injection. Prefer separate op.execute() calls if values become
+    # dynamic.
+    for table, column, constraint, predicate in _NAMED_CHECKS:
+        op.execute(
+            f"""
+            DO $$ BEGIN
+                IF EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = '{table}'
+                      AND column_name = '{column}'
+                ) AND NOT EXISTS (
+                    SELECT 1 FROM pg_constraint c
+                    JOIN pg_class cls ON c.conrelid = cls.oid
+                    WHERE c.conname = '{constraint}'
+                      AND cls.relname = '{table}'
+                ) THEN
+                    ALTER TABLE {table}
+                    ADD CONSTRAINT {constraint}
+                    CHECK ({predicate});
+                END IF;
+            END $$;
+            """
+        )
+
+
+def downgrade() -> None:
+    # Intentional no-op: dropping a CHECK could let an invalid row land
+    # before re-upgrade, breaking subsequent migrations.
+    pass

--- a/backend/config/plans.py
+++ b/backend/config/plans.py
@@ -77,10 +77,26 @@ def _get_plan_override(plan_name: str, db=None):
         return None
 
 
+def _guard_group_buy(row, plan_name: str) -> None:
+    """Reject group-buy plans for the individual-plan price/quota helpers.
+
+    Group-buy billing is `annual_fee × teacher_seats` (see issue #768);
+    silently returning DEFAULT_PRICE (=299) for these names would invoice
+    NT$299/month instead. Detection is by `row.teacher_seats is not None`,
+    not by name pattern, so it stays correct if seed names change.
+    """
+    if row is not None and row.teacher_seats is not None:
+        raise ValueError(
+            f"get_plan_price/quota does not apply to group-buy plan {plan_name!r}; "
+            "use the checkout flow with annual_fee × teacher_seats instead."
+        )
+
+
 def get_plan_price(plan_name: str, db=None) -> int:
     """Return the price for ``plan_name``. Prefer DB override; fall back to
-    PLAN_PRICES; finally DEFAULT_PRICE."""
+    PLAN_PRICES; finally DEFAULT_PRICE. Raises ValueError for group-buy plans."""
     row = _get_plan_override(plan_name, db=db)
+    _guard_group_buy(row, plan_name)
     if row is not None and row.price is not None:
         return row.price
     return PLAN_PRICES.get(plan_name, DEFAULT_PRICE)
@@ -88,8 +104,9 @@ def get_plan_price(plan_name: str, db=None) -> int:
 
 def get_plan_quota(plan_name: str, db=None) -> int:
     """Return the monthly quota for ``plan_name``. Prefer DB override; fall
-    back to PLAN_QUOTAS; finally 0."""
+    back to PLAN_QUOTAS; finally 0. Raises ValueError for group-buy plans."""
     row = _get_plan_override(plan_name, db=db)
+    _guard_group_buy(row, plan_name)
     if row is not None and row.quota is not None:
         return row.quota
     return PLAN_QUOTAS.get(plan_name, 0)

--- a/backend/main.py
+++ b/backend/main.py
@@ -38,6 +38,7 @@ from routers import (
     admin_monitoring,
     admin_billing,
     admin_audio_errors,
+    admin_promo_codes,
     teacher_review,
     subscription,
     payment,
@@ -282,6 +283,7 @@ app.include_router(admin_plans.router)  # Admin 方案 CRUD 路由
 app.include_router(admin_monitoring.router)  # 監控路由（無需認證）
 app.include_router(admin_billing.router)  # Admin 帳單監控路由（Admin only）
 app.include_router(admin_audio_errors.router)  # Admin 錄音錯誤監控路由（Admin only）
+app.include_router(admin_promo_codes.router)  # Admin 推銷碼管理路由（Admin only）
 app.include_router(blog.router)  # Blog 管理路由（Admin only）
 app.include_router(cron.router)  # Cron Job 路由
 app.include_router(debug.router)  # Debug 路由

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -57,6 +57,9 @@ from .organization import (
     StudentSchool,
 )
 
+# Student status history (issue #768 — per-head billing trail)
+from .student_status_history import StudentStatusHistory
+
 # Classroom models
 from .classroom import Classroom, ClassroomStudent
 
@@ -130,6 +133,8 @@ __all__ = [
     "TeacherSchool",
     "ClassroomSchool",
     "StudentSchool",
+    # Student status history
+    "StudentStatusHistory",
     # Classrooms
     "Classroom",
     "ClassroomStudent",

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -38,6 +38,14 @@ from .credit_package_definition import CreditPackageDefinition
 # Plan models (admin-editable price/quota overrides)
 from .plan import Plan
 
+# Promo code / referral models (issue #637)
+from .promo_code import (
+    PromoCode,
+    PromoReferral,
+    PromoRewardConfig,
+    PromoRewardEvent,
+)
+
 # Organization models
 from .organization import (
     Organization,
@@ -110,6 +118,11 @@ __all__ = [
     "CreditPackageDefinition",
     # Plans
     "Plan",
+    # Promo codes / referrals
+    "PromoCode",
+    "PromoReferral",
+    "PromoRewardConfig",
+    "PromoRewardEvent",
     # Organizations
     "Organization",
     "School",

--- a/backend/models/organization.py
+++ b/backend/models/organization.py
@@ -3,15 +3,16 @@ Organization hierarchy models
 """
 
 from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
     Column,
-    Integer,
-    String,
     DateTime,
     ForeignKey,
-    Boolean,
+    Index,
+    Integer,
+    String,
     Text,
     UniqueConstraint,
-    Index,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -94,6 +95,17 @@ class Organization(Base):
         order_by="CreditPackage.expires_at.asc()",
     )
 
+    __table_args__ = (
+        CheckConstraint(
+            "org_type IN ('institution', 'group_buy')",
+            name="ck_organizations_org_type_valid",
+        ),
+        CheckConstraint(
+            "per_student_price IS NULL OR per_student_price > 0",
+            name="ck_organizations_per_student_price_positive",
+        ),
+    )
+
     def __repr__(self):
         return f"<Organization(id={self.id}, name={self.name})>"
 
@@ -155,6 +167,13 @@ class School(Base):
     )
     student_enrollments = relationship(
         "StudentSchool", back_populates="school", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "teacher_seat_limit IS NULL OR teacher_seat_limit > 0",
+            name="ck_schools_teacher_seat_limit_positive",
+        ),
     )
 
     def __repr__(self):

--- a/backend/models/organization.py
+++ b/backend/models/organization.py
@@ -52,6 +52,11 @@ class Organization(Base):
     # 狀態
     is_active = Column(Boolean, nullable=False, default=True, index=True)
 
+    # 機構類型：'institution'（機構，依學生人數計費）/ 'group_buy'（團購）
+    org_type = Column(String(20), nullable=False, server_default="institution")
+    # 機構專用：單位學生月費（NT$）。團購機構為 NULL。
+    per_student_price = Column(Integer, nullable=True)
+
     # 授權限制
     teacher_limit = Column(Integer, nullable=True)  # 教師授權數上限（NULL = 無限制）
 
@@ -123,6 +128,13 @@ class School(Base):
     # 狀態
     is_active = Column(Boolean, nullable=False, default=True, index=True)
 
+    # 團購方案專用：綁定的方案（10/30/50 席）。機構底下 schools 為 NULL。
+    plan_id = Column(
+        Integer, ForeignKey("plans.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    # 團購方案專用：該團教師上限。機構底下 schools 為 NULL。
+    teacher_seat_limit = Column(Integer, nullable=True)
+
     # 設定
     settings = Column(JSONType, nullable=True)  # 學校層級設定
 
@@ -134,6 +146,7 @@ class School(Base):
 
     # Relationships
     organization = relationship("Organization", back_populates="schools")
+    plan = relationship("Plan", foreign_keys=[plan_id], back_populates="schools")
     teacher_schools = relationship(
         "TeacherSchool", back_populates="school", cascade="all, delete-orphan"
     )

--- a/backend/models/plan.py
+++ b/backend/models/plan.py
@@ -10,7 +10,16 @@ Use `config.plans.get_plan_price(name)` and `get_plan_quota(name)` to read —
 those helpers prefer the DB row and fall back to the config constants.
 """
 
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey, Numeric
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+)
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from database import Base
@@ -63,6 +72,25 @@ class Plan(Base):
     # Group-buy: schools bound to this plan (empty for individual plans).
     schools = relationship(
         "School", foreign_keys="School.plan_id", back_populates="plan"
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "teacher_seats IS NULL OR teacher_seats > 0",
+            name="ck_plans_teacher_seats_positive",
+        ),
+        CheckConstraint(
+            "annual_fee IS NULL OR annual_fee > 0",
+            name="ck_plans_annual_fee_positive",
+        ),
+        # Reject 0 (= 100% off → NT$0 charge → TapPay rejects). Real
+        # group-buy discounts are 0.85–0.95; if a "free" plan is ever
+        # needed, that's a separate comped-subscription flow, not a
+        # discounted purchase.
+        CheckConstraint(
+            "topup_discount IS NULL OR (topup_discount > 0 AND topup_discount <= 1)",
+            name="ck_plans_topup_discount_range",
+        ),
     )
 
     def __repr__(self):

--- a/backend/models/plan.py
+++ b/backend/models/plan.py
@@ -10,7 +10,7 @@ Use `config.plans.get_plan_price(name)` and `get_plan_quota(name)` to read —
 those helpers prefer the DB row and fall back to the config constants.
 """
 
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey, Numeric
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from database import Base
@@ -32,6 +32,15 @@ class Plan(Base):
     # Monthly quota of points granted on subscription start.
     quota = Column(Integer, nullable=True)
 
+    # --- Group-buy plan fields (NULL for individual plans) ---
+    # Number of teacher seats in the group (10 / 30 / 50).
+    teacher_seats = Column(Integer, nullable=True)
+    # Annual fee PER TEACHER (NT$), not the team total.
+    # Team total = annual_fee * teacher_seats, computed at checkout.
+    annual_fee = Column(Integer, nullable=True)
+    # Top-up discount applied when buying point packages (e.g. 0.95 / 0.90 / 0.85).
+    topup_discount = Column(Numeric(3, 2), nullable=True)
+
     # Display order in admin UI / checkout list.
     display_order = Column(Integer, nullable=False, default=0)
 
@@ -51,6 +60,10 @@ class Plan(Base):
     )
 
     updated_by = relationship("Teacher", foreign_keys=[updated_by_admin_id])
+    # Group-buy: schools bound to this plan (empty for individual plans).
+    schools = relationship(
+        "School", foreign_keys="School.plan_id", back_populates="plan"
+    )
 
     def __repr__(self):
         return (

--- a/backend/models/promo_code.py
+++ b/backend/models/promo_code.py
@@ -1,0 +1,210 @@
+"""
+Promo Code models (issue #637) — referral tracking for the 特約合作方案.
+
+Four tables form the data layer:
+
+- ``PromoCode``        每位老師的推銷碼（個人預設碼 + admin 特約碼）
+- ``PromoReferral``    被推薦人 ↔ 推薦人的綁定關係（一個被推薦人僅一筆）
+- ``PromoRewardConfig`` admin 可調整的各事件獎勵點數
+- ``PromoRewardEvent`` 已發放紀錄，靠 idempotency_key 防重複發放
+
+PR 1 只建立 schema + 自動產生個人碼；獎勵發放與 API 在後續 PR。
+"""
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Text,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    CheckConstraint,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from database import Base
+from .base import JSONType
+
+
+class PromoCode(Base):
+    """推銷碼本體。
+
+    ``kind``：
+    - ``personal``  每位老師註冊時自動產生一組，``expires_at`` 為 NULL（永久），
+      一師只會有一筆（partial unique index 保證）。
+    - ``affiliate`` admin 為特約老師額外建立，可設定到期日。
+    """
+
+    __tablename__ = "promo_codes"
+    __table_args__ = (
+        # 一師一個人碼；特約碼不受限。
+        Index(
+            "uq_promo_codes_teacher_personal",
+            "teacher_id",
+            unique=True,
+            sqlite_where=text("kind = 'personal'"),
+            postgresql_where=text("kind = 'personal'"),
+        ),
+        Index("ix_promo_codes_teacher_id", "teacher_id"),
+        Index("ix_promo_codes_active_expires", "is_active", "expires_at"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    code = Column(String(16), nullable=False, unique=True, index=True)
+    teacher_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="CASCADE"), nullable=False
+    )
+
+    kind = Column(String(16), nullable=False, default="personal")
+    # NULL = 永久有效；有值 = 到期日
+    expires_at = Column(DateTime(timezone=True), nullable=True)
+    is_active = Column(Boolean, nullable=False, default=True)
+    note = Column(Text, nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    # Admin audit (mirrors CreditPackage pattern)
+    admin_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="SET NULL"), nullable=True
+    )
+    admin_reason = Column(Text, nullable=True)
+    admin_metadata = Column(JSONType, nullable=True)
+
+    teacher = relationship(
+        "Teacher", foreign_keys=[teacher_id], back_populates="promo_codes"
+    )
+    admin = relationship("Teacher", foreign_keys=[admin_id])
+
+    def __repr__(self):
+        return (
+            f"<PromoCode code={self.code} teacher={self.teacher_id} "
+            f"kind={self.kind} active={self.is_active}>"
+        )
+
+
+class PromoReferral(Base):
+    """被推薦人與推薦人的綁定關係。一個被推薦人最多綁定一次。"""
+
+    __tablename__ = "promo_referrals"
+    __table_args__ = (
+        UniqueConstraint(
+            "referred_teacher_id", name="uq_promo_referrals_referred_teacher"
+        ),
+        CheckConstraint(
+            "referrer_teacher_id != referred_teacher_id",
+            name="ck_promo_referrals_no_self_referral",
+        ),
+        Index("ix_promo_referrals_referrer", "referrer_teacher_id"),
+        Index("ix_promo_referrals_promo_code", "promo_code"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    referrer_teacher_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="CASCADE"), nullable=False
+    )
+    referred_teacher_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="CASCADE"), nullable=False
+    )
+
+    # 註冊當下填入的 code（快照，避免日後 code 改動），加上軟參照。
+    promo_code = Column(String(16), nullable=False)
+    promo_code_id = Column(
+        Integer, ForeignKey("promo_codes.id", ondelete="SET NULL"), nullable=True
+    )
+
+    signup_at = Column(DateTime(timezone=True), server_default=func.now())
+    verified_at = Column(DateTime(timezone=True), nullable=True)
+
+    # 「首次付費」獎勵（訂閱 or 點數包二擇一）是否已發。
+    first_paid_event_consumed = Column(Boolean, nullable=False, default=False)
+    # 被推薦人一次性 bonus 是否已發。
+    referred_bonus_granted = Column(Boolean, nullable=False, default=False)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    referrer = relationship("Teacher", foreign_keys=[referrer_teacher_id])
+    referred = relationship("Teacher", foreign_keys=[referred_teacher_id])
+    promo_code_ref = relationship("PromoCode", foreign_keys=[promo_code_id])
+
+    def __repr__(self):
+        return (
+            f"<PromoReferral referrer={self.referrer_teacher_id} "
+            f"referred={self.referred_teacher_id} code={self.promo_code}>"
+        )
+
+
+class PromoRewardConfig(Base):
+    """admin 可編輯的各事件獎勵點數設定（每個 trigger 一列）。"""
+
+    __tablename__ = "promo_reward_configs"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    reward_key = Column(String(64), nullable=False, unique=True, index=True)
+    points = Column(Integer, nullable=False)
+    recipient = Column(String(16), nullable=False, default="referrer")
+    is_active = Column(Boolean, nullable=False, default=True)
+
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+    updated_by_admin_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="SET NULL"), nullable=True
+    )
+
+    updated_by = relationship("Teacher", foreign_keys=[updated_by_admin_id])
+
+    def __repr__(self):
+        return (
+            f"<PromoRewardConfig key={self.reward_key} points={self.points} "
+            f"recipient={self.recipient}>"
+        )
+
+
+class PromoRewardEvent(Base):
+    """已發放點數紀錄。``idempotency_key`` unique 防止重複發放，也是報表來源。"""
+
+    __tablename__ = "promo_reward_events"
+    __table_args__ = (
+        Index("ix_promo_reward_events_granted_to", "granted_to_teacher_id"),
+        Index("ix_promo_reward_events_referral", "referral_id"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    referral_id = Column(
+        Integer, ForeignKey("promo_referrals.id", ondelete="CASCADE"), nullable=False
+    )
+    reward_key = Column(String(64), nullable=False)
+    # signup / subscription / credit_package
+    trigger_type = Column(String(32), nullable=False)
+    points = Column(Integer, nullable=False)
+    granted_to_teacher_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="CASCADE"), nullable=False
+    )
+    # 發點所建立的 CreditPackage（PR 3 填）
+    credit_package_id = Column(
+        Integer, ForeignKey("credit_packages.id", ondelete="SET NULL"), nullable=True
+    )
+
+    idempotency_key = Column(String(128), nullable=False, unique=True, index=True)
+    event_payload = Column(JSONType, nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    referral = relationship("PromoReferral")
+
+    def __repr__(self):
+        return (
+            f"<PromoRewardEvent key={self.reward_key} points={self.points} "
+            f"to={self.granted_to_teacher_id}>"
+        )

--- a/backend/models/student_status_history.py
+++ b/backend/models/student_status_history.py
@@ -7,7 +7,16 @@ per-student monthly billing can compute headcount over a billing period
 Append-only audit trail — never mutated in place.
 """
 
-from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, Index
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+)
 from sqlalchemy.sql import func
 from database import Base
 from .base import UUID
@@ -47,6 +56,10 @@ class StudentStatusHistory(Base):
             "ix_student_status_history_student_changed",
             "student_id",
             "changed_at",
+        ),
+        CheckConstraint(
+            "status IN ('active', 'inactive')",
+            name="ck_student_status_history_status_valid",
         ),
     )
 

--- a/backend/models/student_status_history.py
+++ b/backend/models/student_status_history.py
@@ -1,0 +1,57 @@
+"""Student status-change history (issue #768).
+
+Records every active/inactive transition for a student so institution
+per-student monthly billing can compute headcount over a billing period
+(active days per student x organizations.per_student_price).
+
+Append-only audit trail — never mutated in place.
+"""
+
+from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, Index
+from sqlalchemy.sql import func
+from database import Base
+from .base import UUID
+
+
+class StudentStatusHistory(Base):
+    __tablename__ = "student_status_history"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    student_id = Column(
+        Integer,
+        ForeignKey("students.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # SET NULL (not CASCADE): a school delete must not wipe billing-audit rows.
+    school_id = Column(
+        UUID,
+        ForeignKey("schools.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    # 'active' / 'inactive'
+    status = Column(String(20), nullable=False)
+
+    changed_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+    changed_by = Column(
+        Integer, ForeignKey("teachers.id", ondelete="SET NULL"), nullable=True
+    )
+    note = Column(Text, nullable=True)
+
+    __table_args__ = (
+        Index(
+            "ix_student_status_history_student_changed",
+            "student_id",
+            "changed_at",
+        ),
+    )
+
+    def __repr__(self):
+        return (
+            f"<StudentStatusHistory(student={self.student_id}, "
+            f"status={self.status}, at={self.changed_at})>"
+        )

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -199,6 +199,22 @@ class Teacher(Base):
         back_populates="teacher",
         cascade="all, delete-orphan",
     )
+    # Promo code / referral (issue #637)
+    promo_codes = relationship(
+        "PromoCode",
+        foreign_keys="PromoCode.teacher_id",
+        back_populates="teacher",
+        cascade="all, delete-orphan",
+    )
+    referrals_made = relationship(
+        "PromoReferral",
+        foreign_keys="PromoReferral.referrer_teacher_id",
+    )
+    referral_received = relationship(
+        "PromoReferral",
+        foreign_keys="PromoReferral.referred_teacher_id",
+        uselist=False,
+    )
 
     @property
     def current_period(self):

--- a/backend/routers/admin_promo_codes.py
+++ b/backend/routers/admin_promo_codes.py
@@ -1,0 +1,246 @@
+"""
+Admin Promo Code API (issue #637, PR 3).
+
+Lets admins manage referral promo codes, tune the per-event reward point
+values, and read a referral report. Frontend UI is a separate PR.
+
+All endpoints require admin (`get_current_admin`).
+"""
+
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import func, cast, Integer
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import (
+    Teacher,
+    PromoCode,
+    PromoReferral,
+    PromoRewardConfig,
+    PromoRewardEvent,
+)
+from routers.admin import get_current_admin
+from services.promo_code_service import generate_unique_code
+
+router = APIRouter(prefix="/api/admin/promo-codes", tags=["admin-promo-codes"])
+
+
+# ============ Schemas ============
+class PromoCodeResponse(BaseModel):
+    id: int
+    code: str
+    teacher_id: int
+    kind: str
+    expires_at: Optional[datetime] = None
+    is_active: bool
+    note: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True
+
+
+class AffiliateCodeCreateRequest(BaseModel):
+    teacher_id: int
+    expires_at: Optional[datetime] = None  # None = permanent
+    note: Optional[str] = Field(default=None, max_length=500)
+
+
+class PromoCodeUpdateRequest(BaseModel):
+    is_active: Optional[bool] = None
+    expires_at: Optional[datetime] = None
+    note: Optional[str] = Field(default=None, max_length=500)
+
+
+class RewardConfigResponse(BaseModel):
+    id: int
+    reward_key: str
+    points: int
+    recipient: str
+    is_active: bool
+
+    class Config:
+        from_attributes = True
+
+
+class RewardConfigUpdateRequest(BaseModel):
+    points: Optional[int] = Field(default=None, ge=0)
+    is_active: Optional[bool] = None
+
+
+class ReferralReportRow(BaseModel):
+    referrer_teacher_id: int
+    referral_count: int
+    verified_count: int
+    paid_count: int
+    total_points_awarded: int
+
+
+# ============ Promo code endpoints ============
+@router.get("", response_model=List[PromoCodeResponse])
+async def list_promo_codes(
+    teacher_id: Optional[int] = None,
+    kind: Optional[str] = None,
+    db: Session = Depends(get_db),
+    _: Teacher = Depends(get_current_admin),
+) -> List[PromoCodeResponse]:
+    """List promo codes, newest first. Optional filters by teacher / kind."""
+    query = db.query(PromoCode)
+    if teacher_id is not None:
+        query = query.filter(PromoCode.teacher_id == teacher_id)
+    if kind is not None:
+        query = query.filter(PromoCode.kind == kind)
+    rows = query.order_by(PromoCode.created_at.desc()).all()
+    return [PromoCodeResponse.model_validate(r) for r in rows]
+
+
+@router.post("", response_model=PromoCodeResponse, status_code=201)
+async def create_affiliate_code(
+    request: AffiliateCodeCreateRequest,
+    db: Session = Depends(get_db),
+    admin: Teacher = Depends(get_current_admin),
+) -> PromoCodeResponse:
+    """Create an affiliate promo code for a teacher (optional expiry)."""
+    teacher = db.query(Teacher).filter(Teacher.id == request.teacher_id).first()
+    if teacher is None:
+        raise HTTPException(
+            status_code=404, detail=f"Teacher {request.teacher_id} not found"
+        )
+
+    code = PromoCode(
+        code=generate_unique_code(db),
+        teacher_id=request.teacher_id,
+        kind="affiliate",
+        expires_at=request.expires_at,
+        is_active=True,
+        note=request.note,
+        admin_id=admin.id,
+        admin_reason="affiliate code created",
+    )
+    db.add(code)
+    db.commit()
+    db.refresh(code)
+    return PromoCodeResponse.model_validate(code)
+
+
+@router.patch("/{code_id}", response_model=PromoCodeResponse)
+async def update_promo_code(
+    code_id: int,
+    request: PromoCodeUpdateRequest,
+    db: Session = Depends(get_db),
+    admin: Teacher = Depends(get_current_admin),
+) -> PromoCodeResponse:
+    """Activate / deactivate a code or change its expiry / note."""
+    code = db.query(PromoCode).filter(PromoCode.id == code_id).first()
+    if code is None:
+        raise HTTPException(status_code=404, detail=f"Promo code {code_id} not found")
+
+    payload = request.model_dump(exclude_unset=True)
+    if not payload:
+        raise HTTPException(status_code=400, detail="No fields provided to update")
+
+    for field, value in payload.items():
+        setattr(code, field, value)
+    code.admin_id = admin.id
+    code.admin_reason = "admin update via /admin/promo-codes"
+    db.commit()
+    db.refresh(code)
+    return PromoCodeResponse.model_validate(code)
+
+
+# ============ Reward config endpoints ============
+@router.get("/reward-configs", response_model=List[RewardConfigResponse])
+async def list_reward_configs(
+    db: Session = Depends(get_db),
+    _: Teacher = Depends(get_current_admin),
+) -> List[RewardConfigResponse]:
+    """List the per-event reward point configs."""
+    rows = db.query(PromoRewardConfig).order_by(PromoRewardConfig.id.asc()).all()
+    return [RewardConfigResponse.model_validate(r) for r in rows]
+
+
+@router.patch("/reward-configs/{reward_key}", response_model=RewardConfigResponse)
+async def update_reward_config(
+    reward_key: str,
+    request: RewardConfigUpdateRequest,
+    db: Session = Depends(get_db),
+    admin: Teacher = Depends(get_current_admin),
+) -> RewardConfigResponse:
+    """Update the points / active flag for a reward key."""
+    row = (
+        db.query(PromoRewardConfig)
+        .filter(PromoRewardConfig.reward_key == reward_key)
+        .first()
+    )
+    if row is None:
+        raise HTTPException(
+            status_code=404, detail=f"Reward config '{reward_key}' not found"
+        )
+
+    payload = request.model_dump(exclude_unset=True)
+    if not payload:
+        raise HTTPException(status_code=400, detail="No fields provided to update")
+
+    for field, value in payload.items():
+        setattr(row, field, value)
+    row.updated_by_admin_id = admin.id
+    db.commit()
+    db.refresh(row)
+    return RewardConfigResponse.model_validate(row)
+
+
+# ============ Referral report ============
+def build_referral_report(db: Session) -> List[ReferralReportRow]:
+    """Per-referrer summary. Extracted from the endpoint so it can be unit
+    tested without the admin TestClient (permission-system bootstrap)."""
+    referral_rows = (
+        db.query(
+            PromoReferral.referrer_teacher_id.label("referrer"),
+            func.count(PromoReferral.id).label("referral_count"),
+            func.count(PromoReferral.verified_at).label("verified_count"),
+            func.coalesce(
+                func.sum(cast(PromoReferral.first_paid_event_consumed, Integer)),
+                0,
+            ).label("paid_count"),
+        )
+        .group_by(PromoReferral.referrer_teacher_id)
+        .all()
+    )
+
+    # Points awarded per referrer (referrer is granted_to in referrer-recipient events).
+    points_by_referrer = dict(
+        db.query(
+            PromoReferral.referrer_teacher_id,
+            func.coalesce(func.sum(PromoRewardEvent.points), 0),
+        )
+        .join(PromoRewardEvent, PromoRewardEvent.referral_id == PromoReferral.id)
+        .filter(
+            PromoRewardEvent.granted_to_teacher_id == PromoReferral.referrer_teacher_id
+        )
+        .group_by(PromoReferral.referrer_teacher_id)
+        .all()
+    )
+
+    return [
+        ReferralReportRow(
+            referrer_teacher_id=r.referrer,
+            referral_count=r.referral_count,
+            verified_count=r.verified_count,
+            paid_count=int(r.paid_count or 0),
+            total_points_awarded=int(points_by_referrer.get(r.referrer, 0)),
+        )
+        for r in referral_rows
+    ]
+
+
+@router.get("/report", response_model=List[ReferralReportRow])
+async def referral_report(
+    db: Session = Depends(get_db),
+    _: Teacher = Depends(get_current_admin),
+) -> List[ReferralReportRow]:
+    """Per-referrer summary: referrals, verified, paid-converted, points awarded."""
+    return build_referral_report(db)

--- a/backend/routers/assignments/detail.py
+++ b/backend/routers/assignments/detail.py
@@ -23,6 +23,12 @@ from models import (
     StudentItemProgress,
 )
 from .dependencies import get_current_teacher
+from .utils import compute_speaking_total_score
+
+# Single source of truth for speaking-scored modes (Azure pronunciation assessment,
+# score_category=speaking). Imported — not re-declared — so a new speaking mode added
+# in score_category.py can't silently miss the #813 display fallback here.
+from utils.score_category import _SPEAKING_MODES as _SPEAKING_SCORE_MODES
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +57,21 @@ def _get_total_item_count(assignment_id: int, db: Session) -> int:
     )
 
 
+def _get_canonical_items(assignment_id: int, db: Session):
+    """The assignment's canonical ContentItem rows (AssignmentContent → Content → ContentItem).
+
+    Invariant per assignment — callers hoist this out of per-student loops and
+    pass it into _compute_interim_score to avoid an N+1 in the speaking fallback.
+    """
+    return (
+        db.query(ContentItem)
+        .join(Content, ContentItem.content_id == Content.id)
+        .join(AssignmentContent, AssignmentContent.content_id == Content.id)
+        .filter(AssignmentContent.assignment_id == assignment_id)
+        .all()
+    )
+
+
 def _is_interim_score(sa, assignment) -> bool:
     """Check if a student assignment should show an interim (provisional) score."""
     return (
@@ -62,7 +83,9 @@ def _is_interim_score(sa, assignment) -> bool:
     )
 
 
-def _compute_interim_score(sa, assignment, db: Session, total_items: int | None = None):
+def _compute_interim_score(
+    sa, assignment, db: Session, total_items: int | None = None, canonical_items=None
+):
     """
     Compute display score for /progress endpoint.
 
@@ -124,6 +147,32 @@ def _compute_interim_score(sa, assignment, db: Session, total_items: int | None 
         if total_items == 0:
             return None
         return round(sum(valid_scores) / total_items, 1)
+
+    # Speaking modes (例句朗讀 / 單字朗讀): sa.score is the batch-grade roll-up of
+    # item-level AI scores. Issue #813 — some GRADED rows never got that roll-up
+    # (item scores exist, sa.score=NULL) and surfaced as 0. Recompute from items.
+    if practice_mode in _SPEAKING_SCORE_MODES:
+        # Only recompute for a GRADED assignment — that's the #813 state (batch-grade
+        # finalized status=GRADED but never wrote sa.score). For any other status
+        # (SUBMITTED/RESUBMITTED/RETURNED/IN_PROGRESS) a NULL score is expected because
+        # grading hasn't completed; computing a partial item-level average there would
+        # render as a misleading FINAL score (speaking modes aren't in AUTO_GRADED_MODES,
+        # so _is_interim_score is False and the UI shows no "~" marker).
+        if not (sa.status and sa.status.value == "GRADED"):
+            return None
+        # canonical_items is invariant per assignment — callers pass it pre-fetched
+        # to avoid re-querying once per student (this runs in per-student loops).
+        if canonical_items is None:
+            canonical_items = _get_canonical_items(assignment.id, db)
+        if not canonical_items:
+            return None
+        progress_by_item = {
+            p.content_item_id: p
+            for p in db.query(StudentItemProgress)
+            .filter(StudentItemProgress.student_assignment_id == sa.id)
+            .all()
+        }
+        return compute_speaking_total_score(canonical_items, progress_by_item)
 
     return None
 
@@ -214,6 +263,15 @@ async def get_assignment_detail(
     # Pre-compute total item count once (avoids O(N) redundant queries in the loop)
     total_items = _get_total_item_count(assignment.id, db)
 
+    # Speaking-mode fallback needs the assignment's canonical items; fetch once
+    # here (invariant per assignment) and pass into _compute_interim_score so we
+    # don't re-query per student.
+    speaking_canonical_items = (
+        _get_canonical_items(assignment.id, db)
+        if assignment.practice_mode in _SPEAKING_SCORE_MODES
+        else None
+    )
+
     students_progress = []
     for student in all_students:
         # 檢查這個學生是否已被指派
@@ -270,7 +328,13 @@ async def get_assignment_detail(
                 ),
                 "content_progress": content_progress,
                 "score": (
-                    _compute_interim_score(sa, assignment, db, total_items=total_items)
+                    _compute_interim_score(
+                        sa,
+                        assignment,
+                        db,
+                        total_items=total_items,
+                        canonical_items=speaking_canonical_items,
+                    )
                     if sa
                     else None
                 ),
@@ -367,6 +431,15 @@ async def get_assignment_progress(
     # Pre-compute total item count once (avoids O(N) redundant queries in the loop)
     total_items = _get_total_item_count(assignment.id, db)
 
+    # Speaking-mode fallback needs the assignment's canonical items; fetch once
+    # here (invariant per assignment) and pass into _compute_interim_score so we
+    # don't re-query per student.
+    speaking_canonical_items = (
+        _get_canonical_items(assignment.id, db)
+        if assignment.practice_mode in _SPEAKING_SCORE_MODES
+        else None
+    )
+
     progress_list = []
     for student in all_students:
         # 使用字典快速查找，O(1) 時間複雜度
@@ -388,7 +461,13 @@ async def get_assignment_progress(
                     sa.submitted_at.isoformat() if sa and sa.submitted_at else None
                 ),
                 "score": (
-                    _compute_interim_score(sa, assignment, db, total_items=total_items)
+                    _compute_interim_score(
+                        sa,
+                        assignment,
+                        db,
+                        total_items=total_items,
+                        canonical_items=speaking_canonical_items,
+                    )
                     if sa
                     else None
                 ),

--- a/backend/routers/assignments/grading.py
+++ b/backend/routers/assignments/grading.py
@@ -37,7 +37,11 @@ from .validators import (
     BatchGradeFinalizeResponse,
 )
 from .dependencies import get_current_teacher
-from .detail import _compute_interim_score
+from .detail import (
+    _compute_interim_score,
+    _get_canonical_items,
+    _SPEAKING_SCORE_MODES,
+)
 from services.analysis_quota import (
     reset_analysis_count_for_assignment,
     reset_analysis_count_for_assignments,
@@ -567,6 +571,15 @@ async def get_student_submission(
             actual_assignment_id,
         )
 
+    # Pre-fetch canonical items for speaking-mode fallback so _compute_interim_score
+    # doesn't re-query them inline (mirrors get_assignment_detail / grade reports).
+    speaking_canonical = (
+        _get_canonical_items(parent_assignment.id, db)
+        if parent_assignment
+        and parent_assignment.practice_mode in _SPEAKING_SCORE_MODES
+        else None
+    )
+
     return {
         "student_id": student.id,
         "student_name": student.name,
@@ -586,7 +599,12 @@ async def get_student_submission(
         # parent_assignment may be None for orphaned StudentAssignment rows;
         # the helper would AttributeError on `assignment.practice_mode`.
         "current_score": (
-            _compute_interim_score(assignment, parent_assignment, db)
+            _compute_interim_score(
+                assignment,
+                parent_assignment,
+                db,
+                canonical_items=speaking_canonical,
+            )
             if parent_assignment
             else assignment.score
         ),

--- a/backend/routers/assignments/utils.py
+++ b/backend/routers/assignments/utils.py
@@ -2,6 +2,7 @@
 Utility functions for assignment processing
 """
 
+import json
 from typing import List, Dict, Any
 
 
@@ -149,6 +150,102 @@ def get_score_with_fallback(
         # Don't rollback — caller owns the transaction. Return the JSON
         # value so scoring continues with the right number.
         return float(json_score)
+
+
+# The four Azure pronunciation-assessment component columns / ai_feedback keys.
+_SCORE_FIELDS = (
+    "pronunciation_score",
+    "accuracy_score",
+    "fluency_score",
+    "completeness_score",
+)
+
+
+def _read_component_score(
+    item_progress, field_name: str, ai_feedback_data: dict
+) -> float:
+    """Read one component score read-only (column first, then ai_feedback JSON).
+
+    Mirrors get_score_with_fallback's value resolution but never writes/backfills
+    — safe to call from GET endpoints. Used by compute_speaking_total_score.
+    """
+    score = getattr(item_progress, field_name)
+    if score is not None:
+        return float(score)
+    if ai_feedback_data:
+        json_score = ai_feedback_data.get(field_name)
+        if json_score is not None:
+            try:
+                return float(json_score)
+            except (TypeError, ValueError):
+                return 0.0
+    return 0.0
+
+
+def compute_speaking_total_score(canonical_items, progress_by_item) -> float | None:
+    """Roll up a speaking/reading assignment's total score from item-level AI scores.
+
+    Mirrors batch_grade_assignment's averaging so a displayed fallback equals what a
+    re-grade would produce: per item, average the >0 components
+    (pronunciation/accuracy/fluency/completeness); a missing/un-assessed item scores 0;
+    the total is the mean across all canonical items.
+
+    Args:
+        canonical_items: the assignment's canonical ContentItem rows (the denominator).
+        progress_by_item: dict[content_item_id -> StudentItemProgress].
+
+    Returns the rounded total, or None when there is no assessed work to score
+    (so callers can leave sa.score-less, not-yet-attempted rows blank).
+    """
+    item_scores: list[float] = []
+    any_assessed = False
+    for ci in canonical_items:
+        item = progress_by_item.get(ci.id)
+        if item is None or not item.recording_url or not item.has_ai_assessment:
+            item_scores.append(0.0)
+            continue
+
+        ai_feedback_data = {}
+        if item.ai_feedback:
+            try:
+                ai_feedback_data = (
+                    json.loads(item.ai_feedback)
+                    if isinstance(item.ai_feedback, str)
+                    else item.ai_feedback
+                )
+            except (json.JSONDecodeError, TypeError):
+                ai_feedback_data = {}
+
+        available = [
+            v
+            for v in (
+                _read_component_score(item, field, ai_feedback_data)
+                for field in _SCORE_FIELDS
+            )
+            if v > 0
+        ]
+
+        # ai_assessed_at can be stamped on a corrupt/partial row (all four score
+        # columns NULL, ai_feedback holding only non-score JSON like {"error": ...}).
+        # Such a row carries no real score and must not flip a whole assignment's
+        # None into 0.0 — only count it as assessed when an actual score value
+        # exists. `available` holds only >0 values, so a legitimate zero (column or
+        # JSON == 0) drops out of it but is still real data — the per-field
+        # None-checks below catch that; all-NULL / non-score JSON does not.
+        # (#813 review) — note we check the score keys specifically, NOT bool(json).
+        has_score_data = (
+            bool(available)
+            or any(ai_feedback_data.get(field) is not None for field in _SCORE_FIELDS)
+            or any(getattr(item, field) is not None for field in _SCORE_FIELDS)
+        )
+        if has_score_data:
+            any_assessed = True
+
+        item_scores.append(sum(available) / len(available) if available else 0.0)
+
+    if not item_scores or not any_assessed:
+        return None
+    return round(sum(item_scores) / len(item_scores), 1)
 
 
 def generate_item_comment(

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -5,7 +5,7 @@ from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 from typing import Optional  # noqa: F401
-from pydantic import BaseModel, EmailStr, field_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator
 from database import get_db
 from models import (
     Teacher,
@@ -63,6 +63,10 @@ class TeacherRegisterRequest(BaseModel):
     password: str
     name: str
     phone: Optional[str] = None
+    # Optional referral code (from ?promo= URL param or input field).
+    # max_length bounds the input (DB column is VARCHAR(16)) so an oversized
+    # payload is rejected at parse time rather than hitting the logs / DB.
+    promo_code: Optional[str] = Field(None, max_length=32)
 
     @field_validator("password")
     @classmethod
@@ -282,21 +286,37 @@ async def teacher_register(
         logger.error(f"Onboarding failed for teacher {new_teacher.id}: {e}")
         # User can still complete registration and login, just without default resources
 
-    # 🎯 Issue #637: 為新老師建立個人推銷碼（非致命，失敗不影響註冊）
+    # 建立個人推銷碼（非致命）。獨立 try：即使產碼失敗也不影響後續綁定。
+    # except 內 rollback 避免 session 卡在 PendingRollbackError，後續 email 發送才不會 500。
     try:
         from services.promo_code_service import create_personal_code_for_teacher
-        import logging
 
-        logging.getLogger(__name__).info(
-            f"Creating personal promo code for teacher {new_teacher.id}"
-        )
         create_personal_code_for_teacher(db, new_teacher.id)
     except Exception as e:
-        import logging
-
-        logging.getLogger(__name__).error(
-            f"Promo code creation failed for teacher {new_teacher.id}: {e}"
+        db.rollback()
+        logger.error(
+            f"Personal promo code creation failed for teacher {new_teacher.id}: {e}"
         )
+
+    # 綁定推薦關係（非致命，獨立於個人碼建立）。
+    if register_req.promo_code:
+        try:
+            from services.promo_code_service import bind_referral
+
+            referral = bind_referral(db, register_req.promo_code, new_teacher.id)
+            if referral is None:
+                logger.info(
+                    f"Promo code '{register_req.promo_code}' not bound for "
+                    f"teacher {new_teacher.id} (invalid/expired/self-referral)"
+                )
+            else:
+                logger.info(
+                    f"Referral {referral.id} bound: teacher {new_teacher.id} "
+                    f"referred by {referral.referrer_teacher_id}"
+                )
+        except Exception as e:
+            db.rollback()
+            logger.error(f"Referral binding failed for teacher {new_teacher.id}: {e}")
 
     # 🎯 發送驗證 email
     email_sent = email_service.send_teacher_verification_email(db, new_teacher)
@@ -334,6 +354,20 @@ async def verify_teacher_email(token: str, db: Session = Depends(get_db)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired verification token",
+        )
+
+    # 標記推薦關係已驗證（非致命）。實際發點在獎勵引擎處理。
+    try:
+        from services.promo_code_service import mark_referral_verified
+
+        mark_referral_verified(db, teacher.id)
+    except Exception as e:
+        db.rollback()
+        # verified_at not persisted. The reward engine falls back to the
+        # teacher's email_verified flag, so this is recoverable; log loudly.
+        logger.error(
+            f"ALERT: mark_referral_verified failed for teacher {teacher.id} "
+            f"— verified_at not stamped: {e}"
         )
 
     # 不自動登入，只返回驗證成功訊息

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -32,6 +32,17 @@ from core.limiter import limiter
 
 logger = logging.getLogger(__name__)
 
+
+def _safe_refresh(db, obj) -> None:
+    """Best-effort refresh after a rollback. The object was committed earlier,
+    so its PK is still valid; if the DB is momentarily unreachable, swallow the
+    error rather than 500 a request whose primary work already succeeded."""
+    try:
+        db.refresh(obj)
+    except Exception:
+        pass
+
+
 router = APIRouter(prefix="/api/auth", tags=["authentication"])
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/teacher/login")
@@ -64,9 +75,9 @@ class TeacherRegisterRequest(BaseModel):
     name: str
     phone: Optional[str] = None
     # Optional referral code (from ?promo= URL param or input field).
-    # max_length bounds the input (DB column is VARCHAR(16)) so an oversized
-    # payload is rejected at parse time rather than hitting the logs / DB.
-    promo_code: Optional[str] = Field(None, max_length=32)
+    # max_length matches the DB column (VARCHAR(16)); oversized input is
+    # rejected at parse time rather than hitting the logs / DB.
+    promo_code: Optional[str] = Field(None, max_length=16)
 
     @field_validator("password")
     @classmethod
@@ -294,6 +305,7 @@ async def teacher_register(
         create_personal_code_for_teacher(db, new_teacher.id)
     except Exception as e:
         db.rollback()
+        _safe_refresh(db, new_teacher)
         logger.error(
             f"Personal promo code creation failed for teacher {new_teacher.id}: {e}"
         )
@@ -305,8 +317,10 @@ async def teacher_register(
 
             referral = bind_referral(db, register_req.promo_code, new_teacher.id)
             if referral is None:
+                # repr() neutralizes newline/control chars in user input so a
+                # crafted promo_code can't forge log lines.
                 logger.info(
-                    f"Promo code '{register_req.promo_code}' not bound for "
+                    f"Promo code {register_req.promo_code!r} not bound for "
                     f"teacher {new_teacher.id} (invalid/expired/self-referral)"
                 )
             else:
@@ -316,6 +330,7 @@ async def teacher_register(
                 )
         except Exception as e:
             db.rollback()
+            _safe_refresh(db, new_teacher)
             logger.error(f"Referral binding failed for teacher {new_teacher.id}: {e}")
 
     # 🎯 發送驗證 email
@@ -356,19 +371,14 @@ async def verify_teacher_email(token: str, db: Session = Depends(get_db)):
             detail="Invalid or expired verification token",
         )
 
-    # 標記推薦關係已驗證（非致命）。實際發點在獎勵引擎處理。
+    # 標記推薦關係已驗證並發放註冊獎勵（非致命）。dispatch_signup_rewards 內部會
+    # 在發點同一交易先 stamp verified_at，避免 report 的 verified_count 與發放結果不一致。
     try:
-        from services.promo_code_service import mark_referral_verified
+        from services.promo_reward_service import dispatch_signup_rewards
 
-        mark_referral_verified(db, teacher.id)
+        dispatch_signup_rewards(db, teacher.id)
     except Exception as e:
-        db.rollback()
-        # verified_at not persisted. The reward engine falls back to the
-        # teacher's email_verified flag, so this is recoverable; log loudly.
-        logger.error(
-            f"ALERT: mark_referral_verified failed for teacher {teacher.id} "
-            f"— verified_at not stamped: {e}"
-        )
+        logger.error(f"dispatch_signup_rewards failed for teacher {teacher.id}: {e}")
 
     # 不自動登入，只返回驗證成功訊息
     return {

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -282,6 +282,22 @@ async def teacher_register(
         logger.error(f"Onboarding failed for teacher {new_teacher.id}: {e}")
         # User can still complete registration and login, just without default resources
 
+    # 🎯 Issue #637: 為新老師建立個人推銷碼（非致命，失敗不影響註冊）
+    try:
+        from services.promo_code_service import create_personal_code_for_teacher
+        import logging
+
+        logging.getLogger(__name__).info(
+            f"Creating personal promo code for teacher {new_teacher.id}"
+        )
+        create_personal_code_for_teacher(db, new_teacher.id)
+    except Exception as e:
+        import logging
+
+        logging.getLogger(__name__).error(
+            f"Promo code creation failed for teacher {new_teacher.id}: {e}"
+        )
+
     # 🎯 發送驗證 email
     email_sent = email_service.send_teacher_verification_email(db, new_teacher)
 

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -329,6 +329,18 @@ async def purchase_credit_package(
             f"pkg={package_id} points={points_total} expires={expires_at.date()}"
         )
 
+        # Issue #637: reward the referrer on the referred teacher's first paid
+        # credit-package purchase (non-fatal — never block the purchase).
+        try:
+            from services.promo_reward_service import dispatch_credit_package_reward
+
+            dispatch_credit_package_reward(db, current_teacher.id, package_id)
+        except Exception as e:
+            logger.error(
+                f"Referral credit-package reward failed for teacher "
+                f"{current_teacher.id}: {e}"
+            )
+
         return CreditPackagePurchaseResponse(
             success=True,
             transaction_id=external_transaction_id,

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -5,6 +5,7 @@ Credit Packages API - Purchase and manage credit packages (point bundles)
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal, ROUND_HALF_UP
 from pydantic import BaseModel
 from typing import Optional, Dict, Any, List
 import logging
@@ -24,6 +25,7 @@ from models import (
 )
 from routers.teachers import get_current_teacher
 from services.tappay_service import TapPayService
+from services.topup_discount import get_teacher_topup_discount
 from config.plans import (
     CREDIT_PACKAGES,
     ORG_ALLOWED_PACKAGES,
@@ -151,6 +153,19 @@ async def purchase_credit_package(
     pkg_config = CREDIT_PACKAGES[package_id]
     amount = pkg_config["price"]
     points_total = pkg_config["points"] + pkg_config["bonus"]
+
+    # Group-buy topup discount (issue #768 Phase 2): if the teacher belongs
+    # to one or more active group-buy schools, charge the best discounted
+    # amount instead of the package list price. Frontend price is never
+    # trusted — amount is server-side from CREDIT_PACKAGES, then discounted.
+    # Stay in Decimal end-to-end (no float conversion) for financial precision.
+    topup_discount = get_teacher_topup_discount(current_teacher, db)
+    if topup_discount is not None:
+        amount = int(
+            (Decimal(amount) * topup_discount).quantize(
+                Decimal("1"), rounding=ROUND_HALF_UP
+            )
+        )
 
     # Audit trail
     start_time = time.time()

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -984,7 +984,13 @@ async def get_subscription_status(
                 "expires_at": pkg.expires_at.isoformat() if pkg.expires_at else None,
                 "status": pkg.status,
                 "source": pkg.source,
-                "is_expired": pkg.expires_at <= now if pkg.expires_at else True,
+                # NULL expires_at = no expiry (permanent), not expired.
+                # expires_at is nullable=False at the DB level so a NULL would
+                # be an invariant violation. The defensive `is not None` keeps
+                # the expression total — and if a NULL ever sneaked in via raw
+                # SQL, both this endpoint and QuotaService (which filters
+                # `expires_at > now`) would exclude the row identically.
+                "is_expired": (pkg.expires_at is not None and pkg.expires_at <= now),
             }
             for pkg in credit_packages
         ]

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -416,6 +416,20 @@ async def process_payment(
             )
             # Continue execution - the important part (subscription update) is done
 
+        # Issue #637: reward the referrer on the referred teacher's first paid
+        # subscription (non-fatal — never block payment).
+        try:
+            from services.promo_reward_service import dispatch_subscription_reward
+
+            dispatch_subscription_reward(
+                db, current_teacher.id, payment_request.plan_name
+            )
+        except Exception as e:
+            logger.error(
+                f"Referral subscription reward failed for teacher "
+                f"{current_teacher.id}: {e}"
+            )
+
         return PaymentResponse(
             success=True,
             transaction_id=external_transaction_id,

--- a/backend/routers/teachers/classroom_ops.py
+++ b/backend/routers/teachers/classroom_ops.py
@@ -154,7 +154,13 @@ async def get_teacher_classrooms(
                 "name": classroom.name,
                 "description": classroom.description,
                 "level": classroom.level.value if classroom.level else "A1",
-                "student_count": len([s for s in classroom.students if s.is_active]),
+                "student_count": len(
+                    [
+                        cs
+                        for cs in classroom.students
+                        if cs.is_active and cs.student.is_active
+                    ]
+                ),
                 "program_count": program_count_map.get(
                     classroom.id, 0
                 ),  # Efficient lookup
@@ -197,7 +203,7 @@ async def get_teacher_classrooms(
                         ),
                     }
                     for cs in classroom.students
-                    if cs.is_active
+                    if cs.is_active and cs.student.is_active
                 ],
             }
         )
@@ -306,7 +312,7 @@ async def get_classroom_students(
             ),
         }
         for cs in classroom.students
-        if cs.is_active
+        if cs.is_active and cs.student.is_active
     ]
 
 

--- a/backend/routers/teachers/grade_reports.py
+++ b/backend/routers/teachers/grade_reports.py
@@ -48,7 +48,11 @@ from models import (
     StudentAssignment,
     Teacher,
 )
-from routers.assignments.detail import _compute_interim_score
+from routers.assignments.detail import (
+    _compute_interim_score,
+    _get_canonical_items,
+    _SPEAKING_SCORE_MODES,
+)
 from .dependencies import get_current_teacher
 
 logger = logging.getLogger(__name__)
@@ -146,7 +150,26 @@ def _category_key(assignment: Assignment) -> str:
     return key if key in _CATEGORY_ZH else "writing"
 
 
-def _final_score(sa: Optional[StudentAssignment], assignment: Assignment, db: Session):
+def _speaking_canonical_cache(assignments: List[Assignment], db: Session) -> dict:
+    """Pre-fetch canonical items per speaking-mode assignment.
+
+    _compute_interim_score's speaking fallback would otherwise re-query canonical
+    items for every (student, assignment) cell in the report grid (N+1). Build the
+    per-assignment cache once and thread it through _final_score.
+    """
+    return {
+        a.id: _get_canonical_items(a.id, db)
+        for a in assignments
+        if a.practice_mode in _SPEAKING_SCORE_MODES
+    }
+
+
+def _final_score(
+    sa: Optional[StudentAssignment],
+    assignment: Assignment,
+    db: Session,
+    canonical_items=None,
+):
     """Return a numeric score (or ``None``) for one (student, assignment) cell.
 
     Sample reports show integer scores, so we round to the nearest integer.
@@ -155,7 +178,9 @@ def _final_score(sa: Optional[StudentAssignment], assignment: Assignment, db: Se
         return None
     if sa.score is not None:
         return int(round(float(sa.score)))
-    interim = _compute_interim_score(sa, assignment, db)
+    interim = _compute_interim_score(
+        sa, assignment, db, canonical_items=canonical_items
+    )
     return int(round(float(interim))) if interim is not None else None
 
 
@@ -310,6 +335,7 @@ def _build_class_workbook(
     # --- Data rows ---
     all_scores: List[float] = []
     per_assignment_scores: dict[int, List[float]] = {a.id: [] for a in assignments}
+    canonical_cache = _speaking_canonical_cache(assignments, db)
 
     first_data_row = 6
     for student_idx, student in enumerate(students):
@@ -320,7 +346,7 @@ def _build_class_workbook(
 
         for col_idx, (_, a) in enumerate(ordered):
             sa = sa_by_pair.get((student.id, a.id))
-            score = _final_score(sa, a, db)
+            score = _final_score(sa, a, db, canonical_items=canonical_cache.get(a.id))
             if score is not None:
                 student_scores.append(float(score))
                 per_assignment_scores[a.id].append(float(score))
@@ -429,6 +455,7 @@ def _build_single_student_workbook(
     assignments: List[Assignment],
     sa_by_assignment: dict,
     db: Session,
+    canonical_cache: Optional[dict] = None,
 ) -> Workbook:
     """Build a one-sheet workbook for a single student.
 
@@ -485,6 +512,11 @@ def _build_single_student_workbook(
         cell.alignment = Alignment(horizontal="center")
         cell.border = border
 
+    # Built once by the caller across all students; fall back to building it here
+    # so the builder stays correct when called standalone.
+    if canonical_cache is None:
+        canonical_cache = _speaking_canonical_cache(assignments, db)
+
     # Bucket assignments by category, preserving insertion order within bucket.
     groups: dict[str, List[Assignment]] = {k: [] for k in _CATEGORY_ORDER}
     for a in assignments:
@@ -508,7 +540,7 @@ def _build_single_student_workbook(
 
         for a in items:
             sa = sa_by_assignment.get(a.id)
-            score = _final_score(sa, a, db)
+            score = _final_score(sa, a, db, canonical_items=canonical_cache.get(a.id))
             d = a.created_at.date().isoformat() if a.created_at else ""
             ws.cell(row=cur_row, column=1, value=_CATEGORY_ZH[cat])
             ws.cell(row=cur_row, column=2, value=a.title)
@@ -626,11 +658,15 @@ async def student_grade_report(
     sa_by_pair = {(sa.student_id, sa.assignment_id): sa for sa in sa_rows}
 
     today = _today_yyyymmdd()
+    # Build the speaking canonical-items cache once for all students (invariant
+    # per assignment) rather than re-fetching inside each per-student workbook.
+    canonical_cache = _speaking_canonical_cache(assignments, db)
+
     files: List[Tuple[str, bytes]] = []
     for student in students:
         sa_for_student = {a.id: sa_by_pair.get((student.id, a.id)) for a in assignments}
         wb = _build_single_student_workbook(
-            classroom, student, assignments, sa_for_student, db
+            classroom, student, assignments, sa_for_student, db, canonical_cache
         )
         buf = io.BytesIO()
         wb.save(buf)

--- a/backend/routers/teachers/profile_ops.py
+++ b/backend/routers/teachers/profile_ops.py
@@ -3,7 +3,8 @@ Profile Ops operations for teachers.
 """
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session, selectinload, joinedload
-from sqlalchemy import func
+from sqlalchemy import func, case
+from sqlalchemy.exc import IntegrityError
 from typing import List, Optional, Dict, Any
 from datetime import datetime, timedelta
 
@@ -16,7 +17,11 @@ from models import (
     TeacherSchool,
     Organization,
     School,
+    PromoCode,
+    PromoReferral,
+    PromoRewardEvent,
 )
+from services.promo_code_service import create_personal_code_for_teacher
 from .dependencies import get_current_teacher
 from .validators import *
 from .utils import TEST_SUBSCRIPTION_WHITELIST, parse_birthdate
@@ -110,6 +115,111 @@ async def get_teacher_roles(
         organization_roles=organization_roles,
         school_roles=school_roles,
         all_roles=sorted(list(all_roles_set)),
+    )
+
+
+class MyPromoCodeResponse(BaseModel):
+    code: str
+    expires_at: Optional[str] = None  # ISO string; null = permanent
+    is_active: bool
+    referral_count: int
+    verified_count: int
+    paid_count: int
+    total_points_awarded: int
+
+
+@router.get("/me/promo-code", response_model=MyPromoCodeResponse)
+async def get_my_promo_code(
+    current_teacher: Teacher = Depends(get_current_teacher),
+    db: Session = Depends(get_db),
+):
+    """Teacher's own personal promo code plus their referral stats.
+
+    Auto-creates the personal code if it's missing (older accounts predate the
+    auto-create-on-register flow), so this endpoint is safe to call eagerly.
+    """
+    code = (
+        db.query(PromoCode)
+        .filter(
+            PromoCode.teacher_id == current_teacher.id,
+            PromoCode.kind == "personal",
+        )
+        .first()
+    )
+    if code is None:
+        # Two concurrent first-time requests (e.g. two tabs) both reach this
+        # branch; the second one's INSERT hits the (teacher_id, kind=personal)
+        # unique index. Catch + re-query so the loser gets the row the winner
+        # just committed instead of a 500.
+        try:
+            code = create_personal_code_for_teacher(db, current_teacher.id)
+        except IntegrityError:
+            db.rollback()
+            code = (
+                db.query(PromoCode)
+                .filter(
+                    PromoCode.teacher_id == current_teacher.id,
+                    PromoCode.kind == "personal",
+                )
+                .first()
+            )
+    if code is None:
+        # Defensive: both insert and re-query failed (e.g. transient DB
+        # availability between the two queries). 503 lets the caller retry
+        # without dropping the request.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Promo code temporarily unavailable, please retry.",
+        )
+
+    # SQL-side aggregation so a teacher with many referrals doesn't pay for
+    # loading every row just to count them. The verified count uses explicit
+    # CASE so the intent ("count rows where verified_at IS NOT NULL") survives
+    # any future migration that changes the column's nullability or default.
+    # Stats are scoped to THIS personal code's referrals — a teacher who also
+    # holds affiliate codes shouldn't see those folded into the personal-code
+    # card. Same scoping applies to the points sum via the referral join.
+    stats = (
+        db.query(
+            func.count(PromoReferral.id).label("total"),
+            func.coalesce(
+                func.sum(case((PromoReferral.verified_at.is_not(None), 1), else_=0)),
+                0,
+            ).label("verified"),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (PromoReferral.first_paid_event_consumed.is_(True), 1), else_=0
+                    )
+                ),
+                0,
+            ).label("paid"),
+        )
+        .filter(
+            PromoReferral.referrer_teacher_id == current_teacher.id,
+            PromoReferral.promo_code_id == code.id,
+        )
+        .one()
+    )
+
+    total_points = (
+        db.query(func.coalesce(func.sum(PromoRewardEvent.points), 0))
+        .join(PromoReferral, PromoReferral.id == PromoRewardEvent.referral_id)
+        .filter(
+            PromoRewardEvent.granted_to_teacher_id == current_teacher.id,
+            PromoReferral.promo_code_id == code.id,
+        )
+        .scalar()
+    )
+
+    return MyPromoCodeResponse(
+        code=code.code,
+        expires_at=code.expires_at.isoformat() if code.expires_at else None,
+        is_active=code.is_active,
+        referral_count=int(stats.total),
+        verified_count=int(stats.verified),
+        paid_count=int(stats.paid),
+        total_points_awarded=int(total_points),
     )
 
 

--- a/backend/routers/teachers/student_ops.py
+++ b/backend/routers/teachers/student_ops.py
@@ -456,9 +456,18 @@ async def update_student(
             )
 
     # Update birthdate (no longer syncs password since default password is join date)
-    if update_data.birthdate is not None:
-        new_birthdate = datetime.strptime(update_data.birthdate, "%Y-%m-%d").date()
-        student.birthdate = new_birthdate
+    # An empty string means "no birthdate provided" — skip it instead of crashing
+    # on strptime("") (Issue #787: surfaced to the browser as "Failed to fetch").
+    if update_data.birthdate:
+        try:
+            student.birthdate = datetime.strptime(
+                update_data.birthdate, "%Y-%m-%d"
+            ).date()
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid birthdate format. Please use YYYY-MM-DD format",
+            )
 
     # Update other fields
     if update_data.name is not None:

--- a/backend/services/promo_code_service.py
+++ b/backend/services/promo_code_service.py
@@ -1,0 +1,76 @@
+"""
+Promo code service (issue #637).
+
+PR 1 scope: collision-free code generation and idempotent creation of a
+teacher's personal promo code. Reward dispatch lives in a later PR.
+"""
+
+import secrets
+from sqlalchemy.orm import Session
+
+from models import PromoCode
+
+# Alphabet excludes ambiguous glyphs (0/O, 1/I/L) so codes read cleanly
+# off a screen or printed page.
+CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
+CODE_LENGTH = 8
+_MAX_GENERATION_ATTEMPTS = 10
+
+# Default reward point values, seeded by the migration. `recipient` is who
+# receives the points when the event fires. `package_*` keys map directly to
+# config.plans.CREDIT_PACKAGES keys so the PR 3 dispatcher can look them up.
+DEFAULT_REWARD_CONFIGS = [
+    {"reward_key": "signup_verified", "points": 10, "recipient": "referrer"},
+    {"reward_key": "subscribe_tutor", "points": 1000, "recipient": "referrer"},
+    {"reward_key": "subscribe_school", "points": 2000, "recipient": "referrer"},
+    {"reward_key": "package_pkg-5000", "points": 200, "recipient": "referrer"},
+    {"reward_key": "package_pkg-10000", "points": 500, "recipient": "referrer"},
+    {"reward_key": "package_pkg-20000", "points": 800, "recipient": "referrer"},
+    {"reward_key": "referred_signup_bonus", "points": 300, "recipient": "referred"},
+]
+
+
+def _random_code() -> str:
+    """Return a single random candidate code. Extracted so tests can patch it."""
+    return "".join(secrets.choice(CODE_ALPHABET) for _ in range(CODE_LENGTH))
+
+
+def generate_unique_code(db: Session) -> str:
+    """Generate a code not already present in ``promo_codes``.
+
+    Retries on collision; the keyspace (31^8 ≈ 8.5e11) makes collisions
+    vanishingly rare, so a small attempt cap is plenty.
+    """
+    for _ in range(_MAX_GENERATION_ATTEMPTS):
+        candidate = _random_code()
+        exists = db.query(PromoCode.id).filter(PromoCode.code == candidate).first()
+        if not exists:
+            return candidate
+    raise RuntimeError("Could not generate a unique promo code after retries")
+
+
+def create_personal_code_for_teacher(db: Session, teacher_id: int) -> PromoCode:
+    """Return the teacher's personal promo code, creating it if absent.
+
+    Idempotent: a teacher has at most one ``kind='personal'`` code (enforced
+    by a partial unique index); repeated calls return the existing row.
+    """
+    existing = (
+        db.query(PromoCode)
+        .filter(PromoCode.teacher_id == teacher_id, PromoCode.kind == "personal")
+        .first()
+    )
+    if existing:
+        return existing
+
+    code = PromoCode(
+        code=generate_unique_code(db),
+        teacher_id=teacher_id,
+        kind="personal",
+        expires_at=None,  # permanent
+        is_active=True,
+    )
+    db.add(code)
+    db.commit()
+    db.refresh(code)
+    return code

--- a/backend/services/promo_code_service.py
+++ b/backend/services/promo_code_service.py
@@ -6,9 +6,12 @@ teacher's personal promo code. Reward dispatch lives in a later PR.
 """
 
 import secrets
+from datetime import datetime, timezone
+from typing import Optional
+
 from sqlalchemy.orm import Session
 
-from models import PromoCode
+from models import PromoCode, PromoReferral
 
 # Alphabet excludes ambiguous glyphs (0/O, 1/I/L) so codes read cleanly
 # off a screen or printed page.
@@ -74,3 +77,89 @@ def create_personal_code_for_teacher(db: Session, teacher_id: int) -> PromoCode:
     db.commit()
     db.refresh(code)
     return code
+
+
+def _is_expired(expires_at) -> bool:
+    """NULL expiry means permanent. Tolerate naive datetimes (SQLite) by
+    assuming UTC."""
+    if expires_at is None:
+        return False
+    exp = expires_at
+    if exp.tzinfo is None:
+        exp = exp.replace(tzinfo=timezone.utc)
+    return exp < datetime.now(timezone.utc)
+
+
+def validate_promo_code(db: Session, code: Optional[str]) -> Optional[PromoCode]:
+    """Return an active, non-expired ``PromoCode`` matching ``code`` (case-
+    insensitive), or None. Codes are stored uppercase."""
+    if not code:
+        return None
+    normalized = code.strip().upper()
+    if not normalized:
+        return None
+    pc = (
+        db.query(PromoCode)
+        .filter(PromoCode.code == normalized, PromoCode.is_active.is_(True))
+        .first()
+    )
+    if pc is None or _is_expired(pc.expires_at):
+        return None
+    return pc
+
+
+def bind_referral(
+    db: Session, code: Optional[str], referred_teacher_id: int
+) -> Optional[PromoReferral]:
+    """Bind a newly registered teacher to the owner of ``code``.
+
+    Returns the referral, or None when the binding is disqualified — invalid /
+    expired code, self-referral, or the teacher is already bound (a teacher can
+    only ever be referred once). Idempotent: a second call for an
+    already-bound teacher returns the existing referral. Non-fatal by design
+    so registration never fails because of a bad promo code.
+    """
+    pc = validate_promo_code(db, code)
+    if pc is None:
+        return None
+    if pc.teacher_id == referred_teacher_id:
+        return None  # cannot refer yourself
+
+    existing = (
+        db.query(PromoReferral)
+        .filter(PromoReferral.referred_teacher_id == referred_teacher_id)
+        .first()
+    )
+    if existing is not None:
+        return existing
+
+    referral = PromoReferral(
+        referrer_teacher_id=pc.teacher_id,
+        referred_teacher_id=referred_teacher_id,
+        promo_code=pc.code,
+        promo_code_id=pc.id,
+    )
+    db.add(referral)
+    db.commit()
+    db.refresh(referral)
+    return referral
+
+
+def mark_referral_verified(
+    db: Session, referred_teacher_id: int
+) -> Optional[PromoReferral]:
+    """Stamp ``verified_at`` on the teacher's referral once their email is
+    verified. Idempotent: only sets the timestamp the first time. Returns the
+    referral, or None if the teacher has no referral."""
+    referral = (
+        db.query(PromoReferral)
+        .filter(PromoReferral.referred_teacher_id == referred_teacher_id)
+        .first()
+    )
+    if referral is None:
+        return None
+    if referral.verified_at is None:
+        referral.verified_at = datetime.now(timezone.utc)
+        db.commit()
+        db.refresh(referral)
+    return referral

--- a/backend/services/promo_code_service.py
+++ b/backend/services/promo_code_service.py
@@ -9,6 +9,7 @@ import secrets
 from datetime import datetime, timezone
 from typing import Optional
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from models import PromoCode, PromoReferral
@@ -140,7 +141,17 @@ def bind_referral(
         promo_code_id=pc.id,
     )
     db.add(referral)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # Concurrent registration won the unique(referred_teacher_id) race.
+        # Harmless: return the row the other request committed.
+        db.rollback()
+        return (
+            db.query(PromoReferral)
+            .filter(PromoReferral.referred_teacher_id == referred_teacher_id)
+            .first()
+        )
     db.refresh(referral)
     return referral
 
@@ -161,5 +172,11 @@ def mark_referral_verified(
     if referral.verified_at is None:
         referral.verified_at = datetime.now(timezone.utc)
         db.commit()
-        db.refresh(referral)
+        # A refresh failure must NOT look like a commit failure to the caller:
+        # verified_at is already durably written, so swallow refresh errors and
+        # return the (correct) in-memory row.
+        try:
+            db.refresh(referral)
+        except Exception:
+            pass
     return referral

--- a/backend/services/promo_reward_service.py
+++ b/backend/services/promo_reward_service.py
@@ -1,0 +1,318 @@
+"""
+Promo referral reward engine (issue #637, PR 3).
+
+Grants points to the referrer (and a one-time bonus to the referred teacher)
+when referral milestones fire:
+
+- email verified         → signup_verified (referrer) + referred_signup_bonus
+- first paid subscription→ subscribe_tutor / subscribe_school (referrer)
+- first paid credit pack → package_pkg-5000 / -10000 / -20000 (referrer)
+
+Subscription and credit-package rewards are mutually exclusive and fire only
+on the referred teacher's FIRST paid action. That "first only" guarantee is
+the ``PromoReferral.first_paid_event_consumed`` flag — whichever paid event
+arrives first consumes it; there is no need to scan prior transactions.
+
+Every grant is idempotent via ``PromoRewardEvent.idempotency_key`` so retries
+and races never double-award. All entry points are non-fatal: a failure here
+must never break payment, registration, or verification.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy import update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from config.plans import (
+    PLAN_TUTOR,
+    PLAN_SCHOOL,
+    PLAN_FREE_TRIAL,
+    CREDIT_PACKAGE_VALIDITY_DAYS,
+)
+from models import (
+    PromoReferral,
+    PromoRewardConfig,
+    PromoRewardEvent,
+    CreditPackage,
+)
+
+logger = logging.getLogger(__name__)
+
+# Plan display name -> reward_key for paid-subscription rewards.
+_PLAN_REWARD_KEYS = {
+    PLAN_TUTOR: "subscribe_tutor",
+    PLAN_SCHOOL: "subscribe_school",
+}
+
+_REWARD_PACKAGE_ID = "referral-reward"
+
+
+def _get_referral(db: Session, referred_teacher_id: int) -> Optional[PromoReferral]:
+    return (
+        db.query(PromoReferral)
+        .filter(PromoReferral.referred_teacher_id == referred_teacher_id)
+        .first()
+    )
+
+
+def _recipient_teacher_id(referral: PromoReferral, recipient: str) -> int:
+    if recipient == "referred":
+        return referral.referred_teacher_id
+    return referral.referrer_teacher_id
+
+
+def _get_active_config(db: Session, reward_key: str) -> Optional[PromoRewardConfig]:
+    return (
+        db.query(PromoRewardConfig)
+        .filter(
+            PromoRewardConfig.reward_key == reward_key,
+            PromoRewardConfig.is_active.is_(True),
+        )
+        .first()
+    )
+
+
+def _build_reward_rows(
+    db: Session,
+    referral: PromoReferral,
+    reward_key: str,
+    trigger_type: str,
+    config: PromoRewardConfig,
+    event_payload: Optional[dict] = None,
+) -> PromoRewardEvent:
+    """Create the CreditPackage + PromoRewardEvent in the CURRENT (uncommitted)
+    transaction and return the event. The caller owns the commit, so the grant
+    can be made atomic with other writes (e.g. the first-paid slot claim).
+    Assumes no prior grant for this key exists (idempotency checked by caller)."""
+    idempotency_key = f"{referral.id}:{reward_key}"
+    recipient_id = _recipient_teacher_id(referral, config.recipient)
+    now = datetime.now(timezone.utc)
+
+    credit_package = CreditPackage(
+        teacher_id=recipient_id,
+        package_id=_REWARD_PACKAGE_ID,
+        points_total=config.points,
+        points_used=0,
+        price_paid=0,
+        purchased_at=now,
+        expires_at=now + timedelta(days=CREDIT_PACKAGE_VALIDITY_DAYS),
+        status="active",
+        source="referral_reward",
+        admin_metadata={
+            "reward_key": reward_key,
+            "referral_id": referral.id,
+            "referrer_teacher_id": referral.referrer_teacher_id,
+            "referred_teacher_id": referral.referred_teacher_id,
+        },
+    )
+    db.add(credit_package)
+    db.flush()  # assign credit_package.id without ending the transaction
+
+    event = PromoRewardEvent(
+        referral_id=referral.id,
+        reward_key=reward_key,
+        trigger_type=trigger_type,
+        points=config.points,
+        granted_to_teacher_id=recipient_id,
+        credit_package_id=credit_package.id,
+        idempotency_key=idempotency_key,
+        event_payload=event_payload,
+    )
+    db.add(event)
+    return event
+
+
+def _grant_reward(
+    db: Session,
+    referral: PromoReferral,
+    reward_key: str,
+    trigger_type: str,
+    event_payload: Optional[dict] = None,
+) -> Optional[PromoRewardEvent]:
+    """Grant the points configured for ``reward_key`` to the right teacher,
+    committing on its own.
+
+    Idempotent on ``{referral.id}:{reward_key}``: a prior grant (or a
+    concurrent one losing the unique race) returns the existing event without
+    awarding again. Returns None when the reward is unconfigured or inactive.
+    """
+    config = _get_active_config(db, reward_key)
+    if config is None:
+        return None
+
+    idempotency_key = f"{referral.id}:{reward_key}"
+    existing = (
+        db.query(PromoRewardEvent)
+        .filter(PromoRewardEvent.idempotency_key == idempotency_key)
+        .first()
+    )
+    if existing is not None:
+        return existing
+
+    event = _build_reward_rows(
+        db, referral, reward_key, trigger_type, config, event_payload
+    )
+    try:
+        db.commit()
+    except IntegrityError:
+        # Concurrent grant won the unique(idempotency_key) race.
+        db.rollback()
+        return (
+            db.query(PromoRewardEvent)
+            .filter(PromoRewardEvent.idempotency_key == idempotency_key)
+            .first()
+        )
+    db.refresh(event)
+    logger.info(
+        f"Referral reward granted: {reward_key} ({config.points} pts) "
+        f"to teacher {event.granted_to_teacher_id} (referral {referral.id})"
+    )
+    return event
+
+
+def dispatch_signup_rewards(db: Session, referred_teacher_id: int) -> None:
+    """On email verification: stamp verified_at, then reward the referrer
+    (signup_verified) and the referred teacher (referred_signup_bonus).
+
+    verified_at is stamped and committed BEFORE granting so it can never end up
+    NULL while a reward exists (which would understate the admin report's
+    verified_count). Non-fatal."""
+    try:
+        referral = _get_referral(db, referred_teacher_id)
+        if referral is None:
+            return
+
+        # Stamp verified_at first so verified_count stays consistent with grants.
+        if referral.verified_at is None:
+            referral.verified_at = datetime.now(timezone.utc)
+            db.commit()
+
+        _grant_reward(db, referral, "signup_verified", "signup")
+
+        bonus = _grant_reward(db, referral, "referred_signup_bonus", "signup")
+        if bonus is not None:
+            # Atomic flag set: concurrent double-verify can't double-write.
+            db.execute(
+                update(PromoReferral)
+                .where(PromoReferral.referred_teacher_id == referred_teacher_id)
+                .where(PromoReferral.referred_bonus_granted.is_(False))
+                .values(referred_bonus_granted=True)
+            )
+            db.commit()
+    except Exception as e:
+        db.rollback()
+        logger.error(
+            f"dispatch_signup_rewards failed for teacher {referred_teacher_id}: {e}"
+        )
+
+
+def dispatch_subscription_reward(db: Session, teacher_id: int, plan_name: str) -> None:
+    """On the referred teacher's first paid subscription: reward the referrer
+    based on the plan tier. Non-fatal; no-op if not their first paid action."""
+    try:
+        reward_key = _PLAN_REWARD_KEYS.get(plan_name)
+        if reward_key is None:
+            # Free Trial has no reward (expected). Any OTHER unmapped name is a
+            # surprise (i18n rename / client bug) — log so it's observable.
+            if plan_name not in (PLAN_FREE_TRIAL,):
+                logger.warning(
+                    f"No referral reward mapping for plan_name {plan_name!r} "
+                    f"(teacher {teacher_id})"
+                )
+            return
+        _dispatch_first_paid(
+            db, teacher_id, reward_key, "subscription", {"plan_name": plan_name}
+        )
+    except Exception as e:
+        db.rollback()
+        logger.error(
+            f"dispatch_subscription_reward failed for teacher {teacher_id}: {e}"
+        )
+
+
+def dispatch_credit_package_reward(
+    db: Session, teacher_id: int, package_id: str
+) -> None:
+    """On the referred teacher's first paid credit-package purchase: reward the
+    referrer based on the package. Non-fatal; no-op if not their first paid
+    action or the package has no configured reward."""
+    try:
+        _dispatch_first_paid(
+            db,
+            teacher_id,
+            f"package_{package_id}",
+            "credit_package",
+            {"package_id": package_id},
+        )
+    except Exception as e:
+        db.rollback()
+        logger.error(
+            f"dispatch_credit_package_reward failed for teacher {teacher_id}: {e}"
+        )
+
+
+def _dispatch_first_paid(
+    db: Session,
+    teacher_id: int,
+    reward_key: str,
+    trigger_type: str,
+    payload: dict,
+) -> None:
+    """Shared body for paid-event rewards. Consumes the one-time
+    ``first_paid_event_consumed`` slot so subscription and package rewards are
+    mutually exclusive and fire only once.
+
+    The slot claim and the reward grant share ONE transaction: if the grant
+    fails the claim is rolled back too (no consume-without-grant), while the
+    conditional UPDATE's row lock serializes concurrent paid events so only one
+    ever grants.
+    """
+    referral = _get_referral(db, teacher_id)
+    if referral is None or referral.first_paid_event_consumed:
+        return
+
+    # Skip packages with no active reward (e.g. pkg-1000/2000) BEFORE claiming
+    # the slot, so a later qualifying purchase can still reward. Pass this
+    # config straight to _build_reward_rows so an admin deactivating it mid-flight
+    # cannot leave the slot consumed with nothing granted.
+    config = _get_active_config(db, reward_key)
+    if config is None:
+        return
+
+    idempotency_key = f"{referral.id}:{reward_key}"
+    if (
+        db.query(PromoRewardEvent)
+        .filter(PromoRewardEvent.idempotency_key == idempotency_key)
+        .first()
+        is not None
+    ):
+        return  # already granted
+
+    try:
+        # Atomically claim the one-time slot. Two concurrent paid events with
+        # different reward keys would both pass the in-memory check above; this
+        # conditional UPDATE (row lock) lets only one win.
+        rows_updated = db.execute(
+            update(PromoReferral)
+            .where(PromoReferral.referred_teacher_id == teacher_id)
+            .where(PromoReferral.first_paid_event_consumed.is_(False))
+            .values(first_paid_event_consumed=True)
+        ).rowcount
+        if rows_updated == 0:
+            db.rollback()
+            return  # another paid event already consumed the slot
+
+        # Grant in the SAME transaction so commit persists claim + reward together.
+        _build_reward_rows(db, referral, reward_key, trigger_type, config, payload)
+        db.commit()
+    except IntegrityError:
+        # Lost the idempotency race; rollback reverts the claim too.
+        db.rollback()
+        return
+    logger.info(
+        f"Referral reward granted: {reward_key} ({config.points} pts) "
+        f"(referral {referral.id}, first paid action)"
+    )

--- a/backend/services/topup_discount.py
+++ b/backend/services/topup_discount.py
@@ -1,0 +1,32 @@
+"""Group-buy top-up discount lookup for credit-package purchases (issue #768).
+
+Resolves a teacher to the best (lowest) `plans.topup_discount` across every
+active group-buy school binding the teacher has. Returns None when the teacher
+is not in any group-buy school, in which case the purchase pays full price.
+"""
+
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from models import Plan, School, Teacher, TeacherSchool
+
+
+def get_teacher_topup_discount(teacher: Teacher, db: Session) -> Optional[Decimal]:
+    """Return MIN(topup_discount) across the teacher's active group-buy schools,
+    or None if the teacher has no group-buy binding."""
+    return (
+        db.query(func.min(Plan.topup_discount))
+        .join(School, School.plan_id == Plan.id)
+        .join(TeacherSchool, TeacherSchool.school_id == School.id)
+        .filter(
+            TeacherSchool.teacher_id == teacher.id,
+            TeacherSchool.is_active.is_(True),
+            School.is_active.is_(True),
+            Plan.is_active.is_(True),
+            Plan.topup_discount.isnot(None),
+        )
+        .scalar()
+    )

--- a/backend/tests/integration/api/test_teachers_students_api.py
+++ b/backend/tests/integration/api/test_teachers_students_api.py
@@ -323,3 +323,74 @@ class TestTeachersStudentsAPI:
 
         # Assert
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_update_student_with_empty_birthdate_does_not_500(
+        self, test_client, demo_teacher, demo_student, test_db_session
+    ):
+        """
+        Regression for Issue #787.
+
+        Given: A student being edited with an empty birthdate string ("")
+        When: Teacher updates the student (e.g. to fix the name)
+        Then: Request succeeds (200), birthdate is left unchanged, not a 500
+              (which surfaced to the browser as "Failed to fetch")
+        """
+        access_token = create_access_token(
+            data={"sub": str(demo_teacher.id), "type": "teacher"}
+        )
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+        response = test_client.put(
+            f"/api/teachers/students/{demo_student.id}",
+            json={"name": "Duncan", "birthdate": ""},
+            headers=headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["name"] == "Duncan"
+
+    def test_update_student_with_invalid_birthdate_returns_400(
+        self, test_client, demo_teacher, demo_student, test_db_session
+    ):
+        """
+        Issue #787: an unparseable birthdate should be a clean 400, not a 500.
+        """
+        access_token = create_access_token(
+            data={"sub": str(demo_teacher.id), "type": "teacher"}
+        )
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+        response = test_client.put(
+            f"/api/teachers/students/{demo_student.id}",
+            json={"birthdate": "not-a-date"},
+            headers=headers,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_update_student_with_valid_birthdate_succeeds(
+        self, test_client, demo_teacher, demo_student, test_db_session
+    ):
+        """
+        Issue #787: a valid birthdate is still parsed and persisted.
+        """
+        access_token = create_access_token(
+            data={"sub": str(demo_teacher.id), "type": "teacher"}
+        )
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+        response = test_client.put(
+            f"/api/teachers/students/{demo_student.id}",
+            json={"birthdate": "2015-03-01"},
+            headers=headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        # Verify it persisted (PUT response doesn't echo birthdate)
+        verify = test_client.get(
+            f"/api/teachers/students/{demo_student.id}",
+            headers=headers,
+        )
+        assert verify.status_code == status.HTTP_200_OK
+        assert verify.json()["birthdate"] == "2015-03-01"

--- a/backend/tests/test_get_plan_price_group_buy_guard.py
+++ b/backend/tests/test_get_plan_price_group_buy_guard.py
@@ -1,0 +1,84 @@
+"""Tests for the group-buy guard on get_plan_price / get_plan_quota
+(issue #768 Phase 2, finding F1).
+
+Group-buy plans seed with `price = NULL` and use `annual_fee × teacher_seats`
+for billing. Before this guard, get_plan_price('團購-30席') silently returned
+DEFAULT_PRICE = 299 because the plan name was not in PLAN_PRICES — a real
+billing-correctness risk that would invoice NT$299/month instead of the
+group-buy annual structure.
+
+The guard fires when the loaded Plan row has teacher_seats set (= group-buy),
+not on plan name pattern, so it stays correct if seed names change.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from config.plans import (
+    PLAN_TUTOR,
+    get_plan_price,
+    get_plan_quota,
+)
+from models import Plan
+
+
+@pytest.fixture
+def group_buy_plan(shared_test_session):
+    p = Plan(
+        name="團購-30席",
+        price=None,
+        quota=1000,
+        teacher_seats=30,
+        annual_fee=1300,
+        topup_discount=Decimal("0.90"),
+        is_active=True,
+    )
+    shared_test_session.add(p)
+    shared_test_session.commit()
+    return p
+
+
+@pytest.fixture
+def individual_plan(shared_test_session):
+    p = Plan(
+        name=PLAN_TUTOR,
+        price=299,
+        quota=2000,
+        teacher_seats=None,
+        annual_fee=None,
+        topup_discount=None,
+        is_active=True,
+    )
+    shared_test_session.add(p)
+    shared_test_session.commit()
+    return p
+
+
+def test_get_plan_price_raises_for_group_buy_plan(shared_test_session, group_buy_plan):
+    with pytest.raises(ValueError, match="group-buy"):
+        get_plan_price("團購-30席", db=shared_test_session)
+
+
+def test_get_plan_quota_raises_for_group_buy_plan(shared_test_session, group_buy_plan):
+    with pytest.raises(ValueError, match="group-buy"):
+        get_plan_quota("團購-30席", db=shared_test_session)
+
+
+def test_get_plan_price_still_works_for_individual_plan(
+    shared_test_session, individual_plan
+):
+    assert get_plan_price(PLAN_TUTOR, db=shared_test_session) == 299
+
+
+def test_get_plan_quota_still_works_for_individual_plan(
+    shared_test_session, individual_plan
+):
+    assert get_plan_quota(PLAN_TUTOR, db=shared_test_session) == 2000
+
+
+def test_get_plan_price_falls_back_to_config_when_no_db_row(
+    shared_test_session,
+):
+    # No DB row for this name -> falls back to PLAN_PRICES, no guard fires
+    assert get_plan_price(PLAN_TUTOR, db=shared_test_session) == 299

--- a/backend/tests/test_promo_code_model.py
+++ b/backend/tests/test_promo_code_model.py
@@ -1,0 +1,224 @@
+"""
+PR 1 (issue #637) — Promo Code data-layer tests.
+
+Covers the four new tables and the code-generation service. No reward
+dispatch or API behaviour here (those land in later PRs); this only proves
+the schema, constraints, defaults, and the collision-free code generator.
+"""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from models import (
+    Teacher,
+    PromoCode,
+    PromoReferral,
+    PromoRewardConfig,
+    PromoRewardEvent,
+)
+from services.promo_code_service import (
+    generate_unique_code,
+    create_personal_code_for_teacher,
+    CODE_ALPHABET,
+    CODE_LENGTH,
+)
+
+
+def _make_teacher(db, email):
+    teacher = Teacher(name="T", email=email, password_hash="x")
+    db.add(teacher)
+    db.commit()
+    db.refresh(teacher)
+    return teacher
+
+
+# ---------------------------------------------------------------- generator
+
+
+def test_code_alphabet_excludes_ambiguous_chars():
+    assert CODE_LENGTH == 8
+    for ch in "01OIL":
+        assert ch not in CODE_ALPHABET
+
+
+def test_generate_unique_code_uses_alphabet(test_db_session):
+    code = generate_unique_code(test_db_session)
+    assert len(code) == CODE_LENGTH
+    assert all(c in CODE_ALPHABET for c in code)
+
+
+def test_generate_unique_code_retries_on_collision(test_db_session, monkeypatch):
+    teacher = _make_teacher(test_db_session, "collide@test.com")
+    # Seed an existing code, force the RNG to emit it once, then a fresh one.
+    existing = create_personal_code_for_teacher(test_db_session, teacher.id)
+
+    seq = iter([existing.code, "AAAA2222"])
+    monkeypatch.setattr("services.promo_code_service._random_code", lambda: next(seq))
+    new_code = generate_unique_code(test_db_session)
+    assert new_code == "AAAA2222"
+
+
+# ---------------------------------------------------------------- PromoCode
+
+
+def test_create_personal_code_is_idempotent(test_db_session):
+    teacher = _make_teacher(test_db_session, "idem@test.com")
+    first = create_personal_code_for_teacher(test_db_session, teacher.id)
+    second = create_personal_code_for_teacher(test_db_session, teacher.id)
+    assert first.id == second.id
+    codes = (
+        test_db_session.query(PromoCode)
+        .filter(PromoCode.teacher_id == teacher.id, PromoCode.kind == "personal")
+        .all()
+    )
+    assert len(codes) == 1
+
+
+def test_personal_code_defaults(test_db_session):
+    teacher = _make_teacher(test_db_session, "defaults@test.com")
+    code = create_personal_code_for_teacher(test_db_session, teacher.id)
+    assert code.kind == "personal"
+    assert code.expires_at is None  # NULL = permanent
+    assert code.is_active is True
+
+
+def test_promo_code_unique_code(test_db_session):
+    t1 = _make_teacher(test_db_session, "u1@test.com")
+    t2 = _make_teacher(test_db_session, "u2@test.com")
+    test_db_session.add(PromoCode(code="DUP12345", teacher_id=t1.id, kind="personal"))
+    test_db_session.commit()
+    test_db_session.add(PromoCode(code="DUP12345", teacher_id=t2.id, kind="affiliate"))
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()
+
+
+# ---------------------------------------------------------------- Referral
+
+
+def test_referral_one_per_referred_teacher(test_db_session):
+    referrer = _make_teacher(test_db_session, "ref@test.com")
+    referred = _make_teacher(test_db_session, "new@test.com")
+    test_db_session.add(
+        PromoReferral(
+            referrer_teacher_id=referrer.id,
+            referred_teacher_id=referred.id,
+            promo_code="ABCD2345",
+        )
+    )
+    test_db_session.commit()
+    # Second referral for the same referred teacher must fail.
+    test_db_session.add(
+        PromoReferral(
+            referrer_teacher_id=referrer.id,
+            referred_teacher_id=referred.id,
+            promo_code="WXYZ6789",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()
+
+
+def test_referral_cannot_refer_self(test_db_session):
+    teacher = _make_teacher(test_db_session, "self@test.com")
+    test_db_session.add(
+        PromoReferral(
+            referrer_teacher_id=teacher.id,
+            referred_teacher_id=teacher.id,
+            promo_code="SELF2345",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()
+
+
+def test_referral_flags_default_false(test_db_session):
+    referrer = _make_teacher(test_db_session, "r2@test.com")
+    referred = _make_teacher(test_db_session, "n2@test.com")
+    referral = PromoReferral(
+        referrer_teacher_id=referrer.id,
+        referred_teacher_id=referred.id,
+        promo_code="FLAG2345",
+    )
+    test_db_session.add(referral)
+    test_db_session.commit()
+    test_db_session.refresh(referral)
+    assert referral.first_paid_event_consumed is False
+    assert referral.referred_bonus_granted is False
+    assert referral.verified_at is None
+
+
+# ---------------------------------------------------------------- RewardConfig
+
+
+EXPECTED_DEFAULTS = {
+    "signup_verified": (10, "referrer"),
+    "subscribe_tutor": (1000, "referrer"),
+    "subscribe_school": (2000, "referrer"),
+    "package_pkg-5000": (200, "referrer"),
+    "package_pkg-10000": (500, "referrer"),
+    "package_pkg-20000": (800, "referrer"),
+    "referred_signup_bonus": (300, "referred"),
+}
+
+
+def test_reward_config_seed_defaults():
+    from services.promo_code_service import DEFAULT_REWARD_CONFIGS
+
+    seeded = {
+        c["reward_key"]: (c["points"], c["recipient"]) for c in DEFAULT_REWARD_CONFIGS
+    }
+    assert seeded == EXPECTED_DEFAULTS
+
+
+def test_reward_config_unique_key(test_db_session):
+    test_db_session.add(PromoRewardConfig(reward_key="signup_verified", points=10))
+    test_db_session.commit()
+    test_db_session.add(PromoRewardConfig(reward_key="signup_verified", points=99))
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()
+
+
+# ---------------------------------------------------------------- RewardEvent
+
+
+def test_reward_event_idempotency_key_unique(test_db_session):
+    referrer = _make_teacher(test_db_session, "re@test.com")
+    referred = _make_teacher(test_db_session, "rd@test.com")
+    referral = PromoReferral(
+        referrer_teacher_id=referrer.id,
+        referred_teacher_id=referred.id,
+        promo_code="EVNT2345",
+    )
+    test_db_session.add(referral)
+    test_db_session.commit()
+    test_db_session.refresh(referral)
+
+    key = f"{referral.id}:signup_verified"
+    test_db_session.add(
+        PromoRewardEvent(
+            referral_id=referral.id,
+            reward_key="signup_verified",
+            trigger_type="signup",
+            points=10,
+            granted_to_teacher_id=referrer.id,
+            idempotency_key=key,
+        )
+    )
+    test_db_session.commit()
+    test_db_session.add(
+        PromoRewardEvent(
+            referral_id=referral.id,
+            reward_key="signup_verified",
+            trigger_type="signup",
+            points=10,
+            granted_to_teacher_id=referrer.id,
+            idempotency_key=key,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()

--- a/backend/tests/test_promo_referral_binding.py
+++ b/backend/tests/test_promo_referral_binding.py
@@ -1,0 +1,176 @@
+"""
+PR 2 (issue #637) — referral binding at registration + verify-time stamping.
+
+Backend only: validates promo code, binds the referral, and stamps
+verified_at on email verification. No point granting here (that lands in
+PR 3); these tests assert binding behaviour and edge cases.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from models import Teacher, PromoCode, PromoReferral
+from services.promo_code_service import (
+    create_personal_code_for_teacher,
+    validate_promo_code,
+    bind_referral,
+    mark_referral_verified,
+)
+
+
+def _make_teacher(db, email):
+    t = Teacher(name="T", email=email, password_hash="x")
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+# ------------------------------------------------------------ validate_promo_code
+
+
+def test_validate_active_code(test_db_session):
+    teacher = _make_teacher(test_db_session, "v1@test.com")
+    code = create_personal_code_for_teacher(test_db_session, teacher.id)
+    found = validate_promo_code(test_db_session, code.code)
+    assert found is not None
+    assert found.id == code.id
+
+
+def test_validate_is_case_insensitive(test_db_session):
+    teacher = _make_teacher(test_db_session, "v2@test.com")
+    code = create_personal_code_for_teacher(test_db_session, teacher.id)
+    assert validate_promo_code(test_db_session, code.code.lower()) is not None
+    assert validate_promo_code(test_db_session, f"  {code.code}  ") is not None
+
+
+def test_validate_none_and_empty(test_db_session):
+    assert validate_promo_code(test_db_session, None) is None
+    assert validate_promo_code(test_db_session, "") is None
+    assert validate_promo_code(test_db_session, "   ") is None
+
+
+def test_validate_unknown_code(test_db_session):
+    assert validate_promo_code(test_db_session, "NOTACODE") is None
+
+
+def test_validate_inactive_code(test_db_session):
+    teacher = _make_teacher(test_db_session, "v3@test.com")
+    code = create_personal_code_for_teacher(test_db_session, teacher.id)
+    code.is_active = False
+    test_db_session.commit()
+    assert validate_promo_code(test_db_session, code.code) is None
+
+
+def test_validate_expired_code(test_db_session):
+    teacher = _make_teacher(test_db_session, "v4@test.com")
+    test_db_session.add(
+        PromoCode(
+            code="EXPIRED2",
+            teacher_id=teacher.id,
+            kind="affiliate",
+            expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+    )
+    test_db_session.commit()
+    assert validate_promo_code(test_db_session, "EXPIRED2") is None
+
+
+def test_validate_future_expiry_is_valid(test_db_session):
+    teacher = _make_teacher(test_db_session, "v5@test.com")
+    test_db_session.add(
+        PromoCode(
+            code="FUTURE22",
+            teacher_id=teacher.id,
+            kind="affiliate",
+            expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+        )
+    )
+    test_db_session.commit()
+    assert validate_promo_code(test_db_session, "FUTURE22") is not None
+
+
+# ------------------------------------------------------------ bind_referral
+
+
+def test_bind_referral_success(test_db_session):
+    referrer = _make_teacher(test_db_session, "ref@test.com")
+    referred = _make_teacher(test_db_session, "new@test.com")
+    code = create_personal_code_for_teacher(test_db_session, referrer.id)
+
+    referral = bind_referral(test_db_session, code.code, referred.id)
+    assert referral is not None
+    assert referral.referrer_teacher_id == referrer.id
+    assert referral.referred_teacher_id == referred.id
+    assert referral.promo_code == code.code
+    assert referral.promo_code_id == code.id
+    assert referral.verified_at is None
+
+
+def test_bind_referral_invalid_code_returns_none(test_db_session):
+    referred = _make_teacher(test_db_session, "n2@test.com")
+    assert bind_referral(test_db_session, "NOPE", referred.id) is None
+    assert bind_referral(test_db_session, None, referred.id) is None
+    # No referral row was created.
+    assert (
+        test_db_session.query(PromoReferral)
+        .filter(PromoReferral.referred_teacher_id == referred.id)
+        .count()
+        == 0
+    )
+
+
+def test_bind_referral_rejects_self_referral(test_db_session):
+    teacher = _make_teacher(test_db_session, "selfref@test.com")
+    code = create_personal_code_for_teacher(test_db_session, teacher.id)
+    assert bind_referral(test_db_session, code.code, teacher.id) is None
+
+
+def test_bind_referral_idempotent_when_already_bound(test_db_session):
+    r1 = _make_teacher(test_db_session, "r1@test.com")
+    r2 = _make_teacher(test_db_session, "r2@test.com")
+    referred = _make_teacher(test_db_session, "bound@test.com")
+    code1 = create_personal_code_for_teacher(test_db_session, r1.id)
+    code2 = create_personal_code_for_teacher(test_db_session, r2.id)
+
+    first = bind_referral(test_db_session, code1.code, referred.id)
+    # A second attempt with a different code must NOT rebind; returns existing.
+    second = bind_referral(test_db_session, code2.code, referred.id)
+    assert first.id == second.id
+    assert second.referrer_teacher_id == r1.id
+    assert (
+        test_db_session.query(PromoReferral)
+        .filter(PromoReferral.referred_teacher_id == referred.id)
+        .count()
+        == 1
+    )
+
+
+# ------------------------------------------------------------ mark_referral_verified
+
+
+def test_mark_referral_verified_sets_timestamp(test_db_session):
+    referrer = _make_teacher(test_db_session, "mv1@test.com")
+    referred = _make_teacher(test_db_session, "mv2@test.com")
+    code = create_personal_code_for_teacher(test_db_session, referrer.id)
+    bind_referral(test_db_session, code.code, referred.id)
+
+    referral = mark_referral_verified(test_db_session, referred.id)
+    assert referral is not None
+    assert referral.verified_at is not None
+
+
+def test_mark_referral_verified_idempotent(test_db_session):
+    referrer = _make_teacher(test_db_session, "mv3@test.com")
+    referred = _make_teacher(test_db_session, "mv4@test.com")
+    code = create_personal_code_for_teacher(test_db_session, referrer.id)
+    bind_referral(test_db_session, code.code, referred.id)
+
+    first = mark_referral_verified(test_db_session, referred.id)
+    first_ts = first.verified_at
+    second = mark_referral_verified(test_db_session, referred.id)
+    assert second.verified_at == first_ts  # unchanged on second call
+
+
+def test_mark_referral_verified_no_referral(test_db_session):
+    teacher = _make_teacher(test_db_session, "noref@test.com")
+    assert mark_referral_verified(test_db_session, teacher.id) is None

--- a/backend/tests/test_promo_reward_engine.py
+++ b/backend/tests/test_promo_reward_engine.py
@@ -1,0 +1,316 @@
+"""
+PR 3 (issue #637) — referral reward engine tests.
+
+Covers grant idempotency, signup rewards, first-paid gating (subscription vs
+credit-package mutual exclusivity), admin-editable point values, and the
+no-reward-configured pass-through. Service-level (runs on SQLite).
+"""
+
+from datetime import datetime, timezone
+
+from config.plans import PLAN_TUTOR, PLAN_SCHOOL
+from models import (
+    Teacher,
+    PromoReferral,
+    PromoRewardConfig,
+    PromoRewardEvent,
+    CreditPackage,
+)
+from services.promo_code_service import create_personal_code_for_teacher, bind_referral
+from services.promo_reward_service import (
+    dispatch_signup_rewards,
+    dispatch_subscription_reward,
+    dispatch_credit_package_reward,
+)
+
+
+def _make_teacher(db, email):
+    t = Teacher(name="T", email=email, password_hash="x")
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+def _seed_reward_configs(db):
+    """conftest builds the schema via Base.metadata.create_all, which does not
+    run the seed migration — seed the configs the engine reads."""
+    defaults = [
+        ("signup_verified", 10, "referrer"),
+        ("subscribe_tutor", 1000, "referrer"),
+        ("subscribe_school", 2000, "referrer"),
+        ("package_pkg-5000", 200, "referrer"),
+        ("package_pkg-10000", 500, "referrer"),
+        ("package_pkg-20000", 800, "referrer"),
+        ("referred_signup_bonus", 300, "referred"),
+    ]
+    for key, points, recipient in defaults:
+        if (
+            db.query(PromoRewardConfig)
+            .filter(PromoRewardConfig.reward_key == key)
+            .first()
+            is None
+        ):
+            db.add(
+                PromoRewardConfig(reward_key=key, points=points, recipient=recipient)
+            )
+    db.commit()
+
+
+def _referral(db, referrer_email, referred_email):
+    referrer = _make_teacher(db, referrer_email)
+    referred = _make_teacher(db, referred_email)
+    code = create_personal_code_for_teacher(db, referrer.id)
+    referral = bind_referral(db, code.code, referred.id)
+    return referrer, referred, referral
+
+
+def _points_to(db, teacher_id):
+    return (
+        db.query(CreditPackage)
+        .filter(
+            CreditPackage.teacher_id == teacher_id,
+            CreditPackage.source == "referral_reward",
+        )
+        .all()
+    )
+
+
+# ---------------------------------------------------------------- signup
+
+
+def test_signup_rewards_grant_both_sides(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, referral = _referral(
+        test_db_session, "s_ref@test.com", "s_new@test.com"
+    )
+
+    dispatch_signup_rewards(test_db_session, referred.id)
+
+    referrer_pkgs = _points_to(test_db_session, referrer.id)
+    referred_pkgs = _points_to(test_db_session, referred.id)
+    assert len(referrer_pkgs) == 1 and referrer_pkgs[0].points_total == 10
+    assert len(referred_pkgs) == 1 and referred_pkgs[0].points_total == 300
+
+    test_db_session.refresh(referral)
+    assert referral.referred_bonus_granted is True
+    # dispatch stamps verified_at so the admin report's verified_count stays
+    # consistent with granted rewards.
+    assert referral.verified_at is not None
+
+
+def test_signup_rewards_idempotent(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, _ = _referral(
+        test_db_session, "si_ref@test.com", "si_new@test.com"
+    )
+    dispatch_signup_rewards(test_db_session, referred.id)
+    dispatch_signup_rewards(test_db_session, referred.id)  # second call no-ops
+
+    assert len(_points_to(test_db_session, referrer.id)) == 1
+    assert len(_points_to(test_db_session, referred.id)) == 1
+    events = test_db_session.query(PromoRewardEvent).all()
+    assert len(events) == 2  # signup_verified + referred_signup_bonus, once each
+
+
+def test_signup_rewards_no_referral_noop(test_db_session):
+    _seed_reward_configs(test_db_session)
+    lone = _make_teacher(test_db_session, "lone@test.com")
+    dispatch_signup_rewards(test_db_session, lone.id)
+    assert test_db_session.query(PromoRewardEvent).count() == 0
+
+
+# ---------------------------------------------------------------- subscription
+
+
+def test_subscription_reward_tutor(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, referral = _referral(
+        test_db_session, "sub_ref@test.com", "sub_new@test.com"
+    )
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)
+
+    pkgs = _points_to(test_db_session, referrer.id)
+    assert len(pkgs) == 1 and pkgs[0].points_total == 1000
+    test_db_session.refresh(referral)
+    assert referral.first_paid_event_consumed is True
+
+
+def test_subscription_reward_school(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, _ = _referral(
+        test_db_session, "sch_ref@test.com", "sch_new@test.com"
+    )
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_SCHOOL)
+    pkgs = _points_to(test_db_session, referrer.id)
+    assert len(pkgs) == 1 and pkgs[0].points_total == 2000
+
+
+def test_unknown_plan_no_reward(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, referral = _referral(
+        test_db_session, "fp_ref@test.com", "fp_new@test.com"
+    )
+    dispatch_subscription_reward(test_db_session, referred.id, "Free Trial")
+    assert len(_points_to(test_db_session, referrer.id)) == 0
+    test_db_session.refresh(referral)
+    assert referral.first_paid_event_consumed is False  # slot untouched
+
+
+# ---------------------------------------------------------------- credit package
+
+
+def test_credit_package_reward(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, _ = _referral(
+        test_db_session, "cp_ref@test.com", "cp_new@test.com"
+    )
+    dispatch_credit_package_reward(test_db_session, referred.id, "pkg-10000")
+    pkgs = _points_to(test_db_session, referrer.id)
+    assert len(pkgs) == 1 and pkgs[0].points_total == 500
+
+
+def test_credit_package_without_reward_leaves_slot_open(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, referral = _referral(
+        test_db_session, "cpn_ref@test.com", "cpn_new@test.com"
+    )
+    # pkg-1000 has no configured reward.
+    dispatch_credit_package_reward(test_db_session, referred.id, "pkg-1000")
+    assert len(_points_to(test_db_session, referrer.id)) == 0
+    test_db_session.refresh(referral)
+    assert referral.first_paid_event_consumed is False
+    # A later qualifying purchase still rewards.
+    dispatch_credit_package_reward(test_db_session, referred.id, "pkg-5000")
+    assert len(_points_to(test_db_session, referrer.id)) == 1
+
+
+# ---------------------------------------------------------------- first-paid gate
+
+
+def test_first_paid_is_mutually_exclusive(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, _ = _referral(
+        test_db_session, "me_ref@test.com", "me_new@test.com"
+    )
+    # First paid action = subscription (1000). A later package purchase must
+    # NOT reward again.
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)
+    dispatch_credit_package_reward(test_db_session, referred.id, "pkg-20000")
+
+    pkgs = _points_to(test_db_session, referrer.id)
+    assert len(pkgs) == 1 and pkgs[0].points_total == 1000
+
+
+def test_admin_edited_points_are_used(test_db_session):
+    _seed_reward_configs(test_db_session)
+    config = (
+        test_db_session.query(PromoRewardConfig)
+        .filter(PromoRewardConfig.reward_key == "subscribe_tutor")
+        .first()
+    )
+    config.points = 1234  # admin override
+    test_db_session.commit()
+
+    referrer, referred, _ = _referral(
+        test_db_session, "ae_ref@test.com", "ae_new@test.com"
+    )
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)
+    pkgs = _points_to(test_db_session, referrer.id)
+    assert len(pkgs) == 1 and pkgs[0].points_total == 1234
+
+
+def test_inactive_config_skips_reward(test_db_session):
+    _seed_reward_configs(test_db_session)
+    config = (
+        test_db_session.query(PromoRewardConfig)
+        .filter(PromoRewardConfig.reward_key == "subscribe_tutor")
+        .first()
+    )
+    config.is_active = False
+    test_db_session.commit()
+
+    referrer, referred, referral = _referral(
+        test_db_session, "ia_ref@test.com", "ia_new@test.com"
+    )
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)
+    assert len(_points_to(test_db_session, referrer.id)) == 0
+    # No reward granted, so the first-paid slot stays open.
+    test_db_session.refresh(referral)
+    assert referral.first_paid_event_consumed is False
+
+
+def test_reward_credit_package_has_one_year_expiry(test_db_session):
+    _seed_reward_configs(test_db_session)
+    referrer, referred, _ = _referral(
+        test_db_session, "ex_ref@test.com", "ex_new@test.com"
+    )
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)
+    pkg = _points_to(test_db_session, referrer.id)[0]
+    delta_days = (pkg.expires_at - pkg.purchased_at).days
+    assert 364 <= delta_days <= 366
+
+
+def test_grant_failure_does_not_consume_first_paid_slot(test_db_session, monkeypatch):
+    """If the grant raises, the slot claim must roll back so a retry can still
+    reward (no consume-without-grant)."""
+    _seed_reward_configs(test_db_session)
+    referrer, referred, referral = _referral(
+        test_db_session, "gf_ref@test.com", "gf_new@test.com"
+    )
+
+    import services.promo_reward_service as svc
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated grant failure")
+
+    monkeypatch.setattr(svc, "_build_reward_rows", _boom)
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)
+
+    test_db_session.refresh(referral)
+    assert referral.first_paid_event_consumed is False  # slot rolled back
+    assert len(_points_to(test_db_session, referrer.id)) == 0
+
+    # Retry after the transient failure clears: reward is granted, slot consumed.
+    monkeypatch.undo()
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)
+    test_db_session.refresh(referral)
+    assert referral.first_paid_event_consumed is True
+    assert len(_points_to(test_db_session, referrer.id)) == 1
+
+
+# ---------------------------------------------------------------- admin report
+
+
+def test_referral_report_aggregates(test_db_session):
+    from routers.admin_promo_codes import build_referral_report
+
+    _seed_reward_configs(test_db_session)
+    referrer, referred, _ = _referral(
+        test_db_session, "rep_ref@test.com", "rep_new@test.com"
+    )
+    # second referred teacher for the same referrer, verified + paid
+    referred2 = _make_teacher(test_db_session, "rep_new2@test.com")
+    code = (
+        test_db_session.query(PromoReferral)
+        .filter(PromoReferral.referrer_teacher_id == referrer.id)
+        .first()
+        .promo_code
+    )
+    bind_referral(test_db_session, code, referred2.id)
+
+    # Mirror the real verify flow: stamp verified_at, then grant signup rewards.
+    from services.promo_code_service import mark_referral_verified
+
+    mark_referral_verified(test_db_session, referred.id)
+    dispatch_signup_rewards(test_db_session, referred.id)  # +10pts
+    dispatch_subscription_reward(test_db_session, referred.id, PLAN_TUTOR)  # +1000
+
+    rows = build_referral_report(test_db_session)
+    by_ref = {r.referrer_teacher_id: r for r in rows}
+    row = by_ref[referrer.id]
+    assert row.referral_count == 2
+    assert row.verified_count == 1
+    assert row.paid_count == 1
+    # referrer received 10 (signup) + 1000 (subscription) = 1010
+    assert row.total_points_awarded == 1010

--- a/backend/tests/test_topup_discount.py
+++ b/backend/tests/test_topup_discount.py
@@ -1,0 +1,158 @@
+"""Tests for backend.services.topup_discount (issue #768 Phase 2).
+
+Covers the four scenarios the credit-package purchase flow needs:
+  - teacher not in any group-buy school -> no discount
+  - teacher in one group-buy school     -> that school's discount
+  - teacher in multiple group-buy schools -> best (lowest) discount
+  - teacher's TeacherSchool inactive    -> ignored
+  - school.is_active = False            -> ignored
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from auth import get_password_hash
+from models import (
+    Organization,
+    Plan,
+    School,
+    Teacher,
+    TeacherSchool,
+)
+from services.topup_discount import get_teacher_topup_discount
+
+
+@pytest.fixture
+def org(shared_test_session):
+    o = Organization(name="Test Org", is_active=True)
+    shared_test_session.add(o)
+    shared_test_session.commit()
+    shared_test_session.refresh(o)
+    return o
+
+
+@pytest.fixture
+def teacher(shared_test_session):
+    t = Teacher(
+        email="topup-discount@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="T",
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+def _make_group_buy_plan(db, name, discount):
+    p = Plan(
+        name=name,
+        price=None,
+        quota=1000,
+        teacher_seats=10,
+        annual_fee=1500,
+        topup_discount=Decimal(str(discount)),
+        is_active=True,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+def _bind(db, teacher, org, plan, *, ts_active=True, school_active=True):
+    s = School(
+        organization_id=org.id,
+        name=f"School-{plan.name}",
+        plan_id=plan.id,
+        teacher_seat_limit=plan.teacher_seats,
+        is_active=school_active,
+    )
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    ts = TeacherSchool(
+        teacher_id=teacher.id,
+        school_id=s.id,
+        roles=["teacher"],
+        is_active=ts_active,
+    )
+    db.add(ts)
+    db.commit()
+    return s
+
+
+def test_returns_none_when_teacher_has_no_group_buy_school(
+    shared_test_session, teacher
+):
+    assert get_teacher_topup_discount(teacher, shared_test_session) is None
+
+
+def test_returns_discount_for_single_group_buy_school(
+    shared_test_session, teacher, org
+):
+    plan = _make_group_buy_plan(shared_test_session, "團購-30席", 0.90)
+    _bind(shared_test_session, teacher, org, plan)
+
+    assert get_teacher_topup_discount(teacher, shared_test_session) == Decimal("0.90")
+
+
+def test_returns_best_discount_when_teacher_in_multiple_group_buy_schools(
+    shared_test_session, teacher, org
+):
+    # Lowest topup_discount == best discount (most savings)
+    p1 = _make_group_buy_plan(shared_test_session, "團購-10席", 0.95)
+    p2 = _make_group_buy_plan(shared_test_session, "團購-50席", 0.85)
+    p3 = _make_group_buy_plan(shared_test_session, "團購-30席", 0.90)
+    _bind(shared_test_session, teacher, org, p1)
+    _bind(shared_test_session, teacher, org, p2)
+    _bind(shared_test_session, teacher, org, p3)
+
+    assert get_teacher_topup_discount(teacher, shared_test_session) == Decimal("0.85")
+
+
+def test_ignores_inactive_teacher_school(shared_test_session, teacher, org):
+    plan = _make_group_buy_plan(shared_test_session, "團購-30席", 0.90)
+    _bind(shared_test_session, teacher, org, plan, ts_active=False)
+
+    assert get_teacher_topup_discount(teacher, shared_test_session) is None
+
+
+def test_ignores_inactive_school(shared_test_session, teacher, org):
+    plan = _make_group_buy_plan(shared_test_session, "團購-30席", 0.90)
+    _bind(shared_test_session, teacher, org, plan, school_active=False)
+
+    assert get_teacher_topup_discount(teacher, shared_test_session) is None
+
+
+def test_ignores_inactive_plan(shared_test_session, teacher, org):
+    # Deactivated group-buy plan (contract ended) should not produce a discount
+    plan = _make_group_buy_plan(shared_test_session, "團購-30席", 0.90)
+    plan.is_active = False
+    shared_test_session.commit()
+    _bind(shared_test_session, teacher, org, plan)
+
+    assert get_teacher_topup_discount(teacher, shared_test_session) is None
+
+
+def test_ignores_school_with_no_plan_id(shared_test_session, teacher, org):
+    # School without plan_id (institution school, not group-buy)
+    s = School(
+        organization_id=org.id,
+        name="Institution School",
+        plan_id=None,
+        is_active=True,
+    )
+    shared_test_session.add(s)
+    shared_test_session.commit()
+    shared_test_session.refresh(s)
+    ts = TeacherSchool(
+        teacher_id=teacher.id, school_id=s.id, roles=["teacher"], is_active=True
+    )
+    shared_test_session.add(ts)
+    shared_test_session.commit()
+
+    assert get_teacher_topup_discount(teacher, shared_test_session) is None

--- a/backend/tests/unit/test_speaking_score_813.py
+++ b/backend/tests/unit/test_speaking_score_813.py
@@ -1,0 +1,351 @@
+"""
+Issue #813 — 例句朗讀（reading）AI 批次批改後 Progress & Grade 便利貼成績顯示 0。
+
+Root cause（已用 PROD 資料證實，assignment 433）：
+- 學生 item 層級 AI 分數齊全（ai_assessed_at + pronunciation/accuracy/fluency/
+  completeness 都有值），status=GRADED，但 student_assignment.score 沒被 roll-up，
+  停留在 NULL。
+- 顯示端 _compute_interim_score 對 speaking 模式（reading / word_reading）沒有
+  fallback，sa.score=None 直接回 None → 前端 score ?? 0 → 顯示 0.0。
+  （與 #807 的 mastery 模式同類，#807 只補了 mastery，沒補 speaking。）
+
+Fix（比照 #807 顯示端 fallback）：sa.score 為 None 時，用 item 分數即時重算，
+公式與 batch_grade_assignment 完全一致（每題取 >0 的 4 項平均、缺題 0、全題平均）。
+"""
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from models import ContentItem, StudentItemProgress
+from routers.assignments.detail import (
+    _SPEAKING_SCORE_MODES,
+    _compute_interim_score,
+    _is_interim_score,
+)
+from routers.assignments.utils import compute_speaking_total_score
+
+
+def _item(
+    cid,
+    *,
+    rec="https://gcs/a.wav",
+    ai=True,
+    feedback=None,
+    pron=None,
+    acc=None,
+    flu=None,
+    comp=None
+):
+    return SimpleNamespace(
+        content_item_id=cid,
+        recording_url=rec,
+        has_ai_assessment=ai,
+        ai_feedback=feedback,
+        pronunciation_score=pron,
+        accuracy_score=acc,
+        fluency_score=flu,
+        completeness_score=comp,
+    )
+
+
+def _canonical(*cids):
+    return [SimpleNamespace(id=c) for c in cids]
+
+
+def _mock_db_speaking(canonical_items, progress_list):
+    """db where query(ContentItem)->canonical, query(StudentItemProgress)->progress."""
+    db = MagicMock()
+
+    def query_side_effect(model):
+        q = MagicMock()
+        q.join.return_value = q
+        q.filter.return_value = q
+        if model is ContentItem:
+            q.all.return_value = canonical_items
+        elif model is StudentItemProgress:
+            q.all.return_value = progress_list
+        else:
+            q.all.return_value = []
+        return q
+
+    db.query.side_effect = query_side_effect
+    return db
+
+
+def _sa(status_value, score=None, sa_id=1):
+    return SimpleNamespace(
+        id=sa_id, score=score, status=SimpleNamespace(value=status_value)
+    )
+
+
+def _assignment(practice_mode, assignment_id=1):
+    return SimpleNamespace(id=assignment_id, practice_mode=practice_mode)
+
+
+# ---------------------------------------------------------------------------
+# 純函式：compute_speaking_total_score（與 batch-grade 公式對齊）
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSpeakingTotalScore:
+    def test_real_433_sa4534_case(self):
+        """PROD assignment 433, sa_id 4534 的真實三題分數 → 應算出 71.3（非 0）。"""
+        canonical = _canonical(41620, 41621, 41622)
+        progress = {
+            41620: _item(
+                41620,
+                pron=Decimal("64.60"),
+                acc=Decimal("79"),
+                flu=Decimal("52"),
+                comp=Decimal("88"),
+            ),
+            41621: _item(
+                41621,
+                pron=Decimal("61.20"),
+                acc=Decimal("72"),
+                flu=Decimal("51"),
+                comp=Decimal("81"),
+            ),
+            41622: _item(
+                41622,
+                pron=Decimal("73.40"),
+                acc=Decimal("83"),
+                flu=Decimal("67"),
+                comp=Decimal("83"),
+            ),
+        }
+        # 每題平均: 70.9 / 66.3 / 76.6 → 總平均 71.2667 → 71.3
+        assert compute_speaking_total_score(canonical, progress) == pytest.approx(71.3)
+
+    def test_missing_progress_row_counts_as_zero(self):
+        """缺 progress row 的題目算 0 分（缺題），仍計入分母。"""
+        canonical = _canonical(1, 2)
+        progress = {
+            1: _item(
+                1,
+                pron=Decimal("90"),
+                acc=Decimal("90"),
+                flu=Decimal("90"),
+                comp=Decimal("90"),
+            ),
+        }
+        # 題1=90, 題2=0 → (90+0)/2 = 45.0
+        assert compute_speaking_total_score(canonical, progress) == pytest.approx(45.0)
+
+    def test_recorded_but_not_assessed_counts_as_zero(self):
+        """有錄音但沒 AI 評分（has_ai_assessment=False）算缺題 0 分。"""
+        canonical = _canonical(1, 2)
+        progress = {
+            1: _item(
+                1,
+                pron=Decimal("80"),
+                acc=Decimal("80"),
+                flu=Decimal("80"),
+                comp=Decimal("80"),
+            ),
+            2: _item(2, ai=False, pron=None, acc=None, flu=None, comp=None),
+        }
+        assert compute_speaking_total_score(canonical, progress) == pytest.approx(40.0)
+
+    def test_zero_components_excluded_from_average(self):
+        """單題內只平均 >0 的項目（對齊 batch-grade）。"""
+        canonical = _canonical(1)
+        progress = {
+            1: _item(
+                1,
+                pron=Decimal("80"),
+                acc=Decimal("0"),
+                flu=Decimal("0"),
+                comp=Decimal("40"),
+            ),
+        }
+        # 只取 80 與 40 → (80+40)/2 = 60.0
+        assert compute_speaking_total_score(canonical, progress) == pytest.approx(60.0)
+
+    def test_no_assessed_work_returns_none(self):
+        """完全沒有任何題目被評分 → 回 None（讓未作答的列維持空白，不顯示 0）。"""
+        canonical = _canonical(1, 2)
+        progress = {}
+        assert compute_speaking_total_score(canonical, progress) is None
+
+    def test_reads_from_ai_feedback_json_when_column_null(self):
+        """欄位為 NULL 但 ai_feedback JSON 有值時，read-only 取 JSON（不回填）。"""
+        canonical = _canonical(1)
+        feedback = (
+            '{"pronunciation_score": 90, "accuracy_score": 90, '
+            '"fluency_score": 90, "completeness_score": 90}'
+        )
+        item = _item(1, feedback=feedback, pron=None, acc=None, flu=None, comp=None)
+        progress = {1: item}
+        assert compute_speaking_total_score(canonical, progress) == pytest.approx(90.0)
+        # 確認 read-only：沒有寫回欄位
+        assert item.pronunciation_score is None
+
+    def test_empty_canonical_returns_none(self):
+        assert compute_speaking_total_score([], {}) is None
+
+    def test_uses_real_model_has_ai_assessment_property(self):
+        """Anchor against a real StudentItemProgress so the _item() helper's plain
+        has_ai_assessment attribute can't hide a regression in the model @property
+        (it is backed by `ai_assessed_at is not None`). Review feedback on PR #815.
+        """
+        from datetime import datetime, timezone
+
+        assessed = StudentItemProgress(
+            content_item_id=1,
+            recording_url="https://gcs/a.wav",
+            ai_assessed_at=datetime(2026, 4, 23, tzinfo=timezone.utc),
+            pronunciation_score=Decimal("80"),
+            accuracy_score=Decimal("80"),
+            fluency_score=Decimal("80"),
+            completeness_score=Decimal("80"),
+        )
+        not_assessed = StudentItemProgress(
+            content_item_id=2,
+            recording_url="https://gcs/b.wav",
+            ai_assessed_at=None,
+        )
+        # Property contract: driven purely by ai_assessed_at.
+        assert assessed.has_ai_assessment is True
+        assert not_assessed.has_ai_assessment is False
+
+        canonical = _canonical(1, 2)
+        progress = {1: assessed, 2: not_assessed}
+        # item 2 recorded but un-assessed → missing (0); (80 + 0) / 2 = 40.0
+        assert compute_speaking_total_score(canonical, progress) == pytest.approx(40.0)
+
+    def test_corrupt_item_assessed_flag_but_all_null_returns_none(self):
+        """ai_assessed_at 有值但 4 個分數欄全 NULL、無 ai_feedback（半寫入/壞資料）
+        → 不算 assessed，整份回 None（不顯示 0）。#813 PR review finding 3。"""
+        canonical = _canonical(1)
+        corrupt = _item(
+            1, ai=True, feedback=None, pron=None, acc=None, flu=None, comp=None
+        )
+        assert compute_speaking_total_score(canonical, {1: corrupt}) is None
+
+    def test_non_score_ai_feedback_does_not_count_as_assessed(self):
+        """ai_feedback 只有非分數欄位（如 {"error": "timeout"}）、分數欄全 NULL
+        → 不算 assessed，回 None（不被 bool(json) 誤判）。#813 PR review。"""
+        canonical = _canonical(1)
+        item = _item(
+            1,
+            feedback='{"error": "timeout", "attempt": 2}',
+            pron=None,
+            acc=None,
+            flu=None,
+            comp=None,
+        )
+        assert compute_speaking_total_score(canonical, {1: item}) is None
+
+    def test_legit_zero_scored_item_counts_as_assessed(self):
+        """欄位為實際 0（非 NULL）代表「有評分但得 0」→ 算 assessed，回 0.0（非 None）。"""
+        canonical = _canonical(1)
+        zeroed = _item(
+            1, pron=Decimal("0"), acc=Decimal("0"), flu=Decimal("0"), comp=Decimal("0")
+        )
+        assert compute_speaking_total_score(canonical, {1: zeroed}) == pytest.approx(
+            0.0
+        )
+
+
+# ---------------------------------------------------------------------------
+# 顯示端：_compute_interim_score 的 speaking fallback 分支
+# ---------------------------------------------------------------------------
+
+
+class TestComputeInterimScoreSpeakingFallback:
+    def test_speaking_modes_set(self):
+        assert "reading" in _SPEAKING_SCORE_MODES
+        assert "word_reading" in _SPEAKING_SCORE_MODES
+
+    def test_speaking_modes_use_score_category_single_source(self):
+        """detail._SPEAKING_SCORE_MODES 直接 import 自 score_category（同一物件），
+        不再維護第二份常數，避免新增 speaking 模式漂移、對新模式重演 #813。
+        #813 PR review finding 4。"""
+        from utils.score_category import _SPEAKING_MODES
+
+        assert _SPEAKING_SCORE_MODES is _SPEAKING_MODES
+
+    @pytest.mark.parametrize(
+        "status", ["IN_PROGRESS", "SUBMITTED", "RESUBMITTED", "RETURNED", "NOT_STARTED"]
+    )
+    def test_non_graded_status_returns_none_not_partial_score(self, status):
+        """只有 GRADED 才現算。其他狀態（含 SUBMITTED — 尚未批改，NULL 分數屬正常）
+        即便有部分 item 評分也回 None，避免部分分數被當最終分顯示。#813 PR review finding 2。"""
+        sa = _sa(status, score=None)
+        assignment = _assignment("reading")
+        canonical = _canonical(1, 2)
+        progress = [
+            _item(
+                1,
+                pron=Decimal("80"),
+                acc=Decimal("80"),
+                flu=Decimal("80"),
+                comp=Decimal("80"),
+            ),
+            _item(2, rec=None, ai=False, pron=None, acc=None, flu=None, comp=None),
+        ]
+        db = _mock_db_speaking(canonical, progress)
+        assert _compute_interim_score(sa, assignment, db) is None
+
+    @pytest.mark.parametrize("mode", ["reading", "word_reading"])
+    def test_graded_null_score_recomputes_from_items(self, mode):
+        """核心 case：GRADED 但 sa.score=None → 從 item 分數現算（非 0）。"""
+        sa = _sa("GRADED", score=None)
+        assignment = _assignment(mode)
+        canonical = _canonical(1, 2)
+        progress = [
+            _item(
+                1,
+                pron=Decimal("80"),
+                acc=Decimal("80"),
+                flu=Decimal("80"),
+                comp=Decimal("80"),
+            ),
+            _item(
+                2,
+                pron=Decimal("90"),
+                acc=Decimal("90"),
+                flu=Decimal("90"),
+                comp=Decimal("90"),
+            ),
+        ]
+        db = _mock_db_speaking(canonical, progress)
+        # (80+90)/2 = 85.0
+        assert _compute_interim_score(sa, assignment, db) == pytest.approx(85.0)
+
+    def test_fast_path_existing_score_returned_without_query(self):
+        """sa.score 有值就直接回傳，不去 query item（即使是 0）。"""
+        sa = _sa("GRADED", score=66.3)
+        assignment = _assignment("reading")
+        db = _mock_db_speaking(_canonical(1), [])
+        assert _compute_interim_score(sa, assignment, db) == 66.3
+        db.query.assert_not_called()
+
+    def test_no_canonical_items_returns_none(self):
+        """作業內容關聯查不到題目（如 PROD assignment 415）→ 回 None，不 crash。"""
+        sa = _sa("GRADED", score=None)
+        assignment = _assignment("reading")
+        db = _mock_db_speaking([], [])
+        assert _compute_interim_score(sa, assignment, db) is None
+
+    def test_not_started_no_recordings_returns_none(self):
+        """未作答（item 無錄音/無評分）→ 回 None（不顯示 0）。"""
+        sa = _sa("NOT_STARTED", score=None)
+        assignment = _assignment("reading")
+        canonical = _canonical(1, 2)
+        progress = [
+            _item(1, rec=None, ai=False, pron=None, acc=None, flu=None, comp=None),
+            _item(2, rec=None, ai=False, pron=None, acc=None, flu=None, comp=None),
+        ]
+        db = _mock_db_speaking(canonical, progress)
+        assert _compute_interim_score(sa, assignment, db) is None
+
+    def test_is_interim_score_false_for_graded_speaking(self):
+        """GRADED speaking 即便現算，也不是 interim（不帶 ~ 前綴）。"""
+        sa = _sa("GRADED", score=None)
+        assignment = _assignment("reading")
+        assert _is_interim_score(sa, assignment) is False

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -726,30 +726,46 @@ export function AssignmentDialog({
 
   const loadQuotaInfo = async () => {
     try {
-      // 根據工作區 context 決定查哪個配額
-      const params = new URLSearchParams();
+      // Aggregated balance: subscription period + every active credit package
+      // (trial / referral bonus / purchased pack). Using the old
+      // /api/teachers/subscription endpoint here would silently understate the
+      // teacher's available quota and could block legitimate assignments.
       if (effectiveOrganizationId) {
-        params.append("organization_id", effectiveOrganizationId);
+        const res = await apiClient.get<{
+          total_points: number;
+          used_points: number;
+        }>(`/api/organizations/${effectiveOrganizationId}/points`);
+        if (typeof res.total_points === "number" && res.total_points > 0) {
+          setQuotaInfo({
+            quota_total: res.total_points,
+            quota_used: res.used_points ?? 0,
+            quota_remaining: Math.max(
+              0,
+              res.total_points - (res.used_points ?? 0),
+            ),
+            plan_name: "",
+          });
+        } else {
+          // Reset so a previous workspace's value doesn't linger and let a
+          // teacher act on quota they no longer have here.
+          setQuotaInfo(null);
+        }
+        return;
       }
-      const url = `/api/teachers/subscription${params.toString() ? `?${params.toString()}` : ""}`;
 
-      const response = await apiClient.get<{
-        subscription_period: {
-          quota_total: number;
-          quota_used: number;
-          plan_name: string;
-        };
-      }>(url);
-
-      if (response.subscription_period) {
+      const res = await apiClient.getSubscriptionStatus();
+      if (typeof res.quota_total === "number" && res.quota_total > 0) {
         setQuotaInfo({
-          quota_total: response.subscription_period.quota_total,
-          quota_used: response.subscription_period.quota_used,
-          quota_remaining:
-            response.subscription_period.quota_total -
-            response.subscription_period.quota_used,
-          plan_name: response.subscription_period.plan_name,
+          quota_total: res.quota_total,
+          quota_used: res.quota_used ?? 0,
+          quota_remaining: Math.max(
+            0,
+            (res.quota_total ?? 0) - (res.quota_used ?? 0),
+          ),
+          plan_name: res.plan ?? "",
         });
+      } else {
+        setQuotaInfo(null);
       }
     } catch (error) {
       console.error("Failed to load quota info:", error);

--- a/frontend/src/components/PromoCodeCard.tsx
+++ b/frontend/src/components/PromoCodeCard.tsx
@@ -1,0 +1,292 @@
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  Ticket,
+  Copy,
+  Share2,
+  ChevronDown,
+  ChevronUp,
+  Gift,
+} from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
+import { toast } from "sonner";
+import { apiClient } from "@/lib/api";
+
+interface MyPromoCode {
+  code: string;
+  expires_at: string | null;
+  is_active: boolean;
+  referral_count: number;
+  verified_count: number;
+  paid_count: number;
+  total_points_awarded: number;
+}
+
+// Display-only summary of the seeded defaults from
+// `backend/services/promo_code_service.py::DEFAULT_REWARD_CONFIGS`. Admin can
+// edit the live values via /admin/promo-codes — those changes won't appear
+// here, so keep this list in sync if you change the seed defaults.
+const REWARD_TIERS: { label: string; points: string }[] = [
+  { label: "驗證 Email", points: "+10" },
+  { label: "訂閱 Tutor Teachers", points: "+1,000" },
+  { label: "訂閱 School Teachers", points: "+2,000" },
+  { label: "購買 5,000 點點數包", points: "+200" },
+  { label: "購買 10,000 點點數包", points: "+500" },
+  { label: "購買 20,000 點點數包", points: "+800" },
+];
+
+export default function PromoCodeCard() {
+  const [data, setData] = useState<MyPromoCode | null>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    apiClient
+      .getMyPromoCode()
+      .then((res) => {
+        if (mounted) {
+          setData(res);
+          setError(null);
+        }
+      })
+      .catch((err) => {
+        console.error("Failed to load promo code:", err);
+        if (mounted)
+          setError(err instanceof Error ? err.message : "無法載入推薦碼");
+      })
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  // Always render the card frame so the section is visible. Show a skeleton
+  // while loading and a friendly message on error rather than disappearing.
+  if (loading) {
+    return (
+      <Card className="mb-6 border-indigo-200 dark:border-indigo-800">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Ticket className="h-5 w-5 text-indigo-600" />
+            我的推薦碼
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-16 animate-pulse rounded-lg bg-indigo-50 dark:bg-indigo-950" />
+        </CardContent>
+      </Card>
+    );
+  }
+  if (error || !data) {
+    return (
+      <Card className="mb-6 border-indigo-200 dark:border-indigo-800">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Ticket className="h-5 w-5 text-indigo-600" />
+            我的推薦碼
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-gray-500">
+            {error ? `無法載入推薦碼：${error}` : "尚未產生推薦碼，稍後再試。"}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // encodeURIComponent so a code that ever contains a special char (`+`, `&`,
+  // `%`, …) doesn't silently corrupt the URL.
+  const referralLink = `${window.location.origin}/teacher/register?promo=${encodeURIComponent(data.code)}`;
+
+  const copy = async (text: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success(`已複製${label}`);
+    } catch {
+      toast.error("複製失敗");
+    }
+  };
+
+  const share = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: "Duotopia 推薦邀請",
+          text: `用我的推薦碼 ${data.code} 註冊 Duotopia`,
+          url: referralLink,
+        });
+        return;
+      } catch (err) {
+        // The user explicitly dismissing the native share sheet throws
+        // AbortError — don't surface a "copied" success toast they didn't
+        // ask for. Only fall back to copy on a genuine failure.
+        if (err instanceof Error && err.name === "AbortError") return;
+      }
+    }
+    copy(referralLink, "推薦連結");
+  };
+
+  return (
+    <Card className="mb-6 border-indigo-200 dark:border-indigo-800">
+      <CardHeader>
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="w-full flex items-center justify-between"
+          aria-expanded={expanded}
+        >
+          <CardTitle className="flex items-center gap-2">
+            <Ticket className="h-5 w-5 text-indigo-600" />
+            我的推薦碼
+          </CardTitle>
+          <span className="flex items-center gap-1 text-xs text-gray-500">
+            {expanded ? "收合" : "展開"}
+            {expanded ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+          </span>
+        </button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Code row — always visible */}
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg bg-indigo-50 dark:bg-indigo-950 px-5 py-4">
+          <span className="font-mono text-2xl font-bold tracking-widest text-indigo-700 dark:text-indigo-300">
+            {data.code}
+          </span>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              onClick={() => copy(data.code, "推薦碼")}
+              className="bg-indigo-600 hover:bg-indigo-700"
+            >
+              <Copy className="h-4 w-4 mr-1.5" />
+              複製
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={share}
+              className="border-indigo-200 text-indigo-700 hover:bg-indigo-50"
+            >
+              <Share2 className="h-4 w-4 mr-1.5" />
+              分享
+            </Button>
+          </div>
+        </div>
+
+        {!expanded ? (
+          <p className="text-sm text-gray-500">
+            分享你的推薦碼給朋友，每邀請一位老師完成註冊即可獲得獎勵點數。
+          </p>
+        ) : (
+          <>
+            {/* Referral link + QR (stacked: link first, QR below) */}
+            <div>
+              <label className="text-xs text-gray-500">推薦連結</label>
+              <div className="mt-1 flex items-center gap-2 rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 px-3 py-2">
+                <code className="flex-1 truncate text-xs text-gray-700 dark:text-gray-200">
+                  {referralLink}
+                </code>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => copy(referralLink, "推薦連結")}
+                  className="h-7 px-2"
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+              <p className="mt-2 text-xs text-gray-500">
+                朋友點開時會自動帶入你的推薦碼。
+              </p>
+              <div className="mt-3 flex flex-col items-center gap-1">
+                <div className="rounded-md border border-gray-200 dark:border-gray-700 bg-white p-2">
+                  <QRCodeSVG value={referralLink} size={128} level="M" />
+                </div>
+                <span className="text-xs text-gray-500">掃 QR 直接註冊</span>
+              </div>
+            </div>
+
+            {/* Stats grid */}
+            <div>
+              <div className="mb-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
+                推薦成效
+              </div>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+                <Stat label="已邀請" value={data.referral_count} unit="人" />
+                <Stat label="已驗證" value={data.verified_count} unit="人" />
+                <Stat label="已付費" value={data.paid_count} unit="人" />
+                <Stat
+                  label="累積獲得"
+                  value={data.total_points_awarded}
+                  unit="點"
+                  highlight
+                />
+              </div>
+            </div>
+
+            {/* Reward explainer */}
+            <div className="rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 p-4">
+              <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
+                <Gift className="h-4 w-4 text-indigo-600" />
+                獎勵說明
+              </div>
+              <ul className="space-y-2">
+                {REWARD_TIERS.map((tier) => (
+                  <li
+                    key={tier.label}
+                    className="flex items-center justify-between text-sm"
+                  >
+                    <span className="text-gray-700 dark:text-gray-300">
+                      {tier.label}
+                    </span>
+                    <span className="rounded-md bg-indigo-100 dark:bg-indigo-900 px-2 py-0.5 text-xs font-semibold text-indigo-700 dark:text-indigo-300">
+                      {tier.points} 點
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  unit,
+  highlight,
+}: {
+  label: string;
+  value: number;
+  unit: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
+      <div className="text-xs text-gray-500">{label}</div>
+      <div className="flex items-baseline gap-1">
+        <span
+          className={
+            "text-2xl font-bold " +
+            (highlight ? "text-indigo-600" : "text-gray-900 dark:text-gray-100")
+          }
+        >
+          {value.toLocaleString()}
+        </span>
+        <span className="text-xs text-gray-500">{unit}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/StudentTable.tsx
+++ b/frontend/src/components/StudentTable.tsx
@@ -421,7 +421,7 @@ export default function StudentTable({
                           </span>
                         ) : (
                           <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
-                            {t("studentTable.unassigned")}
+                            {t("studentTable.classroom.unassigned")}
                           </span>
                         )}
                       </div>
@@ -536,7 +536,7 @@ export default function StudentTable({
                       <Button
                         variant="ghost"
                         size="sm"
-                        title={t("studentTable.view")}
+                        title={t("studentTable.actions.view")}
                         onClick={() => onViewStudent(student)}
                       >
                         <Eye className="h-4 w-4" />
@@ -549,7 +549,7 @@ export default function StudentTable({
                         title={
                           disableActions
                             ? disableReason
-                            : t("studentTable.edit")
+                            : t("studentTable.actions.edit")
                         }
                         onClick={() => onEditStudent(student)}
                         disabled={disableActions}
@@ -564,12 +564,12 @@ export default function StudentTable({
                         title={
                           disableActions
                             ? disableReason
-                            : t("studentTable.delete")
+                            : t("studentTable.actions.delete")
                         }
                         onClick={() => {
                           if (
                             confirm(
-                              t("studentTable.confirmDelete", {
+                              t("studentTable.actions.deleteConfirm", {
                                 name: student.name,
                               }),
                             )

--- a/frontend/src/components/TeacherLayout.tsx
+++ b/frontend/src/components/TeacherLayout.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
 import { apiClient } from "@/lib/api";
+import { buildQuotaSources, type QuotaSourceItem } from "@/lib/quotaSources";
 import { useState, useEffect } from "react";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { useTranslation } from "react-i18next";
@@ -47,6 +48,125 @@ interface TeacherProfile {
   is_demo: boolean;
   is_active: boolean;
   is_admin?: boolean;
+}
+
+interface WorkspaceColor {
+  surface: string;
+  accent: string;
+  text: string;
+  bar: string;
+}
+
+interface TokenInfo {
+  used: number;
+  total: number;
+  sources: QuotaSourceItem[];
+}
+
+/**
+ * Sidebar token-balance bar, extracted as a leaf so a token refetch only
+ * re-renders this subtree — the surrounding memoized SidebarContent (which
+ * includes nav, WorkspaceSwitcher, account menu) stays untouched.
+ */
+function SidebarTokenBar({
+  tokenInfo,
+  workspaceColor,
+}: {
+  tokenInfo: TokenInfo | null;
+  workspaceColor: WorkspaceColor;
+}) {
+  if (!tokenInfo || tokenInfo.total <= 0) return null;
+  const barTotal = Math.max(
+    1,
+    tokenInfo.sources.reduce((a, x) => a + x.total, 0),
+  );
+  return (
+    <div className="mt-3 rounded-md px-3 py-2 bg-white/70 dark:bg-gray-900/40">
+      <div className="flex items-center justify-between text-xs">
+        <span className="font-medium text-gray-700 dark:text-gray-300">
+          剩餘點數
+        </span>
+        <span className="font-semibold" style={{ color: workspaceColor.text }}>
+          {Math.max(0, tokenInfo.total - tokenInfo.used).toLocaleString()} /{" "}
+          {tokenInfo.total.toLocaleString()}
+        </span>
+      </div>
+      {tokenInfo.sources.length > 0 ? (
+        <>
+          {/* Stacked-by-source bar (personal). Each segment width is its
+              share of sum-of-sources (avoids white gap if a package expires
+              between QuotaService's two queries). Dark inner fill ∝
+              REMAINING (matches the "剩餘 X / Y" headline above). */}
+          <div className="mt-1.5 flex h-2 w-full overflow-hidden rounded-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
+            {tokenInfo.sources.map((s) => {
+              const segPct = (s.total / barTotal) * 100;
+              const remainingPct =
+                (Math.max(0, s.total - s.used) / Math.max(1, s.total)) * 100;
+              return (
+                <div
+                  key={s.kind}
+                  className="h-full"
+                  style={{
+                    width: `${segPct}%`,
+                    backgroundColor: s.bg,
+                  }}
+                >
+                  <div
+                    className="h-full"
+                    style={{
+                      width: `${remainingPct}%`,
+                      backgroundColor: s.fill,
+                    }}
+                  />
+                </div>
+              );
+            })}
+          </div>
+          <ul className="mt-2 space-y-1">
+            {tokenInfo.sources.map((s) => (
+              <li
+                key={s.kind}
+                className="flex items-center gap-1.5 text-[10px]"
+              >
+                <span
+                  className="inline-block h-2 w-2 rounded-sm"
+                  style={{ backgroundColor: s.fill }}
+                />
+                <span className="text-gray-700 dark:text-gray-300">
+                  {s.label}
+                </span>
+                <span className="ml-auto font-semibold text-gray-700 dark:text-gray-300">
+                  {s.used.toLocaleString()} / {s.total.toLocaleString()}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : (
+        // Org mode: single solid bar; width = REMAINING / total so a
+        // depleted balance reads as an almost-empty bar.
+        <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-white dark:bg-gray-800">
+          <div
+            className="h-full rounded-full"
+            style={{
+              width: `${Math.max(
+                0,
+                Math.min(
+                  100,
+                  Math.round(
+                    (Math.max(0, tokenInfo.total - tokenInfo.used) /
+                      Math.max(1, tokenInfo.total)) *
+                      100,
+                  ),
+                ),
+              )}%`,
+              backgroundColor: workspaceColor.bar,
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
 }
 
 interface SystemConfig {
@@ -79,7 +199,140 @@ function TeacherLayoutInner({
   const userRoles = useTeacherAuthStore((state) => state.userRoles);
 
   // Get workspace context
-  const { mode, selectedSchool } = useWorkspace();
+  const { mode, selectedSchool, selectedOrganization } = useWorkspace();
+
+  // Watch for dark-mode class changes on <html> so we can skip the workspace
+  // tint when dark mode is active (the tinted surface colours are all light
+  // and would read poorly against dark-mode text).
+  const [isDarkMode, setIsDarkMode] = useState(
+    () =>
+      typeof document !== "undefined" &&
+      document.documentElement.classList.contains("dark"),
+  );
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const root = document.documentElement;
+    const obs = new MutationObserver(() => {
+      setIsDarkMode(root.classList.contains("dark"));
+    });
+    obs.observe(root, { attributes: true, attributeFilter: ["class"] });
+    return () => obs.disconnect();
+  }, []);
+
+  // Workspace color palette: Personal = indigo (default), Orgs cycle the next
+  // four colors deterministically by org id so the same org always gets the
+  // same tint. The whole workspace+token block at the bottom of the sidebar
+  // tints to match the active workspace. Memoized so the SidebarContent
+  // useMemo below doesn't recompute on every render.
+  const workspaceColor = useMemo(() => {
+    // `surface` is the whole-sidebar wash (color-100 level — readable but
+    // distinct); `accent` is the inner workspace+token block; `bar` is the
+    // progress fill / strong text.
+    const PALETTE = [
+      {
+        surface: "#E0E7FF",
+        accent: "#C7D2FE",
+        text: "#3730A3",
+        bar: "#4F46E5",
+      }, // indigo (personal)
+      {
+        surface: "#D1FAE5",
+        accent: "#A7F3D0",
+        text: "#065F46",
+        bar: "#059669",
+      }, // emerald
+      {
+        surface: "#FEF3C7",
+        accent: "#FDE68A",
+        text: "#92400E",
+        bar: "#D97706",
+      }, // amber
+      {
+        surface: "#FFE4E6",
+        accent: "#FECDD3",
+        text: "#9F1239",
+        bar: "#E11D48",
+      }, // rose
+      {
+        surface: "#EDE9FE",
+        accent: "#DDD6FE",
+        text: "#5B21B6",
+        bar: "#7C3AED",
+      }, // violet
+    ];
+    if (mode === "personal" || !selectedOrganization) return PALETTE[0];
+    const hash = Array.from(selectedOrganization.id).reduce(
+      (a, c) => a + c.charCodeAt(0),
+      0,
+    );
+    return PALETTE[1 + (hash % 4)];
+    // Key on the .id primitive (not the object reference) so the colour only
+    // recomputes when the org actually changes — matches the token-fetch effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, selectedOrganization?.id]);
+
+  // Workspace-aware token / quota for the sidebar bar.
+  // Personal mode  → /api/subscription/status (AGGREGATED across the active
+  //                  subscription period + every active credit package, e.g.
+  //                  trial + referral bonus + purchased packs — matches what
+  //                  admins see in the per-teacher list)
+  // Org mode       → /api/organizations/{id}/points (org-level points balance)
+  // (/api/teachers/subscription only returns the current subscription_period
+  // and is intentionally NOT used here — it would understate the teacher's
+  // available points by ignoring credit packages.)
+  // sources is non-empty only in personal mode (where we have a breakdown);
+  // org mode just shows total/used without colour-coded segments.
+  const [tokenInfo, setTokenInfo] = useState<{
+    used: number;
+    total: number;
+    sources: QuotaSourceItem[];
+  } | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    const fetchToken = async () => {
+      try {
+        if (mode === "organization" && selectedOrganization) {
+          const res = await apiClient.get<{
+            total_points: number;
+            used_points: number;
+          }>(`/api/organizations/${selectedOrganization.id}/points`);
+          if (cancelled) return;
+          if (res && typeof res.total_points === "number") {
+            setTokenInfo({
+              used: res.used_points ?? 0,
+              total: res.total_points,
+              sources: [],
+            });
+          } else {
+            setTokenInfo(null);
+          }
+        } else {
+          const res = await apiClient.getSubscriptionStatus();
+          if (cancelled) return;
+          if (typeof res.quota_total === "number" && res.quota_total > 0) {
+            setTokenInfo({
+              used: res.quota_used ?? 0,
+              total: res.quota_total,
+              sources: buildQuotaSources(res),
+            });
+          } else {
+            setTokenInfo(null);
+          }
+        }
+      } catch {
+        // Non-fatal — hide the bar rather than break the sidebar (e.g. a
+        // non-admin teacher in an org may not have permission to read points).
+        if (!cancelled) setTokenInfo(null);
+      }
+    };
+    fetchToken();
+    return () => {
+      cancelled = true;
+    };
+    // We intentionally key on .id (a primitive) instead of the whole object so
+    // re-renders with the same org don't refetch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, selectedOrganization?.id]);
 
   // ✅ 切換 workspace mode 時，自動導向 dashboard（避免殘留前一模式的頁面）
   const prevModeRef = useRef(mode);
@@ -215,13 +468,6 @@ function TeacherLayoutInner({
             </div>
           </div>
 
-          {/* Workspace Switcher - Personal / Organization Tabs */}
-          {!sidebarCollapsed && teacherProfile && (
-            <div className="px-3 pt-4">
-              <WorkspaceSwitcher />
-            </div>
-          )}
-
           {/* Navigation */}
           <nav
             className={`flex-1 overflow-y-auto ${sidebarCollapsed ? "p-2" : "p-4"}`}
@@ -239,6 +485,29 @@ function TeacherLayoutInner({
               ))}
             </ul>
           </nav>
+
+          {/* Workspace + token (Variant B: switcher moved to bottom near
+              user). Accent tint is light-mode only — same reason as the
+              parent sidebar background. */}
+          {!sidebarCollapsed && teacherProfile && (
+            <div
+              className="px-3 pt-3 pb-2 border-t dark:border-gray-700"
+              style={
+                isDarkMode
+                  ? undefined
+                  : { backgroundColor: workspaceColor.accent }
+              }
+            >
+              <WorkspaceSwitcher />
+              {/* Render the bar as a child component so that setTokenInfo()
+                  doesn't force the whole memoized SidebarContent to rebuild
+                  — React reconciles this subtree on its own. */}
+              <SidebarTokenBar
+                tokenInfo={tokenInfo}
+                workspaceColor={workspaceColor}
+              />
+            </div>
+          )}
 
           {/* Account Menu */}
           <div className="p-2 border-t dark:border-gray-700">
@@ -386,6 +655,10 @@ function TeacherLayoutInner({
       config,
       hasOrgRole,
       handleLogout,
+      // tokenInfo intentionally omitted: SidebarTokenBar is a child component,
+      // so React reconciles it on its own when tokenInfo changes.
+      workspaceColor,
+      isDarkMode,
     ],
   );
 
@@ -414,7 +687,14 @@ function TeacherLayoutInner({
                 </Button>
               </SheetTrigger>
               <SheetContent side="left" className="w-64 p-0">
-                <div className="flex flex-col h-full bg-white dark:bg-gray-800">
+                <div
+                  className="flex flex-col h-full bg-white dark:bg-gray-800"
+                  style={
+                    isDarkMode
+                      ? undefined
+                      : { backgroundColor: workspaceColor.surface }
+                  }
+                >
                   <SidebarContent onNavigate={() => {}} />
                 </div>
               </SheetContent>
@@ -424,9 +704,13 @@ function TeacherLayoutInner({
       </div>
 
       <div className="flex">
-        {/* Desktop Sidebar */}
+        {/* Desktop Sidebar — tinted by active workspace color (light mode
+            only; in dark mode we let dark:bg-gray-800 win). */}
         <div
           className={`hidden md:flex bg-white dark:bg-gray-800 shadow-lg transition-all duration-300 ${sidebarCollapsed ? "w-16" : "w-64"} flex-col h-screen sticky top-0 ${sidebarDisabled ? "pointer-events-none opacity-50" : ""}`}
+          style={
+            isDarkMode ? undefined : { backgroundColor: workspaceColor.surface }
+          }
         >
           <SidebarContent />
         </div>

--- a/frontend/src/components/TeacherRegisterSheet.tsx
+++ b/frontend/src/components/TeacherRegisterSheet.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useState, useEffect, useRef } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   Sheet,
   SheetContent,
@@ -20,8 +20,9 @@ import {
   ArrowLeft,
   Eye,
   EyeOff,
+  Ticket,
 } from "lucide-react";
-import { apiClient } from "@/lib/api";
+import { apiClient, ApiError } from "@/lib/api";
 import { useTranslation } from "react-i18next";
 import { validatePasswordStrength } from "@/utils/passwordValidation";
 
@@ -38,6 +39,7 @@ export default function TeacherRegisterSheet({
 }: TeacherRegisterSheetProps) {
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
   const [showPassword, setShowPassword] = useState(false);
@@ -48,7 +50,26 @@ export default function TeacherRegisterSheet({
     confirmPassword: "",
     name: "",
     phone: "",
+    promoCode: "",
   });
+
+  // Tracks an intentional clear so reopening the sheet (with ?promo= still in
+  // the URL) doesn't silently re-inject a code the user removed.
+  const userClearedPromo = useRef(false);
+
+  // Prefill the promo code from a ?promo= URL param (referral links). Re-checks
+  // when the sheet opens (it may stay mounted across opens), only fills when
+  // empty, and skips once the user has intentionally cleared it. Clamped to the
+  // DB column length so an oversized URL code can't 422 on submit.
+  useEffect(() => {
+    if (!isOpen) return;
+    const promo = searchParams.get("promo")?.trim().slice(0, 16);
+    if (promo && !userClearedPromo.current) {
+      setFormData((prev) =>
+        prev.promoCode ? prev : { ...prev, promoCode: promo },
+      );
+    }
+  }, [isOpen, searchParams]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -82,6 +103,7 @@ export default function TeacherRegisterSheet({
         password: trimmedPassword,
         name: formData.name,
         phone: formData.phone || undefined,
+        promo_code: formData.promoCode.trim() || undefined,
       })) as RegisterResponse;
 
       onClose();
@@ -98,7 +120,21 @@ export default function TeacherRegisterSheet({
       }
     } catch (err) {
       console.error("Registration error:", err);
-      setError(t("teacherRegister.errors.registerFailed"));
+      // 422 with a promo code most likely means the code is invalid / revoked.
+      if (err instanceof ApiError && err.status === 422 && formData.promoCode) {
+        setError(
+          t(
+            "teacherRegister.errors.invalidPromoCode",
+            "推薦碼無效或已停用，已自動清除欄位，請重試。",
+          ),
+        );
+        // Also mark as intentionally cleared, so the URL ?promo= effect
+        // doesn't immediately re-inject the same bad code on the next render.
+        userClearedPromo.current = true;
+        setFormData((prev) => ({ ...prev, promoCode: "" }));
+      } else {
+        setError(t("teacherRegister.errors.registerFailed"));
+      }
     } finally {
       setIsLoading(false);
     }
@@ -106,12 +142,16 @@ export default function TeacherRegisterSheet({
 
   const handleClose = () => {
     setError("");
+    // Closing the sheet means the form is wiped; clearing the ref lets a fresh
+    // ?promo= URL parameter populate the field on the next open.
+    userClearedPromo.current = false;
     setFormData({
       email: "",
       password: "",
       confirmPassword: "",
       name: "",
       phone: "",
+      promoCode: "",
     });
     onClose();
   };
@@ -207,6 +247,33 @@ export default function TeacherRegisterSheet({
                     setFormData({ ...formData, phone: e.target.value })
                   }
                   className="pl-10"
+                  disabled={isLoading}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="sheet-reg-promo">
+                {t("teacherRegister.form.promoCode", "推薦碼（選填）")}
+              </Label>
+              <div className="relative">
+                <Ticket className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                <Input
+                  id="sheet-reg-promo"
+                  type="text"
+                  placeholder={t(
+                    "teacherRegister.form.promoCodePlaceholder",
+                    "輸入推薦碼",
+                  )}
+                  value={formData.promoCode}
+                  onChange={(e) => {
+                    // Empty after editing = intentional clear; don't re-inject
+                    // the URL code on the next open.
+                    userClearedPromo.current = e.target.value.trim() === "";
+                    setFormData({ ...formData, promoCode: e.target.value });
+                  }}
+                  className="pl-10"
+                  maxLength={16}
                   disabled={isLoading}
                 />
               </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -132,6 +132,7 @@ export interface RegisterRequest {
   password: string;
   name: string;
   phone?: string;
+  promo_code?: string;
 }
 
 export interface AdminCreditPackageOperation {
@@ -157,6 +158,34 @@ interface AdminCreditPackageResult {
   expires_at: string;
   status: string;
   admin_operations: AdminCreditPackageOperation[];
+}
+
+// ============ Promo Code types ============
+export interface PromoCodeRow {
+  id: number;
+  code: string;
+  teacher_id: number;
+  kind: string;
+  expires_at: string | null;
+  is_active: boolean;
+  note: string | null;
+  created_at: string | null;
+}
+
+export interface RewardConfigRow {
+  id: number;
+  reward_key: string;
+  points: number;
+  recipient: string;
+  is_active: boolean;
+}
+
+export interface ReferralReportRow {
+  referrer_teacher_id: number;
+  referral_count: number;
+  verified_count: number;
+  paid_count: number;
+  total_points_awarded: number;
 }
 
 class ApiClient {
@@ -1617,6 +1646,101 @@ class ApiClient {
         body: JSON.stringify(data),
       },
     );
+  }
+
+  async getMyPromoCode() {
+    return this.request<{
+      code: string;
+      expires_at: string | null;
+      is_active: boolean;
+      referral_count: number;
+      verified_count: number;
+      paid_count: number;
+      total_points_awarded: number;
+    }>("/api/teachers/me/promo-code", { method: "GET" });
+  }
+
+  async getSubscriptionStatus() {
+    return this.request<{
+      status: string;
+      plan: string | null;
+      days_remaining: number | null;
+      is_active: boolean;
+      quota_used: number;
+      quota_total: number;
+      quota_remaining: number;
+      subscription_total?: number;
+      subscription_used?: number;
+      subscription_remaining?: number;
+      credit_packages_total?: number;
+      credit_packages_remaining?: number;
+      credit_packages?: Array<{
+        id: number;
+        package_id: string;
+        points_total: number;
+        points_used: number;
+        points_remaining: number;
+        source: string;
+        status: string;
+        is_expired: boolean;
+      }>;
+    }>("/api/subscription/status", { method: "GET" });
+  }
+
+  // ============ Admin Promo Code Methods ============
+  async listPromoCodes(params?: { teacher_id?: number; kind?: string }) {
+    const qs = new URLSearchParams();
+    if (params?.teacher_id !== undefined)
+      qs.append("teacher_id", params.teacher_id.toString());
+    if (params?.kind) qs.append("kind", params.kind);
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return this.request<PromoCodeRow[]>(`/api/admin/promo-codes${suffix}`, {
+      method: "GET",
+    });
+  }
+
+  async createAffiliateCode(data: {
+    teacher_id: number;
+    expires_at?: string | null;
+    note?: string;
+  }) {
+    return this.request<PromoCodeRow>("/api/admin/promo-codes", {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updatePromoCode(
+    codeId: number,
+    data: { is_active?: boolean; expires_at?: string | null; note?: string },
+  ) {
+    return this.request<PromoCodeRow>(`/api/admin/promo-codes/${codeId}`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    });
+  }
+
+  async listRewardConfigs() {
+    return this.request<RewardConfigRow[]>(
+      "/api/admin/promo-codes/reward-configs",
+      { method: "GET" },
+    );
+  }
+
+  async updateRewardConfig(
+    rewardKey: string,
+    data: { points?: number; is_active?: boolean },
+  ) {
+    return this.request<RewardConfigRow>(
+      `/api/admin/promo-codes/reward-configs/${encodeURIComponent(rewardKey)}`,
+      { method: "PATCH", body: JSON.stringify(data) },
+    );
+  }
+
+  async getReferralReport() {
+    return this.request<ReferralReportRow[]>("/api/admin/promo-codes/report", {
+      method: "GET",
+    });
   }
 }
 

--- a/frontend/src/lib/quotaSources.ts
+++ b/frontend/src/lib/quotaSources.ts
@@ -1,0 +1,134 @@
+/**
+ * Quota source breakdown helper (issue #637 design v3).
+ *
+ * Given the response of /api/subscription/status, group it into a small,
+ * ordered list of "sources" the user can recognise — subscription plan,
+ * trial bonus, referral bonus, purchased packs, admin grant — each with its
+ * own colour and used/total so the UI can render a stacked bar + legend.
+ */
+
+export type QuotaSourceKind =
+  | "subscription"
+  | "trial"
+  | "referral"
+  | "pack"
+  | "admin";
+
+export interface QuotaSourceItem {
+  kind: QuotaSourceKind;
+  label: string;
+  fill: string; // strong colour for the REMAINING portion (inner bar / legend dot)
+  bg: string; // light colour for the USED/background portion
+  total: number;
+  used: number;
+}
+
+const META: Record<
+  QuotaSourceKind,
+  { label: string; fill: string; bg: string }
+> = {
+  subscription: { label: "訂閱配額", fill: "#6366F1", bg: "#E0E7FF" },
+  trial: { label: "試用點數", fill: "#3B82F6", bg: "#DBEAFE" },
+  referral: { label: "推薦獎勵", fill: "#059669", bg: "#A7F3D0" },
+  pack: { label: "點數包", fill: "#D97706", bg: "#FED7AA" },
+  admin: { label: "管理員配發", fill: "#7C3AED", bg: "#DDD6FE" },
+};
+
+const ORDER: QuotaSourceKind[] = [
+  "subscription",
+  "trial",
+  "referral",
+  "pack",
+  "admin",
+];
+
+/**
+ * Convert a #RRGGBB hex string to a CSS `rgba(...)` with the given alpha.
+ * Falls back to the original colour if the input isn't a 6-digit hex (safer
+ * than string-concatenating "55" onto an unknown format).
+ */
+export function hexAlpha(hex: string, alpha: number): string {
+  const m = /^#([0-9a-f]{6})$/i.exec(hex);
+  if (!m) return hex;
+  const n = parseInt(m[1], 16);
+  const r = (n >> 16) & 0xff;
+  const g = (n >> 8) & 0xff;
+  const b = n & 0xff;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+export function mapPackageSource(source: string): QuotaSourceKind {
+  switch (source) {
+    case "trial_bonus":
+      return "trial";
+    case "referral_reward":
+      return "referral";
+    case "purchase":
+    case "org_purchase":
+      return "pack";
+    case "admin_grant":
+      return "admin";
+    default:
+      return "pack";
+  }
+}
+
+interface SubscriptionStatusLike {
+  plan?: string | null;
+  subscription_total?: number;
+  subscription_used?: number;
+  credit_packages?: Array<{
+    source: string;
+    points_total: number;
+    points_used: number;
+    is_expired: boolean;
+    status: string;
+  }>;
+}
+
+export function buildQuotaSources(
+  res: SubscriptionStatusLike,
+): QuotaSourceItem[] {
+  const acc = new Map<
+    QuotaSourceKind,
+    { label: string; fill: string; bg: string; used: number; total: number }
+  >();
+
+  if ((res.subscription_total ?? 0) > 0) {
+    acc.set("subscription", {
+      label: res.plan ? `${res.plan} 配額` : META.subscription.label,
+      fill: META.subscription.fill,
+      bg: META.subscription.bg,
+      total: res.subscription_total ?? 0,
+      used: res.subscription_used ?? 0,
+    });
+  }
+
+  for (const pkg of res.credit_packages ?? []) {
+    // Skip refunded / expired / migrated packages — they don't contribute
+    // to the visible balance. The DB column has no CHECK constraint, so guard
+    // against an empty / falsy status by treating anything other than the
+    // literal "active" as inactive (not just "non-empty and not active").
+    if (pkg.is_expired) continue;
+    if (pkg.status !== "active") continue;
+    const kind = mapPackageSource(pkg.source);
+    const existing = acc.get(kind);
+    if (existing) {
+      existing.used += pkg.points_used;
+      existing.total += pkg.points_total;
+    } else {
+      acc.set(kind, {
+        label: META[kind].label,
+        fill: META[kind].fill,
+        bg: META[kind].bg,
+        used: pkg.points_used,
+        total: pkg.points_total,
+      });
+    }
+  }
+
+  return ORDER.filter((k) => acc.has(k)).map((k) => ({
+    kind: k,
+    ...acc.get(k)!,
+  }));
+}

--- a/frontend/src/pages/TeacherRegister.tsx
+++ b/frontend/src/pages/TeacherRegister.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -13,8 +13,17 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Loader2, User, Lock, Mail, Phone, Eye, EyeOff } from "lucide-react";
-import { apiClient } from "../lib/api";
+import {
+  Loader2,
+  User,
+  Lock,
+  Mail,
+  Phone,
+  Eye,
+  EyeOff,
+  Ticket,
+} from "lucide-react";
+import { apiClient, ApiError } from "../lib/api";
 import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { validatePasswordStrength } from "@/utils/passwordValidation";
@@ -25,6 +34,7 @@ import { sendEvent as gaSendEvent } from "@/services/gaService";
 export default function TeacherRegister() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const isAuthenticated = useTeacherAuthStore((state) => state.isAuthenticated);
   const user = useTeacherAuthStore((state) => state.user);
   const [isLoading, setIsLoading] = useState(false);
@@ -46,7 +56,22 @@ export default function TeacherRegister() {
     confirmPassword: "",
     name: "",
     phone: "",
+    promoCode: "",
   });
+
+  // Prefill the promo code from a ?promo= URL param (referral links). Run once
+  // on mount and only when empty, so a later navigation can't re-inject a code
+  // the user manually cleared.
+  useEffect(() => {
+    // Clamp to the DB column length; a value set programmatically bypasses the
+    // input's maxLength, so an oversized URL code would otherwise 422 on submit.
+    const promo = searchParams.get("promo")?.trim().slice(0, 16);
+    if (promo) {
+      setFormData((prev) =>
+        prev.promoCode ? prev : { ...prev, promoCode: promo },
+      );
+    }
+  }, [searchParams]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -82,6 +107,7 @@ export default function TeacherRegister() {
         password: trimmedPassword,
         name: formData.name,
         phone: formData.phone || undefined,
+        promo_code: formData.promoCode.trim() || undefined,
       })) as RegisterResponse;
 
       // 🔴 不要自動登入！顯示驗證提示
@@ -107,8 +133,20 @@ export default function TeacherRegister() {
       }
     } catch (err) {
       console.error("Registration error:", err);
-      // Bug1 Fix: Always use i18n translation, don't show backend error message directly
-      setError(t("teacherRegister.errors.registerFailed"));
+      // 422 with a promo code most likely means the code is invalid / revoked.
+      // Tell the user specifically and wipe the field so a retry isn't blocked
+      // by the same bad value — the rest of the form stays as the user typed.
+      if (err instanceof ApiError && err.status === 422 && formData.promoCode) {
+        setError(
+          t(
+            "teacherRegister.errors.invalidPromoCode",
+            "推薦碼無效或已停用，已自動清除欄位，請重試。",
+          ),
+        );
+        setFormData((prev) => ({ ...prev, promoCode: "" }));
+      } else {
+        setError(t("teacherRegister.errors.registerFailed"));
+      }
     } finally {
       setIsLoading(false);
     }
@@ -198,6 +236,30 @@ export default function TeacherRegister() {
                       setFormData({ ...formData, phone: e.target.value })
                     }
                     className="pl-10"
+                    disabled={isLoading}
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="promoCode">
+                  {t("teacherRegister.form.promoCode", "推薦碼（選填）")}
+                </Label>
+                <div className="relative">
+                  <Ticket className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                  <Input
+                    id="promoCode"
+                    type="text"
+                    placeholder={t(
+                      "teacherRegister.form.promoCodePlaceholder",
+                      "輸入推薦碼",
+                    )}
+                    value={formData.promoCode}
+                    onChange={(e) =>
+                      setFormData({ ...formData, promoCode: e.target.value })
+                    }
+                    className="pl-10"
+                    maxLength={16}
                     disabled={isLoading}
                   />
                 </div>

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -1,11 +1,19 @@
 import { useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Crown, DollarSign, AlertTriangle, Building, Tag } from "lucide-react";
+import {
+  Crown,
+  DollarSign,
+  AlertTriangle,
+  Building,
+  Tag,
+  Ticket,
+} from "lucide-react";
 import AdminSubscriptionDashboard from "./AdminSubscriptionDashboard";
 import AdminBillingDashboard from "./AdminBillingDashboard";
 import AdminAudioErrorDashboard from "./AdminAudioErrorDashboard";
 import AdminOrganizations from "./AdminOrganizations";
 import AdminPlansPage from "./AdminPlansPage";
+import AdminPromoCodesPage from "./AdminPromoCodesPage";
 import AdminLayout from "@/components/admin/AdminLayout";
 
 export default function AdminDashboard() {
@@ -63,6 +71,14 @@ export default function AdminDashboard() {
             <span className="hidden sm:inline">方案管理</span>
             <span className="sm:hidden">方案</span>
           </TabsTrigger>
+          <TabsTrigger
+            value="promo-codes"
+            className="flex items-center gap-2 px-4 py-3 text-sm md:text-base font-medium text-gray-500 bg-transparent border-b-2 border-transparent rounded-none data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:border-blue-600 data-[state=active]:font-semibold data-[state=active]:shadow-none hover:text-gray-700 transition-colors"
+          >
+            <Ticket className="h-4 w-4 md:h-5 md:w-5 flex-shrink-0" />
+            <span className="hidden sm:inline">推薦碼</span>
+            <span className="sm:hidden">推薦</span>
+          </TabsTrigger>
         </TabsList>
 
         {/* Subscription Management Tab */}
@@ -88,6 +104,11 @@ export default function AdminDashboard() {
         {/* Plans Management Tab */}
         <TabsContent value="plans" className="space-y-4">
           <AdminPlansPage />
+        </TabsContent>
+
+        {/* Promo Codes Tab */}
+        <TabsContent value="promo-codes" className="space-y-4">
+          <AdminPromoCodesPage />
         </TabsContent>
       </Tabs>
     </AdminLayout>

--- a/frontend/src/pages/admin/AdminPromoCodesPage.tsx
+++ b/frontend/src/pages/admin/AdminPromoCodesPage.tsx
@@ -1,0 +1,368 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  apiClient,
+  type PromoCodeRow,
+  type RewardConfigRow,
+  type ReferralReportRow,
+} from "@/lib/api";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Ticket, Gift, BarChart3, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+
+const formatDate = (s: string | null) => {
+  if (!s) return "永久";
+  // Normalize so the date renders correctly in UTC+8: a bare "YYYY-MM-DD" is
+  // pinned to local midnight; a datetime without an explicit zone is treated
+  // as UTC (the backend stores tz-aware UTC).
+  const hasZone = s.endsWith("Z") || /[+-]\d{2}:\d{2}$/.test(s);
+  const normalized = s.includes("T")
+    ? hasZone
+      ? s
+      : `${s}Z`
+    : `${s}T00:00:00`;
+  return new Date(normalized).toLocaleDateString("zh-TW", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+};
+
+export default function AdminPromoCodesPage() {
+  const [codes, setCodes] = useState<PromoCodeRow[]>([]);
+  const [configs, setConfigs] = useState<RewardConfigRow[]>([]);
+  const [report, setReport] = useState<ReferralReportRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Local edit buffer for reward-config points, keyed by reward_key.
+  const [pointDrafts, setPointDrafts] = useState<Record<string, string>>({});
+  // In-flight guard so rapid clicks can't fire racing PATCH/fetch calls.
+  const [busy, setBusy] = useState(false);
+
+  // `silent` skips the full-page loading state so post-mutation refetches
+  // don't blank the page to "載入中...".
+  const fetchAll = useCallback(async (silent = false) => {
+    if (!silent) setLoading(true);
+    setError(null);
+    try {
+      const [c, rc, rep] = await Promise.all([
+        apiClient.listPromoCodes(),
+        apiClient.listRewardConfigs(),
+        apiClient.getReferralReport(),
+      ]);
+      setCodes(c);
+      setConfigs(rc);
+      setReport(rep);
+      // Preserve any unsaved point edits across refetch (a toggle elsewhere
+      // triggers fetchAll); only seed keys we don't already have a draft for.
+      setPointDrafts((prev) =>
+        Object.fromEntries(
+          rc.map((r) => [r.reward_key, prev[r.reward_key] ?? String(r.points)]),
+        ),
+      );
+    } catch (err) {
+      console.error("Failed to load promo data:", err);
+      setError(err instanceof Error ? err.message : "載入失敗");
+    } finally {
+      // Symmetric with the top: silent refetches must not flip loading off,
+      // otherwise a post-mutation refetch racing with the initial load could
+      // collapse the spinner before the first response actually lands.
+      if (!silent) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  const toggleCodeActive = async (row: PromoCodeRow) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await apiClient.updatePromoCode(row.id, { is_active: !row.is_active });
+      toast.success(`已${row.is_active ? "停用" : "啟用"}推薦碼 ${row.code}`);
+      await fetchAll(true);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "更新失敗");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveRewardPoints = async (cfg: RewardConfigRow) => {
+    if (busy) return;
+    const draft = pointDrafts[cfg.reward_key];
+    if (draft === undefined) return; // row not yet loaded into drafts
+    // Number("   ") is 0, so trim before parsing to reject whitespace-only.
+    const trimmed = draft.trim();
+    const n = Number(trimmed);
+    if (trimmed === "" || Number.isNaN(n) || n < 0 || !Number.isInteger(n)) {
+      toast.error("點數必須是 0 或正整數");
+      return;
+    }
+    if (n === cfg.points) {
+      toast.info("沒有變更");
+      return;
+    }
+    setBusy(true);
+    try {
+      await apiClient.updateRewardConfig(cfg.reward_key, { points: n });
+      toast.success(`已更新 ${cfg.reward_key} 為 ${n} 點`);
+      // Drop the saved draft so the next fetchAll re-seeds it from the server
+      // (otherwise a stale draft could later overwrite a concurrent change).
+      setPointDrafts((prev) => {
+        const next = { ...prev };
+        delete next[cfg.reward_key];
+        return next;
+      });
+      await fetchAll(true);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "更新失敗");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const toggleRewardActive = async (cfg: RewardConfigRow) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await apiClient.updateRewardConfig(cfg.reward_key, {
+        is_active: !cfg.is_active,
+      });
+      toast.success(`已${cfg.is_active ? "停用" : "啟用"} ${cfg.reward_key}`);
+      await fetchAll(true);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "更新失敗");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="py-8 text-center text-gray-500">載入中...</div>;
+  }
+
+  // On load failure show only the error + retry, not empty-state cards that
+  // would look like the admin genuinely has no data.
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+        <Button variant="outline" onClick={() => fetchAll()}>
+          重新載入
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Reward config editor */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Gift className="h-5 w-5 text-pink-600" />
+            獎勵點數設定
+          </CardTitle>
+          <p className="text-sm text-gray-500 mt-1">
+            調整各事件發放給推薦人／被推薦人的點數。修改後立即生效。
+          </p>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>事件</TableHead>
+                <TableHead>對象</TableHead>
+                <TableHead>點數</TableHead>
+                <TableHead>啟用</TableHead>
+                <TableHead className="text-right">操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {configs.map((cfg) => (
+                <TableRow key={cfg.reward_key}>
+                  <TableCell className="font-medium">
+                    {cfg.reward_key}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="outline">
+                      {cfg.recipient === "referred" ? "被推薦人" : "推薦人"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Input
+                      type="number"
+                      min={0}
+                      className="w-28"
+                      disabled={busy}
+                      value={pointDrafts[cfg.reward_key] ?? ""}
+                      onChange={(e) =>
+                        setPointDrafts({
+                          ...pointDrafts,
+                          [cfg.reward_key]: e.target.value,
+                        })
+                      }
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Switch
+                      checked={cfg.is_active}
+                      disabled={busy}
+                      onCheckedChange={() => toggleRewardActive(cfg)}
+                    />
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={busy}
+                      onClick={() => saveRewardPoints(cfg)}
+                    >
+                      儲存
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {/* Promo codes */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Ticket className="h-5 w-5 text-blue-600" />
+            推薦碼
+          </CardTitle>
+          <p className="text-sm text-gray-500 mt-1">
+            每位老師註冊時自動取得個人碼；可在此停用／啟用。
+          </p>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>推薦碼</TableHead>
+                <TableHead>老師 ID</TableHead>
+                <TableHead>類型</TableHead>
+                <TableHead>到期</TableHead>
+                <TableHead>狀態</TableHead>
+                <TableHead className="text-right">操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {codes.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={6}
+                    className="text-center text-gray-500 py-6"
+                  >
+                    尚無推薦碼
+                  </TableCell>
+                </TableRow>
+              ) : (
+                codes.map((row) => (
+                  <TableRow key={row.id}>
+                    <TableCell className="font-mono">{row.code}</TableCell>
+                    <TableCell>{row.teacher_id}</TableCell>
+                    <TableCell>
+                      <Badge variant="outline">
+                        {row.kind === "affiliate" ? "特約" : "個人"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-sm text-gray-500">
+                      {formatDate(row.expires_at)}
+                    </TableCell>
+                    <TableCell>
+                      {row.is_active ? (
+                        <Badge variant="default">啟用中</Badge>
+                      ) : (
+                        <Badge variant="secondary">已停用</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={busy}
+                        onClick={() => toggleCodeActive(row)}
+                      >
+                        {row.is_active ? "停用" : "啟用"}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {/* Referral report */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <BarChart3 className="h-5 w-5 text-green-600" />
+            推薦成效報表
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>推薦人 ID</TableHead>
+                <TableHead>推薦人數</TableHead>
+                <TableHead>已驗證</TableHead>
+                <TableHead>已付費轉換</TableHead>
+                <TableHead>累積獲得點數</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {report.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={5}
+                    className="text-center text-gray-500 py-6"
+                  >
+                    尚無推薦資料
+                  </TableCell>
+                </TableRow>
+              ) : (
+                report.map((r) => (
+                  <TableRow key={r.referrer_teacher_id}>
+                    <TableCell className="font-medium">
+                      {r.referrer_teacher_id}
+                    </TableCell>
+                    <TableCell>{r.referral_count}</TableCell>
+                    <TableCell>{r.verified_count}</TableCell>
+                    <TableCell>{r.paid_count}</TableCell>
+                    <TableCell>{r.total_points_awarded}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -1129,6 +1129,19 @@ export default function ClassroomDetail({
     ]);
   };
 
+  const handleDeleteStudentRow = async (student: Student) => {
+    try {
+      await apiClient.deleteStudent(student.id);
+      toast.success(
+        t("teacherStudents.messages.studentDeleted", { name: student.name }),
+      );
+      await Promise.all([fetchStudents(), fetchClassroomDetail(false)]);
+    } catch (error) {
+      console.error("Failed to delete student:", error);
+      toast.error(t("teacherStudents.messages.deleteStudentFailed"));
+    }
+  };
+
   const handleCloseDialog = () => {
     setSelectedStudent(null);
     setDialogType(null);
@@ -1756,6 +1769,7 @@ export default function ClassroomDetail({
                     onViewStudent={handleViewStudent}
                     onEditStudent={handleEditStudent}
                     onResetPassword={handleResetPassword}
+                    onDeleteStudent={handleDeleteStudentRow}
                     emptyMessage={t("classroomDetail.messages.noStudents")}
                     disableActions={isOrgMode}
                     disableReason={t(

--- a/frontend/src/pages/teacher/TeacherProfile.tsx
+++ b/frontend/src/pages/teacher/TeacherProfile.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { apiClient } from "@/lib/api";
 import { toast } from "sonner";
 import OneCampusBindSection from "@/components/settings/OneCampusBindSection";
+import PromoCodeCard from "@/components/PromoCodeCard";
 import {
   User,
   Mail,
@@ -19,10 +20,18 @@ import {
   Gauge,
   Eye,
   EyeOff,
+  Share2,
+  ArrowRight,
+  Zap,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { validatePasswordStrength } from "@/utils/passwordValidation";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
+import {
+  buildQuotaSources,
+  hexAlpha,
+  type QuotaSourceItem,
+} from "@/lib/quotaSources";
 
 interface TeacherInfo {
   id: number;
@@ -40,6 +49,7 @@ interface QuotaInfo {
   quota_remaining: number;
   plan_name: string;
   source: "personal" | "organization";
+  sources: QuotaSourceItem[];
 }
 
 // 配額卡片獨立元件（必須在 TeacherLayout/WorkspaceProvider 內才能使用 useWorkspace）
@@ -53,32 +63,45 @@ function QuotaCard() {
 
   const loadQuotaInfo = async () => {
     try {
-      const params = new URLSearchParams();
+      // Aggregated view: subscription period + every active credit package
+      // (trial, referral bonus, purchased packs). Mirrors what admins see in
+      // the per-teacher list, so the user sees their FULL available balance.
+      // Org mode is read from the org's points balance instead.
       if (mode === "organization" && selectedOrganization) {
-        params.append("organization_id", selectedOrganization.id);
+        const res = await apiClient.get<{
+          total_points: number;
+          used_points: number;
+        }>(`/api/organizations/${selectedOrganization.id}/points`);
+        if (typeof res.total_points === "number" && res.total_points > 0) {
+          setQuotaInfo({
+            quota_total: res.total_points,
+            quota_used: res.used_points ?? 0,
+            quota_remaining: Math.max(
+              0,
+              res.total_points - (res.used_points ?? 0),
+            ),
+            plan_name: selectedOrganization.name,
+            source: "organization",
+            sources: [], // org mode has no per-source breakdown
+          });
+        } else {
+          setQuotaInfo(null);
+        }
+        return;
       }
-      const url = `/api/teachers/subscription${params.toString() ? `?${params.toString()}` : ""}`;
 
-      const response = await apiClient.get<{
-        subscription_period: {
-          quota_total: number;
-          quota_used: number;
-          plan_name: string;
-        } | null;
-        source?: string;
-      }>(url);
-
-      if (response.subscription_period) {
-        const remaining =
-          response.subscription_period.quota_total -
-          response.subscription_period.quota_used;
+      const res = await apiClient.getSubscriptionStatus();
+      if (typeof res.quota_total === "number" && res.quota_total > 0) {
         setQuotaInfo({
-          quota_total: response.subscription_period.quota_total,
-          quota_used: response.subscription_period.quota_used,
-          quota_remaining: Math.max(0, remaining),
-          plan_name: response.subscription_period.plan_name,
-          source:
-            (response.source as "personal" | "organization") || "personal",
+          quota_total: res.quota_total,
+          quota_used: res.quota_used ?? 0,
+          quota_remaining: Math.max(
+            0,
+            (res.quota_total ?? 0) - (res.quota_used ?? 0),
+          ),
+          plan_name: res.plan ?? "",
+          source: "personal",
+          sources: buildQuotaSources(res),
         });
       } else {
         setQuotaInfo(null);
@@ -100,7 +123,7 @@ function QuotaCard() {
       </CardHeader>
       <CardContent>
         {quotaInfo ? (
-          <div className="space-y-3">
+          <div className="space-y-4">
             <p className="text-sm text-gray-500">
               目前工作區：
               <span className="font-medium text-gray-700">
@@ -110,41 +133,185 @@ function QuotaCard() {
               </span>
             </p>
 
-            <div className="flex items-baseline gap-2">
-              <span
-                className={`text-2xl font-bold ${
-                  quotaInfo.quota_remaining > quotaInfo.quota_total * 0.3
-                    ? "text-green-600"
-                    : quotaInfo.quota_remaining > quotaInfo.quota_total * 0.1
-                      ? "text-orange-600"
-                      : "text-red-600"
-                }`}
+            <div className="flex items-end justify-between gap-2">
+              <div className="flex items-baseline gap-2">
+                <span
+                  className={`text-3xl font-bold ${
+                    quotaInfo.quota_remaining > quotaInfo.quota_total * 0.3
+                      ? "text-green-600"
+                      : quotaInfo.quota_remaining > quotaInfo.quota_total * 0.1
+                        ? "text-orange-600"
+                        : "text-red-600"
+                  }`}
+                >
+                  {quotaInfo.quota_remaining.toLocaleString()}
+                </span>
+                <span className="text-gray-500">
+                  / {quotaInfo.quota_total.toLocaleString()} 秒
+                </span>
+              </div>
+              <span className="text-xs text-gray-500">
+                已用 {quotaInfo.quota_used.toLocaleString()} 秒
+              </span>
+            </div>
+
+            {/* Stacked-by-source bar (personal). Each segment's width is its
+                share of the visible sources (using sum-of-sources, not
+                quota_total, so a package that expired between the aggregator's
+                two queries can't leave a white gap at the right). Inner dark
+                fill = REMAINING of that source. */}
+            {quotaInfo.sources.length > 0 ? (
+              <div className="flex h-3.5 w-full overflow-hidden rounded-full border border-gray-200 bg-white">
+                {quotaInfo.sources.map((s) => {
+                  const barTotal = Math.max(
+                    1,
+                    quotaInfo.sources.reduce((a, x) => a + x.total, 0),
+                  );
+                  const segPct = (s.total / barTotal) * 100;
+                  const remainingPct =
+                    (Math.max(0, s.total - s.used) / Math.max(1, s.total)) *
+                    100;
+                  return (
+                    <div
+                      key={s.kind}
+                      style={{
+                        width: `${segPct}%`,
+                        backgroundColor: s.bg,
+                      }}
+                    >
+                      <div
+                        className="h-full"
+                        style={{
+                          width: `${remainingPct}%`,
+                          backgroundColor: s.fill,
+                        }}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              // Fallback single bar: width = REMAINING / total, colour by
+              // remaining ratio so the visual matches the headline number.
+              <div className="w-full bg-gray-200 rounded-full h-2.5">
+                <div
+                  className={`h-2.5 rounded-full ${
+                    quotaInfo.quota_remaining > quotaInfo.quota_total * 0.3
+                      ? "bg-green-500"
+                      : quotaInfo.quota_remaining > quotaInfo.quota_total * 0.1
+                        ? "bg-orange-500"
+                        : "bg-red-500"
+                  }`}
+                  style={{
+                    width: `${Math.max(0, Math.min(100, (quotaInfo.quota_remaining / Math.max(1, quotaInfo.quota_total)) * 100))}%`,
+                  }}
+                />
+              </div>
+            )}
+
+            {/* Per-source rows (personal mode only) */}
+            {quotaInfo.sources.length > 0 && (
+              <div className="space-y-2 pt-1">
+                <div className="text-sm font-semibold text-gray-900">
+                  點數來源
+                </div>
+                <ul className="space-y-2">
+                  {quotaInfo.sources.map((s) => {
+                    // Fill = REMAINING share, so a near-empty source draws as
+                    // an almost-empty bar (matches the headline metaphor).
+                    const remainingPct =
+                      s.total > 0
+                        ? Math.round(
+                            (Math.max(0, s.total - s.used) / s.total) * 100,
+                          )
+                        : 0;
+                    const isReferral = s.kind === "referral";
+                    return (
+                      <li
+                        key={s.kind}
+                        className="rounded-md border bg-gray-50 px-3 py-2"
+                        style={
+                          isReferral
+                            ? {
+                                borderColor: s.fill,
+                                backgroundColor: hexAlpha(s.bg, 0.33),
+                              }
+                            : { borderColor: "#E5E7EB" }
+                        }
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="flex items-center gap-2">
+                            <span
+                              className="inline-block h-3 w-3 rounded-sm"
+                              style={{ backgroundColor: s.fill }}
+                            />
+                            <span className="text-sm font-medium text-gray-900">
+                              {s.label}
+                            </span>
+                            {isReferral && (
+                              <span
+                                className="inline-flex items-center gap-1 rounded-md bg-white px-2 py-0.5 text-[10px] font-semibold"
+                                style={{
+                                  color: s.fill,
+                                  border: `1px solid ${s.fill}`,
+                                }}
+                              >
+                                <Zap className="h-2.5 w-2.5" /> 推薦獎勵點數
+                              </span>
+                            )}
+                          </div>
+                          <div className="flex flex-col items-end">
+                            <span
+                              className="text-sm font-bold"
+                              style={{ color: s.fill }}
+                            >
+                              {Math.max(0, s.total - s.used).toLocaleString()} /{" "}
+                              {s.total.toLocaleString()}
+                            </span>
+                            <span className="text-[10px] text-gray-500">
+                              已用 {s.used.toLocaleString()}
+                            </span>
+                          </div>
+                        </div>
+                        <div className="mt-1.5 h-1 w-full overflow-hidden rounded-full bg-white border border-gray-200">
+                          <div
+                            className="h-full"
+                            style={{
+                              width: `${remainingPct}%`,
+                              backgroundColor: s.fill,
+                            }}
+                          />
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
+
+            {/* CTA to the promo-code card on the same page */}
+            {quotaInfo.source === "personal" && (
+              <a
+                href="#my-promo-code"
+                className="flex items-center justify-between gap-2 rounded-md border border-violet-200 bg-violet-50 px-4 py-3 transition hover:bg-violet-100"
               >
-                {quotaInfo.quota_remaining.toLocaleString()}
-              </span>
-              <span className="text-gray-500">
-                / {quotaInfo.quota_total.toLocaleString()} 秒
-              </span>
-            </div>
-
-            <div className="w-full bg-gray-200 rounded-full h-2.5">
-              <div
-                className={`h-2.5 rounded-full transition-all ${
-                  quotaInfo.quota_remaining > quotaInfo.quota_total * 0.3
-                    ? "bg-green-500"
-                    : quotaInfo.quota_remaining > quotaInfo.quota_total * 0.1
-                      ? "bg-orange-500"
-                      : "bg-red-500"
-                }`}
-                style={{
-                  width: `${Math.max(0, Math.min(100, (quotaInfo.quota_remaining / quotaInfo.quota_total) * 100))}%`,
-                }}
-              />
-            </div>
-
-            <p className="text-xs text-gray-400">
-              已使用 {quotaInfo.quota_used.toLocaleString()} 秒
-            </p>
+                <div className="flex items-center gap-3">
+                  <Share2 className="h-4 w-4 text-violet-600" />
+                  <div className="flex flex-col">
+                    <span className="text-sm font-semibold text-violet-800">
+                      想要更多點數？
+                    </span>
+                    <span className="text-xs text-violet-700">
+                      分享你的推薦碼，每邀請一人最高拿 2,000 點。
+                    </span>
+                  </div>
+                </div>
+                <span className="flex items-center gap-1 rounded-md bg-violet-600 px-3 py-1.5 text-xs font-semibold text-white">
+                  前往推薦碼
+                  <ArrowRight className="h-3 w-3" />
+                </span>
+              </a>
+            )}
           </div>
         ) : (
           <p className="text-sm text-gray-500">
@@ -467,6 +634,11 @@ export default function TeacherProfile() {
 
       {/* Quota Info Card */}
       <QuotaCard />
+
+      {/* Promo Code Card (issue #637) */}
+      <div id="my-promo-code" className="scroll-mt-20">
+        <PromoCodeCard />
+      </div>
 
       {/* Password Settings Card */}
       <Card className="mb-6">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -325,6 +325,7 @@ export interface RegisterRequest {
   password: string;
   name: string;
   phone?: string;
+  promo_code?: string;
 }
 
 // ============ Form Types ============


### PR DESCRIPTION
## Summary
Promote staging to production (main). Includes **8 PRs**, primarily the **#637 promo-code / referral system** (4 PRs) and the schema foundation for **#768 機構方案優化** (Phase 1 only).

### #637 Promo code / referral system (4 PRs)
- **#809** `feat(#637)` promo code data layer + auto personal code on register
- **#810** `feat(#637)` bind referral at registration + stamp verified_at
- **#811** `feat(#637)` referral reward engine + admin promo-code API
- **#814** `feat(#637)` promo code frontend — register `?promo=`, admin page, points bar

### #768 機構方案優化 — Phase 1 only (1 PR)
- **#819** `chore(#768)` org/school/plan schema + `student_status_history` table — **pure additive schema**, no consumer code yet

### Bug fixes (3 PRs)
- **#818** `fix(#787)` 班級詳情頁 Students tab 補上刪除學生按鈕
- **#815** `fix(#813)` 例句朗讀成績便利貼顯示 0 — speaking 顯示端 fallback
- **#812** `fix(#787)` 編輯學生時空白生日導致 500/Failed to fetch

## New migrations (idempotent, additive)
- `20260525_1000_add_promo_code_tables.py` — promo codes, referrals, reward configs/events
- `20260527_1000_org_plan_optimization.py` — `organizations.org_type`/`per_student_price`, `schools.plan_id`/`teacher_seat_limit`, `plans.teacher_seats`/`annual_fee`/`topup_discount` + 3 group-buy plan seeds, new `student_status_history` table

Both follow the project's idempotency rules (`CREATE TABLE/ADD COLUMN IF NOT EXISTS`, `DO $$` constraint guards, `ON CONFLICT DO NOTHING` for seeds). No DROP / RENAME / ALTER TYPE.

## Risk assessment
- **#637 promo system**: new feature, user-visible (`/blog` admin section, register flow with `?promo=` query). Frontend + backend self-contained.
- **#768 Phase 1**: zero existing code references the new columns; no UI exposes the new group-buy plan seeds yet. Schema additions are safe to ship before the consumer logic lands.
- **Bug fixes**: small, scoped.
- **Frontend impact for #768**: **none** (verified — no frontend file references any new column).

## Held back for the next release (intentional)
- **PR #820** (open) — Phase 2 of #768: group-buy topup discount + constraint cleanup. User opted to hold this from the current release; will land on staging after this release ships, then promoted in the next cycle.

## Test plan
- [ ] CI green on staging→main
- [ ] Verify register flow with `?promo=<code>` correctly binds referral and stamps `verified_at`
- [ ] Verify `/blog` admin promo-code CRUD + reward engine
- [ ] Verify points bar shows correct referral credit
- [ ] Verify 班級詳情頁 Students tab delete-student button
- [ ] Verify 例句朗讀 0-score fallback display
- [ ] Verify 編輯學生 with empty birthday no longer 500s
- [ ] Confirm `student_status_history` and new `organizations`/`schools`/`plans` columns exist post-deploy (no consumer code yet, just schema sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)