### PR TITLE
feat: migration only — allow word_selection_quiz

### DIFF
--- a/backend/alembic/versions/20260602_1000_add_word_selection_quiz_to_constraint.py
+++ b/backend/alembic/versions/20260602_1000_add_word_selection_quiz_to_constraint.py
@@ -1,0 +1,60 @@
+"""Add word_selection_quiz to check_practice_mode
+
+Issue #833: extend the 小考 (quiz) variants to word_selection. Adds
+``word_selection_quiz`` to the practice_sessions.check_practice_mode
+whitelist so the upcoming application-layer changes can persist it.
+
+Idempotent: drops the constraint if it exists and re-creates it with
+the full known whitelist.
+
+Revision ID: 20260602_1000
+Revises: 20260601_1000
+Create Date: 2026-06-02
+"""
+from typing import Union
+
+from alembic import op
+
+
+revision: str = "20260602_1000"
+down_revision: Union[str, None] = "20260601_1000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'check_practice_mode'
+                  AND conrelid = 'practice_sessions'::regclass
+            ) THEN
+                ALTER TABLE practice_sessions
+                    DROP CONSTRAINT check_practice_mode;
+            END IF;
+
+            ALTER TABLE practice_sessions
+            ADD CONSTRAINT check_practice_mode
+            CHECK (practice_mode IN (
+                'listening',
+                'writing',
+                'word_selection',
+                'word_selection_quiz',
+                'word_reading',
+                'word_spelling',
+                'word_cloze',
+                'word_spelling_quiz',
+                'word_cloze_quiz',
+                'rearrangement',
+                'tug_of_war'
+            ));
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    """No-op: forward-only migration per project policy."""
+    pass


### PR DESCRIPTION
Closes #833

## Scope

擴 \`practice_sessions.check_practice_mode\` 白名單，加入 \`word_selection_quiz\`。
不含任何應用層程式碼變動（enum、validator、UI 等留待後續 PR）。

## 變更

- 新檔：\`backend/alembic/versions/20260602_1000_add_word_selection_quiz_to_constraint.py\`
- revision: \`20260602_1000\`，down_revision: \`20260601_1000\`
- 動作：DROP IF EXISTS + 重建 CHECK 白名單，含全部已知 practice_mode 值
- Idempotent，符合 CLAUDE.md migration 鐵則

## 影響

- staging schema 接受新值，但目前沒有 router 會寫入這個值（後續 PR 才加），所以這次 PR 行為上是 no-op
- 既有 mode 行為完全不變

## 後續

合併後再開應用層 PR：PracticeMode enum 補值、AssignmentDialog 拆 chip（既有 word_selection 加「·艾賓浩斯」、新增「·小考」），學生端與 preview 納入 Phase 2。