### PR TITLE
fix(#842): 單字選擇題目外距 + 選項長文字縮字呈現 + 例句集編輯器單一卷軸

### DIFF
--- a/frontend/src/components/ReadingAssessmentPanel.tsx
+++ b/frontend/src/components/ReadingAssessmentPanel.tsx
@@ -2685,7 +2685,7 @@ const ReadingAssessmentPanel = forwardRef<
   }
 
   return (
-    <div className="flex flex-col h-full max-h-[calc(100vh-70px)]">
+    <div className="flex flex-col">
       {/* Fixed Header Section */}
       <div className="flex-shrink-0 space-y-4 pb-4">
         {/* Assignment Copy Warning Banner */}
@@ -2790,12 +2790,13 @@ const ReadingAssessmentPanel = forwardRef<
       </div>
 
       {/* Desktop: Side-by-side layout / Mobile: Editor only */}
-      <div className="flex flex-1 gap-4 min-h-0">
+      <div className="flex gap-4">
         {/* Left: Batch Work Area (Desktop only) */}
         <BatchWorkPanel
           text={batchPasteText}
           onTextChange={setBatchPasteText}
           maxItems={MAX_BATCH_ITEMS}
+          pasteLabel={t("contentEditor.labels.pasteSentences")}
           placeholder="put&#10;Put it away.&#10;It's time to put everything away. Right now."
           autoTranslate={batchPasteAutoTranslate}
           onAutoTranslateChange={setBatchPasteAutoTranslate}
@@ -2830,7 +2831,7 @@ const ReadingAssessmentPanel = forwardRef<
         />
 
         {/* Right: Editor Area */}
-        <div className="flex-1 flex flex-col min-h-0">
+        <div className="flex-1 flex flex-col">
           {/* Scrollable Content Rows with dnd-kit */}
           <DndContext
             sensors={sensors}
@@ -2841,7 +2842,7 @@ const ReadingAssessmentPanel = forwardRef<
               items={rows.map((row) => row.id)}
               strategy={verticalListSortingStrategy}
             >
-              <div className="space-y-3 pr-2 flex-1 min-h-0 overflow-y-auto">
+              <div className="space-y-3 pr-2">
                 {rows.map((row, index) => {
                   // useSortable must be called inside the component that's in SortableContext
                   // so we'll use a nested component

--- a/frontend/src/components/ReadingAssessmentPanel.tsx
+++ b/frontend/src/components/ReadingAssessmentPanel.tsx
@@ -2841,7 +2841,7 @@ const ReadingAssessmentPanel = forwardRef<
               items={rows.map((row) => row.id)}
               strategy={verticalListSortingStrategy}
             >
-              <div className="space-y-3 pr-2">
+              <div className="space-y-3 pr-2 flex-1 min-h-0 overflow-y-auto">
                 {rows.map((row, index) => {
                   // useSortable must be called inside the component that's in SortableContext
                   // so we'll use a nested component

--- a/frontend/src/components/activities/WordSelectionActivity.tsx
+++ b/frontend/src/components/activities/WordSelectionActivity.tsx
@@ -972,7 +972,7 @@ export default function WordSelectionActivity({
           {/* Word Text — show_image 模式時隱藏英文（避免答案太明顯），改顯示翻譯提示
               即使老師勾了 show_image 但實際沒附圖，仍套用此規則 — 否則英文題目+英文選項會秒解 */}
           {!playAudio && (
-            <div className="text-center">
+            <div className="text-center py-4 sm:py-6">
               <h2 className="text-[clamp(2rem,9vh,6rem)] font-bold text-gray-800 select-none">
                 {showImage ? currentWord.translation : currentWord.text}
               </h2>

--- a/frontend/src/components/activities/WordSelectionQuizActivity.tsx
+++ b/frontend/src/components/activities/WordSelectionQuizActivity.tsx
@@ -20,7 +20,7 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
-import { Loader2, Send, Volume2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, Loader2, Send, Volume2 } from "lucide-react";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 
@@ -504,7 +504,7 @@ export default function WordSelectionQuizActivity({
   );
 
   return (
-    <div className="flex flex-col gap-4 min-h-[calc(98dvh-14rem)] max-h-[98dvh]">
+    <div className="flex flex-col gap-4 pb-6 sm:pb-8 min-h-[calc(100dvh-14rem)] max-h-[100dvh]">
       {navSlot ? (
         createPortal(navBar, navSlot)
       ) : (
@@ -592,7 +592,7 @@ export default function WordSelectionQuizActivity({
 
               {/* show_image=true → 顯示翻譯（圖+翻譯，避免英文選項秒解）；否則顯示英文題 */}
               {!settings.play_audio && (
-                <div className="text-center">
+                <div className="text-center py-4 sm:py-6">
                   <h2 className="text-[clamp(2rem,9vh,6rem)] font-bold text-gray-800 select-none">
                     {settings.show_image
                       ? currentWord.translation

--- a/frontend/src/components/activities/WordSelectionQuizActivity.tsx
+++ b/frontend/src/components/activities/WordSelectionQuizActivity.tsx
@@ -20,7 +20,7 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
-import { ChevronLeft, ChevronRight, Loader2, Send, Volume2 } from "lucide-react";
+import { Loader2, Send, Volume2 } from "lucide-react";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 

--- a/frontend/src/components/activities/shared/WordSelectionOptionButton.tsx
+++ b/frontend/src/components/activities/shared/WordSelectionOptionButton.tsx
@@ -4,7 +4,9 @@
  * 設計：
  * - 4 色循環（OPTION_COLORS）：藍 / 紫 / 琥珀 / 青，由呼叫端傳 colorIndex
  * - 圖片模式 (showAsImage=true 且有 imageUrl)：上圖下標籤
- * - 字級自適應：button 內層 div 套 [container-type:size]，文字用 cqh + cqw min() 隨選項框縮放
+ * - 字級自適應：button 內層 div 套 [container-type:size]，文字 max 字級用 cqh + cqw min() 隨選項框縮放
+ *   （#842：改為 content-aware shrink-to-fit — useShrinkToFit hook 量測 overflow 後動態縮字，
+ *    取代純 clamp()，確保長文字完整顯示而非 ... 截斷。min: 純文字 10px、圖片模式 8px）
  * - 揭示態（quiz 模式不傳 showCorrect/showIncorrect）：
  *   - showCorrect → 綠底/邊/字 + 左上角 ✓
  *   - showIncorrect → 紅底/邊/字 + 左上角 ✗
@@ -12,8 +14,10 @@
  * - 選中態（!showResult）：ring-2 ring-indigo-400 + scale-95
  */
 
+import { useRef } from "react";
 import { CheckCircle, XCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useShrinkToFit } from "./useShrinkToFit";
 
 export const OPTION_COLORS = [
   "bg-blue-50 border-blue-200 hover:bg-blue-100 hover:border-blue-400",
@@ -53,6 +57,15 @@ export default function WordSelectionOptionButton({
   const renderAsImage = showAsImage && !!imageUrl;
   const dimmed = showResult && !showCorrect && !showIncorrect;
 
+  // #842 content-aware shrink：max 比例對齊原 cqh/cqw，min 守住可讀下限
+  // ready=false 時 span 以 opacity-0 隱藏，避免閃過 fallback 字型 / 過大字
+  const textSpanRef = useRef<HTMLSpanElement>(null);
+  const { fontSize, ready } = useShrinkToFit(textSpanRef, {
+    maxRatio: renderAsImage ? { h: 0.1, w: 0.08 } : { h: 0.16, w: 0.11 },
+    minFontSize: renderAsImage ? 7 : 8,
+    deps: [text, renderAsImage],
+  });
+
   return (
     <button
       type="button"
@@ -73,7 +86,7 @@ export default function WordSelectionOptionButton({
           "bg-green-100 border-green-500 text-green-800 shadow-green-200",
         showIncorrect &&
           "bg-red-100 border-red-500 text-red-800 shadow-red-200",
-        isSelected && !showResult && "ring-2 ring-indigo-400 scale-95",
+        isSelected && !showResult && "ring-[6px] ring-indigo-500 scale-95",
         dimmed && "opacity-50",
       )}
     >
@@ -91,8 +104,8 @@ export default function WordSelectionOptionButton({
           )}
         </span>
       )}
-      {/* 內層 div = container query root，cqh/cqw 依此 div 大小算（button 對 container-type 有 quirk） */}
-      <div className="w-full h-full flex flex-col items-center justify-center gap-2 [container-type:size]">
+      {/* 字級用 useShrinkToFit 量測 overflow 後動態縮放（取代純 clamp） */}
+      <div className="w-full h-full flex flex-col items-center justify-center gap-2">
         {renderAsImage ? (
           <>
             <img
@@ -100,12 +113,26 @@ export default function WordSelectionOptionButton({
               alt={text}
               className="flex-1 min-h-0 w-full object-contain rounded-md"
             />
-            <span className="shrink-0 leading-tight break-words line-clamp-2 text-[clamp(1rem,min(13cqh,10cqw),2.75rem)]">
+            <span
+              ref={textSpanRef}
+              className={cn(
+                "shrink-0 inline-block leading-tight break-words w-full max-w-full overflow-hidden transition-opacity duration-150 px-2 py-1.5",
+                ready ? "opacity-100" : "opacity-0",
+              )}
+              style={{ fontSize: `${fontSize}px` }}
+            >
               {text}
             </span>
           </>
         ) : (
-          <span className="leading-tight break-words line-clamp-4 text-[clamp(1rem,min(20cqh,14cqw),8rem)]">
+          <span
+            ref={textSpanRef}
+            className={cn(
+              "inline-block leading-tight break-words w-full max-w-full max-h-full overflow-hidden transition-opacity duration-150 px-2 py-3 sm:py-4",
+              ready ? "opacity-100" : "opacity-0",
+            )}
+            style={{ fontSize: `${fontSize}px` }}
+          >
             {text}
           </span>
         )}

--- a/frontend/src/components/activities/shared/useShrinkToFit.ts
+++ b/frontend/src/components/activities/shared/useShrinkToFit.ts
@@ -1,0 +1,111 @@
+/**
+ * useShrinkToFit — content-aware 字級縮放 hook
+ *
+ * 目的（#842）：選項文字過長時自動縮字確保完整顯示，而非以 ... 截斷。
+ * 純 CSS clamp(cqh/cqw) 只看容器、不看文字長度 → 長文字一樣 overflow。
+ *
+ * 設計重點：
+ * - `useLayoutEffect` + `opacity-0` 直到 ready：paint 前完成量測，避免閃過大字
+ * - 等 `document.fonts.ready`：避免 fallback 字型量寬偏差
+ * - max 由 parent 動態算（maxRatio.h × clientH、maxRatio.w × clientW），對齊原 clamp(cqh/cqw) 行為
+ * - rAF 內二分搜尋字級（最多 5 圈）；read 與 write 分到不同 frame 避免 layout thrashing
+ * - ResizeObserver 觀察 parent 尺寸變化 → 重算
+ *
+ * 元件端要求：
+ * - ref 指到要量的文字 element，需為 block / inline-block（inline 量不到 overflow）
+ * - 該 element 需有 `max-h-full max-w-full overflow-hidden`，讓 scrollH > clientH 偵測 overflow
+ */
+
+import { useLayoutEffect, useRef, useState, type RefObject } from "react";
+
+interface Options {
+  maxRatio: { h: number; w: number }; // 對齊 cqh/cqw（例如 {h:0.2, w:0.14}）
+  minFontSize: number; // px
+  deps?: unknown[]; // 內容變動時觸發重算
+}
+
+interface Result {
+  fontSize: number;
+  ready: boolean;
+}
+
+export function useShrinkToFit(
+  ref: RefObject<HTMLElement | null>,
+  { maxRatio, minFontSize, deps = [] }: Options,
+): Result {
+  const [fontSize, setFontSize] = useState(minFontSize);
+  const [ready, setReady] = useState(false);
+  const rafRef = useRef<number | null>(null);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    const parent = el?.parentElement;
+    if (!el || !parent) return;
+
+    let cancelled = false;
+
+    const isOverflow = () =>
+      el.scrollHeight > el.clientHeight + 1 ||
+      el.scrollWidth > el.clientWidth + 1;
+
+    const computeMax = () => {
+      const ph = parent.clientHeight;
+      const pw = parent.clientWidth;
+      return Math.max(
+        minFontSize,
+        Math.floor(Math.min(ph * maxRatio.h, pw * maxRatio.w)),
+      );
+    };
+
+    const measure = () => {
+      if (cancelled) return;
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(() => {
+        if (cancelled || !ref.current) return;
+        const maxFs = computeMax();
+        // 先試 max
+        el.style.fontSize = `${maxFs}px`;
+        if (!isOverflow()) {
+          setFontSize(maxFs);
+          setReady(true);
+          return;
+        }
+        // 二分搜尋能放下的最大字級
+        let lo = minFontSize;
+        let hi = maxFs;
+        let best = minFontSize;
+        for (let i = 0; i < 6 && lo <= hi; i++) {
+          const mid = Math.floor((lo + hi) / 2);
+          el.style.fontSize = `${mid}px`;
+          if (isOverflow()) {
+            hi = mid - 1;
+          } else {
+            best = mid;
+            lo = mid + 1;
+          }
+        }
+        el.style.fontSize = `${best}px`;
+        setFontSize(best);
+        setReady(true);
+      });
+    };
+
+    // 等字型載完才量；fonts API 不支援的瀏覽器直接量
+    const fontsReady = document.fonts?.ready ?? Promise.resolve();
+    fontsReady.then(() => {
+      if (!cancelled) measure();
+    });
+
+    const ro = new ResizeObserver(measure);
+    ro.observe(parent);
+
+    return () => {
+      cancelled = true;
+      ro.disconnect();
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ref, maxRatio.h, maxRatio.w, minFontSize, ...deps]);
+
+  return { fontSize, ready };
+}

--- a/frontend/src/components/shared/BatchWorkPanel.tsx
+++ b/frontend/src/components/shared/BatchWorkPanel.tsx
@@ -5,6 +5,9 @@
  * 並提供確認/暫停按鈕與進度條。
  *
  * 各 panel 透過 props 傳入自己的解析邏輯（onConfirm）和額外 slot（children）。
+ *
+ * pasteLabel：覆寫貼上區標題文字（往下傳給 BatchPasteArea 的 label）。
+ *   未傳則沿用 BatchPasteArea 預設（單字用字串）；例句集/朗讀應傳入句子相關文案。
  */
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
@@ -28,6 +31,8 @@ export interface BatchWorkPanelProps {
   onTextChange: (text: string) => void;
   maxItems: number;
   placeholder?: string;
+  /** 貼上區標題文字（往下傳給 BatchPasteArea 的 label）；未傳則用其預設 */
+  pasteLabel?: string;
 
   // --- Translate settings ---
   autoTranslate: boolean;
@@ -59,6 +64,7 @@ export function BatchWorkPanel({
   onTextChange,
   maxItems,
   placeholder,
+  pasteLabel,
   autoTranslate,
   onAutoTranslateChange,
   selectedLanguage,
@@ -86,6 +92,7 @@ export function BatchWorkPanel({
           text={text}
           onChange={onTextChange}
           maxItems={maxItems}
+          label={pasteLabel}
           placeholder={placeholder}
           variant="inline"
         />

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -4480,6 +4480,7 @@
     "labels": {
       "title": "Title",
       "pasteContent": "Paste vocabulary",
+      "pasteSentences": "Paste sentences",
       "batchOperations": "Batch Operations",
       "aiGenerateTTS": "AI Generate Audio",
       "aiGenerateTranslation": "AI Auto Translate",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -4498,6 +4498,7 @@
     "labels": {
       "title": "標題",
       "pasteContent": "請貼上單字",
+      "pasteSentences": "請貼上句子",
       "batchOperations": "批次操作",
       "aiGenerateTTS": "AI 生成語音",
       "aiGenerateTranslation": "AI 自動翻譯",


### PR DESCRIPTION
## 概述

修正 issue #842：單字選擇「艾賓浩斯／小考」的 UI 問題，並處理事後補充的例句集編輯器卷軸需求。

Fixes #842

## 變更內容

### 1. 題目文字外距不足
- `WordSelectionActivity.tsx`：題目文字區塊加上 `py-4 sm:py-6`，增加上下呼吸感

### 2. 選項長文字勿用 `...` 截斷 → 改自動縮字
- 新增 `useShrinkToFit.ts` hook：量測 overflow 後以二分搜尋動態縮放字級（取代純 CSS `clamp()`，後者只看容器不看文字長度）
  - `useLayoutEffect` + `opacity-0` 直到量測完成，避免閃過大字
  - 等 `document.fonts.ready` 避免 fallback 字型量寬偏差
  - `ResizeObserver` 觀察容器尺寸變化重算
- `WordSelectionOptionButton.tsx`：套用 shrink-to-fit，純文字最小 8px、圖片模式 7px；兩個活動行為一致

### 3. 例句集 > 編輯器：內容多時顯示單一卷軸（補充需求）
- `ReadingAssessmentPanel.tsx`：移除根容器高度鎖定與內層清單 overflow，改由外層面板單一捲動，消除右側雙卷軸、左欄 sticky 不再被切掉
- `BatchWorkPanel.tsx`：新增 `pasteLabel` prop 往下傳給 `BatchPasteArea`
- i18n：新增 `contentEditor.labels.pasteSentences`（zh/en），例句集顯示「請貼上句子」

## 驗收

- [x] 題目文字上下外距增加
- [x] 選項文字過長時自動縮小字體完整顯示，不再 `...` 截斷
- [x] 兩個活動行為一致
- [x] 例句集編輯器內容多時顯示卷軸（測試者已於預覽環境驗證通過；先前回報無卷軸為瀏覽器快取舊 bundle）

## 測試環境
已於 issue-842 預覽環境驗證通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)