### PR TITLE
fix(#850): 1Campus SSO 老師建立時補上 email_verified

### DIFF
--- a/backend/alembic/versions/20260615_1000_backfill_sso_teacher_email_verified.py
+++ b/backend/alembic/versions/20260615_1000_backfill_sso_teacher_email_verified.py
@@ -1,0 +1,60 @@
+"""Backfill email_verified on existing 1Campus SSO teachers.
+
+Revision ID: 20260615_1000
+Revises: 20260608_1000
+Create Date: 2026-06-15 10:00:00
+
+Issue #850: teachers created via 1Campus/ischool SSO never had
+`teachers.email_verified` set, so it kept the model default `False`. The
+admin subscription dashboard's "Unverified" badge reads
+`teachers.email_verified`, so verified SSO teachers showed up as
+Unverified — even though their linked Identity was correctly marked
+`email_verified=True` (and one teacher had been manually patched on the
+*Identity* row, which the admin never reads).
+
+The service is fixed in the same PR so new SSO teachers land verified.
+This migration repairs existing rows: any teacher whose linked Identity
+is a verified 1Campus identity but whose own `email_verified` is not TRUE
+is set to verified, timestamped from the Identity (falling back to NOW()).
+
+Idempotent:
+  - `t.email_verified IS DISTINCT FROM TRUE` skips already-verified rows
+    (covers both FALSE and NULL); a second run touches zero rows.
+  - Scoped to 1Campus-linked identities only — never touches non-SSO
+    teachers (e.g. email/password accounts pending real verification).
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "20260615_1000"
+down_revision: Union[str, None] = "20260608_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE teachers t
+        SET email_verified = TRUE,
+            email_verified_at = COALESCE(i.email_verified_at, NOW())
+        FROM identities i
+        WHERE t.identity_id = i.id
+          AND i.email_verified = TRUE
+          AND (
+              i.one_campus_account IS NOT NULL
+              OR i.one_campus_uuid IS NOT NULL
+          )
+          AND t.email_verified IS DISTINCT FROM TRUE;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Intentional no-op: reverting would re-introduce the admin "Unverified"
+    # badge bug for legitimately-verified SSO teachers. The service fix keeps
+    # new rows correct going forward.
+    pass

--- a/backend/services/one_campus_account_service.py
+++ b/backend/services/one_campus_account_service.py
@@ -503,11 +503,17 @@ class OneCampusAccountService:
         else:
             teacher_email = one_campus_account
 
+        # 1Campus is the IdP and verifies institutional emails on its side,
+        # so we trust the returned account as already verified (mirrors the
+        # OAuth flow below). The admin "Unverified" badge reads
+        # Teacher.email_verified, so both rows must carry the verified flag.
+        verified_at = datetime.now(timezone.utc)
         identity = Identity(
             email=one_campus_account if not identity_email_taken else None,
             one_campus_account=one_campus_account,
             national_id_hash=national_id_hash,
-            email_verified=False,
+            email_verified=bool(one_campus_account),
+            email_verified_at=verified_at if one_campus_account else None,
             is_active=True,
         )
         db.add(identity)
@@ -520,6 +526,8 @@ class OneCampusAccountService:
             has_password=False,
             identity_id=identity.id,
             is_active=True,
+            email_verified=True,
+            email_verified_at=verified_at,
         )
         db.add(teacher)
         db.commit()
@@ -821,6 +829,11 @@ class OneCampusAccountService:
                 has_password=False,
                 identity_id=identity.id,
                 is_active=True,
+                # 1Campus verifies institutional emails on its side; the admin
+                # "Unverified" badge reads Teacher.email_verified, so a verified
+                # SSO login must set it here too.
+                email_verified=True,
+                email_verified_at=datetime.now(timezone.utc),
             )
             db.add(teacher)
             db.commit()

--- a/backend/tests/unit/test_one_campus_account_merge.py
+++ b/backend/tests/unit/test_one_campus_account_merge.py
@@ -227,6 +227,65 @@ class TestTeacherEmailAutoMerge:
 
 
 # ---------------------------------------------------------------------------
+# New SSO teachers must be auto-verified (Issue #850)
+#
+# 1Campus is the IdP and verifies institutional emails on its side, so a
+# teacher created via SSO must land with email_verified=True on BOTH the
+# Identity AND the Teacher. The admin "Unverified" badge reads
+# Teacher.email_verified, so a False there shows verified SSO teachers as
+# unverified.
+# ---------------------------------------------------------------------------
+
+
+class TestSsoTeacherAutoVerified:
+    """Newly-created SSO teachers must have email_verified=True."""
+
+    def test_identity_code_flow_new_teacher_is_verified(self, shared_test_session):
+        """find_or_create_teacher (Identity Code flow) → teacher & identity verified."""
+        db = shared_test_session
+
+        identity, teacher, action = OneCampusAccountService.find_or_create_teacher(
+            db,
+            one_campus_account="newteacher@school.edu.tw",
+            teacher_name="New SSO Teacher",
+            national_id_hash="c" * 64,
+        )
+
+        assert action == "created"
+        # Teacher is what the admin list reads — must be verified
+        assert teacher.email_verified is True
+        assert teacher.email_verified_at is not None
+        # Identity must also reflect the trusted-IdP verification
+        assert identity.email_verified is True
+        assert identity.email_verified_at is not None
+
+    def test_oauth_flow_new_teacher_is_verified(self, shared_test_session):
+        """find_or_create_by_oauth (OAuth flow) → teacher & identity verified."""
+        db = shared_test_session
+
+        (
+            identity,
+            teacher,
+            role_type,
+            action,
+        ) = OneCampusAccountService.find_or_create_by_oauth(
+            db,
+            uuid="oauth-uuid-verified-001",
+            mail="oauthteacher@school.edu.tw",
+            first_name="OAuth",
+            last_name="Teacher",
+            role_type="teacher",
+            teacher_name="OAuth Teacher",
+        )
+
+        assert action == "created"
+        assert role_type == "teacher"
+        assert teacher.email_verified is True
+        assert teacher.email_verified_at is not None
+        assert identity.email_verified is True
+
+
+# ---------------------------------------------------------------------------
 # Aggregated classrooms via identity_id
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #850

## 問題
老師透過 1Campus/ischool SSO 登入時，`teachers.email_verified` 從未被設值（吃 model default `False`）。但 admin 訂閱列表的「Unverified」徽章正是讀 `teachers.email_verified`，導致已由 IdP 驗證的 SSO 老師在後台顯示為未驗證。其 linked Identity 其實已正確標 `email_verified=True`（先前對某帳號的手動修補補在 Identity 上，admin 根本不讀）。

## 修正
1. **OAuth flow Teacher**（`one_campus_account_service.py`）建立時補 `email_verified=True, email_verified_at`
2. **Identity Code flow Teacher** 同樣補上
3. **Identity Code flow Identity** 由寫死 `email_verified=False` 改為 `bool(one_campus_account)`（對齊 OAuth flow）
4. 學生不動（無 email、與 admin 老師驗證無關）

## Backfill
新增 idempotent migration `20260615_1000_backfill_sso_teacher_email_verified.py`：
- 把「linked Identity 為已驗證的 1Campus identity、但自身 `email_verified` 不為 TRUE」的老師補成已驗證
- `email_verified_at = COALESCE(identity.email_verified_at, NOW())`
- 僅 scope 1Campus-linked identities，`IS DISTINCT FROM TRUE` 確保重跑觸碰 0 列

## 測試
- 新增 `TestSsoTeacherAutoVerified`（兩條建立路徑各一），先 red 後 green
- 28 個 SSO 相關測試 + 10 個 OAuth/bind 測試全綠
- black ✅ flake8 ✅ alembic 單一 head ✅

## 驗收
- SSO 老師首次登入後 admin 直接顯示已驗證
- 既有受影響老師（PROD teacher_id 125/126/127 等）backfill 後不再 Unverified

🤖 Generated with [Claude Code](https://claude.com/claude-code)