### PR TITLE
chore(#768): Phase 5-1 backend cleanup (14 backlog items)

### DIFF
--- a/backend/alembic/versions/20260528_1000_phase2_constraint_followups.py
+++ b/backend/alembic/versions/20260528_1000_phase2_constraint_followups.py
@@ -67,7 +67,7 @@ def upgrade() -> None:
     )
 
     # ------------------------------------------------------------------
-    # Named-CHECK mirrors for 5 fields that got inline (auto-named) CHECKs
+    # Named-CHECK mirrors for 6 fields that got inline (auto-named) CHECKs
     # in Phase 1. Adding the named versions so the ORM model layer's
     # `CheckConstraint(name='ck_...')` claims match reality in Postgres
     # (the auto-named ones — e.g. organizations_org_type_check — also

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -7,6 +7,8 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, ROUND_HALF_UP
+
+from dateutil.relativedelta import relativedelta
 from pydantic import BaseModel
 from typing import Optional, Dict, Any, List
 import logging
@@ -28,6 +30,12 @@ from models import (
 from routers.teachers import get_current_teacher
 from services.tappay_service import TapPayService
 from services.topup_discount import get_teacher_topup_discount
+from services.group_buy import (
+    compute_group_buy_total,
+    create_group_buy_org_and_school,
+    create_group_buy_period,
+    validate_group_buy_plan,
+)
 from config.plans import (
     CREDIT_PACKAGES,
     ORG_ALLOWED_PACKAGES,
@@ -751,6 +759,7 @@ async def org_renew_credit_package(
 @router.post("/group-buy-open", response_model=GroupBuyOpenResponse)
 async def open_group_buy(
     request: Request,
+    open_request: GroupBuyOpenRequest,
     db: Session = Depends(get_db),
     current_teacher: Teacher = Depends(get_current_teacher),
 ):
@@ -766,23 +775,11 @@ async def open_group_buy(
     if not ENABLE_PAYMENT:
         return GroupBuyOpenResponse(success=False, message="付款功能尚未開放，敬請期待！")
 
-    # Parse request
-    try:
-        body = await request.body()
-        body_json = json.loads(body)
-        open_request = GroupBuyOpenRequest(**body_json)
-    except Exception as e:
-        logger.error(f"Failed to parse group-buy open request: {e}")
-        raise HTTPException(status_code=400, detail="Invalid request format")
+    # Reconstruct the raw body dict for audit logging (FastAPI already
+    # validated `open_request` and would return 422 on bad input).
+    body_json = open_request.model_dump()
 
     # Server-side plan validation and amount computation
-    from services.group_buy import (
-        compute_group_buy_total,
-        create_group_buy_org_and_school,
-        create_group_buy_period,
-        validate_group_buy_plan,
-    )
-
     try:
         plan = validate_group_buy_plan(open_request.plan_name, db)
     except ValueError as e:
@@ -817,6 +814,13 @@ async def open_group_buy(
     # pass the check and double-charge. Lock auto-releases at request end.
     # SQLite tests are single-threaded; the dialect guard is a no-op there.
     # Use db.get_bind() (SQLAlchemy 2.x idiom) instead of db.bind.
+    #
+    # NOTE: lock key intentionally scopes by (teacher_id, plan_name) only.
+    # Two concurrent requests for DIFFERENT plans from the same teacher
+    # would not serialise on this lock. That edge is covered by the
+    # R2-F2 single-org-per-teacher guard below: the first request to
+    # commit creates the TeacherOrganization, and the second request's
+    # R2-F2 check finds it and returns 409.
     if db.get_bind().dialect.name == "postgresql":
         lock_key = f"group_buy_open:{current_teacher.id}:{plan.name}"
         locked = db.execute(
@@ -892,6 +896,11 @@ async def open_group_buy(
             .order_by(Organization.created_at.desc())
             .first()
         )
+        # 5-1 R3.2 — If a SUCCESS transaction exists but the org/school
+        # records don't, the data is inconsistent (soft-delete race, manual
+        # deactivation, or a partial provisioning failure that wasn't
+        # caught). Returning success with null IDs would silently break
+        # the frontend redirect — fail loud instead so ops can investigate.
         owned_school = (
             db.query(School)
             .filter(
@@ -903,20 +912,34 @@ async def open_group_buy(
             if owned_org is not None
             else None
         )
+        if owned_org is None or owned_school is None:
+            logger.error(
+                "Idempotency-shortcut data inconsistency: SUCCESS txn "
+                f"id={recent.id} rec_trade_id={recent.external_transaction_id} "
+                f"for teacher={current_teacher.id} plan={plan.name} but "
+                f"owned_org={owned_org!r} owned_school={owned_school!r}. "
+                "Manual investigation required."
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    "Team setup is incomplete despite a prior successful "
+                    "charge. Our team has been alerted — please contact "
+                    "support."
+                ),
+            )
         return GroupBuyOpenResponse(
             success=True,
             message="此筆開團已完成",
             transaction_id=recent.external_transaction_id,
-            organization_id=str(owned_org.id) if owned_org else None,
-            school_id=str(owned_school.id) if owned_school else None,
+            organization_id=str(owned_org.id),
+            school_id=str(owned_school.id),
             subscription_end_date=(
                 owned_org.subscription_end_date.isoformat()
-                if owned_org and owned_org.subscription_end_date
+                if owned_org.subscription_end_date
                 else None
             ),
-            teacher_seat_limit=(
-                owned_school.teacher_seat_limit if owned_school else None
-            ),
+            teacher_seat_limit=owned_school.teacher_seat_limit,
         )
 
     try:
@@ -963,7 +986,7 @@ async def open_group_buy(
                 status="FAILED",
                 months=12,
                 period_start=now,
-                period_end=now + timedelta(days=365),
+                period_end=now + relativedelta(years=1),
                 new_end_date=now,
                 idempotency_key=idempotency_key,
                 ip_address=client_host,
@@ -1066,7 +1089,7 @@ async def open_group_buy(
                     status="FAILED",
                     months=12,
                     period_start=now,
-                    period_end=now + timedelta(days=365),
+                    period_end=now + relativedelta(years=1),
                     new_end_date=now,
                     idempotency_key=idempotency_key,
                     ip_address=client_host,
@@ -1085,10 +1108,57 @@ async def open_group_buy(
                 )
                 db.add(comp_txn)
                 db.commit()
-            except Exception:
-                logger.exception(
-                    "Failed to persist compensation FAILED transaction record"
+            except Exception as comp_persist_err:
+                # 5-1 R3.3 — If even the FAILED-record insert fails (DB
+                # connection dropped mid-handler, network partition), emit
+                # a structured ERROR-level log line carrying ALL fields ops
+                # needs to refund manually. Log scrapers / alert rules
+                # should match on the "GROUP_BUY_COMPENSATION_DB_LOST"
+                # token. Also re-issue the original log_payment_failure
+                # with a distinct error_code so BigQuery's payment_log table
+                # picks it up via the independent client (not affected by
+                # the broken DB session).
+                logger.error(
+                    "🚨 GROUP_BUY_COMPENSATION_DB_LOST — "
+                    f"teacher_id={current_teacher.id} "
+                    f"teacher_email={current_teacher.email} "
+                    f"plan={plan.name} amount={amount} currency=TWD "
+                    f"rec_trade_id={external_transaction_id} "
+                    f"order_number={order_number} "
+                    f"provisioning_err={provisioning_err!r} "
+                    f"compensation_persist_err={comp_persist_err!r}",
+                    exc_info=comp_persist_err,
                 )
+                try:
+                    log_payment_failure(
+                        transaction_id=order_number,
+                        user_id=current_teacher.id,
+                        user_email=current_teacher.email,
+                        amount=amount,
+                        plan_name=plan.name,
+                        error_stage="compensation_record_lost",
+                        error_code="GROUP_BUY_COMPENSATION_DB_LOST",
+                        error_message=(
+                            f"REFUND REQUIRED rec_trade_id="
+                            f"{external_transaction_id}: provisioning failed "
+                            f"({provisioning_err!r}) AND compensation insert "
+                            f"failed ({comp_persist_err!r})"
+                        ),
+                        request_data=body_json,
+                        response_status=500,
+                        response_body={
+                            "rec_trade_id": external_transaction_id,
+                            "order_number": order_number,
+                            "provisioning_err": str(provisioning_err),
+                            "compensation_persist_err": str(comp_persist_err),
+                        },
+                        execution_time_ms=execution_time,
+                    )
+                except Exception:
+                    logger.exception(
+                        "BigQuery log_payment_failure also failed during "
+                        "compensation-loss path"
+                    )
             raise HTTPException(
                 status_code=500,
                 detail=(

--- a/backend/routers/cron.py
+++ b/backend/routers/cron.py
@@ -24,6 +24,7 @@ from models import (
 )
 from services.email_service import email_service
 from services.tappay_service import TapPayService
+from services.group_buy import grant_monthly_for_group_buy
 from google.cloud import bigquery
 
 router = APIRouter(prefix="/api/cron", tags=["cron"])
@@ -393,8 +394,6 @@ async def monthly_renewal_cron(
     logger.info("🎁 Phase 3: Group-buy monthly grants")
     group_buy_failed = False
     try:
-        from services.group_buy import grant_monthly_for_group_buy
-
         gb_result = grant_monthly_for_group_buy(now_taipei, db)
         results["group_buy_grants_created"] = gb_result["grants_created"]
         results["group_buy_grants_skipped_duplicate"] = gb_result[

--- a/backend/routers/organizations.py
+++ b/backend/routers/organizations.py
@@ -1569,6 +1569,10 @@ async def get_monthly_billing(
 
     try:
         result = compute_monthly_billing(org, year, month, db)
+    # `_month_window` (and the Query(ge=1, le=9998) decorator) converts every
+    # year/month range error into a ValueError before any datetime arithmetic,
+    # so raw OverflowError cannot reach this layer. See
+    # test_month_window_rejects_year_9999_to_prevent_overflow for the invariant.
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 

--- a/backend/routers/organizations.py
+++ b/backend/routers/organizations.py
@@ -1536,22 +1536,20 @@ async def get_monthly_billing(
     `services.institution_billing` for the detailed derivation.
     """
     # Auth: admin bypasses org-membership check; otherwise must be the
-    # org's `org_owner` specifically (NOT just any member). `check_org_permission`
-    # only verifies membership, not role — so billing requires its own
-    # explicit role check to keep PII (student names + billable status) out
-    # of org_admin / teacher hands.
-    if current_teacher.is_admin:
-        org = (
-            db.query(Organization)
-            .filter(Organization.id == org_id, Organization.is_active.is_(True))
-            .first()
+    # org's `org_owner` specifically (NOT just any member). Billing exposes
+    # PII (student names + billable status) so org_admin / teacher roles
+    # are explicitly excluded.
+    org = (
+        db.query(Organization)
+        .filter(Organization.id == org_id, Organization.is_active.is_(True))
+        .first()
+    )
+    if org is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found"
         )
-        if org is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found"
-            )
-    else:
-        org = check_org_permission(current_teacher.id, org_id, db)
+
+    if not current_teacher.is_admin:
         is_owner = (
             db.query(TeacherOrganization)
             .filter(
@@ -1571,7 +1569,7 @@ async def get_monthly_billing(
 
     try:
         result = compute_monthly_billing(org, year, month, db)
-    except (ValueError, OverflowError) as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     return result

--- a/backend/services/group_buy.py
+++ b/backend/services/group_buy.py
@@ -203,11 +203,15 @@ def grant_monthly_for_group_buy(today: datetime, db: Session) -> dict:
     test path is a no-op.
     """
     if db.get_bind().dialect.name == "postgresql":
+        # Fixed int64 advisory-lock key — replaces hashtext() which returns
+        # int32 (~1-in-4-billion collision risk with other advisory locks).
+        # Value is a hand-picked random int64 dedicated to this cron job;
+        # never reuse across other lock sites in this codebase.
+        # Mnemonic: "GBMG" (Group-Buy Monthly Grant) encoded.
+        GRANT_MONTHLY_LOCK_KEY = 7386349847423521791
         locked = db.execute(
-            text(
-                "SELECT pg_try_advisory_xact_lock(hashtext("
-                "'grant_monthly_for_group_buy'))"
-            )
+            text("SELECT pg_try_advisory_xact_lock(:k)"),
+            {"k": GRANT_MONTHLY_LOCK_KEY},
         ).scalar()
         if not locked:
             # Another invocation holds the lock — bail out cleanly. The

--- a/backend/services/group_buy.py
+++ b/backend/services/group_buy.py
@@ -11,6 +11,8 @@ from datetime import datetime, timedelta
 from typing import Tuple
 from zoneinfo import ZoneInfo
 
+from dateutil.relativedelta import relativedelta
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from models import (
@@ -104,7 +106,9 @@ def create_group_buy_org_and_school(
         name=f"{owner.name or owner.email}'s 團購",
         org_type="group_buy",
         subscription_start_date=now,
-        subscription_end_date=now + timedelta(days=365),
+        # relativedelta(years=1) handles Feb 29 → Feb 28 edge correctly;
+        # `timedelta(days=365)` would produce an off-by-one in leap years.
+        subscription_end_date=now + relativedelta(years=1),
         is_active=True,
     )
     db.add(org)
@@ -190,7 +194,27 @@ def grant_monthly_for_group_buy(today: datetime, db: Session) -> dict:
     this plan whose start_date is on/after the current month-start, skip —
     that handles the edge case where the cron runs after the open endpoint
     has already created the period for day 1.
+
+    Race-safety (Phase 5-1 R3.1): a Postgres advisory xact-lock on a fixed
+    cron-job key prevents two concurrent invocations (Cloud Scheduler
+    at-least-once retries, or `?force=true` ops re-run while the scheduled
+    fire is still in flight) from both reading an empty existing_keys set
+    and double-granting. Lock auto-releases on commit/rollback. SQLite
+    test path is a no-op.
     """
+    if db.get_bind().dialect.name == "postgresql":
+        locked = db.execute(
+            text(
+                "SELECT pg_try_advisory_xact_lock(hashtext("
+                "'grant_monthly_for_group_buy'))"
+            )
+        ).scalar()
+        if not locked:
+            # Another invocation holds the lock — bail out cleanly. The
+            # other run will grant the points; this caller returns zero
+            # counters so its summary reflects "did nothing".
+            return {"grants_created": 0, "grants_skipped_duplicate": 0}
+
     taipei = ZoneInfo("Asia/Taipei")
     today_local = (
         today.astimezone(taipei) if today.tzinfo else today.replace(tzinfo=taipei)

--- a/backend/services/institution_billing.py
+++ b/backend/services/institution_billing.py
@@ -15,8 +15,7 @@ when the mechanism was introduced), the fallback is Student.is_active,
 treated as the status held throughout the queried month.
 """
 
-from calendar import monthrange
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import List, Optional
 from zoneinfo import ZoneInfo
 
@@ -75,19 +74,10 @@ def _is_billable(
     """Decide if a single student is billable for the queried month.
 
     `history_rows` MUST be already filtered to this student and ordered by
-    changed_at ASC. We pass it in (rather than querying) so the caller can
-    bulk-load history for the whole org in one round-trip.
+    changed_at ASC. The sort-order invariant is enforced once by
+    `compute_monthly_billing` immediately after the bulk query (so the
+    O(n) check fires once per request, not once per student).
     """
-    # R3-F1: sort-order invariant. Use an explicit raise instead of assert
-    # so Python's -O flag (which strips asserts) cannot silently disable
-    # this guard in production — a sort-order violation produces wrong
-    # billing totals with no error surfaced otherwise.
-    for i in range(len(history_rows) - 1):
-        if _ensure_taipei(history_rows[i].changed_at) > _ensure_taipei(
-            history_rows[i + 1].changed_at
-        ):
-            raise ValueError("history_rows must be sorted ASC by changed_at")
-
     if not history_rows:
         # No history at all → student pre-dates the mechanism; fall back to
         # Student.is_active treated as the steady-state for the whole month.
@@ -205,6 +195,22 @@ def compute_monthly_billing(
     )
     for row in rows:
         history_by_student[row.student_id].append(row)
+
+    # W2: sort-order invariant for all per-student row lists. Runs ONCE
+    # here (after the bulk fetch is partitioned), not per-student inside
+    # `_is_billable`. Use explicit raise instead of `assert` so Python's
+    # -O flag cannot silently disable the guard in production — a
+    # sort-order violation otherwise produces wrong billing with no error
+    # surfaced. The SQL `ORDER BY changed_at ASC, id ASC` enforces this on
+    # the happy path; the guard catches a future refactor that breaks it.
+    for sid, rows_for_student in history_by_student.items():
+        for i in range(len(rows_for_student) - 1):
+            if _ensure_taipei(rows_for_student[i].changed_at) > _ensure_taipei(
+                rows_for_student[i + 1].changed_at
+            ):
+                raise ValueError(
+                    f"history_rows for student {sid} must be sorted ASC by changed_at"
+                )
 
     breakdown = []
     billable_count = 0

--- a/backend/services/institution_billing.py
+++ b/backend/services/institution_billing.py
@@ -138,11 +138,12 @@ def compute_monthly_billing(
         raise ValueError(
             f"Organization {org.id} is not an institution (org_type={org.org_type!r})"
         )
-    # Catches None, 0, AND negative values. The DB CHECK constraint added
-    # in Phase 2 already rejects ≤0 on write, but the service layer guards
-    # explicitly so a stale ORM object or a future caller can't slip in a
-    # negative that would produce a negative total_amount.
-    if not org.per_student_price or org.per_student_price < 0:
+    # Explicit `is None or <= 0` is clearer than the truthiness shorthand
+    # for billing-critical preconditions. The DB CHECK constraint added in
+    # Phase 2 already rejects ≤0 on write; the service layer guards
+    # explicitly so a stale ORM object or future caller cannot slip a
+    # non-positive through and produce a zero/negative total_amount.
+    if org.per_student_price is None or org.per_student_price <= 0:
         raise ValueError(
             f"Organization {org.id} per_student_price is not a positive integer."
         )

--- a/backend/services/topup_discount.py
+++ b/backend/services/topup_discount.py
@@ -16,8 +16,15 @@ from models import Plan, School, Teacher, TeacherSchool
 
 def get_teacher_topup_discount(teacher: Teacher, db: Session) -> Optional[Decimal]:
     """Return MIN(topup_discount) across the teacher's active group-buy schools,
-    or None if the teacher has no group-buy binding."""
-    return (
+    or None if the teacher has no group-buy binding.
+
+    Detection of "group-buy plan" is by `Plan.teacher_seats IS NOT NULL` —
+    matches `_guard_group_buy` in config/plans.py. Filtering only on
+    `Plan.topup_discount IS NOT NULL` would silently apply discounts to
+    individual plans if an admin sets a topup_discount value on a Tutor
+    plan (the CHECK constraint doesn't forbid that combination).
+    """
+    raw = (
         db.query(func.min(Plan.topup_discount))
         .join(School, School.plan_id == Plan.id)
         .join(TeacherSchool, TeacherSchool.school_id == School.id)
@@ -26,7 +33,12 @@ def get_teacher_topup_discount(teacher: Teacher, db: Session) -> Optional[Decima
             TeacherSchool.is_active.is_(True),
             School.is_active.is_(True),
             Plan.is_active.is_(True),
+            Plan.teacher_seats.isnot(None),  # canonical group-buy signal
             Plan.topup_discount.isnot(None),
         )
         .scalar()
     )
+    # Defensive cast: Postgres returns Decimal, but SQLite test path may
+    # return float. Stay in Decimal so downstream financial math (in
+    # credit_packages.py) keeps its precision guarantees.
+    return None if raw is None else Decimal(str(raw))

--- a/backend/tests/test_group_buy_service.py
+++ b/backend/tests/test_group_buy_service.py
@@ -14,6 +14,7 @@ from decimal import Decimal
 from zoneinfo import ZoneInfo
 
 import pytest
+from dateutil.relativedelta import relativedelta
 
 from auth import get_password_hash
 from models import (
@@ -167,7 +168,9 @@ def test_open_creates_org_school_and_owner_binding(shared_test_session, owner):
     assert org.org_type == "group_buy"
     # SQLite strips tzinfo on TIMESTAMPTZ store; compare naive values.
     assert _naive(org.subscription_start_date) == _naive(now)
-    assert _naive(org.subscription_end_date) == _naive(now + timedelta(days=365))
+    # W3 — Production uses relativedelta(years=1), NOT timedelta(days=365).
+    # The two diverge on leap-year boundaries (Feb 29 + 1y → Feb 28 vs Mar 1).
+    assert _naive(org.subscription_end_date) == _naive(now + relativedelta(years=1))
     assert school.organization_id == org.id
     assert school.plan_id == plan.id
     assert school.teacher_seat_limit == plan.teacher_seats

--- a/backend/tests/test_institution_billing.py
+++ b/backend/tests/test_institution_billing.py
@@ -119,6 +119,24 @@ def test_month_window_rejects_invalid_month():
         _month_window(2026, 13)
 
 
+def test_month_window_rejects_year_zero():
+    with pytest.raises(ValueError, match="year"):
+        _month_window(0, 1)
+
+
+def test_month_window_rejects_year_negative():
+    with pytest.raises(ValueError, match="year"):
+        _month_window(-1, 6)
+
+
+def test_month_window_rejects_year_9999_to_prevent_overflow():
+    """9999 + month=12 would compute datetime(10000, ...) and OverflowError.
+    The guard rejects 9999 with a friendly ValueError so the router returns
+    a clean 400 / 422 instead."""
+    with pytest.raises(ValueError, match="year"):
+        _month_window(9999, 12)
+
+
 # ---------- compute_monthly_billing ----------
 
 

--- a/backend/tests/test_institution_billing_endpoint.py
+++ b/backend/tests/test_institution_billing_endpoint.py
@@ -124,6 +124,39 @@ def test_outsider_teacher_gets_403(
     assert r.status_code == 403
 
 
+def test_deactivated_org_owner_gets_403(
+    test_client, shared_test_session, institution_org_with_one_active_student
+):
+    """5-1 R2-F1 lock-in: a TeacherOrganization row with role='org_owner'
+    but `is_active=False` must NOT pass the role check (revoked-owner case).
+    Locks in the `is_active.is_(True)` filter against future refactor."""
+    org, _, _ = institution_org_with_one_active_student
+    revoked = Teacher(
+        email="bill-revoked-owner@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="RevokedOwner",
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(revoked)
+    shared_test_session.flush()
+    shared_test_session.add(
+        TeacherOrganization(
+            teacher_id=revoked.id,
+            organization_id=org.id,
+            role="org_owner",
+            is_active=False,  # revoked
+        )
+    )
+    shared_test_session.commit()
+
+    r = test_client.get(
+        f"/api/organizations/{org.id}/billing/monthly?year=2026&month=6",
+        headers=_bearer(revoked.id),
+    )
+    assert r.status_code == 403
+
+
 def test_org_member_non_owner_gets_403(
     test_client, shared_test_session, institution_org_with_one_active_student
 ):

--- a/backend/tests/test_monthly_renewal_group_buy_phase.py
+++ b/backend/tests/test_monthly_renewal_group_buy_phase.py
@@ -39,7 +39,7 @@ def test_cron_phase3_invokes_group_buy_helper_and_surfaces_counters(
     with patch("routers.cron.CRON_SECRET", "test-secret"), patch(
         "routers.cron.datetime", _FakeDatetime
     ), patch(
-        "services.group_buy.grant_monthly_for_group_buy",
+        "routers.cron.grant_monthly_for_group_buy",
         return_value={"grants_created": 7, "grants_skipped_duplicate": 2},
     ) as mock_grant:
         r = _post_cron(test_client)
@@ -61,7 +61,7 @@ def test_cron_skips_phase3_when_not_first_of_month(test_client):
 
     with patch("routers.cron.CRON_SECRET", "test-secret"), patch(
         "routers.cron.datetime", _MidMonth
-    ), patch("services.group_buy.grant_monthly_for_group_buy") as mock_grant:
+    ), patch("routers.cron.grant_monthly_for_group_buy") as mock_grant:
         r = _post_cron(test_client)
 
     body = r.json()
@@ -84,7 +84,7 @@ def test_cron_force_true_bypasses_day_1_guard_and_runs_phase3(test_client):
     with patch("routers.cron.CRON_SECRET", "test-secret"), patch(
         "routers.cron.datetime", _MidMonth
     ), patch(
-        "services.group_buy.grant_monthly_for_group_buy",
+        "routers.cron.grant_monthly_for_group_buy",
         return_value={"grants_created": 4, "grants_skipped_duplicate": 1},
     ) as mock_grant:
         r = test_client.post(


### PR DESCRIPTION
## Summary
Phase 5-1 of 2 for issue #768「機構方案優化」. **Pure backend cleanup** — consolidates the 14 deferred review findings from PR #820 / #822 / #823 reviews into a single PR before Phase 5-2 (frontend). No new endpoints, no new migrations, no behaviour change for success paths — only defensive guards and code-quality improvements.

## Source breakdown

### From PR #820 (Phase 2) round 2 — 3 items
- **1.1** `topup_discount.py` detection consistency: filter on `Plan.teacher_seats IS NOT NULL` so the canonical group-buy signal matches `_guard_group_buy`
- **1.2** Defensive `Decimal(str(...))` cast on `func.min(...).scalar()` for SQLite-vs-Postgres consistency
- **1.3** Migration inline comment off-by-one (5→6 fields)

### From PR #822 (Phase 3) round 2 — 4 items
- **2.1** `open_group_buy` now takes `GroupBuyOpenRequest` Pydantic body param → clean 422 on bad input
- **2.2** Moved deferred `from services.group_buy import …` to module-top in `credit_packages.py` and `cron.py` (startup-time failure vs first-request 500); test patches updated to `routers.cron.…`
- **2.3** Documented advisory-lock key scope: `(teacher_id, plan_name)` intentionally excludes cross-plan serialisation (R2-F2 single-org guard covers that)
- **2.4** `timedelta(days=365)` → `relativedelta(years=1)` in 3 sites; fixes Feb 29 leap-year off-by-one

### From PR #822 (Phase 3) round 3 — 3 items (deferred 🔴/🟡)
- **3.1 🔴** `grant_monthly_for_group_buy` now acquires a Postgres advisory xact-lock on a fixed cron-job key before reading `existing_keys`. Prevents Cloud Scheduler at-least-once + `?force=true` race from double-granting
- **3.2 🔴** Idempotency-shortcut raises `HTTPException(500)` with ERROR log when SUCCESS txn exists but `owned_org` / `owned_school` is `None` (was silently returning success + null IDs)
- **3.3 🟡** Compensation-record fallback when the secondary INSERT itself fails — emits structured `GROUP_BUY_COMPENSATION_DB_LOST` ERROR log with all refund-needed fields + secondary `log_payment_failure` call via the independent BigQuery client

### From PR #823 (Phase 4) round 3 — 3 items
- **4.1** Merged the non-admin double-query (`check_org_permission` + role check) into a single Organization lookup + single role check; also switched literal `400` → `status.HTTP_400_BAD_REQUEST`
- **4.3** `not x or x < 0` → `x is None or x <= 0` (clearer for billing-critical preconditions)
- **4.4** New tests: `_month_window` rejects year=0 / year=-1 / year=9999

### Deliberately skipped (per user decision)
- **4.2** Sort-invariant guard kept as explicit `raise ValueError` instead of `if __debug__:` — production doesn't run `-O` so the explicit form is preferable, and the O(n) overhead is negligible for billing workloads.

## Test plan
- [x] Black clean
- [x] **147/147 relevant tests pass** — institution_billing (24) + group_buy service+endpoint+cron (27) + topup_discount (6) + get_plan_price guard (5) + admin_plans/orgs/credit_packages (60) + existing cron (16) + new year-boundary (3) + no regressions
- [x] Test patches updated to `routers.cron.grant_monthly_for_group_buy` after import lift
- [ ] CI green on staging deploy

## Out of scope (Phase 5-2)
- 機構單位學生費前端設定頁
- 團購開團 UI
- 機構月度計費查詢 UI
- 學生啟用/停用 UI（寫 `student_status_history`）

Phase 5-2 is the frontend PR and will include **full end-to-end testing** per user request.

Related to #768 (will not auto-close; closes when Phase 5-2 ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)