### PR TITLE
fix: align Azure Speech token cache lifetimes to prevent 401 race (#136)

### DIFF
--- a/backend/services/azure_speech_token.py
+++ b/backend/services/azure_speech_token.py
@@ -43,20 +43,22 @@ class AzureSpeechTokenService:
         實施策略：
         - Server-side cache（8分鐘內重用同一 token）
         - 提前2分鐘過期，避免前端使用到期 token
+        - Issue #136: cache 命中時回傳「實際剩餘秒數」而非固定 600，
+          避免前端依固定值 over-cache 一個即將到期的 token 而產生 401
         """
         # Check cache (8分鐘內重用，提前2分鐘過期)
         if self._cached_token and self._token_expires_at:
             if datetime.now() < self._token_expires_at - timedelta(minutes=2):
-                expires_in_seconds = (
+                remaining_seconds = (
                     self._token_expires_at - datetime.now()
                 ).total_seconds()
-                logger.info(
-                    f"Returning cached token (expires in {expires_in_seconds:.0f}s)"
-                )
+                # 回傳真實剩餘壽命（clamp 非負），讓前端據此計算 cache 窗口
+                expires_in = max(0, int(remaining_seconds))
+                logger.info(f"Returning cached token (expires in {expires_in}s)")
                 return {
                     "token": self._cached_token,
                     "region": self.region,
-                    "expires_in": 600,
+                    "expires_in": expires_in,
                 }
 
         # Call Azure issueToken endpoint

--- a/backend/tests/unit/test_azure_speech_token_api.py
+++ b/backend/tests/unit/test_azure_speech_token_api.py
@@ -162,6 +162,64 @@ class TestAzureSpeechTokenService:
 
     @pytest.mark.asyncio
     @patch("services.azure_speech_token.get_http_client")
+    async def test_fresh_token_reports_full_expires_in(self, mock_get_client):
+        """Issue #136: 全新发放的 token 仍回传 expires_in == 600"""
+        from services.azure_speech_token import AzureSpeechTokenService
+
+        mock_response = AsyncMock()
+        mock_response.text = "fresh-token"
+        mock_response.raise_for_status = AsyncMock()
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        with patch.dict("os.environ", {"AZURE_SPEECH_KEY": "test-key"}):
+            service = AzureSpeechTokenService()
+            result = await service.get_token()
+
+            assert result["expires_in"] == 600
+
+    @pytest.mark.asyncio
+    @patch("services.azure_speech_token.get_http_client")
+    async def test_cached_token_reports_real_remaining_life(self, mock_get_client):
+        """Issue #136: cache 命中时回传「实际剩余秒数」而非固定 600
+
+        避免前端依固定值 over-cache 一个即将到期的 token 而产生 401。
+        """
+        from services.azure_speech_token import AzureSpeechTokenService
+
+        mock_response = AsyncMock()
+        mock_response.text = "cached-token"
+        mock_response.raise_for_status = AsyncMock()
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        with patch.dict("os.environ", {"AZURE_SPEECH_KEY": "test-key"}):
+            service = AzureSpeechTokenService()
+
+            # 第一次发放 → expires_in == 600
+            first = await service.get_token()
+            assert first["expires_in"] == 600
+
+            # 模拟时间已过去约 7.5 分钟（仍在 8 分钟 cache 窗口内，
+            # 真实剩余约 2.5 分钟），手动把到期时间往前挪
+            service._token_expires_at = datetime.now() + timedelta(seconds=150)
+
+            cached = await service.get_token()
+
+            # 仍是同一个 cached token，且未再呼叫 Azure
+            assert cached["token"] == "cached-token"
+            assert mock_client.post.call_count == 1
+
+            # 关键断言：回传的 expires_in 反映真实剩余寿命，远小于 600
+            assert cached["expires_in"] < 600
+            assert 140 <= cached["expires_in"] <= 150
+
+    @pytest.mark.asyncio
+    @patch("services.azure_speech_token.get_http_client")
     async def test_token_refresh_after_expiration(self, mock_get_client):
         """Test 9: Token 过期后重新获取"""
         from services.azure_speech_token import AzureSpeechTokenService

--- a/frontend/src/services/__tests__/azureSpeechService.test.ts
+++ b/frontend/src/services/__tests__/azureSpeechService.test.ts
@@ -141,6 +141,51 @@ describe("AzureSpeechService", () => {
       expect(axios.post).toHaveBeenCalledTimes(2);
     });
 
+    it("should cache with a 120s safety buffer (Issue #136)", async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce({
+        data: { token: "buffer-token", region: "eastasia", expires_in: 600 },
+      });
+
+      const before = Date.now();
+      await service["getToken"]();
+      const after = Date.now();
+
+      const cache = service["tokenCache"];
+      expect(cache).not.toBeNull();
+      const expiresAt = cache!.expiresAt.getTime();
+
+      // expiresAt 应为 now + (600 - 120) = now + 480s（含调用耗时的容差窗口）
+      expect(expiresAt).toBeGreaterThanOrEqual(before + 480 * 1000);
+      expect(expiresAt).toBeLessThanOrEqual(after + 480 * 1000);
+    });
+
+    it("should clamp to a non-negative buffer for small expires_in (Issue #136)", async () => {
+      // 后端 cache 命中时可能回传很小的剩余秒数（如 100s）
+      vi.mocked(axios.post)
+        .mockResolvedValueOnce({
+          data: { token: "small-token", region: "eastasia", expires_in: 100 },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            token: "refetched-token",
+            region: "eastasia",
+            expires_in: 600,
+          },
+        });
+
+      const before = Date.now();
+      await service["getToken"]();
+
+      const cache = service["tokenCache"];
+      // Math.max(0, 100 - 120) = 0 → expiresAt 落在「现在」，绝不落在过去
+      expect(cache!.expiresAt.getTime()).toBeGreaterThanOrEqual(before);
+
+      // 由于已立即过期，下一次调用应重新向 API 取 token，而非用 cache
+      const result = await service["getToken"]();
+      expect(result.token).toBe("refetched-token");
+      expect(axios.post).toHaveBeenCalledTimes(2);
+    });
+
     it("should handle token fetch error gracefully", async () => {
       vi.mocked(axios.post).mockRejectedValueOnce(new Error("Network error"));
 
@@ -200,7 +245,7 @@ describe("AzureSpeechService", () => {
       await service.uploadAnalysisInBackground(mockBlob, {}, 1000);
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "Background upload failed:",
+        "First upload attempt failed:",
         expect.any(Error),
       );
 

--- a/frontend/src/services/azureSpeechService.ts
+++ b/frontend/src/services/azureSpeechService.ts
@@ -35,11 +35,11 @@ export class AzureSpeechService {
   private readonly MAX_RETRIES = 2;
 
   /**
-   * 获取 Azure Speech Token（带缓存，提前1分钟过期）
+   * 获取 Azure Speech Token（带缓存，提前2分钟过期）
    * @private
    */
   private async getToken(): Promise<{ token: string; region: string }> {
-    // 检查 cache 是否有效（提前1分钟过期）
+    // 检查 cache 是否有效（提前2分钟过期）
     if (this.tokenCache && new Date() < this.tokenCache.expiresAt) {
       return {
         token: this.tokenCache.token,
@@ -70,11 +70,13 @@ export class AzureSpeechService {
       );
       const { token, region, expires_in } = response.data;
 
-      // Cache token（提前1分钟过期 = 9分钟有效）
+      // 🎯 Issue #136: 提前 120 秒过期，预留时钟误差/网络延迟的安全缓冲。
+      // 后端在 cache 命中时会回传「实际剩余秒数」，故以 Math.max(0, ...) clamp，
+      // 避免 expires_in 偏小时算出一个已过期（落在过去）的 expiresAt。
       this.tokenCache = {
         token,
         region,
-        expiresAt: new Date(Date.now() + (expires_in - 60) * 1000),
+        expiresAt: new Date(Date.now() + Math.max(0, expires_in - 120) * 1000),
       };
 
       return { token, region };


### PR DESCRIPTION
Fixes #136

## 問題（Root Cause）
Azure Speech token 真實有效期 10 分鐘。後端 `azure_speech_token.py` 不論新發或 cache 命中，**都固定回傳 `expires_in: 600`**。因此在接近 8 分鐘 cache 上限時交付的 token（真實只剩約 2 分鐘壽命）被告知還有 10 分鐘；前端再以 `expires_in - 60`（9 分鐘）cache，導致從 T=10:00 起持續使用已死 token → **連續數分鐘 401**。

Issue 原建議的「只改前端 `expires_in - 180`」無法根除 race —— 後端謊報剩餘壽命時，前端任何固定緩衝都可能超用。

## 修改
**後端根因修復** — `backend/services/azure_speech_token.py`
- cache 命中時回傳**真實剩餘秒數** `max(0, int(remaining))`，取代固定 `600`；全新發放仍回 `600`。

**前端防禦縱深** — `frontend/src/services/azureSpeechService.ts`
- 安全緩衝 `60s → 120s`，並以 `Math.max(0, expires_in - 120)` clamp，避免 `expires_in` 偏小時算出落在過去的 `expiresAt`。

## 測試
- 後端：全新 token 回 `600`；cache 命中回 `< 600` 且反映真實剩餘壽命（`TestAzureSpeechTokenService` 8/8 通過）。
- 前端：cache 採 120s 緩衝；小 `expires_in` 安全 clamp（`azureSpeechService.test.ts` 9/9 通過）。
- 順手修正一個與本 issue 無關、已存在於 `staging` 的失敗測試（Background Upload log 字串對齊 `"First upload attempt failed:"`）。

驗證：Black ✅ · Flake8 ✅ · tsc ✅ · Prettier ✅

https://claude.ai/code/session_01APH2mGWKf5WhBkFmqVNqvS

---
_Generated by [Claude Code](https://claude.ai/code/session_01APH2mGWKf5WhBkFmqVNqvS)_