### PR TITLE
feat(#768): group-buy open API + monthly 1000-pt grant (Phase 3)

### DIFF
--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -3,6 +3,7 @@ Credit Packages API - Purchase and manage credit packages (point bundles)
 """
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, ROUND_HALF_UP
@@ -809,7 +810,29 @@ async def open_group_buy(
         client_ip=client_host,
     )
 
-    # Idempotency: same teacher charging same group-buy plan within 60s
+    # F2 — Race-safe idempotency: acquire a Postgres advisory xact-lock
+    # keyed on (teacher_id, plan_name) BEFORE the recent-transaction lookup
+    # so two concurrent requests (mobile retry, double-tap) can't both pass
+    # the check and double-charge. Lock auto-releases at request end.
+    # SQLite tests are single-threaded; the dialect guard is a no-op there.
+    if db.bind and db.bind.dialect.name == "postgresql":
+        lock_key = f"group_buy_open:{current_teacher.id}:{plan.name}"
+        locked = db.execute(
+            text("SELECT pg_try_advisory_xact_lock(hashtext(:k))"),
+            {"k": lock_key},
+        ).scalar()
+        if not locked:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Another open-group request is in progress for this "
+                    "teacher; please retry in a moment."
+                ),
+            )
+
+    # Idempotency (post-lock): a recent SUCCESS transaction for this
+    # (teacher, plan) within 60s means the previous request already opened
+    # the group — return its transaction id without re-charging.
     recent = (
         db.query(TeacherSubscriptionTransaction)
         .filter(
@@ -893,43 +916,122 @@ async def open_group_buy(
             db.commit()
             raise HTTPException(status_code=400, detail=error_msg)
 
-        # Payment success — atomically create org/school/binding/period
+        # F1 — Payment captured. Card is already charged. Any DB failure
+        # past this line means the user paid but did not receive their team,
+        # so we MUST surface a compensation record (manual refund or hand-
+        # provision) — we cannot silently 500 and swallow the rec_trade_id.
         external_transaction_id = gateway_response.get("rec_trade_id")
-        org, school, _ = create_group_buy_org_and_school(
-            current_teacher, plan, db, now=now
-        )
-        create_group_buy_period(
-            current_teacher,
-            plan,
-            db,
-            start=now,
-            payment_id=external_transaction_id,
-        )
+        try:
+            org, school, _, _ = create_group_buy_org_and_school(
+                current_teacher, plan, db, now=now
+            )
+            create_group_buy_period(
+                current_teacher,
+                plan,
+                db,
+                start=now,
+                payment_id=external_transaction_id,
+            )
 
-        success_txn = TeacherSubscriptionTransaction(
-            teacher_id=current_teacher.id,
-            teacher_email=current_teacher.email,
-            transaction_type=TransactionType.RECHARGE,
-            subscription_type=plan.name,
-            amount=amount,
-            currency="TWD",
-            status="SUCCESS",
-            months=12,
-            period_start=now,
-            period_end=org.subscription_end_date,
-            new_end_date=org.subscription_end_date,
-            idempotency_key=idempotency_key,
-            ip_address=client_host,
-            user_agent=user_agent,
-            request_id=request_id,
-            payment_provider="tappay",
-            payment_method="credit_card",
-            external_transaction_id=external_transaction_id,
-            gateway_response=gateway_response,
-            processed_at=now,
-        )
-        db.add(success_txn)
-        db.commit()
+            success_txn = TeacherSubscriptionTransaction(
+                teacher_id=current_teacher.id,
+                teacher_email=current_teacher.email,
+                transaction_type=TransactionType.RECHARGE,
+                subscription_type=plan.name,
+                amount=amount,
+                currency="TWD",
+                status="SUCCESS",
+                months=12,
+                period_start=now,
+                period_end=org.subscription_end_date,
+                new_end_date=org.subscription_end_date,
+                idempotency_key=idempotency_key,
+                ip_address=client_host,
+                user_agent=user_agent,
+                request_id=request_id,
+                payment_provider="tappay",
+                payment_method="credit_card",
+                external_transaction_id=external_transaction_id,
+                gateway_response=gateway_response,
+                processed_at=now,
+            )
+            db.add(success_txn)
+            db.commit()
+        except Exception as provisioning_err:
+            db.rollback()
+            logger.error(
+                "🚨 GROUP-BUY OPEN COMPENSATION REQUIRED — card was charged "
+                "but DB provisioning failed. Refund or hand-provision needed. "
+                f"teacher={current_teacher.id} email={current_teacher.email} "
+                f"plan={plan.name} amount={amount} "
+                f"rec_trade_id={external_transaction_id} "
+                f"error={provisioning_err!r}"
+            )
+            execution_time = int((time.time() - start_time) * 1000)
+            log_payment_failure(
+                transaction_id=order_number,
+                user_id=current_teacher.id,
+                user_email=current_teacher.email,
+                amount=amount,
+                plan_name=plan.name,
+                error_stage="provisioning_after_payment",
+                error_code="DB_PROVISIONING_FAILED",
+                error_message=(
+                    f"REFUND REQUIRED rec_trade_id={external_transaction_id}: "
+                    f"{provisioning_err}"
+                ),
+                request_data=body_json,
+                response_status=500,
+                response_body={
+                    "rec_trade_id": external_transaction_id,
+                    "error": str(provisioning_err),
+                },
+                execution_time_ms=execution_time,
+            )
+            # Best-effort: persist a FAILED transaction record carrying the
+            # rec_trade_id so finance/audit queries can find the orphaned charge.
+            try:
+                comp_txn = TeacherSubscriptionTransaction(
+                    teacher_id=current_teacher.id,
+                    teacher_email=current_teacher.email,
+                    transaction_type=TransactionType.RECHARGE,
+                    subscription_type=plan.name,
+                    amount=amount,
+                    currency="TWD",
+                    status="FAILED",
+                    months=12,
+                    period_start=now,
+                    period_end=now + timedelta(days=365),
+                    new_end_date=now,
+                    idempotency_key=idempotency_key,
+                    ip_address=client_host,
+                    user_agent=user_agent,
+                    request_id=request_id,
+                    payment_provider="tappay",
+                    payment_method="credit_card",
+                    external_transaction_id=external_transaction_id,
+                    failure_reason=(
+                        "REFUND REQUIRED — provisioning failed after charge: "
+                        f"{provisioning_err!r}"
+                    ),
+                    error_code="PROVISIONING_AFTER_PAYMENT",
+                    gateway_response=gateway_response,
+                    processed_at=now,
+                )
+                db.add(comp_txn)
+                db.commit()
+            except Exception:
+                logger.exception(
+                    "Failed to persist compensation FAILED transaction record"
+                )
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    f"Payment captured (rec_trade_id={external_transaction_id})"
+                    " but team provisioning failed. Our team has been alerted"
+                    " and will refund or complete setup manually."
+                ),
+            )
 
         execution_time = int((time.time() - start_time) * 1000)
         log_payment_success(

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -23,6 +23,7 @@ from models import (
     TransactionType,
     Organization,
     TeacherOrganization,
+    School,
 )
 from routers.teachers import get_current_teacher
 from services.tappay_service import TapPayService
@@ -810,12 +811,13 @@ async def open_group_buy(
         client_ip=client_host,
     )
 
-    # F2 — Race-safe idempotency: acquire a Postgres advisory xact-lock
-    # keyed on (teacher_id, plan_name) BEFORE the recent-transaction lookup
-    # so two concurrent requests (mobile retry, double-tap) can't both pass
-    # the check and double-charge. Lock auto-releases at request end.
+    # F2 — Race-safe concurrent-request guard: acquire a Postgres advisory
+    # xact-lock keyed on (teacher_id, plan_name) BEFORE the recent-transaction
+    # lookup so two concurrent requests (mobile retry, double-tap) can't both
+    # pass the check and double-charge. Lock auto-releases at request end.
     # SQLite tests are single-threaded; the dialect guard is a no-op there.
-    if db.bind and db.bind.dialect.name == "postgresql":
+    # Use db.get_bind() (SQLAlchemy 2.x idiom) instead of db.bind.
+    if db.get_bind().dialect.name == "postgresql":
         lock_key = f"group_buy_open:{current_teacher.id}:{plan.name}"
         locked = db.execute(
             text("SELECT pg_try_advisory_xact_lock(hashtext(:k))"),
@@ -829,6 +831,28 @@ async def open_group_buy(
                     "teacher; please retry in a moment."
                 ),
             )
+
+    # R2-F2 — Long-term guard: a teacher already owning an active group-buy
+    # org (role='org_owner') cannot open another. The 60-second idempotency
+    # window only catches retries; this prevents a deliberate re-open the
+    # next day from double-charging the user and creating 2× monthly grants.
+    existing_owned = (
+        db.query(TeacherOrganization)
+        .join(Organization, Organization.id == TeacherOrganization.organization_id)
+        .filter(
+            TeacherOrganization.teacher_id == current_teacher.id,
+            TeacherOrganization.role == "org_owner",
+            TeacherOrganization.is_active.is_(True),
+            Organization.org_type == "group_buy",
+            Organization.is_active.is_(True),
+        )
+        .first()
+    )
+    if existing_owned is not None:
+        raise HTTPException(
+            status_code=409,
+            detail="您已開設一個團購方案，不可重複開設。",
+        )
 
     # Idempotency (post-lock): a recent SUCCESS transaction for this
     # (teacher, plan) within 60s means the previous request already opened
@@ -848,10 +872,49 @@ async def open_group_buy(
             f"Duplicate group-buy open detected: teacher={current_teacher.id} "
             f"plan={plan.name}"
         )
+        # R2-F5 — Frontend uses org_id / school_id / subscription_end_date to
+        # redirect the user to their new team page. On a 60s retry we must
+        # populate the same fields, not return null.
+        owned_org = (
+            db.query(Organization)
+            .join(
+                TeacherOrganization,
+                TeacherOrganization.organization_id == Organization.id,
+            )
+            .filter(
+                TeacherOrganization.teacher_id == current_teacher.id,
+                TeacherOrganization.role == "org_owner",
+                TeacherOrganization.is_active.is_(True),
+                Organization.org_type == "group_buy",
+            )
+            .order_by(Organization.created_at.desc())
+            .first()
+        )
+        owned_school = (
+            db.query(School)
+            .filter(
+                School.organization_id == owned_org.id,
+                School.plan_id == plan.id,
+            )
+            .order_by(School.created_at.desc())
+            .first()
+            if owned_org is not None
+            else None
+        )
         return GroupBuyOpenResponse(
             success=True,
             message="此筆開團已完成",
             transaction_id=recent.external_transaction_id,
+            organization_id=str(owned_org.id) if owned_org else None,
+            school_id=str(owned_school.id) if owned_school else None,
+            subscription_end_date=(
+                owned_org.subscription_end_date.isoformat()
+                if owned_org and owned_org.subscription_end_date
+                else None
+            ),
+            teacher_seat_limit=(
+                owned_school.teacher_seat_limit if owned_school else None
+            ),
         )
 
     try:

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -833,9 +833,10 @@ async def open_group_buy(
             )
 
     # R2-F2 — Long-term guard: a teacher already owning an active group-buy
-    # org (role='org_owner') cannot open another. The 60-second idempotency
-    # window only catches retries; this prevents a deliberate re-open the
-    # next day from double-charging the user and creating 2× monthly grants.
+    # org (role='org_owner') cannot open another. Filtered to orgs created
+    # more than 60 seconds ago so a same-submission retry (network timeout,
+    # mobile re-send) falls through to the idempotency-shortcut block below
+    # and returns the original transaction id, instead of getting 409.
     existing_owned = (
         db.query(TeacherOrganization)
         .join(Organization, Organization.id == TeacherOrganization.organization_id)
@@ -845,6 +846,7 @@ async def open_group_buy(
             TeacherOrganization.is_active.is_(True),
             Organization.org_type == "group_buy",
             Organization.is_active.is_(True),
+            Organization.created_at < now - timedelta(seconds=60),
         )
         .first()
     )

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -89,6 +89,22 @@ class OrgRenewRequest(BaseModel):
     cardholder: Optional[Dict[str, Any]] = None
 
 
+class GroupBuyOpenRequest(BaseModel):
+    prime: str
+    plan_name: str  # group-buy plan name e.g. "團購-30席"
+    cardholder: Optional[Dict[str, Any]] = None
+
+
+class GroupBuyOpenResponse(BaseModel):
+    success: bool
+    message: str
+    transaction_id: Optional[str] = None
+    organization_id: Optional[str] = None
+    school_id: Optional[str] = None
+    subscription_end_date: Optional[str] = None
+    teacher_seat_limit: Optional[int] = None
+
+
 # === Endpoints ===
 
 
@@ -728,3 +744,218 @@ async def org_renew_credit_package(
     except Exception as e:
         logger.error(f"Org credit package renewal error: {e}")
         raise HTTPException(status_code=500, detail="Renewal processing failed")
+
+
+@router.post("/group-buy-open", response_model=GroupBuyOpenResponse)
+async def open_group_buy(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_teacher: Teacher = Depends(get_current_teacher),
+):
+    """Open a new group-buy team (issue #768 Phase 3, 五.3).
+
+    Charges `teacher_seats × annual_fee` (server-authoritative — frontend
+    plan_name is the only input from the client, total is derived from the
+    Plan row) via TapPay, then atomically creates a new Organization,
+    School, owner TeacherSchool binding, and first month's SubscriptionPeriod
+    for the team leader. Subsequent monthly grants are issued by
+    /api/cron/monthly-renewal Phase 3.
+    """
+    if not ENABLE_PAYMENT:
+        return GroupBuyOpenResponse(success=False, message="付款功能尚未開放，敬請期待！")
+
+    # Parse request
+    try:
+        body = await request.body()
+        body_json = json.loads(body)
+        open_request = GroupBuyOpenRequest(**body_json)
+    except Exception as e:
+        logger.error(f"Failed to parse group-buy open request: {e}")
+        raise HTTPException(status_code=400, detail="Invalid request format")
+
+    # Server-side plan validation and amount computation
+    from services.group_buy import (
+        compute_group_buy_total,
+        create_group_buy_org_and_school,
+        create_group_buy_period,
+        validate_group_buy_plan,
+    )
+
+    try:
+        plan = validate_group_buy_plan(open_request.plan_name, db)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    amount = compute_group_buy_total(plan)
+    now = datetime.now(timezone.utc)
+
+    # Audit trail
+    start_time = time.time()
+    idempotency_key = str(uuid.uuid4())
+    order_number = f"GBOPEN_{now.strftime('%Y%m%d%H%M%S%f')}_{current_teacher.id}"
+    client_host = request.client.host if request.client else None
+    user_agent = request.headers.get("user-agent", "")
+    request_id = request.headers.get("x-request-id", str(uuid.uuid4()))
+
+    log_payment_attempt(
+        transaction_id=order_number,
+        user_id=current_teacher.id,
+        user_email=current_teacher.email,
+        amount=amount,
+        plan_name=plan.name,
+        prime_token=open_request.prime,
+        request_data=body_json,
+        user_agent=user_agent,
+        client_ip=client_host,
+    )
+
+    # Idempotency: same teacher charging same group-buy plan within 60s
+    recent = (
+        db.query(TeacherSubscriptionTransaction)
+        .filter(
+            TeacherSubscriptionTransaction.teacher_id == current_teacher.id,
+            TeacherSubscriptionTransaction.subscription_type == plan.name,
+            TeacherSubscriptionTransaction.status == "SUCCESS",
+            TeacherSubscriptionTransaction.processed_at > now - timedelta(seconds=60),
+        )
+        .first()
+    )
+    if recent is not None:
+        logger.warning(
+            f"Duplicate group-buy open detected: teacher={current_teacher.id} "
+            f"plan={plan.name}"
+        )
+        return GroupBuyOpenResponse(
+            success=True,
+            message="此筆開團已完成",
+            transaction_id=recent.external_transaction_id,
+        )
+
+    try:
+        tappay_service = TapPayService()
+        gateway_response = tappay_service.process_payment(
+            prime=open_request.prime,
+            amount=amount,
+            details={
+                "item_name": f"Group Buy: {plan.name}",
+                "type": "group_buy_open",
+            },
+            cardholder=open_request.cardholder
+            or {"name": current_teacher.name, "email": current_teacher.email},
+            order_number=order_number,
+            remember=False,
+        )
+
+        if gateway_response.get("status") != 0:
+            error_msg = TapPayService.parse_error_code(
+                gateway_response.get("status"), gateway_response.get("msg")
+            )
+            execution_time = int((time.time() - start_time) * 1000)
+            log_payment_failure(
+                transaction_id=order_number,
+                user_id=current_teacher.id,
+                user_email=current_teacher.email,
+                amount=amount,
+                plan_name=plan.name,
+                error_stage="tappay_api",
+                error_code=str(gateway_response.get("status")),
+                error_message=error_msg,
+                request_data=body_json,
+                response_status=400,
+                response_body=gateway_response,
+                execution_time_ms=execution_time,
+            )
+            failed_txn = TeacherSubscriptionTransaction(
+                teacher_id=current_teacher.id,
+                teacher_email=current_teacher.email,
+                transaction_type=TransactionType.RECHARGE,
+                subscription_type=plan.name,
+                amount=amount,
+                currency="TWD",
+                status="FAILED",
+                months=12,
+                period_start=now,
+                period_end=now + timedelta(days=365),
+                new_end_date=now,
+                idempotency_key=idempotency_key,
+                ip_address=client_host,
+                user_agent=user_agent,
+                request_id=request_id,
+                payment_provider="tappay",
+                payment_method="credit_card",
+                external_transaction_id=gateway_response.get("rec_trade_id"),
+                failure_reason=error_msg,
+                error_code=str(gateway_response.get("status")),
+                gateway_response=gateway_response,
+                processed_at=now,
+            )
+            db.add(failed_txn)
+            db.commit()
+            raise HTTPException(status_code=400, detail=error_msg)
+
+        # Payment success — atomically create org/school/binding/period
+        external_transaction_id = gateway_response.get("rec_trade_id")
+        org, school, _ = create_group_buy_org_and_school(
+            current_teacher, plan, db, now=now
+        )
+        create_group_buy_period(
+            current_teacher,
+            plan,
+            db,
+            start=now,
+            payment_id=external_transaction_id,
+        )
+
+        success_txn = TeacherSubscriptionTransaction(
+            teacher_id=current_teacher.id,
+            teacher_email=current_teacher.email,
+            transaction_type=TransactionType.RECHARGE,
+            subscription_type=plan.name,
+            amount=amount,
+            currency="TWD",
+            status="SUCCESS",
+            months=12,
+            period_start=now,
+            period_end=org.subscription_end_date,
+            new_end_date=org.subscription_end_date,
+            idempotency_key=idempotency_key,
+            ip_address=client_host,
+            user_agent=user_agent,
+            request_id=request_id,
+            payment_provider="tappay",
+            payment_method="credit_card",
+            external_transaction_id=external_transaction_id,
+            gateway_response=gateway_response,
+            processed_at=now,
+        )
+        db.add(success_txn)
+        db.commit()
+
+        execution_time = int((time.time() - start_time) * 1000)
+        log_payment_success(
+            transaction_id=order_number,
+            user_id=current_teacher.id,
+            user_email=current_teacher.email,
+            amount=amount,
+            plan_name=plan.name,
+            tappay_response=gateway_response,
+            tappay_rec_trade_id=external_transaction_id,
+            execution_time_ms=execution_time,
+        )
+
+        return GroupBuyOpenResponse(
+            success=True,
+            message="開團成功",
+            transaction_id=external_transaction_id,
+            organization_id=str(org.id),
+            school_id=str(school.id),
+            subscription_end_date=org.subscription_end_date.isoformat(),
+            teacher_seat_limit=school.teacher_seat_limit,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Group-buy open error: {e}")
+        raise HTTPException(status_code=500, detail="Group-buy open failed")

--- a/backend/routers/cron.py
+++ b/backend/routers/cron.py
@@ -133,6 +133,9 @@ async def monthly_renewal_cron(
         "renewal_failed": 0,
         "auto_renew_disabled": 0,
         "skipped": 0,
+        # Group-buy monthly grants (issue #768 Phase 3, 五.2)
+        "group_buy_grants_created": 0,
+        "group_buy_grants_skipped_duplicate": 0,
         "errors": [],
     }
 
@@ -367,13 +370,37 @@ async def monthly_renewal_cron(
             results["renewal_failed"] += 1
             results["errors"].append({"teacher": teacher.email, "error": str(e)})
 
+    # ========================================
+    # Phase 3 (issue #768 五.2): 團購月配發 1000 點
+    # ========================================
+    # For every active group-buy school where the org's annual subscription
+    # is still in date, create a fresh 1000-quota SubscriptionPeriod for
+    # every bound teacher. Old periods get marked expired by Phase 1 above.
+    logger.info("🎁 Phase 3: Group-buy monthly grants")
+    try:
+        from services.group_buy import grant_monthly_for_group_buy
+
+        gb_result = grant_monthly_for_group_buy(now_taipei, db)
+        results["group_buy_grants_created"] = gb_result["grants_created"]
+        results["group_buy_grants_skipped_duplicate"] = gb_result[
+            "grants_skipped_duplicate"
+        ]
+        logger.info(
+            f"✅ Group-buy grants: created={gb_result['grants_created']} "
+            f"skipped_duplicate={gb_result['grants_skipped_duplicate']}"
+        )
+    except Exception as e:
+        logger.error(f"❌ Group-buy grant phase failed: {e}")
+        results["errors"].append({"phase": "group_buy_grant", "error": str(e)})
+
     logger.info(
         f"🔄 Monthly renewal completed: "
         f"Marked expired: {results['marked_expired']}, "
         f"Auto-renewed: {results['auto_renewed']}, "
         f"Failed: {results['renewal_failed']}, "
         f"Auto-renew disabled: {results['auto_renew_disabled']}, "
-        f"Skipped: {results['skipped']}"
+        f"Skipped: {results['skipped']}, "
+        f"Group-buy grants: {results['group_buy_grants_created']}"
     )
 
     return results

--- a/backend/routers/cron.py
+++ b/backend/routers/cron.py
@@ -405,6 +405,10 @@ async def monthly_renewal_cron(
             f"skipped_duplicate={gb_result['grants_skipped_duplicate']}"
         )
     except Exception as e:
+        # R2-F4 — Explicit rollback to clear any dirty/pending state from a
+        # partial Phase 3 commit attempt, so subsequent DB access in this
+        # request (e.g. logging) interacts with a clean session.
+        db.rollback()
         logger.error(f"❌ Group-buy grant phase failed: {e}")
         results["errors"].append({"phase": "group_buy_grant", "error": str(e)})
         group_buy_failed = True

--- a/backend/routers/cron.py
+++ b/backend/routers/cron.py
@@ -35,7 +35,9 @@ CRON_SECRET = os.getenv("CRON_SECRET", "dev-secret-change-me")
 
 @router.post("/monthly-renewal")
 async def monthly_renewal_cron(
-    x_cron_secret: str = Header(None), db: Session = Depends(get_db)
+    x_cron_secret: str = Header(None),
+    db: Session = Depends(get_db),
+    force: bool = False,
 ):
     """
     每月 1 號執行的自動續訂任務
@@ -70,8 +72,11 @@ async def monthly_renewal_cron(
     logger.info(f"   Taipei time: {now_taipei}")
     logger.info(f"   UTC time: {now_utc}")
 
-    # 檢查是否為每月 1 號（台北時間）
-    if today_taipei.day != 1:
+    # 檢查是否為每月 1 號（台北時間）— `?force=true` (cron-secret gated)
+    # bypasses the day-1 guard for ops recovery (e.g. Phase 3 failed on day 1
+    # and we need to re-run on day 2). The CRON_SECRET check above already
+    # gates this.
+    if today_taipei.day != 1 and not force:
         logger.info(
             f"Not the 1st of the month (Taipei: {today_taipei}), skipping renewal"
         )
@@ -80,17 +85,26 @@ async def monthly_renewal_cron(
             "message": f"Not the 1st of the month. Today is {today_taipei}",
             "date": today_taipei.isoformat(),
         }
+    if force:
+        logger.warning(
+            f"⚠️  Day-1 guard bypassed via force=true (today={today_taipei})"
+        )
 
     # ========================================
     # Phase 1: 標記所有過期訂閱為 expired
     # ========================================
     logger.info("📋 Phase 1: Marking expired subscriptions")
 
+    # F6 — Compare against the full tz-aware now_taipei datetime, not the
+    # naive .date(). end_date is timestamptz; comparing to a bare `date`
+    # forces Postgres to cast using the session timezone (UTC on Cloud Run),
+    # which incorrectly preserves a Taipei-end-of-Dec-31 period as active
+    # past Taipei Jan 1.
     expired_periods = (
         db.query(SubscriptionPeriod)
         .filter(
             SubscriptionPeriod.status == "active",
-            SubscriptionPeriod.end_date < today_taipei,
+            SubscriptionPeriod.end_date < now_taipei,
         )
         .all()
     )
@@ -377,6 +391,7 @@ async def monthly_renewal_cron(
     # is still in date, create a fresh 1000-quota SubscriptionPeriod for
     # every bound teacher. Old periods get marked expired by Phase 1 above.
     logger.info("🎁 Phase 3: Group-buy monthly grants")
+    group_buy_failed = False
     try:
         from services.group_buy import grant_monthly_for_group_buy
 
@@ -392,6 +407,7 @@ async def monthly_renewal_cron(
     except Exception as e:
         logger.error(f"❌ Group-buy grant phase failed: {e}")
         results["errors"].append({"phase": "group_buy_grant", "error": str(e)})
+        group_buy_failed = True
 
     logger.info(
         f"🔄 Monthly renewal completed: "
@@ -402,6 +418,18 @@ async def monthly_renewal_cron(
         f"Skipped: {results['skipped']}, "
         f"Group-buy grants: {results['group_buy_grants_created']}"
     )
+
+    # F7 — Surface Phase 3 total failure as HTTP 500 so Cloud Scheduler's
+    # failure threshold triggers an alert. Partial Phase-2 per-teacher
+    # failures stay 200 to match historical behaviour.
+    if group_buy_failed:
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "message": "Group-buy monthly grant phase failed; manual recovery needed.",
+                "results": results,
+            },
+        )
 
     return results
 

--- a/backend/services/group_buy.py
+++ b/backend/services/group_buy.py
@@ -19,6 +19,7 @@ from models import (
     School,
     SubscriptionPeriod,
     Teacher,
+    TeacherOrganization,
     TeacherSchool,
 )
 
@@ -90,10 +91,15 @@ def create_group_buy_org_and_school(
     db: Session,
     *,
     now: datetime,
-) -> Tuple[Organization, School, TeacherSchool]:
-    """Atomically create the Organization, School, and owner TeacherSchool
-    for a new group-buy purchase. Subscription dates set on the Organization
-    (1 year from `now`)."""
+) -> Tuple[Organization, School, TeacherSchool, TeacherOrganization]:
+    """Atomically create the Organization, School, owner TeacherSchool, AND
+    owner TeacherOrganization (role='org_owner') for a new group-buy
+    purchase. Subscription dates set on the Organization (1 year from `now`).
+
+    TeacherOrganization is required so the opener can use the existing
+    /org-purchase and /org-renew endpoints, both of which gate on
+    `TeacherOrganization.role == 'org_owner'`.
+    """
     org = Organization(
         name=f"{owner.name or owner.email}'s 團購",
         org_type="group_buy",
@@ -121,9 +127,17 @@ def create_group_buy_org_and_school(
         is_active=True,
     )
     db.add(teacher_school)
+
+    teacher_org = TeacherOrganization(
+        teacher_id=owner.id,
+        organization_id=org.id,
+        role="org_owner",
+        is_active=True,
+    )
+    db.add(teacher_org)
     db.flush()
 
-    return org, school, teacher_school
+    return org, school, teacher_school, teacher_org
 
 
 def create_group_buy_period(
@@ -136,17 +150,24 @@ def create_group_buy_period(
 ) -> SubscriptionPeriod:
     """Insert a fresh group-buy SubscriptionPeriod for a teacher.
 
+    Both start_date and end_date are normalised to Taipei time so they
+    represent the same calendar reference (avoids the late-UTC-evening
+    open-purchase that would otherwise mix UTC start with Taipei end).
     end_date = month_end_taipei(start) so next month's cron Phase 1 expires
     it and Phase 3 grants the next month's points.
     """
+    taipei = ZoneInfo("Asia/Taipei")
+    start_taipei = (
+        start.astimezone(taipei) if start.tzinfo else start.replace(tzinfo=taipei)
+    )
     period = SubscriptionPeriod(
         teacher_id=teacher.id,
         plan_name=plan.name,
         amount_paid=0,  # group-buy quota is bundled in the annual school fee
         quota_total=GROUP_BUY_MONTHLY_QUOTA,
         quota_used=0,
-        start_date=start,
-        end_date=month_end_taipei(start),
+        start_date=start_taipei,
+        end_date=month_end_taipei(start_taipei),
         payment_method="group_buy",
         payment_id=payment_id,
         payment_status="paid",
@@ -195,22 +216,32 @@ def grant_monthly_for_group_buy(today: datetime, db: Session) -> dict:
         .all()
     )
 
+    # Bulk-load existing group-buy periods for the affected teachers in a
+    # single round-trip (kills N+1). The duplicate check filters on
+    # payment_method='group_buy' so an individual SubscriptionPeriod that
+    # happens to share a plan_name can't mask the grant.
     counters = {"grants_created": 0, "grants_skipped_duplicate": 0}
-    for teacher, plan in rows:
-        existing = (
-            db.query(SubscriptionPeriod)
+    teacher_ids = {t.id for t, _ in rows}
+    existing_keys: set[tuple[int, str]] = set()
+    if teacher_ids:
+        existing_keys = {
+            (p.teacher_id, p.plan_name)
+            for p in db.query(
+                SubscriptionPeriod.teacher_id, SubscriptionPeriod.plan_name
+            )
             .filter(
-                SubscriptionPeriod.teacher_id == teacher.id,
-                SubscriptionPeriod.plan_name == plan.name,
+                SubscriptionPeriod.teacher_id.in_(teacher_ids),
                 SubscriptionPeriod.status == "active",
+                SubscriptionPeriod.payment_method == "group_buy",
                 SubscriptionPeriod.start_date >= month_start,
             )
-            .first()
-        )
-        if existing is not None:
+            .all()
+        }
+
+    for teacher, plan in rows:
+        if (teacher.id, plan.name) in existing_keys:
             counters["grants_skipped_duplicate"] += 1
             continue
-
         create_group_buy_period(teacher, plan, db, start=today_local)
         counters["grants_created"] += 1
 

--- a/backend/services/group_buy.py
+++ b/backend/services/group_buy.py
@@ -1,0 +1,218 @@
+"""Group-buy domain helpers (issue #768 Phase 3).
+
+Centralizes the open-group flow and the monthly point-grant logic so both
+the HTTP endpoint and the cron job share identical Period creation rules.
+
+All amount/quota computations are server-side from the Plan row — never
+trust the frontend.
+"""
+
+from datetime import datetime, timedelta
+from typing import Tuple
+from zoneinfo import ZoneInfo
+
+from sqlalchemy.orm import Session
+
+from models import (
+    Organization,
+    Plan,
+    School,
+    SubscriptionPeriod,
+    Teacher,
+    TeacherSchool,
+)
+
+
+# Each monthly grant gives this many points to every teacher bound to an
+# active group-buy school. Matches the spec in issue #768.
+GROUP_BUY_MONTHLY_QUOTA = 1000
+
+
+# ---------- pure helpers ----------
+
+
+def validate_group_buy_plan(plan_name: str, db: Session) -> Plan:
+    """Load the Plan row and verify it is a group-buy plan (teacher_seats set).
+
+    Detection by column, not by name pattern, so seed-name changes never
+    silently let an individual plan slip through.
+    """
+    plan = db.query(Plan).filter(Plan.name == plan_name).first()
+    if plan is None:
+        raise ValueError(f"Unknown plan: {plan_name!r}")
+    if not plan.is_active:
+        raise ValueError(f"Plan {plan_name!r} is not active")
+    if plan.teacher_seats is None or plan.annual_fee is None:
+        raise ValueError(
+            f"Plan {plan_name!r} is not a group-buy plan "
+            "(teacher_seats / annual_fee not set)"
+        )
+    return plan
+
+
+def compute_group_buy_total(plan: Plan) -> int:
+    """Server-authoritative total: annual_fee × teacher_seats. Integer NT$."""
+    return int(plan.annual_fee) * int(plan.teacher_seats)
+
+
+def month_end_taipei(today: datetime) -> datetime:
+    """End-of-current-month at 23:59:59.999999 in Asia/Taipei timezone.
+
+    Used as the end_date for monthly group-buy SubscriptionPeriods so the
+    next month's cron Phase 1 (`end_date < today`) marks them expired and
+    Phase 3 creates the next month's grant.
+    """
+    taipei = ZoneInfo("Asia/Taipei")
+    base = today.astimezone(taipei) if today.tzinfo else today.replace(tzinfo=taipei)
+    if base.month == 12:
+        first_of_next = base.replace(
+            year=base.year + 1,
+            month=1,
+            day=1,
+            hour=0,
+            minute=0,
+            second=0,
+            microsecond=0,
+        )
+    else:
+        first_of_next = base.replace(
+            month=base.month + 1, day=1, hour=0, minute=0, second=0, microsecond=0
+        )
+    return first_of_next - timedelta(microseconds=1)
+
+
+# ---------- creation primitives ----------
+
+
+def create_group_buy_org_and_school(
+    owner: Teacher,
+    plan: Plan,
+    db: Session,
+    *,
+    now: datetime,
+) -> Tuple[Organization, School, TeacherSchool]:
+    """Atomically create the Organization, School, and owner TeacherSchool
+    for a new group-buy purchase. Subscription dates set on the Organization
+    (1 year from `now`)."""
+    org = Organization(
+        name=f"{owner.name or owner.email}'s 團購",
+        org_type="group_buy",
+        subscription_start_date=now,
+        subscription_end_date=now + timedelta(days=365),
+        is_active=True,
+    )
+    db.add(org)
+    db.flush()  # need org.id for FK
+
+    school = School(
+        organization_id=org.id,
+        name=f"{org.name} School",
+        plan_id=plan.id,
+        teacher_seat_limit=plan.teacher_seats,
+        is_active=True,
+    )
+    db.add(school)
+    db.flush()
+
+    teacher_school = TeacherSchool(
+        teacher_id=owner.id,
+        school_id=school.id,
+        roles=["school_admin"],
+        is_active=True,
+    )
+    db.add(teacher_school)
+    db.flush()
+
+    return org, school, teacher_school
+
+
+def create_group_buy_period(
+    teacher: Teacher,
+    plan: Plan,
+    db: Session,
+    *,
+    start: datetime,
+    payment_id: str | None = None,
+) -> SubscriptionPeriod:
+    """Insert a fresh group-buy SubscriptionPeriod for a teacher.
+
+    end_date = month_end_taipei(start) so next month's cron Phase 1 expires
+    it and Phase 3 grants the next month's points.
+    """
+    period = SubscriptionPeriod(
+        teacher_id=teacher.id,
+        plan_name=plan.name,
+        amount_paid=0,  # group-buy quota is bundled in the annual school fee
+        quota_total=GROUP_BUY_MONTHLY_QUOTA,
+        quota_used=0,
+        start_date=start,
+        end_date=month_end_taipei(start),
+        payment_method="group_buy",
+        payment_id=payment_id,
+        payment_status="paid",
+        status="active",
+    )
+    db.add(period)
+    db.flush()
+    return period
+
+
+# ---------- monthly cron primitive ----------
+
+
+def grant_monthly_for_group_buy(today: datetime, db: Session) -> dict:
+    """Cron Phase 3: create one fresh GROUP_BUY_MONTHLY_QUOTA-point period
+    for every teacher actively bound to an active group-buy school whose
+    organization subscription is still in date.
+
+    Idempotency: if the teacher already has an active group-buy period for
+    this plan whose start_date is on/after the current month-start, skip —
+    that handles the edge case where the cron runs after the open endpoint
+    has already created the period for day 1.
+    """
+    taipei = ZoneInfo("Asia/Taipei")
+    today_local = (
+        today.astimezone(taipei) if today.tzinfo else today.replace(tzinfo=taipei)
+    )
+    month_start = today_local.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    rows = (
+        db.query(Teacher, Plan)
+        .join(TeacherSchool, TeacherSchool.teacher_id == Teacher.id)
+        .join(School, School.id == TeacherSchool.school_id)
+        .join(Plan, Plan.id == School.plan_id)
+        .join(Organization, Organization.id == School.organization_id)
+        .filter(
+            TeacherSchool.is_active.is_(True),
+            School.is_active.is_(True),
+            Teacher.is_active.is_(True),
+            Plan.is_active.is_(True),
+            Plan.teacher_seats.isnot(None),
+            Organization.org_type == "group_buy",
+            Organization.is_active.is_(True),
+            Organization.subscription_end_date >= today_local,
+        )
+        .all()
+    )
+
+    counters = {"grants_created": 0, "grants_skipped_duplicate": 0}
+    for teacher, plan in rows:
+        existing = (
+            db.query(SubscriptionPeriod)
+            .filter(
+                SubscriptionPeriod.teacher_id == teacher.id,
+                SubscriptionPeriod.plan_name == plan.name,
+                SubscriptionPeriod.status == "active",
+                SubscriptionPeriod.start_date >= month_start,
+            )
+            .first()
+        )
+        if existing is not None:
+            counters["grants_skipped_duplicate"] += 1
+            continue
+
+        create_group_buy_period(teacher, plan, db, start=today_local)
+        counters["grants_created"] += 1
+
+    db.commit()
+    return counters

--- a/backend/services/group_buy.py
+++ b/backend/services/group_buy.py
@@ -243,6 +243,10 @@ def grant_monthly_for_group_buy(today: datetime, db: Session) -> dict:
             counters["grants_skipped_duplicate"] += 1
             continue
         create_group_buy_period(teacher, plan, db, start=today_local)
+        # R2-F3 — Update the dedup set inside the loop so a teacher bound to
+        # multiple group-buy schools sharing the same plan_name doesn't
+        # receive 2× grants in the same cron run.
+        existing_keys.add((teacher.id, plan.name))
         counters["grants_created"] += 1
 
     db.commit()

--- a/backend/tests/test_group_buy_open_endpoint.py
+++ b/backend/tests/test_group_buy_open_endpoint.py
@@ -17,6 +17,7 @@ from models import (
     School,
     SubscriptionPeriod,
     Teacher,
+    TeacherOrganization,
     TeacherSchool,
     TeacherSubscriptionTransaction,
 )
@@ -162,6 +163,18 @@ def test_happy_path_creates_org_school_binding_period(
         .one()
     )
     assert ts.roles == ["school_admin"]
+    # F3 — TeacherOrganization with role='org_owner' must also be created so
+    # the opener can use /org-purchase and /org-renew.
+    t_org = (
+        shared_test_session.query(TeacherOrganization)
+        .filter(
+            TeacherOrganization.teacher_id == teacher.id,
+            TeacherOrganization.organization_id == org.id,
+        )
+        .one()
+    )
+    assert t_org.role == "org_owner"
+    assert t_org.is_active is True
     period = (
         shared_test_session.query(SubscriptionPeriod)
         .filter(

--- a/backend/tests/test_group_buy_open_endpoint.py
+++ b/backend/tests/test_group_buy_open_endpoint.py
@@ -1,0 +1,227 @@
+"""Endpoint tests for POST /api/credit-packages/group-buy-open (issue #768 Phase 3).
+
+TapPay is mocked. The endpoint's own try/except, audit-log, and Period
+creation logic is verified end-to-end; deeper service logic is covered by
+test_group_buy_service.py.
+"""
+
+from decimal import Decimal
+from unittest.mock import Mock, patch
+
+import pytest
+
+from auth import create_access_token, get_password_hash
+from models import (
+    Organization,
+    Plan,
+    School,
+    SubscriptionPeriod,
+    Teacher,
+    TeacherSchool,
+    TeacherSubscriptionTransaction,
+)
+
+
+@pytest.fixture
+def teacher(shared_test_session):
+    t = Teacher(
+        email="gb-open@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="Owner",
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+@pytest.fixture
+def auth_header(teacher):
+    token = create_access_token({"sub": str(teacher.id), "type": "teacher"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def gb_plan(shared_test_session):
+    p = Plan(
+        name="團購-30席",
+        price=None,
+        quota=1000,
+        teacher_seats=30,
+        annual_fee=1300,
+        topup_discount=Decimal("0.90"),
+        is_active=True,
+    )
+    shared_test_session.add(p)
+    shared_test_session.commit()
+    shared_test_session.refresh(p)
+    return p
+
+
+@pytest.fixture
+def individual_plan(shared_test_session):
+    p = Plan(name="Tutor Teachers", price=299, quota=2000, is_active=True)
+    shared_test_session.add(p)
+    shared_test_session.commit()
+    return p
+
+
+def test_returns_payment_disabled_when_enable_payment_false(
+    test_client, auth_header, gb_plan
+):
+    with patch("routers.credit_packages.ENABLE_PAYMENT", False):
+        r = test_client.post(
+            "/api/credit-packages/group-buy-open",
+            json={"prime": "prime-x", "plan_name": gb_plan.name},
+            headers=auth_header,
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["success"] is False
+    assert "尚未開放" in body["message"]
+
+
+def test_rejects_unknown_plan_with_400(test_client, auth_header):
+    with patch("routers.credit_packages.ENABLE_PAYMENT", True), patch(
+        "routers.credit_packages.TapPayService"
+    ) as mock_tappay_class:
+        r = test_client.post(
+            "/api/credit-packages/group-buy-open",
+            json={"prime": "prime-x", "plan_name": "does-not-exist"},
+            headers=auth_header,
+        )
+    assert r.status_code == 400
+    assert "Unknown plan" in r.json()["detail"]
+    mock_tappay_class.assert_not_called()
+
+
+def test_rejects_individual_plan_with_400(test_client, auth_header, individual_plan):
+    with patch("routers.credit_packages.ENABLE_PAYMENT", True), patch(
+        "routers.credit_packages.TapPayService"
+    ) as mock_tappay_class:
+        r = test_client.post(
+            "/api/credit-packages/group-buy-open",
+            json={"prime": "prime-x", "plan_name": individual_plan.name},
+            headers=auth_header,
+        )
+    assert r.status_code == 400
+    assert "not a group-buy plan" in r.json()["detail"]
+    mock_tappay_class.assert_not_called()
+
+
+def test_happy_path_creates_org_school_binding_period(
+    test_client, auth_header, teacher, gb_plan, shared_test_session
+):
+    mock_tappay = Mock()
+    mock_tappay.process_payment.return_value = {
+        "status": 0,
+        "rec_trade_id": "REC-OPEN-123",
+        "card_secret": {},
+    }
+    with patch("routers.credit_packages.ENABLE_PAYMENT", True), patch(
+        "routers.credit_packages.TapPayService", return_value=mock_tappay
+    ):
+        r = test_client.post(
+            "/api/credit-packages/group-buy-open",
+            json={"prime": "prime-x", "plan_name": gb_plan.name},
+            headers=auth_header,
+        )
+
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert body["success"] is True
+    assert body["transaction_id"] == "REC-OPEN-123"
+    assert body["teacher_seat_limit"] == gb_plan.teacher_seats
+    assert body["organization_id"]
+    assert body["school_id"]
+
+    # Verify the charged amount = annual_fee * teacher_seats (server-side)
+    call_kwargs = mock_tappay.process_payment.call_args.kwargs
+    assert call_kwargs["amount"] == gb_plan.annual_fee * gb_plan.teacher_seats
+
+    # Side effects in DB
+    shared_test_session.expire_all()
+    org = (
+        shared_test_session.query(Organization)
+        .filter(Organization.id == body["organization_id"])
+        .one()
+    )
+    assert org.org_type == "group_buy"
+    school = (
+        shared_test_session.query(School).filter(School.id == body["school_id"]).one()
+    )
+    assert school.plan_id == gb_plan.id
+    ts = (
+        shared_test_session.query(TeacherSchool)
+        .filter(
+            TeacherSchool.teacher_id == teacher.id,
+            TeacherSchool.school_id == school.id,
+        )
+        .one()
+    )
+    assert ts.roles == ["school_admin"]
+    period = (
+        shared_test_session.query(SubscriptionPeriod)
+        .filter(
+            SubscriptionPeriod.teacher_id == teacher.id,
+            SubscriptionPeriod.plan_name == gb_plan.name,
+        )
+        .one()
+    )
+    assert period.quota_total == 1000
+    assert period.payment_id == "REC-OPEN-123"
+    # Successful TeacherSubscriptionTransaction logged
+    txn = (
+        shared_test_session.query(TeacherSubscriptionTransaction)
+        .filter(TeacherSubscriptionTransaction.teacher_id == teacher.id)
+        .one()
+    )
+    assert txn.status == "SUCCESS"
+    assert txn.amount == gb_plan.annual_fee * gb_plan.teacher_seats
+    assert txn.subscription_type == gb_plan.name
+
+
+def test_idempotent_within_60s_returns_existing_transaction(
+    test_client, auth_header, teacher, gb_plan, shared_test_session
+):
+    # Seed a recent successful transaction for this teacher + plan
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    existing = TeacherSubscriptionTransaction(
+        teacher_id=teacher.id,
+        teacher_email=teacher.email,
+        transaction_type="RECHARGE",
+        subscription_type=gb_plan.name,
+        amount=gb_plan.annual_fee * gb_plan.teacher_seats,
+        currency="TWD",
+        status="SUCCESS",
+        months=12,
+        period_start=now,
+        period_end=now,
+        new_end_date=now,
+        payment_provider="tappay",
+        payment_method="credit_card",
+        external_transaction_id="REC-PREVIOUS",
+        processed_at=now,
+    )
+    shared_test_session.add(existing)
+    shared_test_session.commit()
+
+    with patch("routers.credit_packages.ENABLE_PAYMENT", True), patch(
+        "routers.credit_packages.TapPayService"
+    ) as mock_tappay_class:
+        r = test_client.post(
+            "/api/credit-packages/group-buy-open",
+            json={"prime": "prime-x", "plan_name": gb_plan.name},
+            headers=auth_header,
+        )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["success"] is True
+    assert body["transaction_id"] == "REC-PREVIOUS"
+    # TapPay should NOT be called again
+    mock_tappay_class.assert_not_called()

--- a/backend/tests/test_group_buy_open_endpoint.py
+++ b/backend/tests/test_group_buy_open_endpoint.py
@@ -199,14 +199,18 @@ def test_happy_path_creates_org_school_binding_period(
 def test_rejects_when_teacher_already_owns_a_group_buy_org(
     test_client, auth_header, teacher, gb_plan, shared_test_session
 ):
-    """R2-F2 — A teacher who already owns a group-buy organization must not
-    be able to open another (would result in a second NT$X charge and 2x
-    monthly grants)."""
-    # Seed an existing owned group-buy org for this teacher
+    """R2-F2 — A teacher who already owns a group-buy organization (older
+    than the 60s retry window) must not be able to open another (would
+    result in a second NT$X charge and 2x monthly grants)."""
+    from datetime import datetime, timedelta, timezone
+
+    # Seed an existing owned group-buy org for this teacher, created
+    # well outside the 60s same-submission window.
     org = Organization(
         name="Pre-existing 團",
         org_type="group_buy",
         is_active=True,
+        created_at=datetime.now(timezone.utc) - timedelta(hours=1),
     )
     shared_test_session.add(org)
     shared_test_session.commit()
@@ -239,10 +243,43 @@ def test_rejects_when_teacher_already_owns_a_group_buy_org(
 def test_idempotent_within_60s_returns_existing_transaction(
     test_client, auth_header, teacher, gb_plan, shared_test_session
 ):
-    # Seed a recent successful transaction for this teacher + plan
-    from datetime import datetime, timezone
+    """R2-F5 — A retry within 60s (network timeout, mobile re-send) must
+    return the original transaction AND populate org_id / school_id /
+    subscription_end_date / teacher_seat_limit so the frontend can still
+    redirect the user to their new team page."""
+    from datetime import datetime, timedelta, timezone
 
     now = datetime.now(timezone.utc)
+    # Seed the full production-shape state the original (just-succeeded)
+    # request would have left: Org + School + TeacherOrganization + recent
+    # SUCCESS transaction. The R2-F2 guard skips orgs younger than 60s, so
+    # this lands in the idempotency-shortcut block.
+    org = Organization(
+        name="Existing 團",
+        org_type="group_buy",
+        subscription_start_date=now,
+        subscription_end_date=now + timedelta(days=365),
+        is_active=True,
+    )
+    shared_test_session.add(org)
+    shared_test_session.flush()
+    school = School(
+        organization_id=org.id,
+        name="Existing 團 School",
+        plan_id=gb_plan.id,
+        teacher_seat_limit=gb_plan.teacher_seats,
+        is_active=True,
+    )
+    shared_test_session.add(school)
+    shared_test_session.flush()
+    shared_test_session.add(
+        TeacherOrganization(
+            teacher_id=teacher.id,
+            organization_id=org.id,
+            role="org_owner",
+            is_active=True,
+        )
+    )
     existing = TeacherSubscriptionTransaction(
         teacher_id=teacher.id,
         teacher_email=teacher.email,
@@ -253,8 +290,8 @@ def test_idempotent_within_60s_returns_existing_transaction(
         status="SUCCESS",
         months=12,
         period_start=now,
-        period_end=now,
-        new_end_date=now,
+        period_end=now + timedelta(days=365),
+        new_end_date=now + timedelta(days=365),
         payment_provider="tappay",
         payment_method="credit_card",
         external_transaction_id="REC-PREVIOUS",
@@ -276,5 +313,10 @@ def test_idempotent_within_60s_returns_existing_transaction(
     body = r.json()
     assert body["success"] is True
     assert body["transaction_id"] == "REC-PREVIOUS"
+    # R2-F5 assertions: redirect fields must be populated, not null
+    assert body["organization_id"] == str(org.id)
+    assert body["school_id"] == str(school.id)
+    assert body["subscription_end_date"] is not None
+    assert body["teacher_seat_limit"] == gb_plan.teacher_seats
     # TapPay should NOT be called again
     mock_tappay_class.assert_not_called()

--- a/backend/tests/test_group_buy_open_endpoint.py
+++ b/backend/tests/test_group_buy_open_endpoint.py
@@ -196,6 +196,46 @@ def test_happy_path_creates_org_school_binding_period(
     assert txn.subscription_type == gb_plan.name
 
 
+def test_rejects_when_teacher_already_owns_a_group_buy_org(
+    test_client, auth_header, teacher, gb_plan, shared_test_session
+):
+    """R2-F2 — A teacher who already owns a group-buy organization must not
+    be able to open another (would result in a second NT$X charge and 2x
+    monthly grants)."""
+    # Seed an existing owned group-buy org for this teacher
+    org = Organization(
+        name="Pre-existing 團",
+        org_type="group_buy",
+        is_active=True,
+    )
+    shared_test_session.add(org)
+    shared_test_session.commit()
+    shared_test_session.refresh(org)
+    shared_test_session.add(
+        TeacherOrganization(
+            teacher_id=teacher.id,
+            organization_id=org.id,
+            role="org_owner",
+            is_active=True,
+        )
+    )
+    shared_test_session.commit()
+
+    with patch("routers.credit_packages.ENABLE_PAYMENT", True), patch(
+        "routers.credit_packages.TapPayService"
+    ) as mock_tappay_class:
+        r = test_client.post(
+            "/api/credit-packages/group-buy-open",
+            json={"prime": "prime-x", "plan_name": gb_plan.name},
+            headers=auth_header,
+        )
+
+    assert r.status_code == 409
+    assert "團購方案" in r.json()["detail"]
+    # TapPay must NOT be charged
+    mock_tappay_class.assert_not_called()
+
+
 def test_idempotent_within_60s_returns_existing_transaction(
     test_client, auth_header, teacher, gb_plan, shared_test_session
 ):

--- a/backend/tests/test_group_buy_service.py
+++ b/backend/tests/test_group_buy_service.py
@@ -338,6 +338,73 @@ def test_grant_stacks_alongside_individual_subscription(shared_test_session, own
     assert names == ["Tutor Teachers", plan.name]
 
 
+def test_grant_does_not_double_grant_teacher_in_two_schools_same_plan(
+    shared_test_session, owner
+):
+    """R2-F3 — A teacher bound to two active group-buy schools that share
+    the same plan_name must receive ONE grant, not two. The dedup set must
+    be updated inside the loop so the second iteration sees the first one."""
+    plan = _make_group_buy_plan(shared_test_session)
+    today = datetime(2026, 6, 1, 2, 0, 0, tzinfo=TAIPEI)
+
+    # First active group-buy school the teacher owns
+    _bootstrap_active_group_buy(
+        shared_test_session, owner, plan, now=today - timedelta(days=10)
+    )
+
+    # Second active group-buy school the teacher is bound to (e.g. joined a
+    # second team), same plan_name. Create org/school/binding manually to
+    # avoid duplicating the helper's TeacherOrganization unique-key collision.
+    from models import Organization, School, TeacherSchool
+
+    org2 = Organization(
+        name="Second 團",
+        org_type="group_buy",
+        subscription_start_date=today - timedelta(days=5),
+        subscription_end_date=today + timedelta(days=360),
+        is_active=True,
+    )
+    shared_test_session.add(org2)
+    shared_test_session.flush()
+    school2 = School(
+        organization_id=org2.id,
+        name="Second 團 School",
+        plan_id=plan.id,
+        teacher_seat_limit=plan.teacher_seats,
+        is_active=True,
+    )
+    shared_test_session.add(school2)
+    shared_test_session.flush()
+    shared_test_session.add(
+        TeacherSchool(
+            teacher_id=owner.id,
+            school_id=school2.id,
+            roles=["teacher"],
+            is_active=True,
+        )
+    )
+    shared_test_session.commit()
+
+    result = grant_monthly_for_group_buy(today, shared_test_session)
+    # Critical safety property: even if the join returns >1 row for this
+    # teacher (one per TeacherSchool), exactly ONE SubscriptionPeriod must
+    # be created. grants_created + grants_skipped_duplicate accounts for
+    # every row the join returned.
+    assert result["grants_created"] == 1
+    assert result["grants_created"] + result["grants_skipped_duplicate"] >= 1
+
+    periods = (
+        shared_test_session.query(SubscriptionPeriod)
+        .filter(
+            SubscriptionPeriod.teacher_id == owner.id,
+            SubscriptionPeriod.plan_name == plan.name,
+            SubscriptionPeriod.payment_method == "group_buy",
+        )
+        .all()
+    )
+    assert len(periods) == 1
+
+
 def test_grant_duplicate_check_filters_by_payment_method(shared_test_session, owner):
     """F5 — If a teacher has an active SubscriptionPeriod whose plan_name
     matches the group-buy plan but whose payment_method is NOT 'group_buy'

--- a/backend/tests/test_group_buy_service.py
+++ b/backend/tests/test_group_buy_service.py
@@ -1,0 +1,331 @@
+"""Tests for backend.services.group_buy (issue #768 Phase 3).
+
+Covers:
+  - validate_group_buy_plan: not-found / inactive / individual-plan / valid
+  - compute_group_buy_total: server-authoritative annual_fee × teacher_seats
+  - month_end_taipei: end-of-month edge cases incl. December roll-over
+  - create_group_buy_org_and_school: creates org + school + owner binding
+  - create_group_buy_period: shape of inserted SubscriptionPeriod
+  - grant_monthly_for_group_buy: cron Phase 3 behavior incl. idempotency
+"""
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from auth import get_password_hash
+from models import (
+    Organization,
+    Plan,
+    School,
+    SubscriptionPeriod,
+    Teacher,
+    TeacherSchool,
+)
+from services.group_buy import (
+    GROUP_BUY_MONTHLY_QUOTA,
+    compute_group_buy_total,
+    create_group_buy_org_and_school,
+    create_group_buy_period,
+    grant_monthly_for_group_buy,
+    month_end_taipei,
+    validate_group_buy_plan,
+)
+
+
+TAIPEI = ZoneInfo("Asia/Taipei")
+
+
+def _naive(dt):
+    """SQLite strips tzinfo on TIMESTAMPTZ store; Postgres preserves it.
+    Helper so equality checks survive both."""
+    return dt.replace(tzinfo=None) if dt and dt.tzinfo else dt
+
+
+# ---------- fixtures ----------
+
+
+@pytest.fixture
+def owner(shared_test_session):
+    t = Teacher(
+        email="owner@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="Owner",
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+def _make_group_buy_plan(db, name="團購-30席", seats=30, fee=1300, discount=0.90):
+    p = Plan(
+        name=name,
+        price=None,
+        quota=1000,
+        teacher_seats=seats,
+        annual_fee=fee,
+        topup_discount=Decimal(str(discount)),
+        is_active=True,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+def _make_individual_plan(db, name="Tutor Teachers"):
+    p = Plan(
+        name=name,
+        price=299,
+        quota=2000,
+        teacher_seats=None,
+        annual_fee=None,
+        topup_discount=None,
+        is_active=True,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+# ---------- validate_group_buy_plan ----------
+
+
+def test_validate_raises_for_unknown_plan(shared_test_session):
+    with pytest.raises(ValueError, match="Unknown plan"):
+        validate_group_buy_plan("does-not-exist", shared_test_session)
+
+
+def test_validate_raises_for_inactive_plan(shared_test_session):
+    p = _make_group_buy_plan(shared_test_session)
+    p.is_active = False
+    shared_test_session.commit()
+    with pytest.raises(ValueError, match="not active"):
+        validate_group_buy_plan(p.name, shared_test_session)
+
+
+def test_validate_raises_for_individual_plan(shared_test_session):
+    p = _make_individual_plan(shared_test_session)
+    with pytest.raises(ValueError, match="not a group-buy plan"):
+        validate_group_buy_plan(p.name, shared_test_session)
+
+
+def test_validate_returns_plan_when_valid(shared_test_session):
+    p = _make_group_buy_plan(shared_test_session)
+    got = validate_group_buy_plan(p.name, shared_test_session)
+    assert got.id == p.id
+
+
+# ---------- compute_group_buy_total ----------
+
+
+def test_compute_total_is_annual_fee_times_seats(shared_test_session):
+    p = _make_group_buy_plan(shared_test_session, seats=30, fee=1300)
+    assert compute_group_buy_total(p) == 30 * 1300
+
+
+# ---------- month_end_taipei ----------
+
+
+def test_month_end_normal_month():
+    today = datetime(2026, 5, 15, 10, 0, 0, tzinfo=TAIPEI)
+    end = month_end_taipei(today)
+    assert end.year == 2026 and end.month == 5 and end.day == 31
+    assert end.hour == 23 and end.minute == 59 and end.second == 59
+
+
+def test_month_end_december_rolls_to_next_year():
+    today = datetime(2026, 12, 10, 10, 0, 0, tzinfo=TAIPEI)
+    end = month_end_taipei(today)
+    assert end.year == 2026 and end.month == 12 and end.day == 31
+
+
+def test_month_end_february_leap_year():
+    today = datetime(2028, 2, 5, 10, 0, 0, tzinfo=TAIPEI)
+    end = month_end_taipei(today)
+    assert end.month == 2 and end.day == 29
+
+
+# ---------- create_group_buy_org_and_school ----------
+
+
+def test_open_creates_org_school_and_owner_binding(shared_test_session, owner):
+    plan = _make_group_buy_plan(shared_test_session)
+    now = datetime.now(timezone.utc)
+    org, school, ts = create_group_buy_org_and_school(
+        owner, plan, shared_test_session, now=now
+    )
+    shared_test_session.commit()
+
+    assert org.org_type == "group_buy"
+    # SQLite strips tzinfo on TIMESTAMPTZ store; compare naive values.
+    assert _naive(org.subscription_start_date) == _naive(now)
+    assert _naive(org.subscription_end_date) == _naive(now + timedelta(days=365))
+    assert school.organization_id == org.id
+    assert school.plan_id == plan.id
+    assert school.teacher_seat_limit == plan.teacher_seats
+    assert ts.teacher_id == owner.id
+    assert ts.school_id == school.id
+    assert ts.roles == ["school_admin"]
+
+
+# ---------- create_group_buy_period ----------
+
+
+def test_create_period_inserts_active_1000_quota(shared_test_session, owner):
+    plan = _make_group_buy_plan(shared_test_session)
+    start = datetime(2026, 5, 15, 10, 0, 0, tzinfo=TAIPEI)
+    period = create_group_buy_period(
+        owner, plan, shared_test_session, start=start, payment_id="pay-123"
+    )
+    shared_test_session.commit()
+
+    assert period.teacher_id == owner.id
+    assert period.plan_name == plan.name
+    assert period.quota_total == GROUP_BUY_MONTHLY_QUOTA
+    assert period.quota_used == 0
+    assert _naive(period.start_date) == _naive(start)
+    assert period.end_date.month == 5 and period.end_date.day == 31
+    assert period.payment_method == "group_buy"
+    assert period.payment_id == "pay-123"
+    assert period.status == "active"
+
+
+# ---------- grant_monthly_for_group_buy ----------
+
+
+def _bootstrap_active_group_buy(db, owner, plan, *, now):
+    """Create a full active group-buy: org + school + owner TeacherSchool."""
+    return create_group_buy_org_and_school(owner, plan, db, now=now)
+
+
+def test_grant_creates_one_period_per_bound_teacher(shared_test_session, owner):
+    plan = _make_group_buy_plan(shared_test_session)
+    today = datetime(2026, 6, 1, 2, 0, 0, tzinfo=TAIPEI)
+    _bootstrap_active_group_buy(
+        shared_test_session, owner, plan, now=today - timedelta(days=10)
+    )
+    shared_test_session.commit()
+
+    result = grant_monthly_for_group_buy(today, shared_test_session)
+    assert result == {"grants_created": 1, "grants_skipped_duplicate": 0}
+
+    period = (
+        shared_test_session.query(SubscriptionPeriod)
+        .filter(SubscriptionPeriod.teacher_id == owner.id)
+        .one()
+    )
+    assert period.quota_total == GROUP_BUY_MONTHLY_QUOTA
+    assert period.plan_name == plan.name
+
+
+def test_grant_skips_when_teacher_already_granted_this_month(
+    shared_test_session, owner
+):
+    plan = _make_group_buy_plan(shared_test_session)
+    today = datetime(2026, 6, 1, 14, 0, 0, tzinfo=TAIPEI)
+    _bootstrap_active_group_buy(shared_test_session, owner, plan, now=today)
+    # Pre-existing grant from the open endpoint earlier today
+    create_group_buy_period(owner, plan, shared_test_session, start=today)
+    shared_test_session.commit()
+
+    result = grant_monthly_for_group_buy(today, shared_test_session)
+    assert result == {"grants_created": 0, "grants_skipped_duplicate": 1}
+
+
+def test_grant_skips_inactive_organization(shared_test_session, owner):
+    plan = _make_group_buy_plan(shared_test_session)
+    today = datetime(2026, 6, 1, 2, 0, 0, tzinfo=TAIPEI)
+    org, _, _ = _bootstrap_active_group_buy(
+        shared_test_session, owner, plan, now=today - timedelta(days=10)
+    )
+    org.is_active = False
+    shared_test_session.commit()
+
+    result = grant_monthly_for_group_buy(today, shared_test_session)
+    assert result["grants_created"] == 0
+
+
+def test_grant_skips_expired_subscription(shared_test_session, owner):
+    plan = _make_group_buy_plan(shared_test_session)
+    today = datetime(2026, 6, 1, 2, 0, 0, tzinfo=TAIPEI)
+    org, _, _ = _bootstrap_active_group_buy(
+        shared_test_session, owner, plan, now=today - timedelta(days=400)
+    )
+    # Force expired
+    org.subscription_end_date = today - timedelta(days=1)
+    shared_test_session.commit()
+
+    result = grant_monthly_for_group_buy(today, shared_test_session)
+    assert result["grants_created"] == 0
+
+
+def test_grant_skips_inactive_school(shared_test_session, owner):
+    plan = _make_group_buy_plan(shared_test_session)
+    today = datetime(2026, 6, 1, 2, 0, 0, tzinfo=TAIPEI)
+    _, school, _ = _bootstrap_active_group_buy(
+        shared_test_session, owner, plan, now=today - timedelta(days=10)
+    )
+    school.is_active = False
+    shared_test_session.commit()
+
+    result = grant_monthly_for_group_buy(today, shared_test_session)
+    assert result["grants_created"] == 0
+
+
+def test_grant_skips_inactive_teacher_school_binding(shared_test_session, owner):
+    plan = _make_group_buy_plan(shared_test_session)
+    today = datetime(2026, 6, 1, 2, 0, 0, tzinfo=TAIPEI)
+    _, _, ts = _bootstrap_active_group_buy(
+        shared_test_session, owner, plan, now=today - timedelta(days=10)
+    )
+    ts.is_active = False
+    shared_test_session.commit()
+
+    result = grant_monthly_for_group_buy(today, shared_test_session)
+    assert result["grants_created"] == 0
+
+
+def test_grant_stacks_alongside_individual_subscription(shared_test_session, owner):
+    """Per design decision: group-buy and individual subscriptions are
+    independent; both active SubscriptionPeriods coexist."""
+    plan = _make_group_buy_plan(shared_test_session)
+    today = datetime(2026, 6, 1, 2, 0, 0, tzinfo=TAIPEI)
+    _bootstrap_active_group_buy(
+        shared_test_session, owner, plan, now=today - timedelta(days=10)
+    )
+    # Pre-existing individual Tutor Teachers subscription
+    individual = SubscriptionPeriod(
+        teacher_id=owner.id,
+        plan_name="Tutor Teachers",
+        amount_paid=299,
+        quota_total=2000,
+        quota_used=0,
+        start_date=today - timedelta(days=5),
+        end_date=today + timedelta(days=25),
+        payment_method="auto_renew",
+        payment_status="paid",
+        status="active",
+    )
+    shared_test_session.add(individual)
+    shared_test_session.commit()
+
+    grant_monthly_for_group_buy(today, shared_test_session)
+
+    periods = (
+        shared_test_session.query(SubscriptionPeriod)
+        .filter(
+            SubscriptionPeriod.teacher_id == owner.id,
+            SubscriptionPeriod.status == "active",
+        )
+        .all()
+    )
+    assert len(periods) == 2
+    names = sorted(p.plan_name for p in periods)
+    assert names == ["Tutor Teachers", plan.name]

--- a/backend/tests/test_group_buy_service.py
+++ b/backend/tests/test_group_buy_service.py
@@ -22,6 +22,7 @@ from models import (
     School,
     SubscriptionPeriod,
     Teacher,
+    TeacherOrganization,
     TeacherSchool,
 )
 from services.group_buy import (
@@ -158,7 +159,7 @@ def test_month_end_february_leap_year():
 def test_open_creates_org_school_and_owner_binding(shared_test_session, owner):
     plan = _make_group_buy_plan(shared_test_session)
     now = datetime.now(timezone.utc)
-    org, school, ts = create_group_buy_org_and_school(
+    org, school, ts, t_org = create_group_buy_org_and_school(
         owner, plan, shared_test_session, now=now
     )
     shared_test_session.commit()
@@ -173,6 +174,12 @@ def test_open_creates_org_school_and_owner_binding(shared_test_session, owner):
     assert ts.teacher_id == owner.id
     assert ts.school_id == school.id
     assert ts.roles == ["school_admin"]
+    # F3 — TeacherOrganization with role='org_owner' so the opener can
+    # use /org-purchase and /org-renew, both of which gate on this row.
+    assert t_org.teacher_id == owner.id
+    assert t_org.organization_id == org.id
+    assert t_org.role == "org_owner"
+    assert t_org.is_active is True
 
 
 # ---------- create_group_buy_period ----------
@@ -242,7 +249,7 @@ def test_grant_skips_when_teacher_already_granted_this_month(
 def test_grant_skips_inactive_organization(shared_test_session, owner):
     plan = _make_group_buy_plan(shared_test_session)
     today = datetime(2026, 6, 1, 2, 0, 0, tzinfo=TAIPEI)
-    org, _, _ = _bootstrap_active_group_buy(
+    org, _, _, _ = _bootstrap_active_group_buy(
         shared_test_session, owner, plan, now=today - timedelta(days=10)
     )
     org.is_active = False
@@ -255,7 +262,7 @@ def test_grant_skips_inactive_organization(shared_test_session, owner):
 def test_grant_skips_expired_subscription(shared_test_session, owner):
     plan = _make_group_buy_plan(shared_test_session)
     today = datetime(2026, 6, 1, 2, 0, 0, tzinfo=TAIPEI)
-    org, _, _ = _bootstrap_active_group_buy(
+    org, _, _, _ = _bootstrap_active_group_buy(
         shared_test_session, owner, plan, now=today - timedelta(days=400)
     )
     # Force expired
@@ -269,7 +276,7 @@ def test_grant_skips_expired_subscription(shared_test_session, owner):
 def test_grant_skips_inactive_school(shared_test_session, owner):
     plan = _make_group_buy_plan(shared_test_session)
     today = datetime(2026, 6, 1, 2, 0, 0, tzinfo=TAIPEI)
-    _, school, _ = _bootstrap_active_group_buy(
+    _, school, _, _ = _bootstrap_active_group_buy(
         shared_test_session, owner, plan, now=today - timedelta(days=10)
     )
     school.is_active = False
@@ -282,7 +289,7 @@ def test_grant_skips_inactive_school(shared_test_session, owner):
 def test_grant_skips_inactive_teacher_school_binding(shared_test_session, owner):
     plan = _make_group_buy_plan(shared_test_session)
     today = datetime(2026, 6, 1, 2, 0, 0, tzinfo=TAIPEI)
-    _, _, ts = _bootstrap_active_group_buy(
+    _, _, ts, _ = _bootstrap_active_group_buy(
         shared_test_session, owner, plan, now=today - timedelta(days=10)
     )
     ts.is_active = False
@@ -329,3 +336,34 @@ def test_grant_stacks_alongside_individual_subscription(shared_test_session, own
     assert len(periods) == 2
     names = sorted(p.plan_name for p in periods)
     assert names == ["Tutor Teachers", plan.name]
+
+
+def test_grant_duplicate_check_filters_by_payment_method(shared_test_session, owner):
+    """F5 — If a teacher has an active SubscriptionPeriod whose plan_name
+    matches the group-buy plan but whose payment_method is NOT 'group_buy'
+    (e.g. an individual subscription that happens to share the name), the
+    cron must still create the group-buy grant for them."""
+    plan = _make_group_buy_plan(shared_test_session)
+    today = datetime(2026, 6, 1, 2, 0, 0, tzinfo=TAIPEI)
+    _bootstrap_active_group_buy(
+        shared_test_session, owner, plan, now=today - timedelta(days=10)
+    )
+
+    # Decoy active period with the same plan_name but auto_renew (not group_buy)
+    decoy = SubscriptionPeriod(
+        teacher_id=owner.id,
+        plan_name=plan.name,
+        amount_paid=299,
+        quota_total=2000,
+        quota_used=0,
+        start_date=today,
+        end_date=today + timedelta(days=30),
+        payment_method="auto_renew",
+        payment_status="paid",
+        status="active",
+    )
+    shared_test_session.add(decoy)
+    shared_test_session.commit()
+
+    result = grant_monthly_for_group_buy(today, shared_test_session)
+    assert result["grants_created"] == 1  # NOT skipped despite matching name

--- a/backend/tests/test_monthly_renewal_group_buy_phase.py
+++ b/backend/tests/test_monthly_renewal_group_buy_phase.py
@@ -68,3 +68,35 @@ def test_cron_skips_phase3_when_not_first_of_month(test_client):
     assert body["status"] == "skipped"
     # Day != 1 → cron early-returns BEFORE Phase 3 helper is called
     mock_grant.assert_not_called()
+
+
+def test_cron_force_true_bypasses_day_1_guard_and_runs_phase3(test_client):
+    """R3-F2 — Ops recovery: ?force=true (cron-secret–gated) lets the cron
+    run on a non-day-1 date and still invokes the Phase 3 group-buy grant.
+    Use case: Phase 3 failed on day 1, retry on day 2."""
+
+    class _MidMonth(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            d = datetime(2026, 6, 15, 2, 0, 0)
+            return d.replace(tzinfo=tz) if tz else d
+
+    with patch("routers.cron.CRON_SECRET", "test-secret"), patch(
+        "routers.cron.datetime", _MidMonth
+    ), patch(
+        "services.group_buy.grant_monthly_for_group_buy",
+        return_value={"grants_created": 4, "grants_skipped_duplicate": 1},
+    ) as mock_grant:
+        r = test_client.post(
+            "/api/cron/monthly-renewal?force=true",
+            headers={"x-cron-secret": "test-secret"},
+        )
+
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    # Cron actually ran (not skipped) even though day != 1
+    assert body["status"] == "completed"
+    # Phase 3 was invoked and counters surfaced
+    assert body["group_buy_grants_created"] == 4
+    assert body["group_buy_grants_skipped_duplicate"] == 1
+    mock_grant.assert_called_once()

--- a/backend/tests/test_monthly_renewal_group_buy_phase.py
+++ b/backend/tests/test_monthly_renewal_group_buy_phase.py
@@ -1,0 +1,70 @@
+"""Integration test for cron Phase 3 (group-buy monthly grant), issue #768.
+
+The detailed grant logic is unit-tested in test_group_buy_service.py. This
+test verifies the cron endpoint actually invokes the Phase 3 helper and
+surfaces the counters into its JSON response.
+
+We patch `datetime.now` inside cron.py to land on day 1 (so the cron's
+"not the 1st" early-return doesn't fire) and we patch the helper itself
+to verify the integration without needing real DB setup.
+"""
+
+from datetime import datetime
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+
+TAIPEI = ZoneInfo("Asia/Taipei")
+
+
+class _FakeDatetime(datetime):
+    """A datetime subclass whose `now()` returns a fixed instant."""
+
+    _fixed = datetime(2026, 6, 1, 2, 0, 0)
+
+    @classmethod
+    def now(cls, tz=None):
+        return cls._fixed.replace(tzinfo=tz) if tz else cls._fixed
+
+
+def _post_cron(test_client):
+    return test_client.post(
+        "/api/cron/monthly-renewal", headers={"x-cron-secret": "test-secret"}
+    )
+
+
+def test_cron_phase3_invokes_group_buy_helper_and_surfaces_counters(
+    test_client,
+):
+    with patch("routers.cron.CRON_SECRET", "test-secret"), patch(
+        "routers.cron.datetime", _FakeDatetime
+    ), patch(
+        "services.group_buy.grant_monthly_for_group_buy",
+        return_value={"grants_created": 7, "grants_skipped_duplicate": 2},
+    ) as mock_grant:
+        r = _post_cron(test_client)
+
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert body["status"] == "completed"
+    assert body["group_buy_grants_created"] == 7
+    assert body["group_buy_grants_skipped_duplicate"] == 2
+    mock_grant.assert_called_once()
+
+
+def test_cron_skips_phase3_when_not_first_of_month(test_client):
+    class _MidMonth(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            d = datetime(2026, 6, 15, 2, 0, 0)
+            return d.replace(tzinfo=tz) if tz else d
+
+    with patch("routers.cron.CRON_SECRET", "test-secret"), patch(
+        "routers.cron.datetime", _MidMonth
+    ), patch("services.group_buy.grant_monthly_for_group_buy") as mock_grant:
+        r = _post_cron(test_client)
+
+    body = r.json()
+    assert body["status"] == "skipped"
+    # Day != 1 → cron early-returns BEFORE Phase 3 helper is called
+    mock_grant.assert_not_called()


### PR DESCRIPTION
## Summary
Phase 3 of 5 for issue #768「機構方案優化」. Implements the two backend pieces from the issue spec (五.2 + 五.3). **No frontend changes**; user-facing UI lands in Phase 5.

## A. `POST /api/credit-packages/group-buy-open` (五.3)

Server-authoritative open-group endpoint:
- Validates `plan_name` is a group-buy plan by column (`teacher_seats IS NOT NULL`), not name pattern
- Computes `amount = annual_fee × teacher_seats` from the DB Plan row (frontend can only pass `plan_name`)
- 60-second idempotency: a recent SUCCESS `TeacherSubscriptionTransaction` for the same teacher × plan returns the previous transaction_id without re-charging
- TapPay charge → on success atomically creates:
  - `Organization` (`org_type='group_buy'`, 1-year subscription window)
  - `School` (`plan_id`, `teacher_seat_limit`)
  - `TeacherSchool` for the opener (`roles=['school_admin']`)
  - First month's `SubscriptionPeriod` (1000 quota, end of current month Taipei)
- Failed TapPay charges logged as `FAILED` `TeacherSubscriptionTransaction` and audit log

## B. `monthly_renewal_cron` Phase 3 — group-buy monthly grant (五.2)

After existing Phase 1 (mark expired) and Phase 2 (individual auto-renew), runs:
- For every Teacher actively bound to an active group-buy School whose Organization subscription is still in date
- Insert fresh 1000-quota `SubscriptionPeriod` (start=today, end=Taipei month-end)
- Idempotent: skips teachers who already have an active group-buy period for this plan with `start_date >= current-month-start` (handles day-1 race with open endpoint)
- Last month's periods get marked expired by Phase 1 → naturally implements "月底歸零"

Per the agreed design: group-buy and individual subscriptions **stack** (both coexist as active periods).

## C. New service module

`backend/services/group_buy.py` centralises the logic shared by the endpoint and the cron:

| Function | Purpose |
|---|---|
| `validate_group_buy_plan(name, db)` | Returns Plan or raises ValueError (unknown / inactive / individual) |
| `compute_group_buy_total(plan)` | Server-authoritative `annual_fee × teacher_seats` |
| `month_end_taipei(today)` | End-of-current-month in Asia/Taipei (Dec→year-roll, leap-year-safe) |
| `create_group_buy_org_and_school(...)` | Atomic creation of Org + School + owner TeacherSchool |
| `create_group_buy_period(...)` | Insert one SubscriptionPeriod |
| `grant_monthly_for_group_buy(today, db)` | Cron Phase 3 orchestration, returns counters |

## Test plan
- [x] `tests/test_group_buy_service.py` — **17 cases** (validate × 4, compute, month_end × 3 incl. Dec/leap-year, org+school creation, period shape, grant × 7 incl. duplicate skip / inactive org-school-TS / expired subscription / stacking with individual)
- [x] `tests/test_group_buy_open_endpoint.py` — **5 cases** (ENABLE_PAYMENT=false / unknown plan rejected w/o TapPay / individual plan rejected / happy path with mocked TapPay creates full chain + SUCCESS transaction / 60s idempotency returns previous txn)
- [x] `tests/test_monthly_renewal_group_buy_phase.py` — **2 integration cases** (cron invokes helper on day 1 and surfaces counters / day != 1 early-returns skipping Phase 3)
- [x] Phase 1+2 regression: `test_topup_discount.py` + `test_get_plan_price_group_buy_guard.py` + `test_admin_plans.py` + `test_admin_organizations.py` + `test_admin_credit_packages.py` all green
- [x] Black clean, single alembic head `20260528_1000`
- **Total: 95/95 passing**

## Out of scope (remaining phases)
- **Phase 4**: 機構月度計費查詢 (`student_status_history` × `per_student_price`)
- **Phase 5**: 機構單位學生費前端設定頁 + 團購開團 UI

Related to #768 (will not auto-close; #768 closes when Phase 5 ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)