### PR TITLE
feat(#768): institution monthly billing query (Phase 4)

### DIFF
--- a/backend/routers/organizations.py
+++ b/backend/routers/organizations.py
@@ -1494,3 +1494,65 @@ async def get_teacher_permissions(
         )
 
     return {"teacher_id": teacher_id, "schools": result}
+
+
+# ============ Phase 4 (issue #768 五.5) — Institution monthly billing ============
+
+
+class StudentBillingBreakdown(BaseModel):
+    student_id: int
+    name: str
+    billable: bool
+
+
+class MonthlyBillingResponse(BaseModel):
+    org_id: str
+    year: int
+    month: int
+    per_student_price: int
+    billable_student_count: int
+    total_amount: int
+    currency: str
+    students: List[StudentBillingBreakdown]
+
+
+@router.get("/{org_id}/billing/monthly", response_model=MonthlyBillingResponse)
+async def get_monthly_billing(
+    org_id: uuid.UUID,
+    year: int,
+    month: int,
+    db: Session = Depends(get_db),
+    current_teacher: Teacher = Depends(get_current_teacher),
+):
+    """Compute the institution's monthly invoice for a given (year, month).
+
+    Auth: platform admin OR an org_owner of this org.
+    Validation: org must be `org_type='institution'` with `per_student_price`
+    set. 400 otherwise.
+
+    Billing rule (issue #768 五.5): a student is billable for the month iff
+    they were 'active' at any moment during the Taipei month window. See
+    `services.institution_billing` for the detailed derivation.
+    """
+    # Auth: admin bypasses org-membership check; otherwise must be org_owner.
+    if current_teacher.is_admin:
+        org = (
+            db.query(Organization)
+            .filter(Organization.id == org_id, Organization.is_active.is_(True))
+            .first()
+        )
+        if org is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found"
+            )
+    else:
+        org = check_org_permission(current_teacher.id, org_id, db)
+
+    from services.institution_billing import compute_monthly_billing
+
+    try:
+        result = compute_monthly_billing(org, year, month, db)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return result

--- a/backend/routers/organizations.py
+++ b/backend/routers/organizations.py
@@ -6,7 +6,7 @@ CRUD operations for organizations with Casbin permission checks.
 Note: Per-issue deploy now includes database migrations (2026-01-11 v4 - upgrade heads)
 """
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy import func, distinct, union, select
 from sqlalchemy.orm import Session, joinedload, selectinload, load_only
@@ -1520,8 +1520,8 @@ class MonthlyBillingResponse(BaseModel):
 @router.get("/{org_id}/billing/monthly", response_model=MonthlyBillingResponse)
 async def get_monthly_billing(
     org_id: uuid.UUID,
-    year: int,
-    month: int,
+    year: int = Query(..., ge=1, le=9998, description="Calendar year (Taipei)"),
+    month: int = Query(..., ge=1, le=12, description="Calendar month (1-12)"),
     db: Session = Depends(get_db),
     current_teacher: Teacher = Depends(get_current_teacher),
 ):

--- a/backend/routers/organizations.py
+++ b/backend/routers/organizations.py
@@ -28,6 +28,7 @@ from models import (
 from auth import verify_token, get_password_hash
 from services.casbin_service import get_casbin_service
 from services.email_service import email_service
+from services.institution_billing import compute_monthly_billing
 import secrets
 
 
@@ -1534,7 +1535,11 @@ async def get_monthly_billing(
     they were 'active' at any moment during the Taipei month window. See
     `services.institution_billing` for the detailed derivation.
     """
-    # Auth: admin bypasses org-membership check; otherwise must be org_owner.
+    # Auth: admin bypasses org-membership check; otherwise must be the
+    # org's `org_owner` specifically (NOT just any member). `check_org_permission`
+    # only verifies membership, not role — so billing requires its own
+    # explicit role check to keep PII (student names + billable status) out
+    # of org_admin / teacher hands.
     if current_teacher.is_admin:
         org = (
             db.query(Organization)
@@ -1547,12 +1552,26 @@ async def get_monthly_billing(
             )
     else:
         org = check_org_permission(current_teacher.id, org_id, db)
-
-    from services.institution_billing import compute_monthly_billing
+        is_owner = (
+            db.query(TeacherOrganization)
+            .filter(
+                TeacherOrganization.teacher_id == current_teacher.id,
+                TeacherOrganization.organization_id == org_id,
+                TeacherOrganization.role == "org_owner",
+                TeacherOrganization.is_active.is_(True),
+            )
+            .first()
+            is not None
+        )
+        if not is_owner:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only org_owner can query monthly billing.",
+            )
 
     try:
         result = compute_monthly_billing(org, year, month, db)
-    except ValueError as e:
+    except (ValueError, OverflowError) as e:
         raise HTTPException(status_code=400, detail=str(e))
 
     return result

--- a/backend/services/institution_billing.py
+++ b/backend/services/institution_billing.py
@@ -78,13 +78,15 @@ def _is_billable(
     changed_at ASC. We pass it in (rather than querying) so the caller can
     bulk-load history for the whole org in one round-trip.
     """
-    # R2-F4: cheap invariant guard — fail loud in tests if a future caller
-    # passes unsorted rows. ORDER BY in compute_monthly_billing enforces it.
-    assert all(
-        _ensure_taipei(history_rows[i].changed_at)
-        <= _ensure_taipei(history_rows[i + 1].changed_at)
-        for i in range(len(history_rows) - 1)
-    ), "history_rows must be sorted ASC by changed_at"
+    # R3-F1: sort-order invariant. Use an explicit raise instead of assert
+    # so Python's -O flag (which strips asserts) cannot silently disable
+    # this guard in production — a sort-order violation produces wrong
+    # billing totals with no error surfaced otherwise.
+    for i in range(len(history_rows) - 1):
+        if _ensure_taipei(history_rows[i].changed_at) > _ensure_taipei(
+            history_rows[i + 1].changed_at
+        ):
+            raise ValueError("history_rows must be sorted ASC by changed_at")
 
     if not history_rows:
         # No history at all → student pre-dates the mechanism; fall back to
@@ -136,11 +138,13 @@ def compute_monthly_billing(
         raise ValueError(
             f"Organization {org.id} is not an institution (org_type={org.org_type!r})"
         )
-    # Catches both None and 0: a 0 price would silently zero every invoice
-    # which is indistinguishable from a real bug.
-    if not org.per_student_price:
+    # Catches None, 0, AND negative values. The DB CHECK constraint added
+    # in Phase 2 already rejects ≤0 on write, but the service layer guards
+    # explicitly so a stale ORM object or a future caller can't slip in a
+    # negative that would produce a negative total_amount.
+    if not org.per_student_price or org.per_student_price < 0:
         raise ValueError(
-            f"Organization {org.id} has no per_student_price set or it is zero."
+            f"Organization {org.id} per_student_price is not a positive integer."
         )
 
     month_start, month_end_exclusive = _month_window(year, month)

--- a/backend/services/institution_billing.py
+++ b/backend/services/institution_billing.py
@@ -39,7 +39,14 @@ def _month_window(year: int, month: int) -> tuple[datetime, datetime]:
 
     end_exclusive = midnight of the first day of the NEXT month, so the
     queried range is half-open [start, end_exclusive).
+
+    Year must be 1..9998 (9999 + month=12 would overflow Python's
+    datetime.MAXYEAR=9999 when computing end_exclusive). Both bounds raise
+    a friendly ValueError so the router can return a clean 400 instead of
+    a raw OverflowError → 500.
     """
+    if not 1 <= year <= 9998:
+        raise ValueError(f"year must be 1..9998, got {year}")
     if not 1 <= month <= 12:
         raise ValueError(f"month must be 1..12, got {month}")
     start = datetime(year, month, 1, 0, 0, 0, tzinfo=TAIPEI)
@@ -110,8 +117,12 @@ def compute_monthly_billing(
         raise ValueError(
             f"Organization {org.id} is not an institution (org_type={org.org_type!r})"
         )
-    if org.per_student_price is None:
-        raise ValueError(f"Organization {org.id} has no per_student_price set.")
+    # Catches both None and 0: a 0 price would silently zero every invoice
+    # which is indistinguishable from a real bug.
+    if not org.per_student_price:
+        raise ValueError(
+            f"Organization {org.id} has no per_student_price set or it is zero."
+        )
 
     month_start, month_end_exclusive = _month_window(year, month)
 
@@ -155,8 +166,13 @@ def compute_monthly_billing(
             StudentStatusHistory.student_id.in_(student_ids),
             StudentStatusHistory.changed_at < month_end_exclusive,
         )
+        # `id` tiebreaker: when two rows for the same student share an
+        # identical changed_at, fall back to insertion order so the
+        # status-at-T derivation is deterministic.
         .order_by(
-            StudentStatusHistory.student_id, StudentStatusHistory.changed_at.asc()
+            StudentStatusHistory.student_id,
+            StudentStatusHistory.changed_at.asc(),
+            StudentStatusHistory.id.asc(),
         )
         .all()
     )

--- a/backend/services/institution_billing.py
+++ b/backend/services/institution_billing.py
@@ -1,0 +1,190 @@
+"""Institution per-student monthly billing (issue #768 Phase 4, 五.5).
+
+For an `org_type='institution'` Organization with `per_student_price > 0`,
+computes the monthly invoice amount = (count of billable students this
+month) × per_student_price. Pure read-side: no payment, no DB writes.
+
+Billing rule (per spec "月結計費以人頭計算"):
+  A student is billable for month M iff they were 'active' at any moment
+  during [M_start, M_end_exclusive]. Inactive entire month → not billable;
+  joined or left mid-month → still billable.
+
+"Active at time T" is derived from student_status_history (most recent
+history.changed_at ≤ T). For students with NO history rows (pre-existing
+when the mechanism was introduced), the fallback is Student.is_active,
+treated as the status held throughout the queried month.
+"""
+
+from calendar import monthrange
+from datetime import datetime, timedelta
+from typing import List, Optional
+from zoneinfo import ZoneInfo
+
+from sqlalchemy.orm import Session
+
+from models import (
+    Organization,
+    School,
+    Student,
+    StudentSchool,
+    StudentStatusHistory,
+)
+
+
+TAIPEI = ZoneInfo("Asia/Taipei")
+
+
+def _month_window(year: int, month: int) -> tuple[datetime, datetime]:
+    """Return (start_inclusive, end_exclusive) at Taipei midnight.
+
+    end_exclusive = midnight of the first day of the NEXT month, so the
+    queried range is half-open [start, end_exclusive).
+    """
+    if not 1 <= month <= 12:
+        raise ValueError(f"month must be 1..12, got {month}")
+    start = datetime(year, month, 1, 0, 0, 0, tzinfo=TAIPEI)
+    if month == 12:
+        end_exclusive = datetime(year + 1, 1, 1, 0, 0, 0, tzinfo=TAIPEI)
+    else:
+        end_exclusive = datetime(year, month + 1, 1, 0, 0, 0, tzinfo=TAIPEI)
+    return start, end_exclusive
+
+
+def _ensure_taipei(dt: datetime) -> datetime:
+    """SQLite strips tzinfo on TIMESTAMPTZ load; Postgres preserves it.
+    Normalise to tz-aware Taipei so cross-comparison with the window
+    boundaries works on both backends."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=TAIPEI)
+    return dt.astimezone(TAIPEI)
+
+
+def _is_billable(
+    student: Student,
+    history_rows: List[StudentStatusHistory],
+    month_start: datetime,
+    month_end_exclusive: datetime,
+) -> bool:
+    """Decide if a single student is billable for the queried month.
+
+    `history_rows` MUST be already filtered to this student and ordered by
+    changed_at ASC. We pass it in (rather than querying) so the caller can
+    bulk-load history for the whole org in one round-trip.
+    """
+    if not history_rows:
+        # No history → fall back to Student.is_active treated as steady-state.
+        return bool(student.is_active)
+
+    # Status at month_start = the most recent history row with
+    # changed_at ≤ month_start. If none precede, default to Student.is_active.
+    status_at_start: Optional[str] = None
+    for row in history_rows:
+        if _ensure_taipei(row.changed_at) <= month_start:
+            status_at_start = row.status
+        else:
+            break
+
+    if status_at_start is None:
+        status_at_start = "active" if student.is_active else "inactive"
+
+    if status_at_start == "active":
+        return True
+
+    # Was inactive at month start; billable iff any flip to active happens
+    # within the window.
+    return any(
+        row.status == "active"
+        and month_start <= _ensure_taipei(row.changed_at) < month_end_exclusive
+        for row in history_rows
+    )
+
+
+def compute_monthly_billing(
+    org: Organization, year: int, month: int, db: Session
+) -> dict:
+    """Compute the monthly invoice for an institution org.
+
+    Raises ValueError if org is not 'institution' or per_student_price is NULL.
+    """
+    if org.org_type != "institution":
+        raise ValueError(
+            f"Organization {org.id} is not an institution (org_type={org.org_type!r})"
+        )
+    if org.per_student_price is None:
+        raise ValueError(f"Organization {org.id} has no per_student_price set.")
+
+    month_start, month_end_exclusive = _month_window(year, month)
+
+    # All distinct students enrolled in any school under this org. We
+    # include enrollments regardless of student_schools.is_active because the
+    # billing question is "was the STUDENT active in this org during M",
+    # which lives on student_status_history (canonical), not on the
+    # per-school enrollment row.
+    students = (
+        db.query(Student)
+        .join(StudentSchool, StudentSchool.student_id == Student.id)
+        .join(School, School.id == StudentSchool.school_id)
+        .filter(School.organization_id == org.id)
+        .distinct()
+        .all()
+    )
+
+    if not students:
+        return {
+            "org_id": str(org.id),
+            "year": year,
+            "month": month,
+            "per_student_price": org.per_student_price,
+            "billable_student_count": 0,
+            "total_amount": 0,
+            "currency": "TWD",
+            "students": [],
+        }
+
+    student_ids = [s.id for s in students]
+
+    # Bulk-load all status history rows up to the end of the queried month
+    # in a single query. Each iteration over the loop just walks an in-memory
+    # list; no per-student DB hit.
+    history_by_student: dict[int, List[StudentStatusHistory]] = {
+        sid: [] for sid in student_ids
+    }
+    rows = (
+        db.query(StudentStatusHistory)
+        .filter(
+            StudentStatusHistory.student_id.in_(student_ids),
+            StudentStatusHistory.changed_at < month_end_exclusive,
+        )
+        .order_by(
+            StudentStatusHistory.student_id, StudentStatusHistory.changed_at.asc()
+        )
+        .all()
+    )
+    for row in rows:
+        history_by_student[row.student_id].append(row)
+
+    breakdown = []
+    billable_count = 0
+    for student in students:
+        history_rows = history_by_student.get(student.id, [])
+        billable = _is_billable(student, history_rows, month_start, month_end_exclusive)
+        if billable:
+            billable_count += 1
+        breakdown.append(
+            {
+                "student_id": student.id,
+                "name": student.name,
+                "billable": billable,
+            }
+        )
+
+    return {
+        "org_id": str(org.id),
+        "year": year,
+        "month": month,
+        "per_student_price": org.per_student_price,
+        "billable_student_count": billable_count,
+        "total_amount": billable_count * org.per_student_price,
+        "currency": "TWD",
+        "students": breakdown,
+    }

--- a/backend/services/institution_billing.py
+++ b/backend/services/institution_billing.py
@@ -78,12 +78,21 @@ def _is_billable(
     changed_at ASC. We pass it in (rather than querying) so the caller can
     bulk-load history for the whole org in one round-trip.
     """
+    # R2-F4: cheap invariant guard — fail loud in tests if a future caller
+    # passes unsorted rows. ORDER BY in compute_monthly_billing enforces it.
+    assert all(
+        _ensure_taipei(history_rows[i].changed_at)
+        <= _ensure_taipei(history_rows[i + 1].changed_at)
+        for i in range(len(history_rows) - 1)
+    ), "history_rows must be sorted ASC by changed_at"
+
     if not history_rows:
-        # No history → fall back to Student.is_active treated as steady-state.
+        # No history at all → student pre-dates the mechanism; fall back to
+        # Student.is_active treated as the steady-state for the whole month.
         return bool(student.is_active)
 
     # Status at month_start = the most recent history row with
-    # changed_at ≤ month_start. If none precede, default to Student.is_active.
+    # changed_at ≤ month_start.
     status_at_start: Optional[str] = None
     for row in history_rows:
         if _ensure_taipei(row.changed_at) <= month_start:
@@ -92,7 +101,17 @@ def _is_billable(
             break
 
     if status_at_start is None:
-        status_at_start = "active" if student.is_active else "inactive"
+        # R2-F1: history exists but ALL rows postdate month_start (i.e. the
+        # student's first ever recorded transition is in or after this
+        # window). The pre-window state cannot be inferred from the
+        # CURRENT Student.is_active (which reflects today, not the past),
+        # so derive it from the first row: each history row represents a
+        # state CHANGE, so the prior state is the opposite of what the
+        # first row records.
+        #   first row → 'inactive'  ⇒ was 'active' before  ⇒ billable
+        #   first row → 'active'    ⇒ was 'inactive' before
+        first = history_rows[0]
+        status_at_start = "inactive" if first.status == "active" else "active"
 
     if status_at_start == "active":
         return True
@@ -127,10 +146,13 @@ def compute_monthly_billing(
     month_start, month_end_exclusive = _month_window(year, month)
 
     # All distinct students enrolled in any school under this org. We
-    # include enrollments regardless of student_schools.is_active because the
-    # billing question is "was the STUDENT active in this org during M",
-    # which lives on student_status_history (canonical), not on the
-    # per-school enrollment row.
+    # include enrollments regardless of student_schools.is_active AND
+    # School.is_active — the billing question is "was the STUDENT active in
+    # this org during M", which lives on student_status_history (the
+    # canonical source for billing). A school decommissioned mid-month
+    # doesn't change whether the org received service for its students
+    # during their active days. Status history filtering below ensures
+    # only truly-active students get charged.
     students = (
         db.query(Student)
         .join(StudentSchool, StudentSchool.student_id == Student.id)

--- a/backend/tests/test_institution_billing.py
+++ b/backend/tests/test_institution_billing.py
@@ -130,6 +130,36 @@ def test_rejects_non_institution_org(shared_test_session, teacher):
         compute_monthly_billing(org, 2026, 6, shared_test_session)
 
 
+def test_rejects_zero_per_student_price(shared_test_session):
+    """R3-F2 regression: per_student_price=0 must NOT silently produce a
+    zero invoice. Service-layer guard is defense-in-depth — the DB CHECK
+    constraint from Phase 2 also rejects ≤0, so we construct the org
+    without persisting to exercise the service guard in isolation."""
+    org = Organization(
+        name="ZeroPrice",
+        org_type="institution",
+        per_student_price=0,
+        is_active=True,
+    )
+    # Do NOT add/commit — the DB CHECK constraint would reject first.
+    with pytest.raises(ValueError, match="per_student_price"):
+        compute_monthly_billing(org, 2026, 6, shared_test_session)
+
+
+def test_rejects_negative_per_student_price(shared_test_session):
+    """R3-F2 regression: a negative per_student_price must NOT pass the
+    `not org.per_student_price` check and produce a negative invoice.
+    Defense-in-depth alongside the DB CHECK."""
+    org = Organization(
+        name="NegPrice",
+        org_type="institution",
+        per_student_price=-50,
+        is_active=True,
+    )
+    with pytest.raises(ValueError, match="per_student_price"):
+        compute_monthly_billing(org, 2026, 6, shared_test_session)
+
+
 def test_rejects_org_with_no_per_student_price(shared_test_session):
     org = Organization(
         name="Acme",

--- a/backend/tests/test_institution_billing.py
+++ b/backend/tests/test_institution_billing.py
@@ -238,6 +238,44 @@ def test_flipped_active_inactive_active_is_billable(
     assert result["billable_student_count"] == 1
 
 
+def test_first_ever_history_is_inactivation_within_window_still_billable(
+    shared_test_session, institution_org, institution_school
+):
+    """R2-F1 regression: a student whose FIRST EVER history row is an
+    inactivation inside the queried window was active before — even if
+    Student.is_active is currently False (set by that very inactivation).
+
+    Pre-fix bug: status_at_start fell back to student.is_active=False,
+    masked the active days at the start of the month, and the student
+    was not billed despite being active June 1-9.
+    """
+    s = _student(shared_test_session, "Justin", is_active=True)
+    _enrol(shared_test_session, s, institution_school)
+    # First and only history row: deactivated mid-June. is_active updated
+    # in lock-step (typical app behaviour on a deactivation event).
+    _status(shared_test_session, s, datetime(2026, 6, 10, tzinfo=TAIPEI), "inactive")
+    s.is_active = False
+    shared_test_session.commit()
+
+    result = compute_monthly_billing(institution_org, 2026, 6, shared_test_session)
+    # Was active June 1–9 → MUST be billable, despite current is_active=False
+    assert result["billable_student_count"] == 1
+
+
+def test_first_ever_history_is_activation_within_window_is_billable(
+    shared_test_session, institution_org, institution_school
+):
+    """Companion to F1 regression: a student whose FIRST EVER history row is
+    an activation inside the window was inactive before — billable because
+    they became active during the month (joined mid-month case)."""
+    s = _student(shared_test_session, "Kara", is_active=True)
+    _enrol(shared_test_session, s, institution_school)
+    _status(shared_test_session, s, datetime(2026, 6, 15, tzinfo=TAIPEI), "active")
+
+    result = compute_monthly_billing(institution_org, 2026, 6, shared_test_session)
+    assert result["billable_student_count"] == 1
+
+
 def test_future_history_row_does_not_affect_current_month(
     shared_test_session, institution_org, institution_school
 ):

--- a/backend/tests/test_institution_billing.py
+++ b/backend/tests/test_institution_billing.py
@@ -1,0 +1,295 @@
+"""Tests for backend.services.institution_billing (issue #768 Phase 4, 五.5)."""
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from auth import get_password_hash
+from models import (
+    Organization,
+    School,
+    Student,
+    StudentSchool,
+    StudentStatusHistory,
+    Teacher,
+)
+from services.institution_billing import (
+    _month_window,
+    compute_monthly_billing,
+)
+
+
+TAIPEI = ZoneInfo("Asia/Taipei")
+
+
+# ---------- fixtures ----------
+
+
+@pytest.fixture
+def teacher(shared_test_session):
+    t = Teacher(
+        email="billing-teacher@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="T",
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+@pytest.fixture
+def institution_org(shared_test_session):
+    o = Organization(
+        name="Acme Institution",
+        org_type="institution",
+        per_student_price=100,
+        is_active=True,
+    )
+    shared_test_session.add(o)
+    shared_test_session.commit()
+    shared_test_session.refresh(o)
+    return o
+
+
+@pytest.fixture
+def institution_school(shared_test_session, institution_org):
+    s = School(
+        organization_id=institution_org.id,
+        name="Branch A",
+        is_active=True,
+    )
+    shared_test_session.add(s)
+    shared_test_session.commit()
+    shared_test_session.refresh(s)
+    return s
+
+
+def _enrol(db, student, school):
+    db.add(StudentSchool(student_id=student.id, school_id=school.id, is_active=True))
+    db.commit()
+
+
+def _student(db, name, *, is_active=True):
+    # Student has student_number etc — let's check the columns
+    s = Student(
+        name=name,
+        email=f"{name.lower().replace(' ', '-')}@example.com",
+        password_hash=get_password_hash("x"),
+        is_active=is_active,
+    )
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    return s
+
+
+def _status(db, student, when, status):
+    db.add(StudentStatusHistory(student_id=student.id, status=status, changed_at=when))
+    db.commit()
+
+
+# ---------- _month_window ----------
+
+
+def test_month_window_normal():
+    start, end = _month_window(2026, 6)
+    assert (start.year, start.month, start.day) == (2026, 6, 1)
+    assert (end.year, end.month, end.day) == (2026, 7, 1)
+
+
+def test_month_window_december_rolls():
+    start, end = _month_window(2026, 12)
+    assert start.month == 12
+    assert (end.year, end.month, end.day) == (2027, 1, 1)
+
+
+def test_month_window_february_leap_year():
+    start, end = _month_window(2028, 2)
+    assert (end.month, end.day) == (3, 1)
+    # 29 days in Feb 2028
+    assert (end - start).days == 29
+
+
+def test_month_window_rejects_invalid_month():
+    with pytest.raises(ValueError):
+        _month_window(2026, 13)
+
+
+# ---------- compute_monthly_billing ----------
+
+
+def test_rejects_non_institution_org(shared_test_session, teacher):
+    org = Organization(name="Group Buy", org_type="group_buy", is_active=True)
+    shared_test_session.add(org)
+    shared_test_session.commit()
+    with pytest.raises(ValueError, match="not an institution"):
+        compute_monthly_billing(org, 2026, 6, shared_test_session)
+
+
+def test_rejects_org_with_no_per_student_price(shared_test_session):
+    org = Organization(
+        name="Acme",
+        org_type="institution",
+        per_student_price=None,
+        is_active=True,
+    )
+    shared_test_session.add(org)
+    shared_test_session.commit()
+    with pytest.raises(ValueError, match="per_student_price"):
+        compute_monthly_billing(org, 2026, 6, shared_test_session)
+
+
+def test_zero_students_returns_zero_total(shared_test_session, institution_org):
+    result = compute_monthly_billing(institution_org, 2026, 6, shared_test_session)
+    assert result["billable_student_count"] == 0
+    assert result["total_amount"] == 0
+    assert result["students"] == []
+
+
+def test_no_history_active_student_is_billable(
+    shared_test_session, institution_org, institution_school
+):
+    """Per design decision: no history → fall back to Student.is_active."""
+    s = _student(shared_test_session, "Alice", is_active=True)
+    _enrol(shared_test_session, s, institution_school)
+
+    result = compute_monthly_billing(institution_org, 2026, 6, shared_test_session)
+    assert result["billable_student_count"] == 1
+    assert result["total_amount"] == 100  # per_student_price
+    assert result["students"][0]["billable"] is True
+
+
+def test_no_history_inactive_student_is_not_billable(
+    shared_test_session, institution_org, institution_school
+):
+    s = _student(shared_test_session, "Bob", is_active=False)
+    _enrol(shared_test_session, s, institution_school)
+
+    result = compute_monthly_billing(institution_org, 2026, 6, shared_test_session)
+    assert result["billable_student_count"] == 0
+    assert result["total_amount"] == 0
+
+
+def test_active_throughout_month_is_billable(
+    shared_test_session, institution_org, institution_school
+):
+    s = _student(shared_test_session, "Charlie", is_active=False)
+    _enrol(shared_test_session, s, institution_school)
+    # Activated before the queried month
+    _status(shared_test_session, s, datetime(2026, 5, 15, tzinfo=TAIPEI), "active")
+
+    result = compute_monthly_billing(institution_org, 2026, 6, shared_test_session)
+    assert result["billable_student_count"] == 1
+
+
+def test_inactive_throughout_month_is_not_billable(
+    shared_test_session, institution_org, institution_school
+):
+    s = _student(shared_test_session, "Dave", is_active=True)
+    _enrol(shared_test_session, s, institution_school)
+    # Deactivated before the month, never re-activated
+    _status(shared_test_session, s, datetime(2026, 5, 15, tzinfo=TAIPEI), "active")
+    _status(shared_test_session, s, datetime(2026, 5, 20, tzinfo=TAIPEI), "inactive")
+
+    result = compute_monthly_billing(institution_org, 2026, 6, shared_test_session)
+    assert result["billable_student_count"] == 0
+
+
+def test_joined_mid_month_is_billable(
+    shared_test_session, institution_org, institution_school
+):
+    s = _student(shared_test_session, "Eve", is_active=False)
+    _enrol(shared_test_session, s, institution_school)
+    # Inactive at month start, then activated mid-June
+    _status(shared_test_session, s, datetime(2026, 5, 1, tzinfo=TAIPEI), "inactive")
+    _status(shared_test_session, s, datetime(2026, 6, 15, tzinfo=TAIPEI), "active")
+
+    result = compute_monthly_billing(institution_org, 2026, 6, shared_test_session)
+    assert result["billable_student_count"] == 1
+
+
+def test_left_mid_month_is_still_billable(
+    shared_test_session, institution_org, institution_school
+):
+    s = _student(shared_test_session, "Frank", is_active=True)
+    _enrol(shared_test_session, s, institution_school)
+    # Active at month start, deactivated mid-June
+    _status(shared_test_session, s, datetime(2026, 5, 1, tzinfo=TAIPEI), "active")
+    _status(shared_test_session, s, datetime(2026, 6, 15, tzinfo=TAIPEI), "inactive")
+
+    result = compute_monthly_billing(institution_org, 2026, 6, shared_test_session)
+    assert result["billable_student_count"] == 1
+
+
+def test_flipped_active_inactive_active_is_billable(
+    shared_test_session, institution_org, institution_school
+):
+    s = _student(shared_test_session, "Grace", is_active=True)
+    _enrol(shared_test_session, s, institution_school)
+    _status(shared_test_session, s, datetime(2026, 5, 1, tzinfo=TAIPEI), "inactive")
+    _status(shared_test_session, s, datetime(2026, 6, 10, tzinfo=TAIPEI), "active")
+    _status(shared_test_session, s, datetime(2026, 6, 20, tzinfo=TAIPEI), "inactive")
+
+    result = compute_monthly_billing(institution_org, 2026, 6, shared_test_session)
+    assert result["billable_student_count"] == 1
+
+
+def test_future_history_row_does_not_affect_current_month(
+    shared_test_session, institution_org, institution_school
+):
+    """A history row whose changed_at is AFTER the queried month must not
+    leak into the decision (e.g. July deactivation doesn't affect June bill)."""
+    s = _student(shared_test_session, "Henry", is_active=True)
+    _enrol(shared_test_session, s, institution_school)
+    # Future deactivation, well after June
+    _status(shared_test_session, s, datetime(2026, 7, 10, tzinfo=TAIPEI), "inactive")
+
+    result = compute_monthly_billing(institution_org, 2026, 6, shared_test_session)
+    # Still active throughout June (fallback to is_active=True since no
+    # history row precedes month_start)
+    assert result["billable_student_count"] == 1
+
+
+def test_total_amount_scales_with_count(
+    shared_test_session, institution_org, institution_school
+):
+    s1 = _student(shared_test_session, "Stu1", is_active=True)
+    s2 = _student(shared_test_session, "Stu2", is_active=True)
+    s3 = _student(shared_test_session, "Stu3", is_active=False)
+    _enrol(shared_test_session, s1, institution_school)
+    _enrol(shared_test_session, s2, institution_school)
+    _enrol(shared_test_session, s3, institution_school)
+
+    result = compute_monthly_billing(institution_org, 2026, 6, shared_test_session)
+    assert result["billable_student_count"] == 2
+    assert result["total_amount"] == 200  # 2 × 100
+    assert {b["student_id"] for b in result["students"] if b["billable"]} == {
+        s1.id,
+        s2.id,
+    }
+
+
+def test_student_in_multiple_schools_under_same_org_counts_once(
+    shared_test_session, institution_org, institution_school
+):
+    """A student enrolled in 2 schools under the same institution org should
+    be counted ONCE per month, not twice."""
+    second_school = School(
+        organization_id=institution_org.id,
+        name="Branch B",
+        is_active=True,
+    )
+    shared_test_session.add(second_school)
+    shared_test_session.commit()
+
+    s = _student(shared_test_session, "Iris", is_active=True)
+    _enrol(shared_test_session, s, institution_school)
+    _enrol(shared_test_session, s, second_school)
+
+    result = compute_monthly_billing(institution_org, 2026, 6, shared_test_session)
+    assert result["billable_student_count"] == 1
+    assert result["total_amount"] == 100

--- a/backend/tests/test_institution_billing_endpoint.py
+++ b/backend/tests/test_institution_billing_endpoint.py
@@ -1,0 +1,214 @@
+"""Endpoint tests for GET /api/organizations/{org_id}/billing/monthly
+(issue #768 Phase 4, 五.5).
+
+Covers the auth split (admin / org_owner / outside-teacher), validation
+(non-institution / missing per_student_price), and a happy path with full
+response shape.
+"""
+
+import pytest
+
+from auth import create_access_token, get_password_hash
+from models import (
+    Organization,
+    School,
+    Student,
+    StudentSchool,
+    Teacher,
+    TeacherOrganization,
+)
+
+
+# ---------- fixtures ----------
+
+
+def _bearer(teacher_id):
+    token = create_access_token({"sub": str(teacher_id), "type": "teacher"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def admin(shared_test_session):
+    t = Teacher(
+        email="bill-admin@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="Admin",
+        is_active=True,
+        email_verified=True,
+        is_admin=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+@pytest.fixture
+def owner(shared_test_session):
+    t = Teacher(
+        email="bill-owner@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="Owner",
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+@pytest.fixture
+def outsider(shared_test_session):
+    t = Teacher(
+        email="bill-outsider@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="Outsider",
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+@pytest.fixture
+def institution_org_with_one_active_student(shared_test_session, owner):
+    """Institution org · 1 school · 1 active enrolled student · owner bound."""
+    org = Organization(
+        name="Acme Institution",
+        org_type="institution",
+        per_student_price=150,
+        is_active=True,
+    )
+    shared_test_session.add(org)
+    shared_test_session.flush()
+    school = School(organization_id=org.id, name="Branch", is_active=True)
+    shared_test_session.add(school)
+    shared_test_session.flush()
+    shared_test_session.add(
+        TeacherOrganization(
+            teacher_id=owner.id,
+            organization_id=org.id,
+            role="org_owner",
+            is_active=True,
+        )
+    )
+    student = Student(
+        name="Alice",
+        email="alice@example.com",
+        password_hash=get_password_hash("x"),
+        is_active=True,
+    )
+    shared_test_session.add(student)
+    shared_test_session.flush()
+    shared_test_session.add(
+        StudentSchool(student_id=student.id, school_id=school.id, is_active=True)
+    )
+    shared_test_session.commit()
+    return org, school, student
+
+
+# ---------- auth ----------
+
+
+def test_outsider_teacher_gets_403(
+    test_client, outsider, institution_org_with_one_active_student
+):
+    org, _, _ = institution_org_with_one_active_student
+    r = test_client.get(
+        f"/api/organizations/{org.id}/billing/monthly?year=2026&month=6",
+        headers=_bearer(outsider.id),
+    )
+    assert r.status_code == 403
+
+
+def test_admin_can_query_any_org(
+    test_client, admin, institution_org_with_one_active_student
+):
+    org, _, _ = institution_org_with_one_active_student
+    r = test_client.get(
+        f"/api/organizations/{org.id}/billing/monthly?year=2026&month=6",
+        headers=_bearer(admin.id),
+    )
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert body["org_id"] == str(org.id)
+
+
+def test_owner_can_query_own_org(
+    test_client, owner, institution_org_with_one_active_student
+):
+    org, _, _ = institution_org_with_one_active_student
+    r = test_client.get(
+        f"/api/organizations/{org.id}/billing/monthly?year=2026&month=6",
+        headers=_bearer(owner.id),
+    )
+    assert r.status_code == 200, r.json()
+
+
+# ---------- validation ----------
+
+
+def test_400_when_org_is_not_institution(test_client, admin, shared_test_session):
+    org = Organization(name="Group", org_type="group_buy", is_active=True)
+    shared_test_session.add(org)
+    shared_test_session.commit()
+    r = test_client.get(
+        f"/api/organizations/{org.id}/billing/monthly?year=2026&month=6",
+        headers=_bearer(admin.id),
+    )
+    assert r.status_code == 400
+    assert "not an institution" in r.json()["detail"]
+
+
+def test_400_when_per_student_price_is_null(test_client, admin, shared_test_session):
+    org = Organization(
+        name="No Price",
+        org_type="institution",
+        per_student_price=None,
+        is_active=True,
+    )
+    shared_test_session.add(org)
+    shared_test_session.commit()
+    r = test_client.get(
+        f"/api/organizations/{org.id}/billing/monthly?year=2026&month=6",
+        headers=_bearer(admin.id),
+    )
+    assert r.status_code == 400
+    assert "per_student_price" in r.json()["detail"]
+
+
+def test_404_when_org_does_not_exist(test_client, admin):
+    fake = "00000000-0000-0000-0000-000000000000"
+    r = test_client.get(
+        f"/api/organizations/{fake}/billing/monthly?year=2026&month=6",
+        headers=_bearer(admin.id),
+    )
+    assert r.status_code == 404
+
+
+# ---------- response shape ----------
+
+
+def test_happy_path_full_response(
+    test_client, admin, institution_org_with_one_active_student
+):
+    org, _, student = institution_org_with_one_active_student
+    r = test_client.get(
+        f"/api/organizations/{org.id}/billing/monthly?year=2026&month=6",
+        headers=_bearer(admin.id),
+    )
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert body["org_id"] == str(org.id)
+    assert body["year"] == 2026 and body["month"] == 6
+    assert body["per_student_price"] == 150
+    assert body["billable_student_count"] == 1
+    assert body["total_amount"] == 150
+    assert body["currency"] == "TWD"
+    assert len(body["students"]) == 1
+    assert body["students"][0]["student_id"] == student.id
+    assert body["students"][0]["name"] == "Alice"
+    assert body["students"][0]["billable"] is True

--- a/backend/tests/test_institution_billing_endpoint.py
+++ b/backend/tests/test_institution_billing_endpoint.py
@@ -124,6 +124,39 @@ def test_outsider_teacher_gets_403(
     assert r.status_code == 403
 
 
+def test_org_member_non_owner_gets_403(
+    test_client, shared_test_session, institution_org_with_one_active_student
+):
+    """Auth bypass guard: an active org_admin (member but not org_owner)
+    must NOT receive billing PII (student names + billable status).
+    Locks in the role check added after PR #823 round 0 review F1."""
+    org, _, _ = institution_org_with_one_active_student
+    member = Teacher(
+        email="bill-org-admin@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="OrgAdminMember",
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(member)
+    shared_test_session.flush()
+    shared_test_session.add(
+        TeacherOrganization(
+            teacher_id=member.id,
+            organization_id=org.id,
+            role="org_admin",  # member, but NOT org_owner
+            is_active=True,
+        )
+    )
+    shared_test_session.commit()
+    r = test_client.get(
+        f"/api/organizations/{org.id}/billing/monthly?year=2026&month=6",
+        headers=_bearer(member.id),
+    )
+    assert r.status_code == 403
+    assert "org_owner" in r.json()["detail"]
+
+
 def test_admin_can_query_any_org(
     test_client, admin, institution_org_with_one_active_student
 ):


### PR DESCRIPTION
## Summary
Phase 4 of 5 for issue #768「機構方案優化」. Backend-only read-side endpoint that computes an institution org's monthly per-head invoice. **No frontend changes** (Phase 5), **no migrations**, **no payment flow** (人工請款 per spec).

## Endpoint
```
GET /api/organizations/{org_id}/billing/monthly?year=YYYY&month=MM
```
- **Auth**: platform admin (any org) OR org_owner (own org only) per design decision
- **400** if org is not `org_type='institution'`
- **400** if `per_student_price` is NULL
- **404** if org does not exist
- **200** → `MonthlyBillingResponse` with `per_student_price`, `billable_student_count`, `total_amount`, `currency`, and a per-student breakdown

## Billing rule (per spec 「月結計費以人頭計算」)
A student is billable for month M iff they were `'active'` at any moment during `[M_start, M_end_exclusive]` (Taipei):
- Joined mid-month → bill ✓
- Left mid-month → still bill that month ✓
- Inactive entire month → don't bill ✓
- Flip active → inactive → active in same month → bill ✓
- Same student in 2 schools of one org → count once ✓

"Active at time T" = the most recent `student_status_history.changed_at ≤ T` has `status='active'`. For students with **no history rows** (pre-existing when the mechanism was introduced), fallback to `Student.is_active` treated as steady state — **confirmed Phase 4 design decision**.

## Service layer
`backend/services/institution_billing.py` centralises the logic for both this endpoint and future internal callers:

| Function | Purpose |
|---|---|
| `_month_window(year, month)` | Half-open `[start, end_exclusive)` Taipei boundary (Dec roll, leap-year safe) |
| `_ensure_taipei(dt)` | Normalises `changed_at` to tz-aware Taipei so SQLite (strips tzinfo) and Postgres (preserves) both compare correctly |
| `_is_billable(student, history_rows, ...)` | Pure decision function; caller pre-loads history to avoid N+1 |
| `compute_monthly_billing(org, year, month, db)` | Orchestrator with single bulk `IN` query for status history |

## Test plan
- [x] `tests/test_institution_billing.py` — **17 cases** (`_month_window` × 4 incl. Dec/leap/invalid; rejects non-institution; rejects null `per_student_price`; zero students; no-history active/inactive; active throughout; inactive throughout; joined mid-month; left mid-month; flipped a/i/a; future history doesn't leak; total scales; multi-school dedup)
- [x] `tests/test_institution_billing_endpoint.py` — **7 cases** (outsider 403; admin can query any; owner own only; 400 non-institution; 400 null price; 404 unknown; happy-path full-response shape)
- [x] Phase 1-3 regression: 99 tests still green
- [x] **Total: 123/123 passing**
- [x] Black clean, single alembic head `20260528_1000`

## Out of scope (Phase 5)
- 機構單位學生費前端設定頁 + 月度計費查詢前端 UI
- Bulk monthly export (all institution orgs at once)
- Invoice document generation / sending
- Auto-trigger billing

## Backlog from earlier phases (not in this PR)
- PR #820 round 2: 4 minor nits
- PR #822 round 2: 4 minor nits  
- PR #822 round 3: 3 findings (cron advisory lock, idempotency null guard, compensation fallback)

These are non-blocking; can be addressed in a dedicated cleanup PR or alongside Phase 5.

Related to #768 (will not auto-close; #768 closes when Phase 5 ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)