### PR TITLE
feat(#768): admin subscription group-buy support + org modal display fields

### DIFF
--- a/backend/alembic/versions/20260608_1000_backfill_group_buy_org_display.py
+++ b/backend/alembic/versions/20260608_1000_backfill_group_buy_org_display.py
@@ -1,0 +1,95 @@
+"""Backfill display_name + teacher_limit on existing group-buy Organizations.
+
+Revision ID: 20260608_1000
+Revises: 20260603_1000
+Create Date: 2026-06-08 10:00:00
+
+Issue #768 comment #2: group-buy orgs created via
+`POST /api/credit-packages/group-buy-open` before this fix had NULL
+`display_name` and NULL `teacher_limit`, so the admin "編輯組織" modal
+showed both fields as blank.
+
+This migration backfills the two fields from each group-buy org's
+linked School → Plan (teacher_seats) so existing rows on staging /
+develop / prod are correct. The create flow is also fixed in the same
+PR (services/group_buy.py).
+
+Idempotent:
+  - WHERE clauses skip rows where the values are already correct
+  - Uses ON CONFLICT-free UPDATE with explicit WHERE-not-set guards
+  - Safe to re-run; second run touches zero rows
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "20260608_1000"
+down_revision: Union[str, None] = "20260603_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Backfill display_name on group-buy orgs that don't have one yet.
+    # Source: the org's School's Plan.teacher_seats.
+    # If a group-buy org has multiple schools (not the current design but
+    # possible in the future), this uses the school created earliest.
+    op.execute(
+        """
+        UPDATE organizations
+        SET display_name = (
+            SELECT organizations.name || '-' || p.teacher_seats || '位'
+            FROM schools s
+            JOIN plans p ON p.id = s.plan_id
+            WHERE s.organization_id = organizations.id
+              AND s.is_active = TRUE
+              AND p.teacher_seats IS NOT NULL
+            ORDER BY s.created_at ASC
+            LIMIT 1
+        )
+        WHERE organizations.org_type = 'group_buy'
+          AND organizations.display_name IS NULL
+          AND EXISTS (
+              SELECT 1 FROM schools s
+              JOIN plans p ON p.id = s.plan_id
+              WHERE s.organization_id = organizations.id
+                AND s.is_active = TRUE
+                AND p.teacher_seats IS NOT NULL
+          );
+        """
+    )
+
+    # Backfill teacher_limit on group-buy orgs that don't have one yet.
+    op.execute(
+        """
+        UPDATE organizations
+        SET teacher_limit = (
+            SELECT p.teacher_seats
+            FROM schools s
+            JOIN plans p ON p.id = s.plan_id
+            WHERE s.organization_id = organizations.id
+              AND s.is_active = TRUE
+              AND p.teacher_seats IS NOT NULL
+            ORDER BY s.created_at ASC
+            LIMIT 1
+        )
+        WHERE organizations.org_type = 'group_buy'
+          AND organizations.teacher_limit IS NULL
+          AND EXISTS (
+              SELECT 1 FROM schools s
+              JOIN plans p ON p.id = s.plan_id
+              WHERE s.organization_id = organizations.id
+                AND s.is_active = TRUE
+                AND p.teacher_seats IS NOT NULL
+          );
+        """
+    )
+
+
+def downgrade() -> None:
+    # Intentional no-op: dropping the backfilled values would re-introduce
+    # the admin-modal blank-field bug. The create flow itself populates
+    # them going forward.
+    pass

--- a/backend/alembic/versions/20260608_1000_backfill_group_buy_org_display.py
+++ b/backend/alembic/versions/20260608_1000_backfill_group_buy_org_display.py
@@ -40,7 +40,10 @@ def upgrade() -> None:
         """
         UPDATE organizations
         SET display_name = (
-            SELECT organizations.name || '-' || p.teacher_seats || '位'
+            -- Explicit ::text cast required — PostgreSQL's `||` does not
+            -- implicitly cast integer → text and would error with
+            -- "operator does not exist: text || integer".
+            SELECT organizations.name || '-' || p.teacher_seats::text || '位'
             FROM schools s
             JOIN plans p ON p.id = s.plan_id
             WHERE s.organization_id = organizations.id

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -25,9 +25,16 @@ from models import (
     Assignment,
     PointUsageLog,
     ClassroomStudent,
+    # Issue #768 follow-up — group-buy admin-join branch needs these:
+    Plan,
+    Organization,
+    School,
+    TeacherOrganization,
+    TeacherSchool,
 )
 from models.credit_package import CreditPackage
 from routers.admin import get_current_admin
+from services.group_buy import create_group_buy_period
 
 router = APIRouter(prefix="/api/admin/subscription", tags=["admin-subscription"])
 
@@ -164,14 +171,6 @@ async def _create_group_buy_admin_subscription(
         team this month (otherwise the cron would attempt a second 1000-
         pt grant — confusing for billing)
     """
-    from models import (
-        Organization,
-        School,
-        TeacherOrganization,
-        TeacherSchool,
-    )
-    from services.group_buy import create_group_buy_period
-
     if not request.group_owner_email:
         raise HTTPException(
             status_code=400,
@@ -353,8 +352,6 @@ async def create_subscription(
     # admin is manually adding `teacher` to an existing team led by
     # `group_owner_email`. This skips TapPay (the /group-buy-open flow);
     # admin scenarios are comp / customer-support / migration cases.
-    from models import Plan
-
     plan_row = db.query(Plan).filter(Plan.name == request.plan_name).first()
     if plan_row is None:
         raise HTTPException(status_code=400, detail="Unknown plan_name")

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -207,12 +207,9 @@ async def _create_group_buy_admin_subscription(
     if school is None:
         raise HTTPException(
             status_code=400,
-            detail=(
-                f"Owner {owner.email!r} does not lead an active " f"{plan.name!r} team."
-            ),
+            detail=f"Owner {owner.email!r} does not lead an active {plan.name!r} team.",
         )
 
-    # Seat check
     seat_taken = (
         db.query(func.count(TeacherSchool.id))
         .filter(
@@ -242,7 +239,6 @@ async def _create_group_buy_admin_subscription(
             ),
         )
 
-    # Duplicate binding check
     dup = (
         db.query(TeacherSchool)
         .filter(
@@ -294,19 +290,21 @@ async def _create_group_buy_admin_subscription(
     )
     db.add(ts)
     period = create_group_buy_period(teacher, plan, db, start=now)
-    # Audit fields on the period
     period.admin_id = admin.id
     period.admin_reason = request.reason
+    # All `*_id` fields stringified for uniform JSON shape — school.id is
+    # a UUID that must be cast anyway, and mixing int + str in the same
+    # audit record makes downstream parsers awkward.
     period.admin_metadata = {
         "operations": [
             {
                 "action": "admin_join_group_buy",
                 "timestamp": now.isoformat(),
-                "admin_id": admin.id,
+                "admin_id": str(admin.id),
                 "admin_email": admin.email,
                 "admin_name": admin.name,
                 "reason": request.reason,
-                "group_owner_id": owner.id,
+                "group_owner_id": str(owner.id),
                 "group_owner_email": owner.email,
                 "school_id": str(school.id),
                 "plan_name": plan.name,
@@ -386,8 +384,16 @@ async def create_subscription(
             status_code=400, detail="end_date is required for non-group-buy plans"
         )
 
-    # 計算 quota (VIP 方案可自訂)
-    quota_total = get_plan_quota(request.plan_name, db=db)
+    # 計算 quota (VIP 方案可自訂). Reuses the `plan_row` already fetched
+    # at the top of the handler — avoid a second `get_plan_quota` query.
+    # Fallback to PLAN_QUOTAS matches config.plans.get_plan_quota's logic.
+    from config.plans import PLAN_QUOTAS
+
+    quota_total = (
+        plan_row.quota
+        if plan_row.quota is not None
+        else PLAN_QUOTAS.get(request.plan_name, 0)
+    )
 
     # VIP 方案：使用自訂 quota
     if request.plan_name == "VIP":

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -37,12 +37,18 @@ class CreateSubscriptionRequest(BaseModel):
     """創建訂閱請求"""
 
     teacher_email: EmailStr
-    # "Free Trial" | "Tutor Teachers" | "School Teachers" |
-    # "Demo Unlimited Plan" | "VIP"
+    # Individual: "Free Trial" | "Tutor Teachers" | "School Teachers" |
+    # "Demo Unlimited Plan" | "VIP".
+    # Group-buy (issue #768 follow-up): "團購-10席" | "團購-30席" | "團購-50席"
+    # — admin manually joins an existing team led by `group_owner_email`.
     plan_name: str
-    end_date: str  # YYYY-MM-DD (月底日期)
+    end_date: Optional[str] = None  # YYYY-MM-DD; ignored for group-buy
     quota_total: Optional[int] = None  # VIP 方案可自訂 quota
     reason: str
+    # For group-buy plans only: email of the team owner whose team the
+    # target teacher should be added to. Required when plan_name is a
+    # group-buy plan, ignored otherwise.
+    group_owner_email: Optional[EmailStr] = None
 
 
 class EditSubscriptionRequest(BaseModel):
@@ -134,6 +140,176 @@ def parse_end_date(date_str: str) -> datetime:
     )
 
 
+# ============ Helpers ============
+
+
+async def _create_group_buy_admin_subscription(
+    teacher: Teacher,
+    plan,  # Plan (group-buy)
+    request: "CreateSubscriptionRequest",
+    admin: Teacher,
+    db: Session,
+    now: datetime,
+) -> "SubscriptionResponse":
+    """Admin manually joins `teacher` to the existing group-buy team led
+    by `request.group_owner_email`. Issue #768 comment #1.
+
+    Validations:
+      - group_owner_email is required
+      - team owner exists with active org_owner role on a group-buy org
+      - owner's school must use the SAME plan as requested
+      - seat capacity not exceeded
+      - target teacher not already in this team
+      - target teacher has no active group-buy SubscriptionPeriod for any
+        team this month (otherwise the cron would attempt a second 1000-
+        pt grant — confusing for billing)
+    """
+    from models import (
+        Organization,
+        School,
+        TeacherOrganization,
+        TeacherSchool,
+    )
+    from services.group_buy import create_group_buy_period
+
+    if not request.group_owner_email:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "group_owner_email is required when plan_name is a " "group-buy plan."
+            ),
+        )
+
+    owner = db.query(Teacher).filter_by(email=request.group_owner_email).first()
+    if owner is None:
+        raise HTTPException(
+            status_code=404, detail="Group owner (team leader) not found"
+        )
+
+    # Find the owner's active group-buy school matching this plan
+    school = (
+        db.query(School)
+        .join(
+            TeacherOrganization,
+            TeacherOrganization.organization_id == School.organization_id,
+        )
+        .join(Organization, Organization.id == School.organization_id)
+        .filter(
+            TeacherOrganization.teacher_id == owner.id,
+            TeacherOrganization.role == "org_owner",
+            TeacherOrganization.is_active.is_(True),
+            Organization.org_type == "group_buy",
+            Organization.is_active.is_(True),
+            School.plan_id == plan.id,
+            School.is_active.is_(True),
+        )
+        .first()
+    )
+    if school is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Owner {owner.email!r} does not lead an active " f"{plan.name!r} team."
+            ),
+        )
+
+    # Seat check
+    seat_taken = (
+        db.query(func.count(TeacherSchool.id))
+        .filter(
+            TeacherSchool.school_id == school.id,
+            TeacherSchool.is_active.is_(True),
+        )
+        .scalar()
+        or 0
+    )
+    if school.teacher_seat_limit and seat_taken >= school.teacher_seat_limit:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Team is full ({seat_taken}/{school.teacher_seat_limit} "
+                "seats taken)."
+            ),
+        )
+
+    # Duplicate binding check
+    dup = (
+        db.query(TeacherSchool)
+        .filter(
+            TeacherSchool.teacher_id == teacher.id,
+            TeacherSchool.school_id == school.id,
+            TeacherSchool.is_active.is_(True),
+        )
+        .first()
+    )
+    if dup is not None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Teacher {teacher.email!r} is already in this team.",
+        )
+
+    # Existing active group-buy period this month → don't double-grant
+    month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    existing_gb = (
+        db.query(SubscriptionPeriod)
+        .filter(
+            SubscriptionPeriod.teacher_id == teacher.id,
+            SubscriptionPeriod.payment_method == "group_buy",
+            SubscriptionPeriod.status == "active",
+            SubscriptionPeriod.start_date >= month_start,
+        )
+        .first()
+    )
+    if existing_gb is not None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Teacher already has an active group-buy period this "
+                "month; cannot add to another team until next month."
+            ),
+        )
+
+    # All checks passed — bind + create first period
+    ts = TeacherSchool(
+        teacher_id=teacher.id,
+        school_id=school.id,
+        roles=["teacher"],
+        is_active=True,
+    )
+    db.add(ts)
+    period = create_group_buy_period(teacher, plan, db, start=now)
+    # Audit fields on the period
+    period.admin_id = admin.id
+    period.admin_reason = request.reason
+    period.admin_metadata = {
+        "operations": [
+            {
+                "action": "admin_join_group_buy",
+                "timestamp": now.isoformat(),
+                "admin_id": admin.id,
+                "admin_email": admin.email,
+                "admin_name": admin.name,
+                "reason": request.reason,
+                "group_owner_id": owner.id,
+                "group_owner_email": owner.email,
+                "school_id": str(school.id),
+                "plan_name": plan.name,
+            }
+        ]
+    }
+    db.commit()
+    db.refresh(period)
+
+    return SubscriptionResponse(
+        teacher_email=teacher.email,
+        plan_name=period.plan_name,
+        quota_total=period.quota_total,
+        quota_used=period.quota_used,
+        end_date=period.end_date.isoformat(),
+        status=period.status,
+    )
+
+
 # ============ API Endpoints ============
 @router.post("/create", response_model=SubscriptionResponse)
 async def create_subscription(
@@ -153,8 +329,30 @@ async def create_subscription(
     if not teacher:
         raise HTTPException(status_code=404, detail="Teacher not found")
 
-    # 檢查是否已有活躍訂閱
     now = datetime.now(timezone.utc)
+
+    # ===== Group-buy branch (issue #768 comment #1) =====
+    # If the selected plan is a group-buy plan (teacher_seats not-NULL),
+    # admin is manually adding `teacher` to an existing team led by
+    # `group_owner_email`. This skips TapPay (the /group-buy-open flow);
+    # admin scenarios are comp / customer-support / migration cases.
+    from models import Plan
+
+    plan_row = db.query(Plan).filter(Plan.name == request.plan_name).first()
+    if plan_row is None:
+        raise HTTPException(status_code=400, detail="Unknown plan_name")
+    if plan_row.teacher_seats is not None:
+        return await _create_group_buy_admin_subscription(
+            teacher=teacher,
+            plan=plan_row,
+            request=request,
+            admin=admin,
+            db=db,
+            now=now,
+        )
+
+    # ===== Non-group-buy (existing flow) =====
+    # 檢查是否已有活躍訂閱
     existing = (
         db.query(SubscriptionPeriod)
         .filter_by(teacher_id=teacher.id, status="active")
@@ -166,6 +364,12 @@ async def create_subscription(
             detail=(
                 "Teacher already has an active subscription. " "Use /edit to modify it."
             ),
+        )
+
+    # End_date is required for individual plans
+    if not request.end_date:
+        raise HTTPException(
+            status_code=400, detail="end_date is required for non-group-buy plans"
         )
 
     # 計算 quota (VIP 方案可自訂)

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -223,7 +223,18 @@ async def _create_group_buy_admin_subscription(
         .scalar()
         or 0
     )
-    if school.teacher_seat_limit and seat_taken >= school.teacher_seat_limit:
+    # `is not None` (not truthy): a legacy group-buy school where
+    # `teacher_seat_limit` somehow ended up NULL should NOT silently bypass
+    # the seat check. If we see that data shape, refuse and let ops fix it.
+    if school.teacher_seat_limit is None:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                f"Group-buy school {school.id} has no teacher_seat_limit "
+                "set; data inconsistency — contact ops."
+            ),
+        )
+    if seat_taken >= school.teacher_seat_limit:
         raise HTTPException(
             status_code=400,
             detail=(
@@ -248,7 +259,13 @@ async def _create_group_buy_admin_subscription(
             detail=f"Teacher {teacher.email!r} is already in this team.",
         )
 
-    # Existing active group-buy period this month → don't double-grant
+    # Existing active group-buy period this month → don't double-grant.
+    # `now` here is UTC, so month_start is UTC midnight on day 1. For the
+    # ~8 hours after Taipei month rollover but before UTC rollover, a
+    # period started "today" in Taipei would be in last UTC month and
+    # NOT caught by this guard. Acceptable: admin-driven joins are rare
+    # and the cron's own dedup (services/group_buy.py) is the canonical
+    # protection against double-granting at month boundaries.
     month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     existing_gb = (
         db.query(SubscriptionPeriod)

--- a/backend/services/group_buy.py
+++ b/backend/services/group_buy.py
@@ -102,9 +102,15 @@ def create_group_buy_org_and_school(
     /org-purchase and /org-renew endpoints, both of which gate on
     `TeacherOrganization.role == 'org_owner'`.
     """
+    owner_label = owner.name or owner.email
     org = Organization(
-        name=f"{owner.name or owner.email}'s 團購",
+        name=f"{owner_label}'s 團購",
+        # issue #768 comment #2: populate display_name + teacher_limit so the
+        # admin org edit modal shows meaningful values instead of blanks.
+        # display_name includes seat count for at-a-glance identification.
+        display_name=f"{owner_label}'s 團購-{plan.teacher_seats}位",
         org_type="group_buy",
+        teacher_limit=plan.teacher_seats,
         subscription_start_date=now,
         # relativedelta(years=1) handles Feb 29 → Feb 28 edge correctly;
         # `timedelta(days=365)` would produce an off-by-one in leap years.

--- a/backend/tests/test_admin_subscriptions_group_buy_branch.py
+++ b/backend/tests/test_admin_subscriptions_group_buy_branch.py
@@ -1,0 +1,346 @@
+"""Tests for the group-buy branch of POST /api/admin/subscription/create
+(issue #768 comment #1).
+
+Admin manually joins an existing teacher to an existing group-buy team
+without going through TapPay. Covers validation, seat / duplicate
+checks, and the happy path.
+"""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from auth import create_access_token, get_password_hash
+from models import (
+    Organization,
+    Plan,
+    School,
+    SubscriptionPeriod,
+    Teacher,
+    TeacherOrganization,
+    TeacherSchool,
+)
+
+
+def _bearer(teacher_id):
+    token = create_access_token(data={"sub": str(teacher_id), "type": "teacher"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def admin(shared_test_session):
+    t = Teacher(
+        email="gb-admin@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="GBAdmin",
+        is_active=True,
+        email_verified=True,
+        is_admin=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+@pytest.fixture
+def owner(shared_test_session):
+    """A teacher who has already opened a group-buy team."""
+    t = Teacher(
+        email="gb-team-owner@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="Owner",
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+@pytest.fixture
+def target(shared_test_session):
+    """The teacher admin wants to manually add to the team."""
+    t = Teacher(
+        email="gb-target@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="Target",
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+@pytest.fixture
+def gb_plan_30(shared_test_session):
+    p = Plan(
+        name="團購-30席",
+        price=None,
+        quota=1000,
+        teacher_seats=30,
+        annual_fee=1300,
+        topup_discount=Decimal("0.90"),
+        display_order=11,
+        is_active=True,
+    )
+    shared_test_session.add(p)
+    shared_test_session.commit()
+    shared_test_session.refresh(p)
+    return p
+
+
+@pytest.fixture
+def opened_team(shared_test_session, owner, gb_plan_30):
+    """Simulate the state after owner opened a group-buy team via
+    /credit-packages/group-buy-open: org + school + binding."""
+    from services.group_buy import create_group_buy_org_and_school
+
+    org, school, _, _ = create_group_buy_org_and_school(
+        owner, gb_plan_30, shared_test_session, now=datetime.now(timezone.utc)
+    )
+    shared_test_session.commit()
+    return org, school
+
+
+def _post_create(test_client, admin, body):
+    return test_client.post(
+        "/api/admin/subscription/create",
+        headers=_bearer(admin.id),
+        json=body,
+    )
+
+
+# ---------- validation ----------
+
+
+def test_group_buy_plan_without_owner_email_returns_400(
+    test_client, admin, target, opened_team, gb_plan_30
+):
+    r = _post_create(
+        test_client,
+        admin,
+        {
+            "teacher_email": target.email,
+            "plan_name": gb_plan_30.name,
+            "reason": "test missing owner email",
+        },
+    )
+    assert r.status_code == 400
+    assert "group_owner_email" in r.json()["detail"]
+
+
+def test_group_buy_unknown_owner_email_returns_404(
+    test_client, admin, target, opened_team, gb_plan_30
+):
+    r = _post_create(
+        test_client,
+        admin,
+        {
+            "teacher_email": target.email,
+            "plan_name": gb_plan_30.name,
+            "group_owner_email": "nobody@nowhere.com",
+            "reason": "test unknown owner",
+        },
+    )
+    assert r.status_code == 404
+    assert "owner" in r.json()["detail"].lower()
+
+
+def test_group_buy_owner_not_leading_this_plan_returns_400(
+    test_client, admin, owner, target, opened_team, shared_test_session
+):
+    """Owner leads a 團購-30席 team; admin tries to put target into a
+    團購-10席 team led by the same owner → owner doesn't lead that plan."""
+    p10 = Plan(
+        name="團購-10席",
+        price=None,
+        quota=1000,
+        teacher_seats=10,
+        annual_fee=1500,
+        topup_discount=Decimal("0.95"),
+        display_order=10,
+        is_active=True,
+    )
+    shared_test_session.add(p10)
+    shared_test_session.commit()
+
+    r = _post_create(
+        test_client,
+        admin,
+        {
+            "teacher_email": target.email,
+            "plan_name": p10.name,
+            "group_owner_email": owner.email,
+            "reason": "wrong plan",
+        },
+    )
+    assert r.status_code == 400
+    assert "team" in r.json()["detail"].lower()
+
+
+# ---------- happy path ----------
+
+
+def test_admin_joins_teacher_to_existing_team(
+    test_client,
+    admin,
+    owner,
+    target,
+    opened_team,
+    gb_plan_30,
+    shared_test_session,
+):
+    org, school = opened_team
+
+    r = _post_create(
+        test_client,
+        admin,
+        {
+            "teacher_email": target.email,
+            "plan_name": gb_plan_30.name,
+            "group_owner_email": owner.email,
+            "reason": "comp customer support",
+        },
+    )
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert body["teacher_email"] == target.email
+    assert body["plan_name"] == gb_plan_30.name
+    assert body["quota_total"] == 1000
+
+    shared_test_session.expire_all()
+    # TeacherSchool binding created
+    ts = (
+        shared_test_session.query(TeacherSchool)
+        .filter(
+            TeacherSchool.teacher_id == target.id,
+            TeacherSchool.school_id == school.id,
+            TeacherSchool.is_active.is_(True),
+        )
+        .one()
+    )
+    assert ts.roles == ["teacher"]
+    # SubscriptionPeriod created with group_buy payment_method
+    period = (
+        shared_test_session.query(SubscriptionPeriod)
+        .filter(
+            SubscriptionPeriod.teacher_id == target.id,
+            SubscriptionPeriod.plan_name == gb_plan_30.name,
+            SubscriptionPeriod.payment_method == "group_buy",
+        )
+        .one()
+    )
+    assert period.quota_total == 1000
+    # Audit metadata captured
+    ops = period.admin_metadata.get("operations", [])
+    assert ops and ops[0]["action"] == "admin_join_group_buy"
+    assert ops[0]["group_owner_email"] == owner.email
+
+
+# ---------- post-join guards ----------
+
+
+def test_duplicate_join_returns_400(
+    test_client, admin, owner, target, opened_team, gb_plan_30
+):
+    body = {
+        "teacher_email": target.email,
+        "plan_name": gb_plan_30.name,
+        "group_owner_email": owner.email,
+        "reason": "first join",
+    }
+    r1 = _post_create(test_client, admin, body)
+    assert r1.status_code == 200
+
+    body["reason"] = "second join attempt"
+    r2 = _post_create(test_client, admin, body)
+    # Either duplicate-binding 400 or active-period-this-month 400 is
+    # acceptable — both encode the "already in team" semantics.
+    assert r2.status_code == 400
+
+
+def test_seat_full_returns_400(
+    test_client,
+    admin,
+    owner,
+    target,
+    opened_team,
+    gb_plan_30,
+    shared_test_session,
+):
+    """Force the school to a full-seat state and verify next admin join
+    is rejected."""
+    org, school = opened_team
+    # Fill seats up to the limit (owner already takes 1)
+    seats_to_fill = (school.teacher_seat_limit or 0) - 1  # minus owner
+    for i in range(seats_to_fill):
+        t = Teacher(
+            email=f"filler-{i}@x.com",
+            password_hash=get_password_hash("x"),
+            name=f"Filler{i}",
+            is_active=True,
+            email_verified=True,
+        )
+        shared_test_session.add(t)
+        shared_test_session.flush()
+        shared_test_session.add(
+            TeacherSchool(
+                teacher_id=t.id,
+                school_id=school.id,
+                roles=["teacher"],
+                is_active=True,
+            )
+        )
+    shared_test_session.commit()
+
+    r = _post_create(
+        test_client,
+        admin,
+        {
+            "teacher_email": target.email,
+            "plan_name": gb_plan_30.name,
+            "group_owner_email": owner.email,
+            "reason": "joining full team",
+        },
+    )
+    assert r.status_code == 400
+    assert "full" in r.json()["detail"].lower()
+
+
+# ---------- regression: individual plan path still works ----------
+
+
+def test_individual_plan_path_still_works(
+    test_client, admin, target, shared_test_session
+):
+    """Ensure the new group-buy branch doesn't break the existing
+    individual-plan create flow."""
+    p = Plan(
+        name="Tutor Teachers",
+        price=299,
+        quota=2000,
+        teacher_seats=None,
+        annual_fee=None,
+        is_active=True,
+    )
+    shared_test_session.add(p)
+    shared_test_session.commit()
+
+    r = _post_create(
+        test_client,
+        admin,
+        {
+            "teacher_email": target.email,
+            "plan_name": "Tutor Teachers",
+            "end_date": "2026-12-31",
+            "reason": "regression test",
+        },
+    )
+    assert r.status_code == 200, r.json()
+    assert r.json()["plan_name"] == "Tutor Teachers"
+    assert r.json()["quota_total"] == 2000

--- a/backend/tests/test_admin_subscriptions_group_buy_branch.py
+++ b/backend/tests/test_admin_subscriptions_group_buy_branch.py
@@ -276,8 +276,14 @@ def test_seat_full_returns_400(
     """Force the school to a full-seat state and verify next admin join
     is rejected."""
     org, school = opened_team
+    # Fixture invariant: if teacher_seat_limit were NULL we'd loop range(-1),
+    # add zero fillers, and the endpoint would still 200 — masking a real
+    # bug. Fail loud at setup so a future fixture regression is obvious.
+    assert (
+        school.teacher_seat_limit is not None
+    ), "fixture invariant: group-buy school must have teacher_seat_limit set"
     # Fill seats up to the limit (owner already takes 1)
-    seats_to_fill = (school.teacher_seat_limit or 0) - 1  # minus owner
+    seats_to_fill = school.teacher_seat_limit - 1  # minus owner
     for i in range(seats_to_fill):
         t = Teacher(
             email=f"filler-{i}@x.com",
@@ -310,6 +316,69 @@ def test_seat_full_returns_400(
     )
     assert r.status_code == 400
     assert "full" in r.json()["detail"].lower()
+
+
+# ---------- cross-team active-period guard ----------
+
+
+def test_active_period_in_different_team_blocks_join(
+    test_client,
+    admin,
+    owner,
+    target,
+    opened_team,
+    gb_plan_30,
+    shared_test_session,
+):
+    """Target teacher already has an active group-buy period THIS MONTH
+    bound to a DIFFERENT team's school — adding to a new team would
+    cause Phase 3 cron to grant 2000 points instead of 1000.
+
+    Distinct from `test_duplicate_join_returns_400` which covers the
+    same-school case via the binding-uniqueness path.
+    """
+    from services.group_buy import create_group_buy_period
+
+    # Manually create a previous group-buy period for `target` on a
+    # different school (simulating they were in another team last week).
+    other_owner = Teacher(
+        email="other-owner@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="OtherOwner",
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(other_owner)
+    shared_test_session.commit()
+    from services.group_buy import create_group_buy_org_and_school
+
+    create_group_buy_org_and_school(
+        other_owner,
+        gb_plan_30,
+        shared_test_session,
+        now=datetime.now(timezone.utc),
+    )
+    # Give target an active period under the other team
+    create_group_buy_period(
+        target, gb_plan_30, shared_test_session, start=datetime.now(timezone.utc)
+    )
+    shared_test_session.commit()
+
+    # Admin tries to join target to opened_team's team → should be blocked
+    # by the cross-team active-period guard, NOT by the binding-uniqueness
+    # one (target has no TeacherSchool row in opened_team's school yet).
+    r = _post_create(
+        test_client,
+        admin,
+        {
+            "teacher_email": target.email,
+            "plan_name": gb_plan_30.name,
+            "group_owner_email": owner.email,
+            "reason": "cross-team join attempt",
+        },
+    )
+    assert r.status_code == 400
+    assert "this month" in r.json()["detail"].lower()
 
 
 # ---------- regression: individual plan path still works ----------

--- a/backend/tests/test_group_buy_service.py
+++ b/backend/tests/test_group_buy_service.py
@@ -183,6 +183,12 @@ def test_open_creates_org_school_and_owner_binding(shared_test_session, owner):
     assert t_org.organization_id == org.id
     assert t_org.role == "org_owner"
     assert t_org.is_active is True
+    # Issue #768 comment #2: admin org edit modal shows display_name and
+    # teacher_limit, both of which must be populated by the create flow
+    # (not just `name`) so admin sees meaningful values.
+    owner_label = owner.name or owner.email
+    assert org.display_name == f"{owner_label}'s 團購-{plan.teacher_seats}位"
+    assert org.teacher_limit == plan.teacher_seats
 
 
 # ---------- create_group_buy_period ----------

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -400,27 +400,31 @@ export default function AdminSubscriptionDashboard() {
   // dropdown on slow connections / cold start before plans arrive.
   const [plansLoading, setPlansLoading] = useState<boolean>(true);
   useEffect(() => {
+    // `cancelled` flag prevents setState after unmount (no AbortController
+    // because apiClient.listAdminPlans doesn't accept one yet; the closure
+    // check is equivalent for this use case).
+    let cancelled = false;
     (async () => {
       try {
         const plans = await apiClient.listAdminPlans();
-        // Only show active plans in the dropdown; admin can still see
-        // inactive on the /admin/plans page.
+        if (cancelled) return;
         setAvailablePlans(plans.filter((p) => p.is_active));
         setAvailablePlansError(null);
       } catch (e) {
+        if (cancelled) return;
         console.error("Failed to load plan list:", e);
-        // Without this, admin sees an empty dropdown with no signal —
-        // we now surface a banner inside the edit modal (rendered below
-        // the plan select) so they know to retry.
         setAvailablePlansError(
           e instanceof Error
             ? `無法載入方案清單：${e.message}`
             : "無法載入方案清單；請重新整理頁面再試",
         );
       } finally {
-        setPlansLoading(false);
+        if (!cancelled) setPlansLoading(false);
       }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
   const isGroupBuyPlan = (name: string) =>
     availablePlans.some((p) => p.name === name && p.teacher_seats != null);
@@ -2712,34 +2716,38 @@ export default function AdminSubscriptionDashboard() {
                 </div>
               )}
 
-            {/* End Date (for create and edit) */}
-            {(editForm.action === "create" || editForm.action === "edit") && (
-              <div className="space-y-2">
-                <label className="text-sm font-medium">
-                  {t("adminSubscription.modal.endDate")}{" "}
-                  {editForm.action === "create" ? (
-                    <span className="text-xs text-gray-500">
-                      {t("adminSubscription.modal.endDateOptionalCreate")}
-                    </span>
-                  ) : (
-                    t("adminSubscription.modal.optional")
-                  )}
-                </label>
-                <Input
-                  type="date"
-                  value={editForm.end_date}
-                  onChange={(e) =>
-                    setEditForm({ ...editForm, end_date: e.target.value })
-                  }
-                  placeholder="YYYY-MM-DD"
-                />
-                <p className="text-xs text-gray-500">
-                  {editForm.action === "create"
-                    ? t("adminSubscription.modal.endDateHintCreate")
-                    : t("adminSubscription.modal.endDateHintEdit")}
-                </p>
-              </div>
-            )}
+            {/* End Date (for create and edit).
+                Hidden for group-buy plans — backend uses month-end Taipei
+                automatically; letting admin type a date that gets ignored
+                is confusing. */}
+            {(editForm.action === "create" || editForm.action === "edit") &&
+              !isGroupBuyPlan(editForm.plan_name) && (
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">
+                    {t("adminSubscription.modal.endDate")}{" "}
+                    {editForm.action === "create" ? (
+                      <span className="text-xs text-gray-500">
+                        {t("adminSubscription.modal.endDateOptionalCreate")}
+                      </span>
+                    ) : (
+                      t("adminSubscription.modal.optional")
+                    )}
+                  </label>
+                  <Input
+                    type="date"
+                    value={editForm.end_date}
+                    onChange={(e) =>
+                      setEditForm({ ...editForm, end_date: e.target.value })
+                    }
+                    placeholder="YYYY-MM-DD"
+                  />
+                  <p className="text-xs text-gray-500">
+                    {editForm.action === "create"
+                      ? t("adminSubscription.modal.endDateHintCreate")
+                      : t("adminSubscription.modal.endDateHintEdit")}
+                  </p>
+                </div>
+              )}
 
             {/* Custom Quota (for VIP plan in create and edit) */}
             {(editForm.action === "create" || editForm.action === "edit") &&

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -396,6 +396,9 @@ export default function AdminSubscriptionDashboard() {
   const [availablePlansError, setAvailablePlansError] = useState<string | null>(
     null,
   );
+  // Tracks the in-flight fetch so admin doesn't see a confusingly empty
+  // dropdown on slow connections / cold start before plans arrive.
+  const [plansLoading, setPlansLoading] = useState<boolean>(true);
   useEffect(() => {
     (async () => {
       try {
@@ -414,6 +417,8 @@ export default function AdminSubscriptionDashboard() {
             ? `無法載入方案清單：${e.message}`
             : "無法載入方案清單；請重新整理頁面再試",
         );
+      } finally {
+        setPlansLoading(false);
       }
     })();
   }, []);
@@ -2663,9 +2668,11 @@ export default function AdminSubscriptionDashboard() {
                     ))}
                   </SelectContent>
                 </Select>
-                {/* If /api/admin/plans failed at mount, surface it here
-                    so admin knows why the dropdown is empty (don't just
-                    show no options + console.error). */}
+                {/* Loading / error signals so admin doesn't see an
+                    empty dropdown without explanation. */}
+                {plansLoading && (
+                  <p className="text-xs text-gray-500 mt-1">載入方案清單中…</p>
+                )}
                 {availablePlansError && (
                   <p className="text-xs text-red-600 mt-1">
                     {availablePlansError}

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -334,6 +334,18 @@ function CreditPackageHistory({
   );
 }
 
+// Issue #768 follow-up: shape of /api/admin/plans rows we actually
+// care about inside this dashboard. Hoisted above the component so
+// it's not redefined per render.
+type AdminPlanLite = {
+  name: string;
+  price: number | null;
+  quota: number | null;
+  is_active: boolean;
+  teacher_seats: number | null;
+  annual_fee: number | null;
+};
+
 export default function AdminSubscriptionDashboard() {
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -380,15 +392,10 @@ export default function AdminSubscriptionDashboard() {
   });
 
   // Dynamic plan list (replaces hardcoded 5 plans so group-buy ones show)
-  type AdminPlanLite = {
-    name: string;
-    price: number | null;
-    quota: number | null;
-    is_active: boolean;
-    teacher_seats: number | null;
-    annual_fee: number | null;
-  };
   const [availablePlans, setAvailablePlans] = useState<AdminPlanLite[]>([]);
+  const [availablePlansError, setAvailablePlansError] = useState<string | null>(
+    null,
+  );
   useEffect(() => {
     (async () => {
       try {
@@ -396,9 +403,17 @@ export default function AdminSubscriptionDashboard() {
         // Only show active plans in the dropdown; admin can still see
         // inactive on the /admin/plans page.
         setAvailablePlans(plans.filter((p) => p.is_active));
+        setAvailablePlansError(null);
       } catch (e) {
         console.error("Failed to load plan list:", e);
-        // Fall back to empty; user sees no options and can refresh.
+        // Without this, admin sees an empty dropdown with no signal —
+        // we now surface a banner inside the edit modal (rendered below
+        // the plan select) so they know to retry.
+        setAvailablePlansError(
+          e instanceof Error
+            ? `無法載入方案清單：${e.message}`
+            : "無法載入方案清單；請重新整理頁面再試",
+        );
       }
     })();
   }, []);
@@ -2640,12 +2655,22 @@ export default function AdminSubscriptionDashboard() {
                     {availablePlans.map((p) => (
                       <SelectItem key={p.name} value={p.name}>
                         {p.teacher_seats != null
-                          ? `${p.name}（${p.teacher_seats} 席 / NT$${p.annual_fee?.toLocaleString()} 每席年費）`
+                          ? `${p.name}（${p.teacher_seats} 席 / NT$${
+                              p.annual_fee?.toLocaleString() ?? "—"
+                            } 每席年費）`
                           : p.name}
                       </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
+                {/* If /api/admin/plans failed at mount, surface it here
+                    so admin knows why the dropdown is empty (don't just
+                    show no options + console.error). */}
+                {availablePlansError && (
+                  <p className="text-xs text-red-600 mt-1">
+                    {availablePlansError}
+                  </p>
+                )}
               </div>
             )}
 

--- a/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
+++ b/frontend/src/pages/admin/AdminSubscriptionDashboard.tsx
@@ -374,7 +374,36 @@ export default function AdminSubscriptionDashboard() {
     end_date: "",
     quota_total: undefined as number | undefined,
     reason: "",
+    // issue #768 comment #1: when picking a group-buy plan, admin must
+    // also supply the team owner's email to bind the target teacher.
+    group_owner_email: "",
   });
+
+  // Dynamic plan list (replaces hardcoded 5 plans so group-buy ones show)
+  type AdminPlanLite = {
+    name: string;
+    price: number | null;
+    quota: number | null;
+    is_active: boolean;
+    teacher_seats: number | null;
+    annual_fee: number | null;
+  };
+  const [availablePlans, setAvailablePlans] = useState<AdminPlanLite[]>([]);
+  useEffect(() => {
+    (async () => {
+      try {
+        const plans = await apiClient.listAdminPlans();
+        // Only show active plans in the dropdown; admin can still see
+        // inactive on the /admin/plans page.
+        setAvailablePlans(plans.filter((p) => p.is_active));
+      } catch (e) {
+        console.error("Failed to load plan list:", e);
+        // Fall back to empty; user sees no options and can refresh.
+      }
+    })();
+  }, []);
+  const isGroupBuyPlan = (name: string) =>
+    availablePlans.some((p) => p.name === name && p.teacher_seats != null);
 
   // Refund modal state
   const [refundModalOpen, setRefundModalOpen] = useState(false);
@@ -517,6 +546,7 @@ export default function AdminSubscriptionDashboard() {
         : "",
       quota_total: undefined,
       reason: "",
+      group_owner_email: "",
     });
     setEditModalOpen(true);
   };
@@ -773,12 +803,19 @@ export default function AdminSubscriptionDashboard() {
           reason: editForm.reason,
         });
       } else if (editForm.action === "create") {
+        const isGroupBuy = isGroupBuyPlan(editForm.plan_name);
         response = await apiClient.post("/api/admin/subscription/create", {
           teacher_email: selectedTeacher.teacher_email,
           plan_name: editForm.plan_name,
-          end_date: editForm.end_date,
+          // end_date is required for individual plans, ignored by backend
+          // for group-buy (which uses month-end-Taipei automatically).
+          end_date: isGroupBuy ? undefined : editForm.end_date,
           quota_total: editForm.quota_total,
           reason: editForm.reason,
+          // Only send group_owner_email for group-buy plans
+          group_owner_email: isGroupBuy
+            ? editForm.group_owner_email
+            : undefined,
         });
       } else {
         response = await apiClient.post("/api/admin/subscription/edit", {
@@ -813,6 +850,7 @@ export default function AdminSubscriptionDashboard() {
         end_date: "",
         quota_total: undefined,
         reason: "",
+        group_owner_email: "",
       });
     } catch (error: unknown) {
       console.error("Failed to process subscription:", error);
@@ -2595,21 +2633,52 @@ export default function AdminSubscriptionDashboard() {
                         {t("adminSubscription.modal.noChange")}
                       </SelectItem>
                     )}
-                    <SelectItem value="Free Trial">Free Trial</SelectItem>
-                    <SelectItem value="Tutor Teachers">
-                      Tutor Teachers
-                    </SelectItem>
-                    <SelectItem value="School Teachers">
-                      School Teachers
-                    </SelectItem>
-                    <SelectItem value="Demo Unlimited Plan">
-                      Demo Unlimited Plan
-                    </SelectItem>
-                    <SelectItem value="VIP">VIP</SelectItem>
+                    {/* issue #768 comment #1: dynamic plans from
+                        /api/admin/plans so group-buy plans are
+                        actually selectable here. Annotated with
+                        seats/annual_fee for group-buy clarity. */}
+                    {availablePlans.map((p) => (
+                      <SelectItem key={p.name} value={p.name}>
+                        {p.teacher_seats != null
+                          ? `${p.name}（${p.teacher_seats} 席 / NT$${p.annual_fee?.toLocaleString()} 每席年費）`
+                          : p.name}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
             )}
+
+            {/* issue #768 comment #1: when admin picks a group-buy plan
+                under create action, must also specify which team owner
+                to bind the target teacher to. Skipped for edit because
+                /admin/subscription/edit doesn't accept group_owner_email. */}
+            {editForm.action === "create" &&
+              isGroupBuyPlan(editForm.plan_name) && (
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">
+                    團主 Email <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="email"
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                    placeholder="輸入團主帳號 Email（例：alice@example.com）"
+                    value={editForm.group_owner_email}
+                    onChange={(e) =>
+                      setEditForm({
+                        ...editForm,
+                        group_owner_email: e.target.value,
+                      })
+                    }
+                  />
+                  <p className="text-xs text-gray-500">
+                    系統會將此教師加入該團主已開設的{" "}
+                    <span className="font-semibold">{editForm.plan_name}</span>{" "}
+                    團隊，並建立本月份的 1000 點訂閱週期。團主必須是 org_owner
+                    且該團方案需相符；席次已滿 / 該教師已在團 內會回 400。
+                  </p>
+                </div>
+              )}
 
             {/* End Date (for create and edit) */}
             {(editForm.action === "create" || editForm.action === "edit") && (


### PR DESCRIPTION
## Summary
Two #768 staging-feedback comments rolled into a single PR per user request:

1. **#768 comment 4638087368** — admin subscription edit modal couldn't pick group-buy plans, and even if it could the backend would crash on `get_plan_quota`
2. **#768 comment 4638106872** — group-buy org's admin edit modal showed blank `display_name` and `機構教師` because `/credit-packages/group-buy-open` never set those fields

## Changes

### Comment #1 — admin subscription gains group-buy branch

Use case unlocked: admin manually joins a teacher to an existing group-buy team (for comp / support / migration scenarios) without going through TapPay.

**Backend (`admin_subscriptions.py`)**
- `CreateSubscriptionRequest` gains optional `group_owner_email`
- `create_subscription` branches when `plan.teacher_seats IS NOT NULL`
- New `_create_group_buy_admin_subscription` validates:
  - `group_owner_email` required → 400 if missing
  - owner exists (404 if not), holds active `role='org_owner'` on a group-buy org
  - owner leads a School using **the exact same plan** (400 if owner has 30-seat but admin tries 10-seat)
  - seat capacity not exceeded (400)
  - target not already in this team (400)
  - target has no other active group-buy period this month (400) — prevents Phase 3 cron from double-granting
- On success: insert `TeacherSchool(roles=['teacher'])` + reuse `create_group_buy_period()` for the 1000-pt monthly period; audit metadata records `action='admin_join_group_buy'` with owner email, school id, plan name

**Frontend (`AdminSubscriptionDashboard.tsx`)**
- Hardcoded 5-plan `<SelectItem>` block replaced with `availablePlans` loaded from `apiClient.listAdminPlans()` — already exposes `teacher_seats` since #837
- Group-buy entries render as `團購-30席（30 席 / NT$1,300 每席年費）`
- When the picked plan is group-buy under the `create` action, a conditional **「團主 Email」** input appears with help text explaining seat / duplicate / plan-mismatch failure modes
- `editForm` gains `group_owner_email`; create payload sends it only for group-buy plans and skips `end_date` (backend uses month-end Taipei)

### Comment #2 — group-buy org modal shows real values

**Backend (`services/group_buy.py`)**
- `create_group_buy_org_and_school` now sets:
  - `display_name = f"{owner_label}'s 團購-{teacher_seats}位"` (e.g. `Demo 老師's 團購-10位`)
  - `teacher_limit = plan.teacher_seats`

**Migration — idempotent backfill** (`20260608_1000_backfill_group_buy_org_display.py`)
- `UPDATE organizations SET display_name = ..., teacher_limit = ... WHERE org_type='group_buy' AND display_name IS NULL` (and same for teacher_limit)
- JOIN schools → plans to derive `teacher_seats`
- Safe to re-run; second run touches zero rows
- `down_revision = 20260603_1000`, single head `20260608_1000`

## Test plan
- [x] `tests/test_admin_subscriptions_group_buy_branch.py` — **7 new cases** (missing email → 400, unknown owner → 404, plan mismatch → 400, happy path with binding + period + audit metadata, duplicate join → 400, full team → 400, individual-plan regression)
- [x] `tests/test_group_buy_service.py::test_open_creates_org_school_and_owner_binding` extended with `display_name` + `teacher_limit` assertions
- [x] **49/49 relevant backend tests pass** (group_buy service + group_buy open endpoint + admin_plans + new file)
- [x] Black clean · single alembic head `20260608_1000` · `tsc --noEmit` clean · Prettier clean

## Manual e2e checklist (post-deploy)
- [ ] Migration runs on staging → existing「Demo 老師's 團購」org now shows display_name `Demo 老師's 團購-10位` + 機構教師 `10`
- [ ] Admin opens subscription edit modal → plan dropdown contains 團購-10/30/50席 with seat/fee annotation
- [ ] Pick 團購-30席 (create action) → 團主 Email input appears → submit with owner email of an existing 30-seat team → 200 + teacher bound + 1000-pt period created
- [ ] Submit with non-existent owner email → 404 with clear message
- [ ] Submit while team full → 400 with seat count message
- [ ] Pick Tutor Teachers → input does NOT appear; regression flow unchanged

Related to **#768** — issue stays open for ongoing staging feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)