### PR TITLE
feat(#768): Phase 5-2 — backend status endpoint + 4 frontend UI pieces

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1114,6 +1114,8 @@ async def list_organizations(
                 subscription_end_date=org.subscription_end_date.isoformat()
                 if org.subscription_end_date
                 else None,
+                org_type=org.org_type,
+                per_student_price=org.per_student_price,
             )
         )
 

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -99,6 +99,16 @@ class OrgRenewRequest(BaseModel):
     cardholder: Optional[Dict[str, Any]] = None
 
 
+class GroupBuyPlanInfo(BaseModel):
+    name: str
+    teacher_seats: int
+    annual_fee: int  # per teacher
+    total_amount: int  # annual_fee × teacher_seats
+    topup_discount: float  # 0.85 / 0.90 / 0.95 — for "加購折扣" display
+    monthly_quota: int  # quota_total granted per teacher per month
+    display_order: int
+
+
 class GroupBuyOpenRequest(BaseModel):
     prime: str
     plan_name: str  # group-buy plan name e.g. "團購-30席"
@@ -754,6 +764,43 @@ async def org_renew_credit_package(
     except Exception as e:
         logger.error(f"Org credit package renewal error: {e}")
         raise HTTPException(status_code=500, detail="Renewal processing failed")
+
+
+@router.get("/group-buy-plans", response_model=List[GroupBuyPlanInfo])
+async def list_group_buy_plans(
+    db: Session = Depends(get_db),
+    current_teacher: Teacher = Depends(get_current_teacher),
+):
+    """List active group-buy plans for the open-group page (issue #768 Phase 5-2).
+
+    Auth: any authenticated teacher. Pricing is canonical from the DB; the
+    frontend MUST NOT compute or trust its own totals.
+    """
+    from models import Plan
+
+    rows = (
+        db.query(Plan)
+        .filter(
+            Plan.is_active.is_(True),
+            Plan.teacher_seats.isnot(None),
+            Plan.annual_fee.isnot(None),
+            Plan.topup_discount.isnot(None),
+        )
+        .order_by(Plan.display_order.asc(), Plan.teacher_seats.asc())
+        .all()
+    )
+    return [
+        GroupBuyPlanInfo(
+            name=p.name,
+            teacher_seats=p.teacher_seats,
+            annual_fee=p.annual_fee,
+            total_amount=p.annual_fee * p.teacher_seats,
+            topup_discount=float(p.topup_discount),
+            monthly_quota=p.quota or 0,
+            display_order=p.display_order,
+        )
+        for p in rows
+    ]
 
 
 @router.post("/group-buy-open", response_model=GroupBuyOpenResponse)

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -26,6 +26,7 @@ from models import (
     Organization,
     TeacherOrganization,
     School,
+    Plan,
 )
 from routers.teachers import get_current_teacher
 from services.tappay_service import TapPayService
@@ -776,8 +777,6 @@ async def list_group_buy_plans(
     Auth: any authenticated teacher. Pricing is canonical from the DB; the
     frontend MUST NOT compute or trust its own totals.
     """
-    from models import Plan
-
     rows = (
         db.query(Plan)
         .filter(

--- a/backend/routers/schemas/admin_organization.py
+++ b/backend/routers/schemas/admin_organization.py
@@ -147,6 +147,11 @@ class OrganizationListItem(BaseModel):
     created_at: str
     subscription_start_date: Optional[str] = None
     subscription_end_date: Optional[str] = None
+    # Phase 5-2 (issue #768): expose institution monthly price + org_type so
+    # the admin edit dialog can prefill values and the UI can show org-type
+    # context (institution vs group_buy).
+    org_type: Optional[str] = None
+    per_student_price: Optional[int] = None
 
 
 class OrganizationListResponse(BaseModel):

--- a/backend/routers/schemas/admin_organization.py
+++ b/backend/routers/schemas/admin_organization.py
@@ -171,6 +171,8 @@ class AdminOrganizationUpdate(BaseModel):
     total_points: Optional[int] = None  # Can adjust points allocation
     subscription_start_date: Optional[datetime] = None
     subscription_end_date: Optional[datetime] = None
+    # Phase 5-2 (issue #768): institution monthly per-student price (NT$)
+    per_student_price: Optional[int] = Field(None, gt=0)
 
 
 class AdminOrganizationUpdateResponse(BaseModel):

--- a/backend/routers/teachers/student_ops.py
+++ b/backend/routers/teachers/student_ops.py
@@ -19,6 +19,7 @@ from models import (
     Organization,
     School,
     ClassroomSchool,
+    StudentSchool,
     StudentStatusHistory,
 )
 from pydantic import BaseModel, Field
@@ -1091,14 +1092,20 @@ class StudentStatusUpdateRequest(BaseModel):
     """Request body for POST /students/{id}/status."""
 
     status: str = Field(..., description="'active' or 'inactive'")
-    note: Optional[str] = Field(None, description="Optional audit note")
+    # 500-char cap matches typical audit-note conventions and prevents an
+    # unbounded write to student_status_history.note.
+    note: Optional[str] = Field(
+        None, max_length=500, description="Optional audit note (max 500 chars)"
+    )
 
 
 class StudentStatusUpdateResponse(BaseModel):
     student_id: int
     status: str
-    history_id: int
-    changed_at: datetime
+    # R2-B2 — Optional: None when the request was a no-op (target status
+    # already equals current). A real write produces a positive integer.
+    history_id: Optional[int] = None
+    changed_at: Optional[datetime] = None
 
 
 @router.post(
@@ -1185,28 +1192,20 @@ async def update_student_status(
 
     target_is_active = body.status == "active"
 
-    # No-op short-circuit: same status, no history row, no flush.
+    # No-op short-circuit: same status → don't write a duplicate history
+    # row. history_id/changed_at left None so the caller can distinguish
+    # this from a real write (where both are populated).
     if student.is_active == target_is_active:
-        # Still return the most recent history row id (or 0 if none) so the
-        # frontend has a deterministic shape.
-        last = (
-            db.query(StudentStatusHistory)
-            .filter(StudentStatusHistory.student_id == student_id)
-            .order_by(StudentStatusHistory.changed_at.desc())
-            .first()
-        )
         return StudentStatusUpdateResponse(
             student_id=student_id,
             status=body.status,
-            history_id=last.id if last else 0,
-            changed_at=last.changed_at if last else datetime.utcnow(),
+            history_id=None,
+            changed_at=None,
         )
 
     # Lookup the student's primary school (for school_id on the history row).
     # If the student is enrolled in multiple schools we record the most-recent
     # active enrollment; if none, school_id stays NULL (SET NULL FK).
-    from models import StudentSchool
-
     school_enrol = (
         db.query(StudentSchool)
         .filter(

--- a/backend/routers/teachers/student_ops.py
+++ b/backend/routers/teachers/student_ops.py
@@ -1132,26 +1132,56 @@ async def update_student_status(
             status_code=status.HTTP_404_NOT_FOUND, detail="Student not found"
         )
 
-    # Ownership: the student must be in a classroom owned by current_teacher.
-    classroom_student = (
-        db.query(ClassroomStudent)
-        .filter(ClassroomStudent.student_id == student_id)
-        .first()
-    )
-    if classroom_student is not None:
-        owns = (
-            db.query(Classroom)
-            .filter(
-                Classroom.id == classroom_student.classroom_id,
-                Classroom.teacher_id == current_teacher.id,
-            )
+    # M6 — Distinguish soft-deleted (DELETE /students/{id}, no history row)
+    # from /status-deactivated (this endpoint, leaves a 'inactive' history
+    # row). The former must NOT be reactivatable here — re-creating a
+    # deleted student is a separate flow. The latter is normal toggle.
+    if not student.is_active:
+        last_history = (
+            db.query(StudentStatusHistory)
+            .filter(StudentStatusHistory.student_id == student_id)
+            .order_by(StudentStatusHistory.changed_at.desc())
             .first()
         )
-        if owns is None:
+        if last_history is None or last_history.status != "inactive":
+            # No history (or last change wasn't 'inactive') → student was
+            # soft-deleted via DELETE; refuse to silently un-delete.
             raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="You don't have permission to change this student's status",
+                status_code=status.HTTP_404_NOT_FOUND, detail="Student not found"
             )
+
+    # Ownership: the student must be in an ACTIVE classroom enrollment
+    # owned by current_teacher. C1 — invert to fail-closed: a student with
+    # no active classroom enrollment is NOT manageable by an arbitrary
+    # teacher (would have allowed any teacher to flip any unassigned
+    # student's status). C2 — filter ClassroomStudent.is_active so a stale
+    # enrollment left over after a transfer cannot grant ownership.
+    classroom_student = (
+        db.query(ClassroomStudent)
+        .filter(
+            ClassroomStudent.student_id == student_id,
+            ClassroomStudent.is_active.is_(True),
+        )
+        .first()
+    )
+    if classroom_student is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You don't have permission to change this student's status",
+        )
+    owns = (
+        db.query(Classroom)
+        .filter(
+            Classroom.id == classroom_student.classroom_id,
+            Classroom.teacher_id == current_teacher.id,
+        )
+        .first()
+    )
+    if owns is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You don't have permission to change this student's status",
+        )
 
     target_is_active = body.status == "active"
 

--- a/backend/routers/teachers/student_ops.py
+++ b/backend/routers/teachers/student_ops.py
@@ -19,7 +19,9 @@ from models import (
     Organization,
     School,
     ClassroomSchool,
+    StudentStatusHistory,
 )
+from pydantic import BaseModel, Field
 from .dependencies import get_current_teacher
 from .validators import *
 from .utils import TEST_SUBSCRIPTION_WHITELIST  # parse_birthdate is defined locally
@@ -1080,3 +1082,126 @@ async def batch_import_students(
         "errors": errors,
         "created_students": created_students,
     }
+
+
+# ====== Phase 5-2 (issue #768): student activate / deactivate ======
+
+
+class StudentStatusUpdateRequest(BaseModel):
+    """Request body for POST /students/{id}/status."""
+
+    status: str = Field(..., description="'active' or 'inactive'")
+    note: Optional[str] = Field(None, description="Optional audit note")
+
+
+class StudentStatusUpdateResponse(BaseModel):
+    student_id: int
+    status: str
+    history_id: int
+    changed_at: datetime
+
+
+@router.post(
+    "/students/{student_id}/status", response_model=StudentStatusUpdateResponse
+)
+async def update_student_status(
+    student_id: int,
+    body: StudentStatusUpdateRequest,
+    current_teacher: Teacher = Depends(get_current_teacher),
+    db: Session = Depends(get_db),
+):
+    """Activate or deactivate a student (issue #768 Phase 5-2).
+
+    Writes a row to `student_status_history` so the institution monthly
+    billing query (Phase 4) can determine active days per month, and syncs
+    `Student.is_active` in lock-step so existing UI/auth flows that read
+    that boolean still work.
+
+    Auth: caller must own the classroom the student is enrolled in (matches
+    the existing `DELETE /students/{id}` ownership check).
+    """
+    if body.status not in ("active", "inactive"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="status must be 'active' or 'inactive'",
+        )
+
+    student = db.query(Student).filter(Student.id == student_id).first()
+    if student is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Student not found"
+        )
+
+    # Ownership: the student must be in a classroom owned by current_teacher.
+    classroom_student = (
+        db.query(ClassroomStudent)
+        .filter(ClassroomStudent.student_id == student_id)
+        .first()
+    )
+    if classroom_student is not None:
+        owns = (
+            db.query(Classroom)
+            .filter(
+                Classroom.id == classroom_student.classroom_id,
+                Classroom.teacher_id == current_teacher.id,
+            )
+            .first()
+        )
+        if owns is None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You don't have permission to change this student's status",
+            )
+
+    target_is_active = body.status == "active"
+
+    # No-op short-circuit: same status, no history row, no flush.
+    if student.is_active == target_is_active:
+        # Still return the most recent history row id (or 0 if none) so the
+        # frontend has a deterministic shape.
+        last = (
+            db.query(StudentStatusHistory)
+            .filter(StudentStatusHistory.student_id == student_id)
+            .order_by(StudentStatusHistory.changed_at.desc())
+            .first()
+        )
+        return StudentStatusUpdateResponse(
+            student_id=student_id,
+            status=body.status,
+            history_id=last.id if last else 0,
+            changed_at=last.changed_at if last else datetime.utcnow(),
+        )
+
+    # Lookup the student's primary school (for school_id on the history row).
+    # If the student is enrolled in multiple schools we record the most-recent
+    # active enrollment; if none, school_id stays NULL (SET NULL FK).
+    from models import StudentSchool
+
+    school_enrol = (
+        db.query(StudentSchool)
+        .filter(
+            StudentSchool.student_id == student_id,
+            StudentSchool.is_active.is_(True),
+        )
+        .order_by(StudentSchool.enrolled_at.desc())
+        .first()
+    )
+
+    history = StudentStatusHistory(
+        student_id=student_id,
+        school_id=school_enrol.school_id if school_enrol else None,
+        status=body.status,
+        changed_by=current_teacher.id,
+        note=body.note,
+    )
+    student.is_active = target_is_active
+    db.add(history)
+    db.commit()
+    db.refresh(history)
+
+    return StudentStatusUpdateResponse(
+        student_id=student_id,
+        status=body.status,
+        history_id=history.id,
+        changed_at=history.changed_at,
+    )

--- a/backend/tests/test_group_buy_plans_endpoint.py
+++ b/backend/tests/test_group_buy_plans_endpoint.py
@@ -1,0 +1,143 @@
+"""Tests for GET /api/credit-packages/group-buy-plans (issue #768 Phase 5-2).
+
+Verifies the filter logic (Plan.is_active + teacher_seats/annual_fee/
+topup_discount IS NOT NULL) and the display_order + teacher_seats sort.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from auth import create_access_token, get_password_hash
+from models import Plan, Teacher
+
+
+def _bearer(teacher_id):
+    token = create_access_token({"sub": str(teacher_id), "type": "teacher"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def teacher(shared_test_session):
+    t = Teacher(
+        email="gb-plans@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="T",
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+def _gb_plan(db, *, name, seats, fee, discount, order, quota=1000, active=True):
+    p = Plan(
+        name=name,
+        price=None,
+        quota=quota,
+        teacher_seats=seats,
+        annual_fee=fee,
+        topup_discount=Decimal(str(discount)),
+        display_order=order,
+        is_active=active,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+def test_returns_active_group_buy_plans_ordered_by_display_then_seats(
+    test_client, teacher, shared_test_session
+):
+    # Seed in a deliberately wrong order; assert response sorted
+    _gb_plan(
+        shared_test_session,
+        name="團購-50席",
+        seats=50,
+        fee=1000,
+        discount=0.85,
+        order=12,
+    )
+    _gb_plan(
+        shared_test_session,
+        name="團購-10席",
+        seats=10,
+        fee=1500,
+        discount=0.95,
+        order=10,
+    )
+    _gb_plan(
+        shared_test_session,
+        name="團購-30席",
+        seats=30,
+        fee=1300,
+        discount=0.90,
+        order=11,
+    )
+
+    r = test_client.get(
+        "/api/credit-packages/group-buy-plans", headers=_bearer(teacher.id)
+    )
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert len(body) == 3
+    # Ordered by display_order ASC then teacher_seats ASC
+    assert [p["teacher_seats"] for p in body] == [10, 30, 50]
+    # Server-authoritative total_amount = annual_fee × teacher_seats
+    assert body[0]["total_amount"] == 1500 * 10
+    assert body[1]["total_amount"] == 1300 * 30
+    assert body[2]["total_amount"] == 1000 * 50
+
+
+def test_excludes_inactive_plans(test_client, teacher, shared_test_session):
+    _gb_plan(
+        shared_test_session,
+        name="團購-30席",
+        seats=30,
+        fee=1300,
+        discount=0.90,
+        order=11,
+        active=False,
+    )
+
+    r = test_client.get(
+        "/api/credit-packages/group-buy-plans", headers=_bearer(teacher.id)
+    )
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_excludes_individual_plans_with_null_teacher_seats(
+    test_client, teacher, shared_test_session
+):
+    """An individual plan (teacher_seats IS NULL) must not appear even if
+    active — only group-buy plans should be returned."""
+    individual = Plan(
+        name="Tutor Teachers",
+        price=299,
+        quota=2000,
+        teacher_seats=None,
+        annual_fee=None,
+        topup_discount=None,
+        is_active=True,
+    )
+    shared_test_session.add(individual)
+    shared_test_session.commit()
+
+    r = test_client.get(
+        "/api/credit-packages/group-buy-plans", headers=_bearer(teacher.id)
+    )
+    assert r.status_code == 200
+    names = [p["name"] for p in r.json()]
+    assert "Tutor Teachers" not in names
+
+
+def test_empty_when_no_group_buy_plans(test_client, teacher):
+    r = test_client.get(
+        "/api/credit-packages/group-buy-plans", headers=_bearer(teacher.id)
+    )
+    assert r.status_code == 200
+    assert r.json() == []

--- a/backend/tests/test_student_status_endpoint.py
+++ b/backend/tests/test_student_status_endpoint.py
@@ -1,0 +1,180 @@
+"""Tests for POST /api/teachers/students/{student_id}/status
+(issue #768 Phase 5-2 backend).
+"""
+
+import pytest
+
+from auth import create_access_token, get_password_hash
+from models import (
+    Classroom,
+    ClassroomStudent,
+    Student,
+    StudentStatusHistory,
+    Teacher,
+)
+
+
+def _bearer(teacher_id):
+    token = create_access_token({"sub": str(teacher_id), "type": "teacher"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def owner_teacher(shared_test_session):
+    t = Teacher(
+        email="status-owner@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="Owner",
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+@pytest.fixture
+def other_teacher(shared_test_session):
+    t = Teacher(
+        email="status-other@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="Other",
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+@pytest.fixture
+def student_in_owner_classroom(shared_test_session, owner_teacher):
+    classroom = Classroom(name="Class A", teacher_id=owner_teacher.id, is_active=True)
+    shared_test_session.add(classroom)
+    shared_test_session.flush()
+    s = Student(
+        name="Alice",
+        email="alice@example.com",
+        password_hash=get_password_hash("x"),
+        is_active=True,
+    )
+    shared_test_session.add(s)
+    shared_test_session.flush()
+    shared_test_session.add(
+        ClassroomStudent(student_id=s.id, classroom_id=classroom.id, is_active=True)
+    )
+    shared_test_session.commit()
+    return s
+
+
+def test_rejects_invalid_status(
+    test_client, owner_teacher, student_in_owner_classroom
+):
+    r = test_client.post(
+        f"/api/teachers/students/{student_in_owner_classroom.id}/status",
+        json={"status": "deleted"},
+        headers=_bearer(owner_teacher.id),
+    )
+    assert r.status_code == 400
+    assert "active" in r.json()["detail"]
+
+
+def test_404_when_student_does_not_exist(test_client, owner_teacher):
+    r = test_client.post(
+        "/api/teachers/students/99999/status",
+        json={"status": "inactive"},
+        headers=_bearer(owner_teacher.id),
+    )
+    assert r.status_code == 404
+
+
+def test_other_teacher_cannot_change_status(
+    test_client, other_teacher, student_in_owner_classroom
+):
+    r = test_client.post(
+        f"/api/teachers/students/{student_in_owner_classroom.id}/status",
+        json={"status": "inactive"},
+        headers=_bearer(other_teacher.id),
+    )
+    assert r.status_code == 403
+
+
+def test_deactivate_writes_history_and_flips_is_active(
+    test_client, owner_teacher, student_in_owner_classroom, shared_test_session
+):
+    r = test_client.post(
+        f"/api/teachers/students/{student_in_owner_classroom.id}/status",
+        json={"status": "inactive", "note": "End of semester"},
+        headers=_bearer(owner_teacher.id),
+    )
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert body["status"] == "inactive"
+    assert body["history_id"] > 0
+
+    shared_test_session.expire_all()
+    s = (
+        shared_test_session.query(Student)
+        .filter(Student.id == student_in_owner_classroom.id)
+        .one()
+    )
+    assert s.is_active is False
+
+    history = (
+        shared_test_session.query(StudentStatusHistory)
+        .filter(StudentStatusHistory.student_id == s.id)
+        .one()
+    )
+    assert history.status == "inactive"
+    assert history.changed_by == owner_teacher.id
+    assert history.note == "End of semester"
+
+
+def test_reactivate_writes_separate_history_row(
+    test_client, owner_teacher, student_in_owner_classroom, shared_test_session
+):
+    # Deactivate first
+    test_client.post(
+        f"/api/teachers/students/{student_in_owner_classroom.id}/status",
+        json={"status": "inactive"},
+        headers=_bearer(owner_teacher.id),
+    )
+    # Then reactivate
+    r = test_client.post(
+        f"/api/teachers/students/{student_in_owner_classroom.id}/status",
+        json={"status": "active"},
+        headers=_bearer(owner_teacher.id),
+    )
+    assert r.status_code == 200
+
+    rows = (
+        shared_test_session.query(StudentStatusHistory)
+        .filter(StudentStatusHistory.student_id == student_in_owner_classroom.id)
+        .order_by(StudentStatusHistory.changed_at.asc())
+        .all()
+    )
+    assert len(rows) == 2
+    assert rows[0].status == "inactive"
+    assert rows[1].status == "active"
+
+
+def test_same_status_is_noop_no_new_history_row(
+    test_client, owner_teacher, student_in_owner_classroom, shared_test_session
+):
+    """Posting status='active' on an already-active student must NOT add a
+    history row — otherwise the billing roster gets polluted."""
+    r = test_client.post(
+        f"/api/teachers/students/{student_in_owner_classroom.id}/status",
+        json={"status": "active"},
+        headers=_bearer(owner_teacher.id),
+    )
+    assert r.status_code == 200
+
+    count = (
+        shared_test_session.query(StudentStatusHistory)
+        .filter(StudentStatusHistory.student_id == student_in_owner_classroom.id)
+        .count()
+    )
+    assert count == 0

--- a/backend/tests/test_student_status_endpoint.py
+++ b/backend/tests/test_student_status_endpoint.py
@@ -69,9 +69,7 @@ def student_in_owner_classroom(shared_test_session, owner_teacher):
     return s
 
 
-def test_rejects_invalid_status(
-    test_client, owner_teacher, student_in_owner_classroom
-):
+def test_rejects_invalid_status(test_client, owner_teacher, student_in_owner_classroom):
     r = test_client.post(
         f"/api/teachers/students/{student_in_owner_classroom.id}/status",
         json={"status": "deleted"},
@@ -158,6 +156,89 @@ def test_reactivate_writes_separate_history_row(
     assert len(rows) == 2
     assert rows[0].status == "inactive"
     assert rows[1].status == "active"
+
+
+def test_student_with_no_active_classroom_enrollment_gets_403(
+    test_client, owner_teacher, shared_test_session
+):
+    """C1 lock-in: a student with NO active classroom enrollment must not
+    be writeable by an arbitrary teacher (previously the auth check was
+    skipped entirely when classroom_student was None)."""
+    orphan = Student(
+        name="Orphan",
+        email="orphan@example.com",
+        password_hash=get_password_hash("x"),
+        is_active=True,
+    )
+    shared_test_session.add(orphan)
+    shared_test_session.commit()
+
+    r = test_client.post(
+        f"/api/teachers/students/{orphan.id}/status",
+        json={"status": "inactive"},
+        headers=_bearer(owner_teacher.id),
+    )
+    assert r.status_code == 403
+
+
+def test_stale_inactive_enrollment_does_not_grant_ownership(
+    test_client,
+    owner_teacher,
+    other_teacher,
+    student_in_owner_classroom,
+    shared_test_session,
+):
+    """C2 lock-in: an inactive ClassroomStudent row (left over after a
+    student transfer) must not satisfy the ownership check for the old
+    teacher. Owner teacher's enrollment is set inactive; current owner is
+    other_teacher via a new active enrollment."""
+    # Deactivate the original enrollment
+    cs = (
+        shared_test_session.query(ClassroomStudent)
+        .filter(ClassroomStudent.student_id == student_in_owner_classroom.id)
+        .first()
+    )
+    cs.is_active = False
+    # Create new active enrollment under other_teacher's classroom
+    other_classroom = Classroom(
+        name="Class B", teacher_id=other_teacher.id, is_active=True
+    )
+    shared_test_session.add(other_classroom)
+    shared_test_session.flush()
+    shared_test_session.add(
+        ClassroomStudent(
+            student_id=student_in_owner_classroom.id,
+            classroom_id=other_classroom.id,
+            is_active=True,
+        )
+    )
+    shared_test_session.commit()
+
+    # Original owner_teacher must NOT be able to change status anymore
+    r = test_client.post(
+        f"/api/teachers/students/{student_in_owner_classroom.id}/status",
+        json={"status": "inactive"},
+        headers=_bearer(owner_teacher.id),
+    )
+    assert r.status_code == 403
+
+
+def test_soft_deleted_student_cannot_be_reactivated_via_status(
+    test_client, owner_teacher, student_in_owner_classroom, shared_test_session
+):
+    """M6 lock-in: a student deleted via DELETE /students/{id} (which sets
+    is_active=False but writes NO status_history row) must not be silently
+    'un-deleted' by POSTing status='active' here."""
+    # Simulate the DELETE flow: flip is_active without writing history
+    student_in_owner_classroom.is_active = False
+    shared_test_session.commit()
+
+    r = test_client.post(
+        f"/api/teachers/students/{student_in_owner_classroom.id}/status",
+        json={"status": "active"},
+        headers=_bearer(owner_teacher.id),
+    )
+    assert r.status_code == 404
 
 
 def test_same_status_is_noop_no_new_history_row(

--- a/backend/tests/test_student_status_endpoint.py
+++ b/backend/tests/test_student_status_endpoint.py
@@ -110,7 +110,7 @@ def test_deactivate_writes_history_and_flips_is_active(
     assert r.status_code == 200, r.json()
     body = r.json()
     assert body["status"] == "inactive"
-    assert body["history_id"] > 0
+    assert body["history_id"] is not None and body["history_id"] > 0
 
     shared_test_session.expire_all()
     s = (
@@ -252,6 +252,11 @@ def test_same_status_is_noop_no_new_history_row(
         headers=_bearer(owner_teacher.id),
     )
     assert r.status_code == 200
+    body = r.json()
+    # R2-B2 — no-op response uses None as the sentinel so callers can
+    # distinguish from a real write (where history_id is a positive int)
+    assert body["history_id"] is None
+    assert body["changed_at"] is None
 
     count = (
         shared_test_session.query(StudentStatusHistory)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -373,7 +373,9 @@ function App() {
           path="/teacher/group-buy/open"
           element={
             <ProtectedRoute>
-              <GroupBuyOpenPage />
+              <TeacherLayout>
+                <GroupBuyOpenPage />
+              </TeacherLayout>
             </ProtectedRoute>
           }
         />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,6 +42,8 @@ import DatabaseAdminPage from "./pages/admin/DatabaseAdminPage";
 import AdminMonitoringPage from "./pages/admin/AdminMonitoringPage";
 import AdminDashboard from "./pages/admin/AdminDashboard";
 import CreateOrganization from "./pages/admin/CreateOrganization";
+import AdminOrgMonthlyBilling from "./pages/admin/AdminOrgMonthlyBilling";
+import GroupBuyOpenPage from "./pages/teacher/GroupBuyOpenPage";
 import BlogListPage from "./pages/BlogListPage";
 import BlogPostPage from "./pages/BlogPostPage";
 import AdminBlogPage from "./pages/admin/AdminBlogPage";
@@ -354,6 +356,24 @@ function App() {
           element={
             <ProtectedRoute requireAdmin>
               <CreateOrganization />
+            </ProtectedRoute>
+          }
+        />
+        {/* Phase 5-2 (#768): institution monthly billing query */}
+        <Route
+          path="/admin/organizations/:orgId/billing"
+          element={
+            <ProtectedRoute requireAdmin>
+              <AdminOrgMonthlyBilling />
+            </ProtectedRoute>
+          }
+        />
+        {/* Phase 5-2 (#768): teacher group-buy open page */}
+        <Route
+          path="/teacher/group-buy/open"
+          element={
+            <ProtectedRoute>
+              <GroupBuyOpenPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/OrgMonthlyBillingPanel.tsx
+++ b/frontend/src/components/OrgMonthlyBillingPanel.tsx
@@ -1,0 +1,197 @@
+/**
+ * Institution monthly billing query panel (issue #768 Phase 5-2).
+ *
+ * Year/month picker → calls GET /api/organizations/{orgId}/billing/monthly,
+ * renders aggregate + per-student breakdown.
+ *
+ * Auth at the API layer: admin can query any org, org_owner only their own.
+ * The UI itself is render-neutral — the caller passes orgId.
+ */
+import React from "react";
+import { apiClient, ApiError } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+
+interface MonthlyBilling {
+  org_id: string;
+  year: number;
+  month: number;
+  per_student_price: number;
+  billable_student_count: number;
+  total_amount: number;
+  currency: string;
+  students: Array<{
+    student_id: number;
+    name: string;
+    billable: boolean;
+  }>;
+}
+
+interface Props {
+  orgId: string;
+  defaultYear?: number;
+  defaultMonth?: number;
+}
+
+export default function OrgMonthlyBillingPanel({
+  orgId,
+  defaultYear,
+  defaultMonth,
+}: Props) {
+  const today = new Date();
+  const [year, setYear] = React.useState<number>(
+    defaultYear ?? today.getFullYear(),
+  );
+  const [month, setMonth] = React.useState<number>(
+    defaultMonth ?? today.getMonth() + 1,
+  );
+  const [loading, setLoading] = React.useState(false);
+  const [result, setResult] = React.useState<MonthlyBilling | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const fetchBilling = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient.getOrganizationMonthlyBilling(
+        orgId,
+        year,
+        month,
+      );
+      setResult(data);
+    } catch (e) {
+      const msg =
+        e instanceof ApiError
+          ? typeof e.detail === "string"
+            ? e.detail
+            : e.message
+          : "查詢計費失敗";
+      setError(msg);
+      setResult(null);
+      toast.error(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card className="w-full max-w-3xl">
+      <CardHeader>
+        <CardTitle>機構月度計費查詢</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap items-end gap-4">
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="billing-year">年份</Label>
+            <Input
+              id="billing-year"
+              type="number"
+              min={1}
+              max={9998}
+              value={year}
+              onChange={(e) => setYear(Number(e.target.value))}
+              className="w-28"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="billing-month">月份</Label>
+            <Input
+              id="billing-month"
+              type="number"
+              min={1}
+              max={12}
+              value={month}
+              onChange={(e) => setMonth(Number(e.target.value))}
+              className="w-24"
+            />
+          </div>
+          <Button onClick={fetchBilling} disabled={loading}>
+            {loading ? "查詢中…" : "查詢"}
+          </Button>
+        </div>
+
+        {error && (
+          <div className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {result && (
+          <div className="space-y-3">
+            <div className="rounded border border-gray-200 bg-gray-50 p-4">
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                <div>
+                  <div className="text-gray-500">查詢期間</div>
+                  <div className="font-medium">
+                    {result.year} 年 {result.month} 月
+                  </div>
+                </div>
+                <div>
+                  <div className="text-gray-500">單位學生月費</div>
+                  <div className="font-medium">
+                    NT$ {result.per_student_price.toLocaleString()}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-gray-500">當月活躍學生</div>
+                  <div className="font-medium">
+                    {result.billable_student_count} 位
+                  </div>
+                </div>
+                <div>
+                  <div className="text-gray-500">應收總額</div>
+                  <div className="text-lg font-bold text-blue-600">
+                    {result.currency} {result.total_amount.toLocaleString()}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded border border-gray-200">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-100">
+                  <tr>
+                    <th className="px-3 py-2 text-left">學生 ID</th>
+                    <th className="px-3 py-2 text-left">姓名</th>
+                    <th className="px-3 py-2 text-left">本月計費</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.students.length === 0 && (
+                    <tr>
+                      <td
+                        colSpan={3}
+                        className="px-3 py-4 text-center text-gray-500"
+                      >
+                        此機構目前沒有任何學生
+                      </td>
+                    </tr>
+                  )}
+                  {result.students.map((s) => (
+                    <tr
+                      key={s.student_id}
+                      className="border-t border-gray-200"
+                    >
+                      <td className="px-3 py-2">{s.student_id}</td>
+                      <td className="px-3 py-2">{s.name}</td>
+                      <td className="px-3 py-2">
+                        {s.billable ? (
+                          <span className="text-green-700">✓ 計費</span>
+                        ) : (
+                          <span className="text-gray-400">— 不計費</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/OrgMonthlyBillingPanel.tsx
+++ b/frontend/src/components/OrgMonthlyBillingPanel.tsx
@@ -171,10 +171,7 @@ export default function OrgMonthlyBillingPanel({
                     </tr>
                   )}
                   {result.students.map((s) => (
-                    <tr
-                      key={s.student_id}
-                      className="border-t border-gray-200"
-                    >
+                    <tr key={s.student_id} className="border-t border-gray-200">
                       <td className="px-3 py-2">{s.student_id}</td>
                       <td className="px-3 py-2">{s.name}</td>
                       <td className="px-3 py-2">

--- a/frontend/src/components/StudentTable.tsx
+++ b/frontend/src/components/StudentTable.tsx
@@ -43,10 +43,6 @@ export interface Student {
   organization_id?: string;
   created_at?: string;
   classroom_created_at?: string;
-  // Phase 5-2 (#768): drives the activate/deactivate toggle. Writing this
-  // via POST /api/teachers/students/{id}/status also appends to
-  // student_status_history, which Phase 4 monthly billing reads.
-  is_active?: boolean;
 }
 
 interface StudentTableProps {

--- a/frontend/src/components/StudentTable.tsx
+++ b/frontend/src/components/StudentTable.tsx
@@ -20,6 +20,8 @@ import {
   Copy,
   CheckSquare,
   Square,
+  Power,
+  PowerOff,
 } from "lucide-react";
 
 export interface Student {
@@ -41,6 +43,10 @@ export interface Student {
   organization_id?: string;
   created_at?: string;
   classroom_created_at?: string;
+  // Phase 5-2 (#768): drives the activate/deactivate toggle. Writing this
+  // via POST /api/teachers/students/{id}/status also appends to
+  // student_status_history, which Phase 4 monthly billing reads.
+  is_active?: boolean;
 }
 
 interface StudentTableProps {
@@ -51,6 +57,9 @@ interface StudentTableProps {
   onViewStudent?: (student: Student) => void;
   onResetPassword?: (student: Student) => void;
   onDeleteStudent?: (student: Student) => void;
+  // Phase 5-2 (#768): activate/deactivate. Receives `nextStatus` so the
+  // caller can write the appropriate value to /students/{id}/status.
+  onToggleStatus?: (student: Student, nextStatus: "active" | "inactive") => void;
   onBulkAction?: (action: string, studentIds: number[]) => void;
   emptyMessage?: string;
   emptyDescription?: string;
@@ -68,6 +77,7 @@ export default function StudentTable({
   onViewStudent,
   onResetPassword,
   onDeleteStudent,
+  onToggleStatus,
   onBulkAction,
   emptyMessage,
   emptyDescription,
@@ -555,6 +565,41 @@ export default function StudentTable({
                         disabled={disableActions}
                       >
                         <Edit className="h-4 w-4" />
+                      </Button>
+                    )}
+                    {/* Phase 5-2 (#768): activate/deactivate toggle.
+                        Writes to student_status_history (Phase 4 billing). */}
+                    {onToggleStatus && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        title={
+                          disableActions
+                            ? disableReason
+                            : student.is_active === false
+                              ? "啟用學生"
+                              : "停用學生（保留資料）"
+                        }
+                        onClick={() => {
+                          const nextStatus =
+                            student.is_active === false
+                              ? "active"
+                              : "inactive";
+                          const confirmMsg =
+                            nextStatus === "inactive"
+                              ? `確定停用 ${student.name}？學生資料保留，但下個月起不會計入機構月結計費。`
+                              : `重新啟用 ${student.name}？`;
+                          if (confirm(confirmMsg)) {
+                            onToggleStatus(student, nextStatus);
+                          }
+                        }}
+                        disabled={disableActions}
+                      >
+                        {student.is_active === false ? (
+                          <Power className="h-4 w-4" />
+                        ) : (
+                          <PowerOff className="h-4 w-4" />
+                        )}
                       </Button>
                     )}
                     {onDeleteStudent && (

--- a/frontend/src/components/StudentTable.tsx
+++ b/frontend/src/components/StudentTable.tsx
@@ -59,7 +59,10 @@ interface StudentTableProps {
   onDeleteStudent?: (student: Student) => void;
   // Phase 5-2 (#768): activate/deactivate. Receives `nextStatus` so the
   // caller can write the appropriate value to /students/{id}/status.
-  onToggleStatus?: (student: Student, nextStatus: "active" | "inactive") => void;
+  onToggleStatus?: (
+    student: Student,
+    nextStatus: "active" | "inactive",
+  ) => void;
   onBulkAction?: (action: string, studentIds: number[]) => void;
   emptyMessage?: string;
   emptyDescription?: string;
@@ -568,40 +571,46 @@ export default function StudentTable({
                       </Button>
                     )}
                     {/* Phase 5-2 (#768): activate/deactivate toggle.
-                        Writes to student_status_history (Phase 4 billing). */}
-                    {onToggleStatus && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        title={
-                          disableActions
-                            ? disableReason
-                            : student.is_active === false
-                              ? "啟用學生"
-                              : "停用學生（保留資料）"
-                        }
-                        onClick={() => {
-                          const nextStatus =
-                            student.is_active === false
-                              ? "active"
-                              : "inactive";
-                          const confirmMsg =
-                            nextStatus === "inactive"
-                              ? `確定停用 ${student.name}？學生資料保留，但下個月起不會計入機構月結計費。`
-                              : `重新啟用 ${student.name}？`;
-                          if (confirm(confirmMsg)) {
-                            onToggleStatus(student, nextStatus);
-                          }
-                        }}
-                        disabled={disableActions}
-                      >
-                        {student.is_active === false ? (
-                          <Power className="h-4 w-4" />
-                        ) : (
-                          <PowerOff className="h-4 w-4" />
-                        )}
-                      </Button>
-                    )}
+                        Writes to student_status_history (Phase 4 billing).
+                        Backend serializes inactive students as
+                        `status: 'inactive'`; treat any value other than
+                        'inactive' (incl. undefined / 'active') as active. */}
+                    {onToggleStatus &&
+                      (() => {
+                        const isInactive = student.status === "inactive";
+                        const nextStatus: "active" | "inactive" = isInactive
+                          ? "active"
+                          : "inactive";
+                        return (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            title={
+                              disableActions
+                                ? disableReason
+                                : isInactive
+                                  ? "啟用學生"
+                                  : "停用學生（保留資料）"
+                            }
+                            onClick={() => {
+                              const confirmMsg =
+                                nextStatus === "inactive"
+                                  ? `確定停用 ${student.name}？學生資料保留，但下個月起不會計入機構月結計費。`
+                                  : `重新啟用 ${student.name}？`;
+                              if (confirm(confirmMsg)) {
+                                onToggleStatus(student, nextStatus);
+                              }
+                            }}
+                            disabled={disableActions}
+                          >
+                            {isInactive ? (
+                              <Power className="h-4 w-4" />
+                            ) : (
+                              <PowerOff className="h-4 w-4" />
+                            )}
+                          </Button>
+                        );
+                      })()}
                     {onDeleteStudent && (
                       <Button
                         variant="ghost"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1622,6 +1622,21 @@ class ApiClient {
     );
   }
 
+  // ===== Phase 5-2 (issue #768): group-buy plans listing =====
+  async listGroupBuyPlans() {
+    return this.request<
+      Array<{
+        name: string;
+        teacher_seats: number;
+        annual_fee: number;
+        total_amount: number;
+        topup_discount: number;
+        monthly_quota: number;
+        display_order: number;
+      }>
+    >("/api/credit-packages/group-buy-plans", { method: "GET" });
+  }
+
   // ===== Phase 5-2 (issue #768): group-buy open =====
   async openGroupBuy(body: {
     prime: string;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -884,8 +884,12 @@ class ApiClient {
     return this.request<{
       student_id: number;
       status: "active" | "inactive";
-      history_id: number;
-      changed_at: string;
+      // null on the no-op branch (target status already equals current).
+      // Backend StudentStatusUpdateResponse: history_id / changed_at are
+      // Optional. Callers can treat a non-null history_id as confirmation
+      // of a real write.
+      history_id: number | null;
+      changed_at: string | null;
     }>(`/api/teachers/students/${studentId}/status`, {
       method: "POST",
       body: JSON.stringify(body),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -876,6 +876,22 @@ class ApiClient {
     });
   }
 
+  // ===== Phase 5-2 (issue #768): student activate / deactivate =====
+  async updateStudentStatus(
+    studentId: number,
+    body: { status: "active" | "inactive"; note?: string },
+  ) {
+    return this.request<{
+      student_id: number;
+      status: "active" | "inactive";
+      history_id: number;
+      changed_at: string;
+    }>(`/api/teachers/students/${studentId}/status`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  }
+
   // ============ Program CRUD Methods ============
   async createProgram(data: {
     name: string;
@@ -1572,11 +1588,57 @@ class ApiClient {
       contact_phone?: string;
       address?: string;
       total_points?: number;
+      per_student_price?: number | null;
     },
   ) {
     return this.request(`/api/admin/organizations/${orgId}`, {
       method: "PUT",
       body: JSON.stringify(data),
+    });
+  }
+
+  // ===== Phase 5-2 (issue #768): institution monthly billing query =====
+  async getOrganizationMonthlyBilling(
+    orgId: string,
+    year: number,
+    month: number,
+  ) {
+    return this.request<{
+      org_id: string;
+      year: number;
+      month: number;
+      per_student_price: number;
+      billable_student_count: number;
+      total_amount: number;
+      currency: string;
+      students: Array<{
+        student_id: number;
+        name: string;
+        billable: boolean;
+      }>;
+    }>(
+      `/api/organizations/${orgId}/billing/monthly?year=${year}&month=${month}`,
+      { method: "GET" },
+    );
+  }
+
+  // ===== Phase 5-2 (issue #768): group-buy open =====
+  async openGroupBuy(body: {
+    prime: string;
+    plan_name: string;
+    cardholder?: { name?: string; email?: string; phone_number?: string };
+  }) {
+    return this.request<{
+      success: boolean;
+      message: string;
+      transaction_id?: string;
+      organization_id?: string;
+      school_id?: string;
+      subscription_end_date?: string;
+      teacher_seat_limit?: number;
+    }>("/api/credit-packages/group-buy-open", {
+      method: "POST",
+      body: JSON.stringify(body),
     });
   }
 

--- a/frontend/src/pages/admin/AdminOrgMonthlyBilling.tsx
+++ b/frontend/src/pages/admin/AdminOrgMonthlyBilling.tsx
@@ -43,7 +43,8 @@ export default function AdminOrgMonthlyBilling() {
         </Button>
       </div>
       <p className="text-sm text-gray-600">
-        Org ID: <code className="rounded bg-gray-100 px-1.5 py-0.5">{orgId}</code>
+        Org ID:{" "}
+        <code className="rounded bg-gray-100 px-1.5 py-0.5">{orgId}</code>
       </p>
       <OrgMonthlyBillingPanel orgId={orgId} />
     </div>

--- a/frontend/src/pages/admin/AdminOrgMonthlyBilling.tsx
+++ b/frontend/src/pages/admin/AdminOrgMonthlyBilling.tsx
@@ -1,0 +1,51 @@
+/**
+ * Admin page: institution monthly billing query for a specific org.
+ *
+ * Route: /admin/organizations/:orgId/billing
+ * Auth: requires admin (ProtectedRoute requireAdmin).
+ *
+ * Simple host for OrgMonthlyBillingPanel — keeps the panel reusable so
+ * the org_owner side can embed it in OrganizationDetail later without
+ * touching this page.
+ */
+import { useParams, useNavigate } from "react-router-dom";
+import OrgMonthlyBillingPanel from "@/components/OrgMonthlyBillingPanel";
+import { Button } from "@/components/ui/button";
+
+export default function AdminOrgMonthlyBilling() {
+  const { orgId } = useParams<{ orgId: string }>();
+  const navigate = useNavigate();
+
+  if (!orgId) {
+    return (
+      <div className="p-6 text-red-600">
+        Missing orgId in URL. Go back to{" "}
+        <button
+          className="underline"
+          onClick={() => navigate("/admin/organizations")}
+        >
+          organizations list
+        </button>
+        .
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">機構月度計費查詢</h1>
+        <Button
+          variant="ghost"
+          onClick={() => navigate("/admin/organizations")}
+        >
+          ← 返回機構列表
+        </Button>
+      </div>
+      <p className="text-sm text-gray-600">
+        Org ID: <code className="rounded bg-gray-100 px-1.5 py-0.5">{orgId}</code>
+      </p>
+      <OrgMonthlyBillingPanel orgId={orgId} />
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminOrganizations.tsx
+++ b/frontend/src/pages/admin/AdminOrganizations.tsx
@@ -85,6 +85,7 @@ export default function AdminOrganizations() {
     total_points: "",
     subscription_start_date: "",
     subscription_end_date: "",
+    per_student_price: "", // Phase 5-2 (#768): institution monthly per-student fee
   });
 
   // Validation errors
@@ -178,6 +179,7 @@ export default function AdminOrganizations() {
       subscription_end_date: org.subscription_end_date
         ? org.subscription_end_date.split("T")[0]
         : "",
+      per_student_price: org.per_student_price?.toString() || "",
     });
     setFormErrors({});
     setIsEditDialogOpen(true);
@@ -208,6 +210,20 @@ export default function AdminOrganizations() {
     }
     if (formData.total_points && Number(formData.total_points) < 0) {
       errors.total_points = "總點數不能為負數";
+    }
+
+    // Phase 5-2 (#768): per_student_price validation
+    if (
+      formData.per_student_price &&
+      isNaN(Number(formData.per_student_price))
+    ) {
+      errors.per_student_price = "單位學生月費必須是數字";
+    }
+    if (
+      formData.per_student_price &&
+      Number(formData.per_student_price) <= 0
+    ) {
+      errors.per_student_price = "單位學生月費必須大於 0";
     }
 
     setFormErrors(errors);
@@ -279,6 +295,14 @@ export default function AdminOrganizations() {
         Number(formData.total_points) !== selectedOrg.total_points
       ) {
         updateData.total_points = Number(formData.total_points);
+      }
+      // Phase 5-2 (#768): only send when value actually changed
+      if (
+        formData.per_student_price &&
+        Number(formData.per_student_price) !==
+          (selectedOrg.per_student_price ?? 0)
+      ) {
+        updateData.per_student_price = Number(formData.per_student_price);
       }
 
       const response = (await apiClient.updateOrganization(
@@ -549,15 +573,33 @@ export default function AdminOrganizations() {
 
                           {/* Actions */}
                           <TableCell className="text-center">
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => handleEdit(org.id)}
-                              className="flex items-center gap-1"
-                            >
-                              <Pencil className="h-4 w-4" />
-                              編輯
-                            </Button>
+                            <div className="flex items-center justify-center gap-1">
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => handleEdit(org.id)}
+                                className="flex items-center gap-1"
+                              >
+                                <Pencil className="h-4 w-4" />
+                                編輯
+                              </Button>
+                              {/* Phase 5-2 (#768): institution monthly billing */}
+                              {org.org_type === "institution" && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() =>
+                                    navigate(
+                                      `/admin/organizations/${org.id}/billing`,
+                                    )
+                                  }
+                                  className="flex items-center gap-1"
+                                  title="查看機構月度計費"
+                                >
+                                  月結
+                                </Button>
+                              )}
+                            </div>
                           </TableCell>
                         </TableRow>
                       ))
@@ -703,6 +745,34 @@ export default function AdminOrganizations() {
                         目前有 {selectedOrg.teacher_count} 位教師
                       </p>
                     )}
+                  </div>
+
+                  {/* Phase 5-2 (#768): per-student monthly price (institution only) */}
+                  <div className="space-y-2">
+                    <Label htmlFor="per_student_price">
+                      單位學生月費（NT$，機構月結用）
+                    </Label>
+                    <Input
+                      id="per_student_price"
+                      type="number"
+                      min="1"
+                      value={formData.per_student_price}
+                      onChange={(e) =>
+                        setFormData({
+                          ...formData,
+                          per_student_price: e.target.value,
+                        })
+                      }
+                      placeholder="僅機構方案需要填寫"
+                    />
+                    {formErrors.per_student_price && (
+                      <p className="text-sm text-red-600">
+                        {formErrors.per_student_price}
+                      </p>
+                    )}
+                    <p className="text-xs text-gray-500">
+                      每月應收 = 當月活躍學生人數 × 單位學生月費
+                    </p>
                   </div>
                 </div>
               </div>

--- a/frontend/src/pages/admin/AdminOrganizations.tsx
+++ b/frontend/src/pages/admin/AdminOrganizations.tsx
@@ -219,10 +219,7 @@ export default function AdminOrganizations() {
     ) {
       errors.per_student_price = "單位學生月費必須是數字";
     }
-    if (
-      formData.per_student_price &&
-      Number(formData.per_student_price) <= 0
-    ) {
+    if (formData.per_student_price && Number(formData.per_student_price) <= 0) {
       errors.per_student_price = "單位學生月費必須大於 0";
     }
 
@@ -296,13 +293,19 @@ export default function AdminOrganizations() {
       ) {
         updateData.total_points = Number(formData.total_points);
       }
-      // Phase 5-2 (#768): only send when value actually changed
-      if (
-        formData.per_student_price &&
-        Number(formData.per_student_price) !==
-          (selectedOrg.per_student_price ?? 0)
-      ) {
-        updateData.per_student_price = Number(formData.per_student_price);
+      // Phase 5-2 (#768): explicit clear path. Truthy/falsy on a string
+      // would treat "" as "skip", making the field unclearable once set.
+      // Distinguish: empty input → send null to clear; non-empty → send
+      // parsed value if it differs from current.
+      if (formData.per_student_price === "") {
+        if (selectedOrg.per_student_price != null) {
+          updateData.per_student_price = null;
+        }
+      } else {
+        const parsed = Number(formData.per_student_price);
+        if (parsed !== (selectedOrg.per_student_price ?? 0)) {
+          updateData.per_student_price = parsed;
+        }
       }
 
       const response = (await apiClient.updateOrganization(

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -1113,6 +1113,29 @@ export default function ClassroomDetail({
     }
   };
 
+  // Phase 5-2 (#768): activate/deactivate a student. The endpoint writes
+  // to student_status_history (driving Phase 4 monthly billing) AND syncs
+  // Student.is_active so existing UI flows keep working.
+  const handleToggleStudentStatus = async (
+    student: Student,
+    nextStatus: "active" | "inactive",
+  ) => {
+    try {
+      await apiClient.updateStudentStatus(student.id, { status: nextStatus });
+      toast.success(
+        nextStatus === "inactive"
+          ? `已停用 ${student.name}`
+          : `已啟用 ${student.name}`,
+      );
+      fetchClassroomDetail();
+    } catch (error) {
+      console.error("Failed to update student status:", error);
+      const message =
+        error instanceof ApiError ? error.message : "更新學生狀態失敗";
+      toast.error(message);
+    }
+  };
+
   const handleSaveStudent = async () => {
     // Refresh data after save (parallel requests, no loading spinner)
     await Promise.all([
@@ -1769,6 +1792,7 @@ export default function ClassroomDetail({
                     onViewStudent={handleViewStudent}
                     onEditStudent={handleEditStudent}
                     onResetPassword={handleResetPassword}
+                    onToggleStatus={handleToggleStudentStatus}
                     onDeleteStudent={handleDeleteStudentRow}
                     emptyMessage={t("classroomDetail.messages.noStudents")}
                     disableActions={isOrgMode}

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -1127,7 +1127,9 @@ export default function ClassroomDetail({
           ? `已停用 ${student.name}`
           : `已啟用 ${student.name}`,
       );
-      fetchClassroomDetail();
+      // Refresh BOTH the student list (toggle UI state) AND classroom
+      // metadata. fetchClassroomDetail alone leaves the student array stale.
+      await Promise.all([fetchStudents(), fetchClassroomDetail(false)]);
     } catch (error) {
       console.error("Failed to update student status:", error);
       const message =

--- a/frontend/src/pages/teacher/GroupBuyOpenPage.tsx
+++ b/frontend/src/pages/teacher/GroupBuyOpenPage.tsx
@@ -1,0 +1,194 @@
+/**
+ * Group-buy open page (issue #768 Phase 5-2).
+ *
+ * Route: /teacher/group-buy/open
+ * Auth: any authenticated teacher.
+ *
+ * Flow:
+ *   1. List active group-buy plans (10/30/50 seats) from
+ *      GET /api/credit-packages/group-buy-plans
+ *   2. Teacher picks a plan — total = annual_fee × teacher_seats (server-
+ *      authoritative; we only display it)
+ *   3. Reuse <TapPayPayment> component with apiEndpoint pointing at
+ *      /api/credit-packages/group-buy-open and customPayload supplying
+ *      plan_name. The backend computes amount from the Plan row regardless
+ *      of what we send.
+ *   4. On success, navigate the teacher to /teacher/dashboard.
+ */
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { apiClient, ApiError } from "@/lib/api";
+import TapPayPayment from "@/components/payment/TapPayPayment";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+
+interface GroupBuyPlan {
+  name: string;
+  teacher_seats: number;
+  annual_fee: number;
+  total_amount: number;
+  topup_discount: number;
+  monthly_quota: number;
+  display_order: number;
+}
+
+export default function GroupBuyOpenPage() {
+  const navigate = useNavigate();
+  const [plans, setPlans] = React.useState<GroupBuyPlan[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const [selectedPlan, setSelectedPlan] = React.useState<GroupBuyPlan | null>(
+    null,
+  );
+
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await apiClient.listGroupBuyPlans();
+        if (!cancelled) {
+          setPlans(data);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          const msg =
+            e instanceof ApiError
+              ? typeof e.detail === "string"
+                ? e.detail
+                : e.message
+              : "載入團購方案失敗";
+          setError(msg);
+          toast.error(msg);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handlePaymentSuccess = (transactionId: string) => {
+    toast.success(`開團成功！交易編號 ${transactionId}`);
+    // Frontend redirect — backend response carries org_id/school_id but
+    // we route to the teacher dashboard for simplicity. Manage-team page
+    // can be added later.
+    navigate("/teacher/dashboard");
+  };
+
+  const handlePaymentError = (errMsg: string) => {
+    toast.error(`開團失敗：${errMsg}`);
+  };
+
+  if (loading) {
+    return <div className="p-6">載入中…</div>;
+  }
+  if (error) {
+    return <div className="p-6 text-red-600">{error}</div>;
+  }
+  if (plans.length === 0) {
+    return (
+      <div className="p-6">
+        目前沒有可用的團購方案。請聯絡 Duotopia 客服。
+      </div>
+    );
+  }
+
+  // Plan selection screen
+  if (!selectedPlan) {
+    return (
+      <div className="p-6 space-y-4 max-w-5xl mx-auto">
+        <h1 className="text-2xl font-bold">開設教師團購方案</h1>
+        <p className="text-sm text-gray-600">
+          選擇方案後，刷卡完成即建立團隊。年費 = 每席年費 × 席次。月費贈點
+          將於每月 1 號自動發放給團內所有教師。
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          {plans.map((p) => (
+            <Card key={p.name} className="flex flex-col">
+              <CardHeader>
+                <CardTitle className="text-xl">{p.name}</CardTitle>
+                <CardDescription>
+                  {p.teacher_seats} 位教師席次
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex-1 space-y-2 text-sm">
+                <div>
+                  每席年費：
+                  <span className="font-semibold">
+                    NT$ {p.annual_fee.toLocaleString()}
+                  </span>
+                </div>
+                <div>
+                  月配點：
+                  <span className="font-semibold">
+                    {p.monthly_quota.toLocaleString()} 點 / 教師
+                  </span>
+                </div>
+                <div>
+                  加購折扣：
+                  <span className="font-semibold">
+                    {Math.round((1 - p.topup_discount) * 100)}% off
+                  </span>
+                </div>
+                <div className="pt-2 border-t border-gray-200">
+                  總計：
+                  <span className="text-lg font-bold text-blue-600">
+                    NT$ {p.total_amount.toLocaleString()} / 年
+                  </span>
+                </div>
+                <Button
+                  className="w-full mt-3"
+                  onClick={() => setSelectedPlan(p)}
+                >
+                  選擇此方案
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Payment screen
+  return (
+    <div className="p-6 space-y-4 max-w-2xl mx-auto">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">開團刷卡 — {selectedPlan.name}</h1>
+        <Button variant="ghost" onClick={() => setSelectedPlan(null)}>
+          ← 重新選擇方案
+        </Button>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>付款資訊</CardTitle>
+          <CardDescription>
+            {selectedPlan.teacher_seats} 席 × 每席 NT${" "}
+            {selectedPlan.annual_fee.toLocaleString()} = 共 NT${" "}
+            {selectedPlan.total_amount.toLocaleString()} / 年
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <TapPayPayment
+            amount={selectedPlan.total_amount}
+            planName={selectedPlan.name}
+            apiEndpoint="/api/credit-packages/group-buy-open"
+            customPayload={{ plan_name: selectedPlan.name }}
+            onPaymentSuccess={handlePaymentSuccess}
+            onPaymentError={handlePaymentError}
+            onCancel={() => setSelectedPlan(null)}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/teacher/GroupBuyOpenPage.tsx
+++ b/frontend/src/pages/teacher/GroupBuyOpenPage.tsx
@@ -96,9 +96,7 @@ export default function GroupBuyOpenPage() {
   }
   if (plans.length === 0) {
     return (
-      <div className="p-6">
-        目前沒有可用的團購方案。請聯絡 Duotopia 客服。
-      </div>
+      <div className="p-6">目前沒有可用的團購方案。請聯絡 Duotopia 客服。</div>
     );
   }
 
@@ -116,9 +114,7 @@ export default function GroupBuyOpenPage() {
             <Card key={p.name} className="flex flex-col">
               <CardHeader>
                 <CardTitle className="text-xl">{p.name}</CardTitle>
-                <CardDescription>
-                  {p.teacher_seats} 位教師席次
-                </CardDescription>
+                <CardDescription>{p.teacher_seats} 位教師席次</CardDescription>
               </CardHeader>
               <CardContent className="flex-1 space-y-2 text-sm">
                 <div>

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -86,6 +86,9 @@ export interface AdminOrganizationUpdateRequest {
   total_points?: number;
   subscription_start_date?: string;
   subscription_end_date?: string;
+  // Phase 5-2 (issue #768): institution monthly per-student price (NT$).
+  // Only meaningful for org_type='institution'. Must be > 0.
+  per_student_price?: number;
 }
 
 // Admin organization update response

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -64,6 +64,10 @@ export interface OrganizationListItem {
   created_at: string;
   subscription_start_date: string | null;
   subscription_end_date: string | null;
+  // Phase 5-2 (issue #768): institution monthly per-student price (NT$).
+  // Only meaningful for org_type='institution'; null otherwise.
+  per_student_price?: number | null;
+  org_type?: "institution" | "group_buy" | null;
 }
 
 // Organization list response with pagination

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -91,8 +91,9 @@ export interface AdminOrganizationUpdateRequest {
   subscription_start_date?: string;
   subscription_end_date?: string;
   // Phase 5-2 (issue #768): institution monthly per-student price (NT$).
-  // Only meaningful for org_type='institution'. Must be > 0.
-  per_student_price?: number;
+  // Only meaningful for org_type='institution'. Must be > 0 if set; null
+  // explicitly clears the field from the admin edit UI.
+  per_student_price?: number | null;
 }
 
 // Admin organization update response


### PR DESCRIPTION
## Summary
**Phase 5-2 of 5** for issue #768「機構方案優化」— the final phase. Adds the 1 backend endpoint and 4 frontend UI pieces needed to make the institution and group-buy product lines actually usable end-to-end. **This PR closes #768 on merge.**

Branch has 2 commits:
- `79205f5c` — backend status endpoint + API client foundation
- `e561b33c` — 4 frontend UI pieces + group-buy plans listing endpoint

## End-to-end test routes (for full e2e per your earlier request)

| Route | What to test |
|---|---|
| **`/admin/organizations`** → edit org | Set `per_student_price` (NT$/student/month). New "月結" button visible only for `org_type='institution'` rows. |
| **`/admin/organizations/:orgId/billing`** | Year/month picker → aggregate (per_student_price × billable count = total) + per-student breakdown table. |
| **`ClassroomDetail.tsx`** student tab | New Power/PowerOff toggle next to the existing edit/delete actions. Confirms with billing-impact message; writes to `student_status_history` + flips `Student.is_active`. |
| **`/teacher/group-buy/open`** | Lists 3 plans (10/30/50 seats) with `annual_fee × seats` total. Pick → TapPay card form → success toast + redirect to `/teacher/dashboard`. |

## Backend changes

### New endpoints
- `POST /api/teachers/students/{student_id}/status` — body `{status: 'active'\|'inactive', note?}`. Writes `student_status_history` row + syncs `Student.is_active`. Ownership check mirrors `DELETE /students/{id}`. No-op short-circuit when target == current.
- `GET /api/credit-packages/group-buy-plans` — lists active group-buy plans for the open-group UI. Server-authoritative totals (frontend never computes its own).

### Schema extensions
- `AdminOrganizationUpdate` accepts `per_student_price` (gt=0). Generic setattr loop already propagates.
- `OrganizationListItem` exposes `org_type` + `per_student_price` for the admin edit dialog and the "月結" button visibility check.

## Frontend changes

### New components / pages
| File | Purpose |
|---|---|
| `components/OrgMonthlyBillingPanel.tsx` | Reusable year/month picker + breakdown table — admin and org_owner both use it |
| `pages/admin/AdminOrgMonthlyBilling.tsx` | Admin route that hosts the panel |
| `pages/teacher/GroupBuyOpenPage.tsx` | 3-plan picker + TapPay flow via reused `<TapPayPayment>` |

### Extended files
- `lib/api.ts`: 4 new methods (`updateStudentStatus`, `getOrganizationMonthlyBilling`, `openGroupBuy`, `listGroupBuyPlans`) + `per_student_price` in `updateOrganization`
- `types/admin.ts`: `OrganizationListItem` and `AdminOrganizationUpdateRequest` gain `per_student_price` / `org_type`
- `components/StudentTable.tsx`: optional `is_active`, `onToggleStatus` prop, Power icon toggle button
- `pages/admin/AdminOrganizations.tsx`: per_student_price form field + "月結" row action button (institution-only)
- `pages/teacher/ClassroomDetail.tsx`: `handleToggleStudentStatus` handler wired to the new toggle
- `App.tsx`: 2 new routes (`/admin/organizations/:orgId/billing`, `/teacher/group-buy/open`)

## TapPay integration approach
GroupBuyOpenPage reuses the existing `<TapPayPayment>` component with `apiEndpoint="/api/credit-packages/group-buy-open"` + `customPayload={plan_name}`. The Pydantic `GroupBuyOpenRequest` ignores extra fields, so the `amount`/`details` that `<TapPayPayment>` always sends are harmless — the backend always recomputes `amount = annual_fee × teacher_seats` from the DB Plan row.

## Test plan
- [x] **Black clean** on all touched backend files
- [x] **111/111 backend tests pass** — 6 new (status endpoint) + 105 regression (institution_billing 26, group_buy_service+endpoint+cron+monthly 27, admin_orgs/plans/credit_packages 51, topup_discount 6)
- [x] **`tsc --noEmit` clean** — no new TypeScript errors
- [x] **ESLint warnings unchanged** — 100 pre-existing warnings in staging, none added by this PR
- [ ] **End-to-end manual testing** — done by user on the PR per agreed flow

## Backlog from earlier phases — status
- ✅ All 14 cleanup items from PR #820/#822/#823 reviews were landed in Phase 5-1 (PR #825)
- 4 nits from #825 round 2 (sort contract scope, lock key scope, body_json comment, execution_time check) remain — not blocking; can be a follow-up cleanup PR if desired

## What ships with this PR
| #768 deliverable | Lands |
|---|---|
| 五.1 團購加購折扣 | Phase 2 ✅ |
| 五.2 團購月配發 1000 點 | Phase 3 ✅ |
| 五.3 團購開團 API + UI | Phase 3 (API) ✅ · **Phase 5-2 (UI) ✅** |
| 五.4 機構單位學生費前端頁 | **Phase 5-2 ✅** |
| 五.5 機構月度計費查詢 | Phase 4 (API) ✅ · **Phase 5-2 (UI) ✅** |
| 四. student_status_history 寫入機制 | Phase 1 (schema) ✅ · **Phase 5-2 (write endpoint + toggle UI) ✅** |

Related to #768 — issue stays open for staging-test follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)