### PR TITLE
feat(#768): admin plans dialog clarity + group-buy discovery entry points

### DIFF
--- a/backend/routers/admin_plans.py
+++ b/backend/routers/admin_plans.py
@@ -32,6 +32,12 @@ class PlanResponse(BaseModel):
     is_active: bool
     updated_at: Optional[datetime] = None
     updated_by_admin_id: Optional[int] = None
+    # issue #768 follow-up: expose group-buy fields so the admin UI can
+    # render plan-type-specific labels and totals. teacher_seats not-NULL
+    # is the canonical "this is a group-buy plan" signal.
+    teacher_seats: Optional[int] = None
+    annual_fee: Optional[int] = None  # PER teacher; total = annual_fee * teacher_seats
+    topup_discount: Optional[float] = None
 
     class Config:
         from_attributes = True
@@ -42,6 +48,12 @@ class PlanUpdateRequest(BaseModel):
     quota: Optional[int] = Field(default=None, ge=0)
     is_active: Optional[bool] = None
     display_order: Optional[int] = Field(default=None, ge=0)
+    # issue #768 follow-up: group-buy-only economic levers. Admin can
+    # adjust per-teacher annual_fee + topup_discount without re-seeding;
+    # teacher_seats stays fixed (changing the seat count after the team
+    # is open would orphan existing TeacherSchool bindings).
+    annual_fee: Optional[int] = Field(default=None, gt=0)
+    topup_discount: Optional[float] = Field(default=None, gt=0, le=1)
 
 
 # ============ Endpoints ============
@@ -70,6 +82,21 @@ async def update_plan(
     payload = request.model_dump(exclude_unset=True)
     if not payload:
         raise HTTPException(status_code=400, detail="No fields provided to update")
+
+    # Guard: annual_fee/topup_discount are meaningful only for group-buy
+    # plans (teacher_seats IS NOT NULL). Setting them on an individual plan
+    # would be silently wrong (they wouldn't be read).
+    is_group_buy = row.teacher_seats is not None
+    if not is_group_buy:
+        for field in ("annual_fee", "topup_discount"):
+            if field in payload:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"{field} can only be set on group-buy plans "
+                        f"(plan {plan_name!r} has no teacher_seats)."
+                    ),
+                )
 
     for field, value in payload.items():
         setattr(row, field, value)

--- a/backend/tests/test_admin_plans.py
+++ b/backend/tests/test_admin_plans.py
@@ -219,3 +219,100 @@ def test_get_plan_price_falls_back_when_no_row(shared_test_session):
     from config.plans import get_plan_price
 
     assert get_plan_price("Tutor Teachers", db=shared_test_session) == 299
+
+
+# ============ PR #837 (issue #768): group-buy lever guards ============
+
+
+@pytest.fixture
+def seed_group_buy_plan(shared_test_session):
+    """A group-buy plan (teacher_seats not-NULL) for the new lever tests."""
+    from decimal import Decimal
+
+    p = Plan(
+        name="團購-30席",
+        price=None,
+        quota=1000,
+        teacher_seats=30,
+        annual_fee=1300,
+        topup_discount=Decimal("0.90"),
+        display_order=11,
+        is_active=True,
+    )
+    shared_test_session.add(p)
+    shared_test_session.commit()
+    shared_test_session.refresh(p)
+    return p
+
+
+def test_update_plan_annual_fee_on_non_group_buy_returns_400(
+    seed_plans, auth_headers_admin, test_client
+):
+    """PR #837: annual_fee is a group-buy-only lever. Setting it on an
+    individual plan (teacher_seats IS NULL) must be rejected with 400 so
+    an accidental admin edit can't silently land on a plan that won't
+    actually read the field."""
+    r = test_client.put(
+        "/api/admin/plans/Tutor%20Teachers",
+        headers=auth_headers_admin,
+        json={"annual_fee": 1500},
+    )
+    assert r.status_code == 400
+    assert "annual_fee" in r.json()["detail"]
+    assert "teacher_seats" in r.json()["detail"]
+
+
+def test_update_plan_topup_discount_on_non_group_buy_returns_400(
+    seed_plans, auth_headers_admin, test_client
+):
+    """Same guard as above for the topup_discount lever."""
+    r = test_client.put(
+        "/api/admin/plans/Tutor%20Teachers",
+        headers=auth_headers_admin,
+        json={"topup_discount": 0.9},
+    )
+    assert r.status_code == 400
+    assert "topup_discount" in r.json()["detail"]
+
+
+def test_update_plan_topup_discount_out_of_range_returns_422(
+    seed_group_buy_plan, auth_headers_admin, test_client
+):
+    """Pydantic validation: topup_discount must be 0 < x ≤ 1.
+    Sending 1.5 → 422 (request validation), 0 → 422 (gt=0)."""
+    r = test_client.put(
+        "/api/admin/plans/%E5%9C%98%E8%B3%BC-30%E5%B8%AD",  # 團購-30席 URL-encoded
+        headers=auth_headers_admin,
+        json={"topup_discount": 1.5},
+    )
+    assert r.status_code == 422
+
+    r = test_client.put(
+        "/api/admin/plans/%E5%9C%98%E8%B3%BC-30%E5%B8%AD",
+        headers=auth_headers_admin,
+        json={"topup_discount": 0},
+    )
+    assert r.status_code == 422
+
+
+def test_update_plan_annual_fee_on_group_buy_persists(
+    seed_group_buy_plan, auth_headers_admin, test_client, shared_test_session
+):
+    """Happy path: setting annual_fee on a group-buy plan returns the
+    updated row and the value is persisted to the DB."""
+    r = test_client.put(
+        "/api/admin/plans/%E5%9C%98%E8%B3%BC-30%E5%B8%AD",
+        headers=auth_headers_admin,
+        json={"annual_fee": 1400, "topup_discount": 0.88},
+    )
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert body["annual_fee"] == 1400
+    assert float(body["topup_discount"]) == 0.88
+
+    shared_test_session.expire_all()
+    row = shared_test_session.query(Plan).filter(Plan.name == "團購-30席").one()
+    assert row.annual_fee == 1400
+    assert float(row.topup_discount) == 0.88
+    # teacher_seats stays as-seeded (not editable via this endpoint)
+    assert row.teacher_seats == 30

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1673,6 +1673,11 @@ class ApiClient {
         is_active: boolean;
         updated_at: string | null;
         updated_by_admin_id: number | null;
+        // issue #768: group-buy economic levers. teacher_seats not-null
+        // is the canonical group-buy signal; price is unused for those.
+        teacher_seats: number | null;
+        annual_fee: number | null; // PER teacher
+        topup_discount: number | null;
       }>
     >("/api/admin/plans", { method: "GET" });
   }
@@ -1684,6 +1689,9 @@ class ApiClient {
       quota?: number;
       is_active?: boolean;
       display_order?: number;
+      // issue #768 group-buy levers; backend rejects these on individual plans
+      annual_fee?: number;
+      topup_discount?: number;
     },
   ) {
     return this.request<{
@@ -1695,6 +1703,9 @@ class ApiClient {
       is_active: boolean;
       updated_at: string | null;
       updated_by_admin_id: number | null;
+      teacher_seats: number | null;
+      annual_fee: number | null;
+      topup_discount: number | null;
     }>(`/api/admin/plans/${encodeURIComponent(planName)}`, {
       method: "PUT",
       body: JSON.stringify(data),

--- a/frontend/src/pages/PricingPage.tsx
+++ b/frontend/src/pages/PricingPage.tsx
@@ -428,7 +428,7 @@ export default function PricingPage() {
         {/* Tabs: Monthly Subscription | Point Packages */}
         <div className="max-w-5xl mx-auto">
           {activeTab === "subscription" && (
-            <div className="max-w-4xl mx-auto">
+            <div className="max-w-4xl mx-auto space-y-12">
               <div className="grid md:grid-cols-2 gap-8">
                 {subscriptionPlans.map((plan) => (
                   <SubscriptionPlanCard
@@ -442,6 +442,94 @@ export default function PricingPage() {
                     ctaText={t("pricing.actions.subscribe")}
                   />
                 ))}
+              </div>
+
+              {/* Phase 5-2 follow-up (#768): group-buy discovery surface.
+                  Three hard-coded cards matching the DB seed; admin tunes
+                  the live values via /admin/plans dialog (PR #837). */}
+              <div className="space-y-4">
+                <div className="text-center">
+                  <h2 className="text-2xl font-bold text-gray-900">
+                    👥 教師團購方案
+                  </h2>
+                  <p className="text-sm text-gray-600 mt-2 max-w-2xl mx-auto">
+                    為您的教師團隊一次採購年費方案，享更低的每席費用 +
+                    加購點數包折扣。團主刷卡一次即可開團，月配點自動發放給團內每位教師。
+                  </p>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  {[
+                    {
+                      name: "團購-10席",
+                      seats: 10,
+                      annualFee: 1500,
+                      discount: 0.95,
+                    },
+                    {
+                      name: "團購-30席",
+                      seats: 30,
+                      annualFee: 1300,
+                      discount: 0.9,
+                    },
+                    {
+                      name: "團購-50席",
+                      seats: 50,
+                      annualFee: 1000,
+                      discount: 0.85,
+                    },
+                  ].map((p) => (
+                    <div
+                      key={p.name}
+                      className="rounded-xl border border-gray-200 bg-white p-6 flex flex-col"
+                    >
+                      <div className="text-lg font-bold text-gray-900">
+                        {p.name}
+                      </div>
+                      <div className="text-sm text-gray-500">
+                        {p.seats} 位教師席次
+                      </div>
+                      <div className="my-4 space-y-1 text-sm">
+                        <div>
+                          每席年費{" "}
+                          <span className="font-semibold">
+                            NT$ {p.annualFee.toLocaleString()}
+                          </span>
+                        </div>
+                        <div>
+                          月配點{" "}
+                          <span className="font-semibold">1,000 點 / 教師</span>
+                        </div>
+                        <div>
+                          加購折扣{" "}
+                          <span className="font-semibold">
+                            {Math.round((1 - p.discount) * 100)}% off
+                          </span>
+                        </div>
+                      </div>
+                      <div className="mt-auto pt-3 border-t border-gray-200">
+                        <div className="text-xs text-gray-500">團隊總價</div>
+                        <div className="text-xl font-bold text-blue-600">
+                          NT$ {(p.annualFee * p.seats).toLocaleString()} / 年
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <div className="text-center pt-2">
+                  <button
+                    type="button"
+                    onClick={() => navigate("/teacher/group-buy/open")}
+                    disabled={isStudent}
+                    className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-6 py-3 text-white font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    立即開設團購方案 →
+                  </button>
+                  <p className="text-xs text-gray-500 mt-2">
+                    {isStudent
+                      ? "請先登出學生帳號"
+                      : "需教師帳號登入；尚未登入會引導至教師登入頁。"}
+                  </p>
+                </div>
               </div>
             </div>
           )}

--- a/frontend/src/pages/admin/AdminPlansPage.tsx
+++ b/frontend/src/pages/admin/AdminPlansPage.tsx
@@ -264,7 +264,7 @@ export default function AdminPlansPage() {
       </CardContent>
 
       <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="sm:max-w-md max-h-[90vh] flex flex-col">
           <DialogHeader>
             <DialogTitle>編輯方案：{selectedPlan?.name}</DialogTitle>
             <DialogDescription>
@@ -274,168 +274,173 @@ export default function AdminPlansPage() {
             </DialogDescription>
           </DialogHeader>
 
-          {/* Group-buy context banner — read-only summary */}
-          {selectedPlan && isGroupBuyPlan(selectedPlan) && (
-            <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-xs space-y-1">
-              <div className="font-semibold text-blue-900">團購方案計算</div>
-              <div className="text-blue-800">
-                席次：
-                <span className="font-semibold">
-                  {selectedPlan.teacher_seats}
-                </span>{" "}
-                位教師
-              </div>
-              <div className="text-blue-800">
-                每席年費（編輯下方）× 席次 ={" "}
-                <span className="font-semibold">
-                  NT$
-                  {(
-                    Number(
-                      formData.annual_fee || selectedPlan.annual_fee || 0,
-                    ) * (selectedPlan.teacher_seats || 0)
-                  ).toLocaleString()}
-                </span>{" "}
-                / 年（團隊總價）
-              </div>
-              <div className="text-blue-800">
-                月配點 = 下方「每月配額」×
-                席次（系統每月為每位教師個別建立週期）
-              </div>
-            </div>
-          )}
-
-          <div className="space-y-4 py-2">
-            <div className="space-y-1.5">
-              <Label htmlFor="plan-price">
-                {selectedPlan && isGroupBuyPlan(selectedPlan)
-                  ? "訂閱月費（個人方案才使用，團購方案請留空）"
-                  : "訂閱月費（NT$/教師/月）"}
-              </Label>
-              <Input
-                id="plan-price"
-                type="number"
-                min={0}
-                value={formData.price}
-                disabled={selectedPlan ? isGroupBuyPlan(selectedPlan) : false}
-                onChange={(e) =>
-                  setFormData({ ...formData, price: e.target.value })
-                }
-                placeholder={
-                  selectedPlan && isGroupBuyPlan(selectedPlan)
-                    ? "不適用 — 團購用每席年費計價"
-                    : "例：299"
-                }
-              />
-              {formErrors.price && (
-                <p className="text-xs text-red-600">{formErrors.price}</p>
-              )}
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="plan-quota">
-                {selectedPlan && isGroupBuyPlan(selectedPlan)
-                  ? "每月配額（點數 / 每位教師）"
-                  : "每月配額（點數 / 教師）"}
-              </Label>
-              <Input
-                id="plan-quota"
-                type="number"
-                min={0}
-                value={formData.quota}
-                onChange={(e) =>
-                  setFormData({ ...formData, quota: e.target.value })
-                }
-              />
-              <p className="text-xs text-gray-500">
-                {selectedPlan && isGroupBuyPlan(selectedPlan)
-                  ? `每月 1 號 cron 會為團隊中每位教師建立一筆「${formData.quota || selectedPlan.quota || 0} 點」的週期。團隊總配點 = ${formData.quota || selectedPlan.quota || 0} × ${selectedPlan.teacher_seats || 0} = ${(Number(formData.quota || selectedPlan.quota || 0) * (selectedPlan.teacher_seats || 0)).toLocaleString()} 點 / 月`
-                  : "個人方案：每月為訂閱教師建立一筆此數量的週期"}
-              </p>
-              {formErrors.quota && (
-                <p className="text-xs text-red-600">{formErrors.quota}</p>
-              )}
-            </div>
-
-            {/* Group-buy-only economic levers */}
+          {/* Scrollable middle so DialogHeader + DialogFooter stay pinned
+              when the dialog hits viewport height on small screens. */}
+          <div className="flex-1 overflow-y-auto min-h-0 space-y-3">
+            {/* Group-buy context banner — read-only summary */}
             {selectedPlan && isGroupBuyPlan(selectedPlan) && (
-              <>
-                <div className="space-y-1.5">
-                  <Label htmlFor="plan-annual-fee">
-                    每席年費（NT$ / 教師 / 年）
-                  </Label>
-                  <Input
-                    id="plan-annual-fee"
-                    type="number"
-                    min={1}
-                    value={formData.annual_fee}
-                    onChange={(e) =>
-                      setFormData({ ...formData, annual_fee: e.target.value })
-                    }
-                  />
-                  <p className="text-xs text-gray-500">
-                    這是「每一席」的價格，不是團隊總價。團隊總價 = 此值 ×{" "}
-                    {selectedPlan.teacher_seats} 席。
-                  </p>
-                  {formErrors.annual_fee && (
-                    <p className="text-xs text-red-600">
-                      {formErrors.annual_fee}
-                    </p>
-                  )}
+              <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-xs space-y-1">
+                <div className="font-semibold text-blue-900">團購方案計算</div>
+                <div className="text-blue-800">
+                  席次：
+                  <span className="font-semibold">
+                    {selectedPlan.teacher_seats}
+                  </span>{" "}
+                  位教師
                 </div>
-
-                <div className="space-y-1.5">
-                  <Label htmlFor="plan-topup-discount">
-                    加購點數包折扣（0~1，例：0.90 = 9 折）
-                  </Label>
-                  <Input
-                    id="plan-topup-discount"
-                    type="number"
-                    step="0.01"
-                    min={0}
-                    max={1}
-                    value={formData.topup_discount}
-                    onChange={(e) =>
-                      setFormData({
-                        ...formData,
-                        topup_discount: e.target.value,
-                      })
-                    }
-                  />
-                  <p className="text-xs text-gray-500">
-                    團內教師加購點數時的價格倍率（例：0.85 = 85 折，0.90 = 9
-                    折，0.95 = 95 折）。
-                  </p>
-                  {formErrors.topup_discount && (
-                    <p className="text-xs text-red-600">
-                      {formErrors.topup_discount}
-                    </p>
-                  )}
+                <div className="text-blue-800">
+                  每席年費（編輯下方）× 席次 ={" "}
+                  <span className="font-semibold">
+                    NT$
+                    {(
+                      Number(
+                        formData.annual_fee || selectedPlan.annual_fee || 0,
+                      ) * (selectedPlan.teacher_seats || 0)
+                    ).toLocaleString()}
+                  </span>{" "}
+                  / 年（團隊總價）
                 </div>
-
-                <p className="text-xs text-gray-500 italic">
-                  席次（teacher_seats）在此處不可改 —
-                  變更席次會與既有團隊綁定衝突；如需新席次方案，請在 DB 直接新增
-                  plans row。
-                </p>
-              </>
+                <div className="text-blue-800">
+                  月配點 = 下方「每月配額」×
+                  席次（系統每月為每位教師個別建立週期）
+                </div>
+              </div>
             )}
 
-            <div className="flex items-center justify-between border-t pt-3">
-              <div>
-                <Label htmlFor="plan-active">啟用此方案</Label>
-                <p className="text-xs text-gray-500">
-                  停用後不影響既有訂閱，僅控制是否能新訂。
-                </p>
+            <div className="space-y-4 py-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="plan-price">
+                  {selectedPlan && isGroupBuyPlan(selectedPlan)
+                    ? "訂閱月費（個人方案才使用，團購方案請留空）"
+                    : "訂閱月費（NT$/教師/月）"}
+                </Label>
+                <Input
+                  id="plan-price"
+                  type="number"
+                  min={0}
+                  value={formData.price}
+                  disabled={selectedPlan ? isGroupBuyPlan(selectedPlan) : false}
+                  onChange={(e) =>
+                    setFormData({ ...formData, price: e.target.value })
+                  }
+                  placeholder={
+                    selectedPlan && isGroupBuyPlan(selectedPlan)
+                      ? "不適用 — 團購用每席年費計價"
+                      : "例：299"
+                  }
+                />
+                {formErrors.price && (
+                  <p className="text-xs text-red-600">{formErrors.price}</p>
+                )}
               </div>
-              <Switch
-                id="plan-active"
-                checked={formData.is_active}
-                onCheckedChange={(checked) =>
-                  setFormData({ ...formData, is_active: checked })
-                }
-              />
+
+              <div className="space-y-1.5">
+                <Label htmlFor="plan-quota">
+                  {selectedPlan && isGroupBuyPlan(selectedPlan)
+                    ? "每月配額（點數 / 每位教師）"
+                    : "每月配額（點數 / 教師）"}
+                </Label>
+                <Input
+                  id="plan-quota"
+                  type="number"
+                  min={0}
+                  value={formData.quota}
+                  onChange={(e) =>
+                    setFormData({ ...formData, quota: e.target.value })
+                  }
+                />
+                <p className="text-xs text-gray-500">
+                  {selectedPlan && isGroupBuyPlan(selectedPlan)
+                    ? `每月 1 號 cron 會為團隊中每位教師建立一筆「${formData.quota || selectedPlan.quota || 0} 點」的週期。團隊總配點 = ${formData.quota || selectedPlan.quota || 0} × ${selectedPlan.teacher_seats || 0} = ${(Number(formData.quota || selectedPlan.quota || 0) * (selectedPlan.teacher_seats || 0)).toLocaleString()} 點 / 月`
+                    : "個人方案：每月為訂閱教師建立一筆此數量的週期"}
+                </p>
+                {formErrors.quota && (
+                  <p className="text-xs text-red-600">{formErrors.quota}</p>
+                )}
+              </div>
+
+              {/* Group-buy-only economic levers */}
+              {selectedPlan && isGroupBuyPlan(selectedPlan) && (
+                <>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="plan-annual-fee">
+                      每席年費（NT$ / 教師 / 年）
+                    </Label>
+                    <Input
+                      id="plan-annual-fee"
+                      type="number"
+                      min={1}
+                      value={formData.annual_fee}
+                      onChange={(e) =>
+                        setFormData({ ...formData, annual_fee: e.target.value })
+                      }
+                    />
+                    <p className="text-xs text-gray-500">
+                      這是「每一席」的價格，不是團隊總價。團隊總價 = 此值 ×{" "}
+                      {selectedPlan.teacher_seats} 席。
+                    </p>
+                    {formErrors.annual_fee && (
+                      <p className="text-xs text-red-600">
+                        {formErrors.annual_fee}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <Label htmlFor="plan-topup-discount">
+                      加購點數包折扣（0~1，例：0.90 = 9 折）
+                    </Label>
+                    <Input
+                      id="plan-topup-discount"
+                      type="number"
+                      step="0.01"
+                      min={0}
+                      max={1}
+                      value={formData.topup_discount}
+                      onChange={(e) =>
+                        setFormData({
+                          ...formData,
+                          topup_discount: e.target.value,
+                        })
+                      }
+                    />
+                    <p className="text-xs text-gray-500">
+                      團內教師加購點數時的價格倍率（例：0.85 = 85 折，0.90 = 9
+                      折，0.95 = 95 折）。
+                    </p>
+                    {formErrors.topup_discount && (
+                      <p className="text-xs text-red-600">
+                        {formErrors.topup_discount}
+                      </p>
+                    )}
+                  </div>
+
+                  <p className="text-xs text-gray-500 italic">
+                    席次（teacher_seats）在此處不可改 —
+                    變更席次會與既有團隊綁定衝突；如需新席次方案，請在 DB
+                    直接新增 plans row。
+                  </p>
+                </>
+              )}
+
+              <div className="flex items-center justify-between border-t pt-3">
+                <div>
+                  <Label htmlFor="plan-active">啟用此方案</Label>
+                  <p className="text-xs text-gray-500">
+                    停用後不影響既有訂閱，僅控制是否能新訂。
+                  </p>
+                </div>
+                <Switch
+                  id="plan-active"
+                  checked={formData.is_active}
+                  onCheckedChange={(checked) =>
+                    setFormData({ ...formData, is_active: checked })
+                  }
+                />
+              </div>
             </div>
           </div>
+          {/* /flex-1 overflow-y-auto */}
 
           <DialogFooter>
             <Button

--- a/frontend/src/pages/admin/AdminPlansPage.tsx
+++ b/frontend/src/pages/admin/AdminPlansPage.tsx
@@ -292,15 +292,19 @@ export default function AdminPlansPage() {
                   每席年費（編輯下方）× 席次 ={" "}
                   <span className="font-semibold">
                     NT$
-                    {(
-                      Number(
-                        // `||` on string "0" falls through (0 is falsy);
-                        // use empty-string check so the typed value wins.
+                    {(() => {
+                      // Empty-string check (not `||`) so admin typing 0
+                      // is preserved; NaN fallback so mid-typing invalid
+                      // input (letters, "-") doesn't render "NT$NaN".
+                      const feeNum =
                         formData.annual_fee !== ""
-                          ? formData.annual_fee
-                          : (selectedPlan.annual_fee ?? 0),
-                      ) * (selectedPlan.teacher_seats ?? 0)
-                    ).toLocaleString()}
+                          ? Number(formData.annual_fee)
+                          : (selectedPlan.annual_fee ?? 0);
+                      const seats = selectedPlan.teacher_seats ?? 0;
+                      return (
+                        (Number.isFinite(feeNum) ? feeNum : 0) * seats
+                      ).toLocaleString();
+                    })()}
                   </span>{" "}
                   / 年（團隊總價）
                 </div>
@@ -357,15 +361,19 @@ export default function AdminPlansPage() {
                   {selectedPlan &&
                     isGroupBuyPlan(selectedPlan) &&
                     (() => {
-                      // `||` on string "0" would fall through; use
-                      // empty-string check so admin typing 0 reflects.
-                      const quotaStr =
+                      // Empty-string check (not `||`) so admin typing 0
+                      // is preserved; NaN fallback so mid-typing invalid
+                      // input doesn't render "NaN 點" in the help text.
+                      const quotaNum =
                         formData.quota !== ""
-                          ? formData.quota
-                          : String(selectedPlan.quota ?? 0);
+                          ? Number(formData.quota)
+                          : (selectedPlan.quota ?? 0);
+                      const safeQuota = Number.isFinite(quotaNum)
+                        ? quotaNum
+                        : 0;
                       const seats = selectedPlan.teacher_seats ?? 0;
-                      const total = Number(quotaStr) * seats;
-                      return `每月 1 號 cron 會為團隊中每位教師建立一筆「${quotaStr} 點」的週期。團隊總配點 = ${quotaStr} × ${seats} = ${total.toLocaleString()} 點 / 月`;
+                      const total = safeQuota * seats;
+                      return `每月 1 號 cron 會為團隊中每位教師建立一筆「${safeQuota} 點」的週期。團隊總配點 = ${safeQuota} × ${seats} = ${total.toLocaleString()} 點 / 月`;
                     })()}
                   {selectedPlan &&
                     !isGroupBuyPlan(selectedPlan) &&

--- a/frontend/src/pages/admin/AdminPlansPage.tsx
+++ b/frontend/src/pages/admin/AdminPlansPage.tsx
@@ -35,18 +35,33 @@ interface Plan {
   is_active: boolean;
   updated_at: string | null;
   updated_by_admin_id: number | null;
+  // issue #768: group-buy economic levers. teacher_seats not-null marks
+  // a group-buy plan; for those `price` is unused (group buys the team
+  // upfront via annual_fee × teacher_seats) and `quota` is per-teacher.
+  teacher_seats: number | null;
+  annual_fee: number | null; // PER teacher
+  topup_discount: number | null;
 }
+
+// Helper: a plan is group-buy iff teacher_seats is set. Detection by
+// column (not name pattern) matches backend `_guard_group_buy`.
+const isGroupBuyPlan = (p: Plan) => p.teacher_seats != null;
 
 interface FormState {
   price: string;
   quota: string;
   is_active: boolean;
+  // group-buy only — empty string when not editing a group-buy plan
+  annual_fee: string;
+  topup_discount: string;
 }
 
 const initialFormState: FormState = {
   price: "",
   quota: "",
   is_active: true,
+  annual_fee: "",
+  topup_discount: "",
 };
 
 export default function AdminPlansPage() {
@@ -84,6 +99,8 @@ export default function AdminPlansPage() {
       price: plan.price?.toString() ?? "",
       quota: plan.quota?.toString() ?? "",
       is_active: plan.is_active,
+      annual_fee: plan.annual_fee?.toString() ?? "",
+      topup_discount: plan.topup_discount?.toString() ?? "",
     });
     setFormErrors({});
     setIsEditDialogOpen(true);
@@ -104,6 +121,19 @@ export default function AdminPlansPage() {
         errors.quota = "配額必須是 0 或正整數";
       }
     }
+    // Group-buy fields
+    if (formData.annual_fee !== "") {
+      const n = Number(formData.annual_fee);
+      if (Number.isNaN(n) || n <= 0 || !Number.isInteger(n)) {
+        errors.annual_fee = "每席年費必須是正整數";
+      }
+    }
+    if (formData.topup_discount !== "") {
+      const n = Number(formData.topup_discount);
+      if (Number.isNaN(n) || n <= 0 || n > 1) {
+        errors.topup_discount = "加購折扣必須在 0~1 之間（例：0.90 = 9 折）";
+      }
+    }
 
     setFormErrors(errors);
     return Object.keys(errors).length === 0;
@@ -112,17 +142,30 @@ export default function AdminPlansPage() {
   const handleSave = async () => {
     if (!selectedPlan || !validateForm()) return;
 
+    const isGroupBuy = isGroupBuyPlan(selectedPlan);
     setIsSaving(true);
     try {
       const payload: {
         price?: number;
         quota?: number;
         is_active?: boolean;
+        annual_fee?: number;
+        topup_discount?: number;
       } = {};
       if (formData.price !== "") payload.price = Number(formData.price);
       if (formData.quota !== "") payload.quota = Number(formData.quota);
       if (formData.is_active !== selectedPlan.is_active) {
         payload.is_active = formData.is_active;
+      }
+      // Only send group-buy levers when editing a group-buy plan; backend
+      // would otherwise reject with 400.
+      if (isGroupBuy) {
+        if (formData.annual_fee !== "") {
+          payload.annual_fee = Number(formData.annual_fee);
+        }
+        if (formData.topup_discount !== "") {
+          payload.topup_discount = Number(formData.topup_discount);
+        }
       }
 
       if (Object.keys(payload).length === 0) {
@@ -225,20 +268,62 @@ export default function AdminPlansPage() {
           <DialogHeader>
             <DialogTitle>編輯方案：{selectedPlan?.name}</DialogTitle>
             <DialogDescription>
-              調整價格與配額。空白表示不變更該欄位。
+              {selectedPlan && isGroupBuyPlan(selectedPlan)
+                ? `團購方案（${selectedPlan.teacher_seats} 席）。團隊年費 = 每席年費 × 席次；月配點為「每位教師」的數量。空白表示不變更該欄位。`
+                : "個人訂閱方案。價格為月費、配額為每月點數。空白表示不變更該欄位。"}
             </DialogDescription>
           </DialogHeader>
 
+          {/* Group-buy context banner — read-only summary */}
+          {selectedPlan && isGroupBuyPlan(selectedPlan) && (
+            <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-xs space-y-1">
+              <div className="font-semibold text-blue-900">團購方案計算</div>
+              <div className="text-blue-800">
+                席次：
+                <span className="font-semibold">
+                  {selectedPlan.teacher_seats}
+                </span>{" "}
+                位教師
+              </div>
+              <div className="text-blue-800">
+                每席年費（編輯下方）× 席次 ={" "}
+                <span className="font-semibold">
+                  NT$
+                  {(
+                    Number(
+                      formData.annual_fee || selectedPlan.annual_fee || 0,
+                    ) * (selectedPlan.teacher_seats || 0)
+                  ).toLocaleString()}
+                </span>{" "}
+                / 年（團隊總價）
+              </div>
+              <div className="text-blue-800">
+                月配點 = 下方「每月配額」×
+                席次（系統每月為每位教師個別建立週期）
+              </div>
+            </div>
+          )}
+
           <div className="space-y-4 py-2">
             <div className="space-y-1.5">
-              <Label htmlFor="plan-price">價格（TWD/月）</Label>
+              <Label htmlFor="plan-price">
+                {selectedPlan && isGroupBuyPlan(selectedPlan)
+                  ? "訂閱月費（個人方案才使用，團購方案請留空）"
+                  : "訂閱月費（NT$/教師/月）"}
+              </Label>
               <Input
                 id="plan-price"
                 type="number"
                 min={0}
                 value={formData.price}
+                disabled={selectedPlan ? isGroupBuyPlan(selectedPlan) : false}
                 onChange={(e) =>
                   setFormData({ ...formData, price: e.target.value })
+                }
+                placeholder={
+                  selectedPlan && isGroupBuyPlan(selectedPlan)
+                    ? "不適用 — 團購用每席年費計價"
+                    : "例：299"
                 }
               />
               {formErrors.price && (
@@ -247,7 +332,11 @@ export default function AdminPlansPage() {
             </div>
 
             <div className="space-y-1.5">
-              <Label htmlFor="plan-quota">每月配額（點數）</Label>
+              <Label htmlFor="plan-quota">
+                {selectedPlan && isGroupBuyPlan(selectedPlan)
+                  ? "每月配額（點數 / 每位教師）"
+                  : "每月配額（點數 / 教師）"}
+              </Label>
               <Input
                 id="plan-quota"
                 type="number"
@@ -257,10 +346,79 @@ export default function AdminPlansPage() {
                   setFormData({ ...formData, quota: e.target.value })
                 }
               />
+              <p className="text-xs text-gray-500">
+                {selectedPlan && isGroupBuyPlan(selectedPlan)
+                  ? `每月 1 號 cron 會為團隊中每位教師建立一筆「${formData.quota || selectedPlan.quota || 0} 點」的週期。團隊總配點 = ${formData.quota || selectedPlan.quota || 0} × ${selectedPlan.teacher_seats || 0} = ${(Number(formData.quota || selectedPlan.quota || 0) * (selectedPlan.teacher_seats || 0)).toLocaleString()} 點 / 月`
+                  : "個人方案：每月為訂閱教師建立一筆此數量的週期"}
+              </p>
               {formErrors.quota && (
                 <p className="text-xs text-red-600">{formErrors.quota}</p>
               )}
             </div>
+
+            {/* Group-buy-only economic levers */}
+            {selectedPlan && isGroupBuyPlan(selectedPlan) && (
+              <>
+                <div className="space-y-1.5">
+                  <Label htmlFor="plan-annual-fee">
+                    每席年費（NT$ / 教師 / 年）
+                  </Label>
+                  <Input
+                    id="plan-annual-fee"
+                    type="number"
+                    min={1}
+                    value={formData.annual_fee}
+                    onChange={(e) =>
+                      setFormData({ ...formData, annual_fee: e.target.value })
+                    }
+                  />
+                  <p className="text-xs text-gray-500">
+                    這是「每一席」的價格，不是團隊總價。團隊總價 = 此值 ×{" "}
+                    {selectedPlan.teacher_seats} 席。
+                  </p>
+                  {formErrors.annual_fee && (
+                    <p className="text-xs text-red-600">
+                      {formErrors.annual_fee}
+                    </p>
+                  )}
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="plan-topup-discount">
+                    加購點數包折扣（0~1，例：0.90 = 9 折）
+                  </Label>
+                  <Input
+                    id="plan-topup-discount"
+                    type="number"
+                    step="0.01"
+                    min={0}
+                    max={1}
+                    value={formData.topup_discount}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        topup_discount: e.target.value,
+                      })
+                    }
+                  />
+                  <p className="text-xs text-gray-500">
+                    團內教師加購點數時的價格倍率（例：0.85 = 85 折，0.90 = 9
+                    折，0.95 = 95 折）。
+                  </p>
+                  {formErrors.topup_discount && (
+                    <p className="text-xs text-red-600">
+                      {formErrors.topup_discount}
+                    </p>
+                  )}
+                </div>
+
+                <p className="text-xs text-gray-500 italic">
+                  席次（teacher_seats）在此處不可改 —
+                  變更席次會與既有團隊綁定衝突；如需新席次方案，請在 DB 直接新增
+                  plans row。
+                </p>
+              </>
+            )}
 
             <div className="flex items-center justify-between border-t pt-3">
               <div>

--- a/frontend/src/pages/admin/AdminPlansPage.tsx
+++ b/frontend/src/pages/admin/AdminPlansPage.tsx
@@ -294,8 +294,12 @@ export default function AdminPlansPage() {
                     NT$
                     {(
                       Number(
-                        formData.annual_fee || selectedPlan.annual_fee || 0,
-                      ) * (selectedPlan.teacher_seats || 0)
+                        // `||` on string "0" falls through (0 is falsy);
+                        // use empty-string check so the typed value wins.
+                        formData.annual_fee !== ""
+                          ? formData.annual_fee
+                          : (selectedPlan.annual_fee ?? 0),
+                      ) * (selectedPlan.teacher_seats ?? 0)
                     ).toLocaleString()}
                   </span>{" "}
                   / 年（團隊總價）
@@ -311,7 +315,7 @@ export default function AdminPlansPage() {
               <div className="space-y-1.5">
                 <Label htmlFor="plan-price">
                   {selectedPlan && isGroupBuyPlan(selectedPlan)
-                    ? "訂閱月費（個人方案才使用，團購方案請留空）"
+                    ? "訂閱月費（不適用 — 團購方案以每席年費計價）"
                     : "訂閱月費（NT$/教師/月）"}
                 </Label>
                 <Input
@@ -350,9 +354,22 @@ export default function AdminPlansPage() {
                   }
                 />
                 <p className="text-xs text-gray-500">
-                  {selectedPlan && isGroupBuyPlan(selectedPlan)
-                    ? `每月 1 號 cron 會為團隊中每位教師建立一筆「${formData.quota || selectedPlan.quota || 0} 點」的週期。團隊總配點 = ${formData.quota || selectedPlan.quota || 0} × ${selectedPlan.teacher_seats || 0} = ${(Number(formData.quota || selectedPlan.quota || 0) * (selectedPlan.teacher_seats || 0)).toLocaleString()} 點 / 月`
-                    : "個人方案：每月為訂閱教師建立一筆此數量的週期"}
+                  {selectedPlan &&
+                    isGroupBuyPlan(selectedPlan) &&
+                    (() => {
+                      // `||` on string "0" would fall through; use
+                      // empty-string check so admin typing 0 reflects.
+                      const quotaStr =
+                        formData.quota !== ""
+                          ? formData.quota
+                          : String(selectedPlan.quota ?? 0);
+                      const seats = selectedPlan.teacher_seats ?? 0;
+                      const total = Number(quotaStr) * seats;
+                      return `每月 1 號 cron 會為團隊中每位教師建立一筆「${quotaStr} 點」的週期。團隊總配點 = ${quotaStr} × ${seats} = ${total.toLocaleString()} 點 / 月`;
+                    })()}
+                  {selectedPlan &&
+                    !isGroupBuyPlan(selectedPlan) &&
+                    "個人方案：每月為訂閱教師建立一筆此數量的週期"}
                 </p>
                 {formErrors.quota && (
                   <p className="text-xs text-red-600">{formErrors.quota}</p>

--- a/frontend/src/pages/teacher/TeacherSubscription.tsx
+++ b/frontend/src/pages/teacher/TeacherSubscription.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { PLAN_NAMES } from "@/constants/plans";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -209,6 +210,7 @@ const PLAN_RANK: Record<string, number> = { free: 0, tutor: 1, school: 2 };
 
 export default function TeacherSubscription() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const [subscription, setSubscription] = useState<SubscriptionInfo | null>(
     null,
@@ -540,6 +542,32 @@ export default function TeacherSubscription() {
 
           {/* Tab 3: Subscription Management */}
           <TabsContent value="management" className="space-y-6">
+            {/* Phase 5-2 follow-up (#768): group-buy upsell CTA for
+                existing individual subscribers. Logged-in teacher landing
+                here is the natural funnel for "upgrade to team". */}
+            <Card className="mb-6 border-blue-200 bg-gradient-to-br from-blue-50 to-white">
+              <CardContent className="py-5">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                  <div className="flex-1">
+                    <div className="font-semibold text-gray-900">
+                      👥 想為團隊一起採購？
+                    </div>
+                    <div className="text-sm text-gray-600 mt-1">
+                      開設 10 / 30 / 50 席教師團購方案，享更低每席費用 +
+                      加購點數包折扣。團主刷卡一次即可開團。
+                    </div>
+                  </div>
+                  <Button
+                    variant="outline"
+                    className="border-blue-300 text-blue-700 hover:bg-blue-100 shrink-0"
+                    onClick={() => navigate("/teacher/group-buy/open")}
+                  >
+                    了解團購方案 →
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+
             <Card className="mb-6">
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">

--- a/frontend/src/pages/teacher/TeacherSubscription.tsx
+++ b/frontend/src/pages/teacher/TeacherSubscription.tsx
@@ -543,30 +543,35 @@ export default function TeacherSubscription() {
           {/* Tab 3: Subscription Management */}
           <TabsContent value="management" className="space-y-6">
             {/* Phase 5-2 follow-up (#768): group-buy upsell CTA for
-                existing individual subscribers. Logged-in teacher landing
-                here is the natural funnel for "upgrade to team". */}
-            <Card className="mb-6 border-blue-200 bg-gradient-to-br from-blue-50 to-white">
-              <CardContent className="py-5">
-                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                  <div className="flex-1">
-                    <div className="font-semibold text-gray-900">
-                      👥 想為團隊一起採購？
+                existing individual subscribers. Hide for teachers already
+                on a group-buy plan — clicking through would hit R2-F2
+                single-org guard and 409.
+                TODO: replace prefix check with a backend-supplied flag
+                when SubscriptionInfo exposes teacher_seats or org_type. */}
+            {!subscription?.plan?.startsWith("團購") && (
+              <Card className="mb-6 border-blue-200 bg-gradient-to-br from-blue-50 to-white">
+                <CardContent className="py-5">
+                  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                    <div className="flex-1">
+                      <div className="font-semibold text-gray-900">
+                        👥 想為團隊一起採購？
+                      </div>
+                      <div className="text-sm text-gray-600 mt-1">
+                        開設 10 / 30 / 50 席教師團購方案，享更低每席費用 +
+                        加購點數包折扣。團主刷卡一次即可開團。
+                      </div>
                     </div>
-                    <div className="text-sm text-gray-600 mt-1">
-                      開設 10 / 30 / 50 席教師團購方案，享更低每席費用 +
-                      加購點數包折扣。團主刷卡一次即可開團。
-                    </div>
+                    <Button
+                      variant="outline"
+                      className="border-blue-300 text-blue-700 hover:bg-blue-100 shrink-0"
+                      onClick={() => navigate("/teacher/group-buy/open")}
+                    >
+                      了解團購方案 →
+                    </Button>
                   </div>
-                  <Button
-                    variant="outline"
-                    className="border-blue-300 text-blue-700 hover:bg-blue-100 shrink-0"
-                    onClick={() => navigate("/teacher/group-buy/open")}
-                  >
-                    了解團購方案 →
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
+            )}
 
             <Card className="mb-6">
               <CardHeader>


### PR DESCRIPTION
## Summary
Two related #768 follow-ups bundled per user request (option 3 — fold both into this PR):

### 1. Admin plans edit dialog — clarify per-seat vs total + expose group-buy levers
Staging feedback: the `/admin/plans` edit dialog showed `price`/`quota` for the 3 seeded group-buy plans (團購-10/30/50席) without indicating whether the values were per-seat or team-total, and `teacher_seats` / `annual_fee` / `topup_discount` were not exposed at all.

### 2. Group-buy discovery entry points
`/teacher/group-buy/open` was previously reachable only by typing the URL. Adds two natural discovery surfaces.

---

## Changes

### Backend (`backend/routers/admin_plans.py`)
- `PlanResponse` now exposes `teacher_seats`, `annual_fee`, `topup_discount`
- `PlanUpdateRequest` accepts `annual_fee` (gt=0) and `topup_discount` (0 < x ≤ 1)
- `teacher_seats` is intentionally read-only — changing seat count after a team is open would orphan existing `TeacherSchool` bindings
- Guard: setting `annual_fee` / `topup_discount` on a non-group-buy plan returns 400 with a clear message

### Frontend — Admin dialog (`AdminPlansPage.tsx`)
**Group-buy plan dialog now shows:**
- 🟦 Blue context banner: "團購方案計算" with 席次, live-computed team total (`annual_fee × seats`), and the formula
- "訂閱月費" disabled with placeholder *"不適用 — 團購用每席年費計價"*
- "每月配額" label changed to "**每月配額（點數 / 每位教師）**" + help line showing total monthly grant = quota × teacher_seats
- **NEW: 每席年費 input** with explicit help text: *"這是「每一席」的價格，不是團隊總價。團隊總價 = 此值 × N 席"*
- **NEW: 加購點數包折扣 input** with 0~1 explanation and examples
- Footnote: 席次 is non-editable (orphan risk explained)

### Frontend — Discovery entry points

**A. `PricingPage.tsx` — public surface**
Under the "subscription" tab, after the existing Tutor/School cards, a new section:
- "👥 教師團購方案" header + tagline
- 3 cards matching DB seed (10/30/50 seats × 1500/1300/1000 NT$/seat × 95%/90%/85% topup discount)
- Each card shows live-computed team total
- Single CTA "立即開設團購方案 →" (disabled for student accounts; non-authenticated visitors get redirected to teacher login by the existing ProtectedRoute pattern)

> ⚠️ Plan values are **hardcoded to match the seed**. If admin tunes prices via the new dialog, PricingPage cards drift. Future refactor: public group-buy plans endpoint.

**B. `TeacherSubscription.tsx` — upgrade-from-individual surface**
Above the "current status" card in the Management tab — a blue banner "👥 想為團隊一起採購？" with "了解團購方案 →" button. Existing individual subscribers are the natural funnel for the upgrade-to-team flow.

---

## ✅ Staging E2E Testing Checklist (#768 全 phase 驗收)

> 測試環境 staging URL：https://duotopia-staging-frontend-316409492201.asia-east1.run.app

### A. Admin 方案管理（this PR）
- [ ] `/admin/plans` 編輯「團購-30席」→ dialog 顯示藍色 banner + 各欄位清楚標明 per-teacher
- [ ] 訂閱月費對團購是 disabled（顯示「不適用」）
- [ ] 改「每席年費」為 1500 → banner 即時更新成 1500×30=45000
- [ ] 改「加購折扣」為 0.85 → 存檔成功
- [ ] 編輯 Tutor Teachers（個人方案）→ dialog 無藍色 banner、無每席年費欄位
- [ ] 試圖透過 curl POST annual_fee 到 Tutor → 預期回 400

### B. 機構單位學生費 + 月度計費（Phase 1+4）
- [ ] `/admin/organizations` 新增 / 編輯一個 institution org → 設 `per_student_price`
- [ ] 該列出現「月結」按鈕 → 進入 `/admin/organizations/:id/billing`
- [ ] 選 year/month → 看到 breakdown：學生 ID / 姓名 / 本月計費 + 總額
- [ ] 同月份多次查詢 → 結果一致

### C. 學生啟用/停用（Phase 5-2）
- [ ] `/teacher/classrooms/:id` 學生列表有 Power 圖示
- [ ] 點停用 → 確認對話框 → 學生狀態切換、history row 新增
- [ ] 再點 → 切回啟用 + 第二筆 history row
- [ ] 重查 B 月結 → 該學生本月仍計費（曾 active），下個月才不計費
- [ ] DELETE `/api/teachers/students/{id}` → 再 POST `/status` `active` → 預期 404

### D. 團購開團（this PR + Phase 3+5-2）
- [ ] **Discovery (this PR)**：`/pricing` → 看到「教師團購方案」3 張卡 + CTA → 點按鈕進開團頁
- [ ] **Discovery (this PR)**：`/teacher/subscription` → Management tab 上方藍色 banner → 點「了解團購方案 →」進開團頁
- [ ] `/teacher/group-buy/open` 有 TeacherLayout sidebar + 3 個方案卡
- [ ] 點選方案 → 進入刷卡頁
- [ ] 使用 TapPay test 卡刷卡成功 → toast 成功 + 跳轉 dashboard
- [ ] DB 驗證：建立 Organization(group_buy) + School(plan_id) + TeacherSchool(school_admin) + TeacherOrganization(org_owner) + SubscriptionPeriod(quota=1000)
- [ ] 60 秒內再點 → 回傳原 transaction_id（idempotency）
- [ ] 隔天再開 → 預期 409「您已開設一個團購方案」

### E. 團購加購折扣（Phase 2）
- [ ] D 步驟開團成功後，同 teacher 買 1000 點點數包（原價 NT$180）→ 實際扣 180×topup_discount
  - 10 席方案：NT$171（×0.95）
  - 30 席方案：NT$162（×0.90）
  - 50 席方案：NT$153（×0.85）
- [ ] 不在團購團的 teacher 買同一包 → 扣完整 180

### F. 月配點 cron（Phase 3）
- [ ] 等 6/1 凌晨 cron 跑 或 admin 觸發 `POST /api/cron/monthly-renewal?force=true` 帶 cron secret
- [ ] DB 驗證：團購團裡每位 teacher 多了 6 月份 SubscriptionPeriod（quota=1000, payment_method='group_buy', end_date=2026-06-30）
- [ ] 重複觸發 `?force=true` → 預期 `grants_skipped_duplicate += N`、`grants_created = 0`

### G. group-buy plans 公開列表
- [ ] GET `/api/credit-packages/group-buy-plans`（authenticated teacher）→ 回 3 筆，依 display_order/teacher_seats 排序
- [ ] 把某方案透過本 PR 的 admin dialog 設 `is_active=false` → 列表少掉那筆

---

## Verified locally
- Black clean
- 13/13 `test_admin_plans.py` pass
- `tsc --noEmit` clean
- Prettier clean

## Related
- 母 issue: #768
- 後續：#838（機構月度請款工具：CSV / PDF / Email / 應收帳款管理）— 補齊請款流程

**Related to #768** — issue stays open for ongoing staging feedback (will not auto-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)