### PR TITLE
feat(#828): migration only — allow word_spelling_quiz / word_cloze_quiz

### DIFF
--- a/backend/alembic/versions/20260601_1000_add_quiz_practice_modes_to_constraint.py
+++ b/backend/alembic/versions/20260601_1000_add_quiz_practice_modes_to_constraint.py
@@ -1,0 +1,59 @@
+"""Add word_spelling_quiz and word_cloze_quiz to check_practice_mode
+
+Issue #828 introduces two new practice modes (word_spelling_quiz,
+word_cloze_quiz) for the new 小考 (quiz) feature. They must be allowed
+by the practice_sessions.check_practice_mode constraint.
+
+Idempotent: drops the constraint if it exists and re-creates it with
+the full known whitelist.
+
+Revision ID: 20260601_1000
+Revises: 20260528_1000
+Create Date: 2026-06-01
+"""
+from typing import Union
+
+from alembic import op
+
+
+revision: str = "20260601_1000"
+down_revision: Union[str, None] = "20260528_1000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'check_practice_mode'
+                  AND conrelid = 'practice_sessions'::regclass
+            ) THEN
+                ALTER TABLE practice_sessions
+                    DROP CONSTRAINT check_practice_mode;
+            END IF;
+
+            ALTER TABLE practice_sessions
+            ADD CONSTRAINT check_practice_mode
+            CHECK (practice_mode IN (
+                'listening',
+                'writing',
+                'word_selection',
+                'word_reading',
+                'word_spelling',
+                'word_cloze',
+                'word_spelling_quiz',
+                'word_cloze_quiz',
+                'rearrangement',
+                'tug_of_war'
+            ));
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    """No-op: forward-only migration per project policy."""
+    pass


### PR DESCRIPTION
Refs #828 — Phase 1 拆解，僅 migration。

## Scope

只擴充 \`practice_sessions.check_practice_mode\` 白名單，允許 \`word_spelling_quiz\` 與 \`word_cloze_quiz\` 兩個新值寫入。

不含任何應用層程式碼變動（enum、validator、UI 等留待後續 PR）。先讓 schema 變更安全進 staging，降低後續 PR 的 review 範圍與 merge 風險。

## 變更

- 新檔：\`backend/alembic/versions/20260601_1000_add_quiz_practice_modes_to_constraint.py\`
- revision: \`20260601_1000\`，down_revision: \`20260528_1000\`
- 動作：DROP IF EXISTS + 重建 CHECK 白名單，含全部已知 practice_mode 值
- Idempotent，符合 CLAUDE.md migration 鐵則

## 影響

- staging schema 接受新值，但目前沒有 router 會寫入這些值（後續 PR 才加），所以這次 PR 行為上是 no-op
- 既有 mode 行為完全不變

## 後續

合併後 \`claude/issue-828\` 會 rebase 掉重複的 migration 檔，後續 PR 帶上 enum / validator / 派發 UI 等應用層變更。