### PR TITLE
fix(#768): subscription status + cards on /teacher/subscription + leader phone

### DIFF
--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -121,6 +121,11 @@ class GroupBuyOpenRequest(BaseModel):
     # only the leader's binding is created (legacy path; admin uses PR #841
     # to add members later via /admin/subscription/create).
     member_emails: List[EmailStr] = []
+    # Issue #768 comment 4638082532 item 2 — team leader's contact phone.
+    # The original spec said "連絡電話(必填)"; we capture it here for the
+    # leader's row only and persist into the audit metadata so support
+    # can reach the buyer if needed. Frontend enforces non-empty.
+    leader_phone: Optional[str] = None
 
 
 class GroupBuyOpenResponse(BaseModel):

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal, ROUND_HALF_UP
 
 from dateutil.relativedelta import relativedelta
-from pydantic import BaseModel, EmailStr, field_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator
 from typing import Optional, Dict, Any, List
 import logging
 import uuid
@@ -122,10 +122,23 @@ class GroupBuyOpenRequest(BaseModel):
     # to add members later via /admin/subscription/create).
     member_emails: List[EmailStr] = []
     # Issue #768 comment 4638082532 item 2 — team leader's contact phone.
-    # The original spec said "連絡電話(必填)"; we capture it here for the
-    # leader's row only and persist into the audit metadata so support
-    # can reach the buyer if needed. Frontend enforces non-empty.
-    leader_phone: Optional[str] = None
+    # The original spec said "連絡電話(必填)"; we capture it here and ship
+    # it into BigQuery audit so support can reach the buyer on refunds /
+    # disputes. Server-side `min_length=1` (after strip) so a client
+    # bypassing the frontend with curl can't silently submit empty —
+    # which would defeat the audit purpose. `max_length=20` mirrors a
+    # reasonable phone-number ceiling (intl prefix + digits + dashes).
+    leader_phone: Optional[str] = Field(None, max_length=20)
+
+    @field_validator("leader_phone")
+    @classmethod
+    def _phone_non_blank(cls, v):
+        if v is None:
+            return v
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("leader_phone must not be empty or whitespace-only")
+        return stripped
 
 
 class GroupBuyOpenResponse(BaseModel):

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -15,6 +15,9 @@ from models import (
     SubscriptionPeriod,
     PointUsageLog,
     TeacherOrganization,
+    Organization,
+    School,
+    TeacherSchool,
 )
 from routers.teachers import get_current_teacher
 from services.tappay_service import TapPayService
@@ -964,17 +967,38 @@ async def get_subscription_status(
         # Owner is a special case: they're ALSO a member, and we
         # surface a distinct `plan_type` so the frontend can show
         # team-management UI (future).
-        from models import (
-            Organization,
-            School,
-            TeacherOrganization,
-            TeacherSchool,
-        )
-
-        gb_membership = (
-            db.query(Organization, School)
+        #
+        # Multi-org edge case: the R2-F2 single-org guard in
+        # `open_group_buy` prevents a teacher from opening more than
+        # one team they own, and the validate-team-emails check rejects
+        # adding a member who is already in another group-buy team. So
+        # in normal operation each teacher belongs to at most one
+        # active group-buy org. The `order_by(...end_date.desc()
+        # .nullslast())` here is purely defensive: if a manual data
+        # fix or admin override ever produced two active rows, we'd
+        # surface the longer-lived one, which is the more useful date
+        # to show the user.
+        #
+        # Single LEFT JOIN against TeacherOrganization on the same
+        # query so the owner-vs-member determination is one round-trip
+        # instead of two. For individual teachers this stays a single
+        # zero-row query; for the (much rarer) group-buy case it's one
+        # query for both bits of info.
+        gb_query = (
+            db.query(
+                Organization,
+                School,
+                TeacherOrganization.role,
+            )
             .join(School, School.organization_id == Organization.id)
             .join(TeacherSchool, TeacherSchool.school_id == School.id)
+            .outerjoin(
+                TeacherOrganization,
+                (TeacherOrganization.organization_id == Organization.id)
+                & (TeacherOrganization.teacher_id == current_teacher.id)
+                & (TeacherOrganization.is_active.is_(True))
+                & (TeacherOrganization.role == "org_owner"),
+            )
             .filter(
                 TeacherSchool.teacher_id == current_teacher.id,
                 TeacherSchool.is_active.is_(True),
@@ -988,23 +1012,13 @@ async def get_subscription_status(
         plan_type = "individual"
         gb_end_date_override = None
         gb_auto_renew_override = None
-        if gb_membership is not None:
-            gb_org, _ = gb_membership
-            # Member by default; promote to owner if a matching
-            # TeacherOrganization row exists.
-            plan_type = "group_buy_member"
-            is_owner = (
-                db.query(TeacherOrganization)
-                .filter(
-                    TeacherOrganization.teacher_id == current_teacher.id,
-                    TeacherOrganization.organization_id == gb_org.id,
-                    TeacherOrganization.role == "org_owner",
-                    TeacherOrganization.is_active.is_(True),
-                )
-                .first()
+        if gb_query is not None:
+            gb_org, _gb_school, gb_owner_role = gb_query
+            plan_type = (
+                "group_buy_owner"
+                if gb_owner_role == "org_owner"
+                else "group_buy_member"
             )
-            if is_owner is not None:
-                plan_type = "group_buy_owner"
             gb_end_date_override = gb_org.subscription_end_date
             # Group-buy plans don't have per-teacher auto-renew — points
             # come from the team leader's annual fee.

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -931,6 +931,13 @@ async def get_subscription_status(
     - 是否自動續訂
     - 取消時間
     - 配額使用狀況
+
+    Issue #768 — group-buy members see their team's ANNUAL end date
+    (Organization.subscription_end_date) and no "auto_renew" UI, even
+    though their underlying monthly SubscriptionPeriod ends at month
+    boundary (cron grants the next month). Without this override the
+    UI showed the monthly date as the user's expiry, which was a
+    user-visible defect (issue #768 comment 4638082532 item 4).
     """
     try:
         # Calculate is_active
@@ -950,6 +957,58 @@ async def get_subscription_status(
         except Exception as e:
             logger.error(f"Error fetching current_period: {e}")
             # Continue without period data
+
+        # Issue #768 — Detect group-buy membership and override expiry +
+        # auto-renew semantics. A teacher is a group-buy member if they
+        # have an active TeacherSchool in an active group-buy School.
+        # Owner is a special case: they're ALSO a member, and we
+        # surface a distinct `plan_type` so the frontend can show
+        # team-management UI (future).
+        from models import (
+            Organization,
+            School,
+            TeacherOrganization,
+            TeacherSchool,
+        )
+
+        gb_membership = (
+            db.query(Organization, School)
+            .join(School, School.organization_id == Organization.id)
+            .join(TeacherSchool, TeacherSchool.school_id == School.id)
+            .filter(
+                TeacherSchool.teacher_id == current_teacher.id,
+                TeacherSchool.is_active.is_(True),
+                School.is_active.is_(True),
+                Organization.is_active.is_(True),
+                Organization.org_type == "group_buy",
+            )
+            .order_by(Organization.subscription_end_date.desc().nullslast())
+            .first()
+        )
+        plan_type = "individual"
+        gb_end_date_override = None
+        gb_auto_renew_override = None
+        if gb_membership is not None:
+            gb_org, _ = gb_membership
+            # Member by default; promote to owner if a matching
+            # TeacherOrganization row exists.
+            plan_type = "group_buy_member"
+            is_owner = (
+                db.query(TeacherOrganization)
+                .filter(
+                    TeacherOrganization.teacher_id == current_teacher.id,
+                    TeacherOrganization.organization_id == gb_org.id,
+                    TeacherOrganization.role == "org_owner",
+                    TeacherOrganization.is_active.is_(True),
+                )
+                .first()
+            )
+            if is_owner is not None:
+                plan_type = "group_buy_owner"
+            gb_end_date_override = gb_org.subscription_end_date
+            # Group-buy plans don't have per-teacher auto-renew — points
+            # come from the team leader's annual fee.
+            gb_auto_renew_override = False
 
         # Aggregated quota (subscription + credit packages)
         from services.quota_service import QuotaService
@@ -995,21 +1054,45 @@ async def get_subscription_status(
             for pkg in credit_packages
         ]
 
-        return {
-            "status": current_teacher.subscription_status or "INACTIVE",
-            "plan": current_period.plan_name if current_period else None,
-            "end_date": (
-                current_teacher.subscription_end_date.isoformat()
-                if current_teacher.subscription_end_date
-                else None
-            ),
-            "days_remaining": current_teacher.days_remaining,
-            "is_active": is_active,
-            "auto_renew": (
+        # Build end_date with group-buy override when applicable.
+        if gb_end_date_override is not None:
+            effective_end_date = gb_end_date_override
+            now = datetime.now(timezone.utc)
+            end_utc = (
+                effective_end_date.replace(tzinfo=timezone.utc)
+                if effective_end_date.tzinfo is None
+                else effective_end_date
+            )
+            is_active = end_utc > now
+            days_remaining = max(0, (end_utc - now).days)
+        else:
+            effective_end_date = current_teacher.subscription_end_date
+            days_remaining = current_teacher.days_remaining
+
+        if gb_auto_renew_override is not None:
+            auto_renew = gb_auto_renew_override
+        else:
+            auto_renew = (
                 current_teacher.subscription_auto_renew
                 if current_teacher.subscription_auto_renew is not None
                 else True
+            )
+
+        return {
+            "status": current_teacher.subscription_status or "INACTIVE",
+            "plan": current_period.plan_name if current_period else None,
+            # Issue #768 — surfaces whether this teacher is on an
+            # individual plan, a group-buy member, or the group-buy
+            # team leader. Frontend reads this to pick the right
+            # quota label, auto-renew banner visibility, and any
+            # team-management CTAs.
+            "plan_type": plan_type,
+            "end_date": (
+                effective_end_date.isoformat() if effective_end_date else None
             ),
+            "days_remaining": days_remaining,
+            "is_active": is_active,
+            "auto_renew": auto_renew,
             "cancelled_at": (
                 current_teacher.subscription_cancelled_at.isoformat()
                 if current_teacher.subscription_cancelled_at

--- a/backend/tests/test_subscription_status_group_buy.py
+++ b/backend/tests/test_subscription_status_group_buy.py
@@ -148,10 +148,19 @@ def test_group_buy_member_status_overrides_end_date_and_plan_type(
     body = r.json()
     assert body["plan_type"] == "group_buy_member"
     assert body["auto_renew"] is False
-    # end_date should match the org's annual subscription end date,
-    # NOT the member's monthly period end_date.
-    org_end_iso = org.subscription_end_date.isoformat()
-    assert body["end_date"] == org_end_iso
+    # Refresh from session so we compare the DB-persisted value (the
+    # ORM may return tz-naive on a TIMESTAMP WITHOUT TIME ZONE column;
+    # the in-memory fixture value is tz-aware via datetime.now(utc)).
+    # Compare both sides as datetimes (tz-stripped) instead of ISO
+    # strings so the assertion is robust across both representations.
+    shared_test_session.refresh(org)
+    body_end = datetime.fromisoformat(body["end_date"])
+    org_end = org.subscription_end_date
+    if body_end.tzinfo is not None:
+        body_end = body_end.replace(tzinfo=None)
+    if org_end.tzinfo is not None:
+        org_end = org_end.replace(tzinfo=None)
+    assert body_end == org_end
     # ~365 days minus the time elapsed since fixture setup (sub-second).
     assert body["days_remaining"] >= 360
     assert body["is_active"] is True

--- a/backend/tests/test_subscription_status_group_buy.py
+++ b/backend/tests/test_subscription_status_group_buy.py
@@ -1,0 +1,189 @@
+"""Tests for GET /api/subscription/status group-buy branch
+(issue #768 comment 4638082532 item 4).
+
+Verifies the backend overrides applied for group-buy members so the
+frontend can render the correct expiry, auto-renew semantics, and a
+distinct plan_type for UI dispatch.
+"""
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from auth import create_access_token, get_password_hash
+from models import (
+    Organization,
+    Plan,
+    School,
+    SubscriptionPeriod,
+    Teacher,
+    TeacherOrganization,
+    TeacherSchool,
+)
+
+
+def _bearer(teacher_id):
+    token = create_access_token(data={"sub": str(teacher_id), "type": "teacher"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def gb_plan(shared_test_session):
+    p = Plan(
+        name="團購-10席-sub-status",
+        price=None,
+        quota=1000,
+        teacher_seats=10,
+        annual_fee=1500,
+        topup_discount=Decimal("0.95"),
+        is_active=True,
+    )
+    shared_test_session.add(p)
+    shared_test_session.commit()
+    shared_test_session.refresh(p)
+    return p
+
+
+def _make_teacher(shared_test_session, email):
+    t = Teacher(
+        email=email,
+        password_hash=get_password_hash("x"),
+        name=email.split("@")[0],
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+def _make_group_buy_team(
+    shared_test_session, gb_plan, owner, members, *, end_in_days=365
+):
+    """Seed a fully-shaped group-buy org + school + owner / member
+    bindings. Returns (org, school)."""
+    now = datetime.now(timezone.utc)
+    org = Organization(
+        name="Sub-status 團",
+        org_type="group_buy",
+        subscription_start_date=now,
+        subscription_end_date=now + timedelta(days=end_in_days),
+        is_active=True,
+    )
+    shared_test_session.add(org)
+    shared_test_session.flush()
+    school = School(
+        organization_id=org.id,
+        name="Sub-status 團 School",
+        plan_id=gb_plan.id,
+        teacher_seat_limit=gb_plan.teacher_seats,
+        is_active=True,
+    )
+    shared_test_session.add(school)
+    shared_test_session.flush()
+    shared_test_session.add(
+        TeacherOrganization(
+            teacher_id=owner.id,
+            organization_id=org.id,
+            role="org_owner",
+            is_active=True,
+        )
+    )
+    shared_test_session.add(
+        TeacherSchool(
+            teacher_id=owner.id,
+            school_id=school.id,
+            roles=["school_admin"],
+            is_active=True,
+        )
+    )
+    for m in members:
+        shared_test_session.add(
+            TeacherSchool(
+                teacher_id=m.id,
+                school_id=school.id,
+                roles=["teacher"],
+                is_active=True,
+            )
+        )
+        # Each member also has a current month's SubscriptionPeriod —
+        # what the cron grants. End date is month-end, but the status
+        # endpoint must override it with the org's annual end date.
+        shared_test_session.add(
+            SubscriptionPeriod(
+                teacher_id=m.id,
+                plan_name=gb_plan.name,
+                amount_paid=0,
+                quota_total=1000,
+                quota_used=0,
+                start_date=datetime.now(timezone.utc),
+                end_date=datetime.now(timezone.utc).replace(day=28, hour=23, minute=59),
+                payment_method="group_buy",
+                payment_status="paid",
+                status="active",
+            )
+        )
+    shared_test_session.commit()
+    return org, school
+
+
+def test_group_buy_member_status_overrides_end_date_and_plan_type(
+    test_client, shared_test_session, gb_plan
+):
+    """Member's `current_period.end_date` is month-end; status endpoint
+    MUST surface the org's annual `subscription_end_date` instead so
+    the UI shows the correct user-perceived expiry. Also asserts
+    plan_type=group_buy_member, auto_renew=False, days_remaining
+    derived from the annual end date."""
+    owner = _make_teacher(shared_test_session, "gbsub-owner@duotopia.com")
+    member = _make_teacher(shared_test_session, "gbsub-member@duotopia.com")
+    org, _ = _make_group_buy_team(
+        shared_test_session, gb_plan, owner, [member], end_in_days=365
+    )
+
+    r = test_client.get("/api/subscription/status", headers=_bearer(member.id))
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert body["plan_type"] == "group_buy_member"
+    assert body["auto_renew"] is False
+    # end_date should match the org's annual subscription end date,
+    # NOT the member's monthly period end_date.
+    org_end_iso = org.subscription_end_date.isoformat()
+    assert body["end_date"] == org_end_iso
+    # ~365 days minus the time elapsed since fixture setup (sub-second).
+    assert body["days_remaining"] >= 360
+    assert body["is_active"] is True
+
+
+def test_group_buy_owner_status_returns_group_buy_owner_plan_type(
+    test_client, shared_test_session, gb_plan
+):
+    """Owner gets the distinct `group_buy_owner` plan_type so the
+    frontend can later surface team-management UI without re-querying."""
+    owner = _make_teacher(shared_test_session, "gbsub-owner2@duotopia.com")
+    member = _make_teacher(shared_test_session, "gbsub-member2@duotopia.com")
+    _make_group_buy_team(shared_test_session, gb_plan, owner, [member])
+
+    r = test_client.get("/api/subscription/status", headers=_bearer(owner.id))
+    assert r.status_code == 200
+    body = r.json()
+    assert body["plan_type"] == "group_buy_owner"
+    assert body["auto_renew"] is False
+
+
+def test_individual_teacher_status_unaffected_by_group_buy_branch(
+    test_client, shared_test_session
+):
+    """Regression guard: a teacher with no group-buy binding still
+    returns plan_type='individual' and the existing auto_renew /
+    end_date semantics."""
+    solo = _make_teacher(shared_test_session, "gbsub-solo@duotopia.com")
+    r = test_client.get("/api/subscription/status", headers=_bearer(solo.id))
+    assert r.status_code == 200
+    body = r.json()
+    assert body["plan_type"] == "individual"
+    # auto_renew defaults to True per the existing endpoint behaviour
+    # when the teacher has no explicit subscription_auto_renew flag.
+    assert body["auto_renew"] is True

--- a/frontend/src/components/pricing/GroupBuyPlanCards.tsx
+++ b/frontend/src/components/pricing/GroupBuyPlanCards.tsx
@@ -1,0 +1,168 @@
+/**
+ * Group-buy plan cards (issue #768 comment 4638082532 item 3).
+ *
+ * Extracted from `PricingPage` so the same 3-card grid + identical
+ * fallback semantics can be re-used on `/teacher/subscription` (the
+ * subscription-management page also needs to surface group-buy plans
+ * to teachers who already have an individual subscription).
+ *
+ * Data flow:
+ *   - fetch `/api/credit-packages/group-buy-plans` (public endpoint,
+ *     no auth required).
+ *   - on success, render the live values.
+ *   - on failure, fall back to the seed snapshot below so anonymous /
+ *     transient-error visitors still see something useful instead of
+ *     an empty card grid.
+ *
+ * IMPORTANT: the fallback values mirror the DB seed as of 2026-06-15.
+ * Admin action path: after editing any 團購 plan at `/admin/plans`
+ * (quota, annual_fee, topup_discount, teacher_seats), ALSO update the
+ * corresponding entry in `GROUP_BUY_FALLBACK` below. Live PricingPage /
+ * TeacherSubscription will reflect the new values as long as the API
+ * request succeeds; the fallback only fires on network failure / 5xx,
+ * and at that point will silently show stale data unless kept in sync.
+ */
+import React from "react";
+import { apiClient } from "@/lib/api";
+
+export interface GroupBuyMarketingPlan {
+  name: string;
+  teacher_seats: number;
+  annual_fee: number;
+  total_amount: number;
+  topup_discount: number;
+  monthly_quota: number;
+  display_order: number;
+}
+
+export const GROUP_BUY_FALLBACK: GroupBuyMarketingPlan[] = [
+  {
+    name: "團購-10席",
+    teacher_seats: 10,
+    annual_fee: 1500,
+    total_amount: 15000,
+    topup_discount: 0.95,
+    monthly_quota: 1000,
+    display_order: 10,
+  },
+  {
+    name: "團購-30席",
+    teacher_seats: 30,
+    annual_fee: 1300,
+    total_amount: 39000,
+    topup_discount: 0.9,
+    monthly_quota: 1000,
+    display_order: 11,
+  },
+  {
+    name: "團購-50席",
+    teacher_seats: 50,
+    annual_fee: 1000,
+    total_amount: 50000,
+    topup_discount: 0.85,
+    monthly_quota: 1000,
+    display_order: 12,
+  },
+];
+
+interface Props {
+  /**
+   * Optional click handler for each card's body. When provided,
+   * clicking the card fires the callback with the plan name; useful
+   * for callers that want to chain into the open-team flow. When
+   * omitted, cards are inert (PricingPage uses a single CTA button
+   * outside the grid, so per-card click would be misleading).
+   */
+  onSelectPlan?: (planName: string) => void;
+}
+
+export function GroupBuyPlanCards({ onSelectPlan }: Props) {
+  const [plans, setPlans] =
+    React.useState<GroupBuyMarketingPlan[]>(GROUP_BUY_FALLBACK);
+  React.useEffect(() => {
+    let cancelled = false;
+    apiClient
+      .listGroupBuyPlans()
+      .then((data) => {
+        if (cancelled) return;
+        if (Array.isArray(data) && data.length > 0) setPlans(data);
+      })
+      .catch(() => {
+        // Keep fallback; the page already renders something useful.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return (
+    <>
+      <div className="text-center">
+        <h2 className="text-2xl font-bold text-gray-900">👥 教師團購方案</h2>
+        <p className="text-sm text-gray-600 mt-2 max-w-2xl mx-auto">
+          為您的教師團隊一次採購年費方案，享更低的每席費用 +
+          加購點數包折扣。團主刷卡一次即可開團，月配點自動發放給團內每位教師。
+        </p>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {plans.map((p) => {
+          const clickable = Boolean(onSelectPlan);
+          return (
+            <div
+              key={p.name}
+              role={clickable ? "button" : undefined}
+              tabIndex={clickable ? 0 : undefined}
+              onClick={clickable ? () => onSelectPlan?.(p.name) : undefined}
+              onKeyDown={
+                clickable
+                  ? (e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onSelectPlan?.(p.name);
+                      }
+                    }
+                  : undefined
+              }
+              className={
+                "rounded-xl border border-gray-200 bg-white p-6 flex flex-col" +
+                (clickable
+                  ? " cursor-pointer hover:border-blue-400 hover:shadow-md transition"
+                  : "")
+              }
+            >
+              <div className="text-lg font-bold text-gray-900">{p.name}</div>
+              <div className="text-sm text-gray-500">
+                {p.teacher_seats} 位教師席次
+              </div>
+              <div className="my-4 space-y-1 text-sm">
+                <div>
+                  每席年費{" "}
+                  <span className="font-semibold">
+                    NT$ {p.annual_fee.toLocaleString()}
+                  </span>
+                </div>
+                <div>
+                  月配點{" "}
+                  <span className="font-semibold">
+                    {p.monthly_quota.toLocaleString()} 點 / 教師
+                  </span>
+                </div>
+                <div>
+                  加購折扣{" "}
+                  <span className="font-semibold">
+                    {Math.round((1 - p.topup_discount) * 100)}% off
+                  </span>
+                </div>
+              </div>
+              <div className="mt-auto pt-3 border-t border-gray-200">
+                <div className="text-xs text-gray-500">團隊總價</div>
+                <div className="text-xl font-bold text-blue-600">
+                  NT$ {p.total_amount.toLocaleString()} / 年
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/PricingPage.tsx
+++ b/frontend/src/pages/PricingPage.tsx
@@ -37,6 +37,7 @@ import LineContactButton, {
   LINE_FRIEND_URL,
 } from "@/components/LineContactButton";
 import { apiClient } from "@/lib/api";
+import { GroupBuyPlanCards } from "@/components/pricing/GroupBuyPlanCards";
 
 function getSubscriptionPlans(t: (key: string) => string): SubscriptionPlan[] {
   return [
@@ -110,128 +111,10 @@ const pointPackages: PointPackage[] = [
 
 const BASE_UNIT_COST = 0.18; // highest unit cost for discount calculation
 
-// Issue #768 comment #3 part 2 — group-buy marketing cards. Fetched from
-// the (now public) /api/credit-packages/group-buy-plans endpoint so admin
-// edits to the Plan table propagate live. Hardcoded seed used as fallback
-// only if the request fails — keeps anonymous visitors from seeing an
-// empty card grid on transient API hiccups.
-interface GroupBuyMarketingPlan {
-  name: string;
-  teacher_seats: number;
-  annual_fee: number;
-  total_amount: number;
-  topup_discount: number;
-  monthly_quota: number;
-  display_order: number;
-}
-
-// IMPORTANT: these values mirror the DB seed as of 2026-06-15.
-// Admin action path: after editing any 團購 plan at `/admin/plans`
-// (quota, annual_fee, topup_discount, teacher_seats), ALSO update the
-// corresponding entry in this `GROUP_BUY_FALLBACK` constant. Live
-// PricingPage will reflect the new values as long as the API request
-// succeeds; this fallback only fires on network failure / 5xx, and at
-// that point will silently show stale data unless kept in sync. There
-// is no automated enforcement — this comment is the only safety net.
-const GROUP_BUY_FALLBACK: GroupBuyMarketingPlan[] = [
-  {
-    name: "團購-10席",
-    teacher_seats: 10,
-    annual_fee: 1500,
-    total_amount: 15000,
-    topup_discount: 0.95,
-    monthly_quota: 1000,
-    display_order: 10,
-  },
-  {
-    name: "團購-30席",
-    teacher_seats: 30,
-    annual_fee: 1300,
-    total_amount: 39000,
-    topup_discount: 0.9,
-    monthly_quota: 1000,
-    display_order: 11,
-  },
-  {
-    name: "團購-50席",
-    teacher_seats: 50,
-    annual_fee: 1000,
-    total_amount: 50000,
-    topup_discount: 0.85,
-    monthly_quota: 1000,
-    display_order: 12,
-  },
-];
-
-function GroupBuyCards() {
-  const [plans, setPlans] =
-    useState<GroupBuyMarketingPlan[]>(GROUP_BUY_FALLBACK);
-  useEffect(() => {
-    let cancelled = false;
-    apiClient
-      .listGroupBuyPlans()
-      .then((data) => {
-        if (cancelled) return;
-        if (Array.isArray(data) && data.length > 0) setPlans(data);
-      })
-      .catch(() => {
-        // Keep the fallback; the page already renders something useful.
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-  return (
-    <>
-      <div className="text-center">
-        <h2 className="text-2xl font-bold text-gray-900">👥 教師團購方案</h2>
-        <p className="text-sm text-gray-600 mt-2 max-w-2xl mx-auto">
-          為您的教師團隊一次採購年費方案，享更低的每席費用 +
-          加購點數包折扣。團主刷卡一次即可開團，月配點自動發放給團內每位教師。
-        </p>
-      </div>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        {plans.map((p) => (
-          <div
-            key={p.name}
-            className="rounded-xl border border-gray-200 bg-white p-6 flex flex-col"
-          >
-            <div className="text-lg font-bold text-gray-900">{p.name}</div>
-            <div className="text-sm text-gray-500">
-              {p.teacher_seats} 位教師席次
-            </div>
-            <div className="my-4 space-y-1 text-sm">
-              <div>
-                每席年費{" "}
-                <span className="font-semibold">
-                  NT$ {p.annual_fee.toLocaleString()}
-                </span>
-              </div>
-              <div>
-                月配點{" "}
-                <span className="font-semibold">
-                  {p.monthly_quota.toLocaleString()} 點 / 教師
-                </span>
-              </div>
-              <div>
-                加購折扣{" "}
-                <span className="font-semibold">
-                  {Math.round((1 - p.topup_discount) * 100)}% off
-                </span>
-              </div>
-            </div>
-            <div className="mt-auto pt-3 border-t border-gray-200">
-              <div className="text-xs text-gray-500">團隊總價</div>
-              <div className="text-xl font-bold text-blue-600">
-                NT$ {p.total_amount.toLocaleString()} / 年
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-    </>
-  );
-}
+// Group-buy marketing cards extracted to a shared component so
+// `/teacher/subscription` can render the same grid + fetch + fallback
+// semantics (issue #768 comment 4638082532 item 3). See the component
+// for the admin-update sync rule and DB-seed snapshot.
 
 export default function PricingPage() {
   const navigate = useNavigate();
@@ -575,7 +458,7 @@ export default function PricingPage() {
                   case the API request fails so anonymous visitors still
                   see something useful. */}
               <div className="space-y-4">
-                <GroupBuyCards />
+                <GroupBuyPlanCards />
                 <div className="text-center pt-2">
                   <button
                     type="button"

--- a/frontend/src/pages/teacher/GroupBuyOpenPage.tsx
+++ b/frontend/src/pages/teacher/GroupBuyOpenPage.tsx
@@ -179,6 +179,12 @@ export default function GroupBuyOpenPage() {
   const [csvOpen, setCsvOpen] = React.useState(false);
   const [shareTarget, setShareTarget] = React.useState<string | null>(null);
   const [promoCode, setPromoCode] = React.useState<string | null>(null);
+  // Issue #768 comment 4638082532 item 2 — leader's contact phone is a
+  // required field on the roster step. We persist it via localStorage
+  // alongside the roster so it survives navigation, and ship it to
+  // backend in the open-team payload (audit log captures it for
+  // support to reach the buyer).
+  const [leaderPhone, setLeaderPhone] = React.useState("");
   const csvInputRef = React.useRef<HTMLInputElement>(null);
 
   // ----- plan list (Step 1) -----
@@ -232,7 +238,10 @@ export default function GroupBuyOpenPage() {
     try {
       const stored = window.localStorage.getItem(key);
       if (stored) {
-        const parsed = JSON.parse(stored) as { rows?: RosterRow[] };
+        const parsed = JSON.parse(stored) as {
+          rows?: RosterRow[];
+          leaderPhone?: string;
+        };
         if (parsed.rows && parsed.rows.length === selectedPlan.teacher_seats) {
           // Any "checking" left over from a prior session is stale — reset
           // so the next blur runs a fresh validation request.
@@ -241,6 +250,9 @@ export default function GroupBuyOpenPage() {
             status: r.status === "checking" ? "idle" : r.status,
             id: r.id || makeRowId(),
           }));
+        }
+        if (typeof parsed.leaderPhone === "string") {
+          setLeaderPhone(parsed.leaderPhone);
         }
       }
     } catch {
@@ -284,11 +296,14 @@ export default function GroupBuyOpenPage() {
     if (!selectedPlan || !teacher || roster.length === 0) return;
     const key = lsKey(teacher.id, selectedPlan.name);
     try {
-      window.localStorage.setItem(key, JSON.stringify({ rows: roster }));
+      window.localStorage.setItem(
+        key,
+        JSON.stringify({ rows: roster, leaderPhone }),
+      );
     } catch {
       // Storage full / private mode — degrade silently.
     }
-  }, [roster, selectedPlan, teacher]);
+  }, [roster, leaderPhone, selectedPlan, teacher]);
 
   // ----- per-row validation on blur -----
   // Row 0 (leader) is also validated here so that if the leader edits their
@@ -517,10 +532,14 @@ export default function GroupBuyOpenPage() {
   // ----- derived: row counters with deduped statuses -----
   const dedupedRoster = React.useMemo(() => dedupeStatuses(roster), [roster]);
   const okCount = dedupedRoster.filter((r) => r.status === "ok").length;
+  // Issue #768 comment 4638082532 item 2 — phone is part of the
+  // payment gate. Trim guard so whitespace-only doesn't satisfy.
+  const phoneOk = leaderPhone.trim().length > 0;
   const allOk =
     selectedPlan !== null &&
     dedupedRoster.length === selectedPlan.teacher_seats &&
-    okCount === selectedPlan.teacher_seats;
+    okCount === selectedPlan.teacher_seats &&
+    phoneOk;
 
   // ----- payment handlers -----
   const handlePaymentSuccess = (transactionId: string) => {
@@ -644,6 +663,38 @@ export default function GroupBuyOpenPage() {
           帳號，付款按鈕在全部 ✓ 後才會啟用。
         </p>
 
+        {/* Issue #768 comment 4638082532 item 2 — 連絡電話(必填) for
+            the team leader. Required to enable the payment button so
+            support can reach the buyer if there's a refund / dispute. */}
+        <Card>
+          <CardContent className="p-4 space-y-3">
+            <div className="text-sm font-semibold">團主資訊</div>
+            <div className="flex flex-wrap items-center gap-3 text-sm">
+              <span className="w-20 text-gray-600">Email</span>
+              <span className="text-gray-900">
+                {teacher?.email || "（尚未登入）"}
+              </span>
+              <span className="text-xs text-gray-500">（不可修改）</span>
+            </div>
+            <div className="flex flex-wrap items-center gap-3 text-sm">
+              <label className="w-20 text-gray-600" htmlFor="gb-leader-phone">
+                連絡電話 <span className="text-red-600">*</span>
+              </label>
+              <Input
+                id="gb-leader-phone"
+                type="tel"
+                className="flex-1 max-w-xs"
+                placeholder="如 0912345678"
+                value={leaderPhone}
+                onChange={(e) => setLeaderPhone(e.target.value)}
+              />
+              {!phoneOk && (
+                <span className="text-xs text-red-600">必填欄位</span>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
         <div className="flex flex-wrap items-center gap-2">
           <Button variant="outline" onClick={() => setCsvOpen(true)}>
             📂 從 CSV 匯入
@@ -729,7 +780,9 @@ export default function GroupBuyOpenPage() {
             title={
               allOk
                 ? ""
-                : `${selectedPlan.teacher_seats - okCount} 位老師尚未通過驗證`
+                : !phoneOk
+                  ? "請填寫連絡電話"
+                  : `${selectedPlan.teacher_seats - okCount} 位老師尚未通過驗證`
             }
           >
             下一步：付款 →
@@ -856,6 +909,7 @@ export default function GroupBuyOpenPage() {
             customPayload={{
               plan_name: selectedPlan.name,
               member_emails: memberEmails,
+              leader_phone: leaderPhone.trim(),
             }}
             onPaymentSuccess={handlePaymentSuccess}
             onPaymentError={handlePaymentError}

--- a/frontend/src/pages/teacher/GroupBuyOpenPage.tsx
+++ b/frontend/src/pages/teacher/GroupBuyOpenPage.tsx
@@ -183,7 +183,10 @@ export default function GroupBuyOpenPage() {
   // required field on the roster step. We persist it via localStorage
   // alongside the roster so it survives navigation, and ship it to
   // backend in the open-team payload (audit log captures it for
-  // support to reach the buyer).
+  // support to reach the buyer). Intentionally not cleared on plan
+  // change: phone belongs to the leader (constant across plan picks)
+  // rather than to the plan; clearing on swap would just force the
+  // user to re-type the same number.
   const [leaderPhone, setLeaderPhone] = React.useState("");
   const csvInputRef = React.useRef<HTMLInputElement>(null);
 

--- a/frontend/src/pages/teacher/TeacherSubscription.tsx
+++ b/frontend/src/pages/teacher/TeacherSubscription.tsx
@@ -56,6 +56,7 @@ import {
 } from "@/components/pricing/PointPackageCard";
 import { useTeacherAuthStore } from "@/stores/teacherAuthStore";
 import { apiClient } from "@/lib/api";
+import { GroupBuyPlanCards } from "@/components/pricing/GroupBuyPlanCards";
 
 interface CreditPackageInfo {
   id: number;
@@ -71,9 +72,20 @@ interface CreditPackageInfo {
   is_expired: boolean;
 }
 
+// Backend-supplied flag (issue #768 comment 4638082532 item 4) so the
+// UI can pick the right quota label, expiry date (annual vs monthly),
+// and hide the "auto-renew" banner for group-buy members whose points
+// come from the team leader's annual fee rather than a personal
+// recurring charge.
+type SubscriptionPlanType =
+  | "individual"
+  | "group_buy_member"
+  | "group_buy_owner";
+
 interface SubscriptionInfo {
   status: string;
   plan: string | null;
+  plan_type?: SubscriptionPlanType;
   end_date: string | null;
   days_remaining: number;
   is_active: boolean;
@@ -464,7 +476,7 @@ export default function TeacherSubscription() {
 
           {/* Tab 1: Plans */}
           <TabsContent value="plans">
-            <div>
+            <div className="space-y-10">
               <div className="grid md:grid-cols-3 gap-6">
                 {subscriptionPlans.map((plan) => {
                   const isCurrentPlan = currentPlanId === plan.id;
@@ -517,6 +529,30 @@ export default function TeacherSubscription() {
                   );
                 })}
               </div>
+
+              {/* Issue #768 comment 4638082532 item 3 — surface the 3
+                  group-buy plans directly in the subscription page so
+                  teachers don't have to navigate to /pricing to learn
+                  about them. Cards are clickable: any click jumps
+                  straight into the open-team flow. Hidden for teachers
+                  who are already on a group-buy plan (R2-F2 single-org
+                  guard would 409 their open attempt anyway). */}
+              {subscription?.plan_type !== "group_buy_member" &&
+                subscription?.plan_type !== "group_buy_owner" && (
+                  <div className="space-y-4">
+                    <GroupBuyPlanCards
+                      onSelectPlan={() => navigate("/teacher/group-buy/open")}
+                    />
+                    <div className="text-center">
+                      <Button
+                        variant="outline"
+                        onClick={() => navigate("/teacher/group-buy/open")}
+                      >
+                        立即開設團購方案 →
+                      </Button>
+                    </div>
+                  </div>
+                )}
             </div>
           </TabsContent>
 
@@ -611,13 +647,28 @@ export default function TeacherSubscription() {
                             : t("teacherSubscription.subscription.statusGood")}
                         </p>
                         <p className="text-sm text-blue-600 mt-1 font-medium">
-                          {subscription.plan === "School Teachers"
-                            ? t("teacherSubscription.subscription.quotaSchool")
-                            : subscription.plan === PLAN_NAMES.FREE_TRIAL
-                              ? t("teacherSubscription.subscription.quotaTrial")
-                              : t(
-                                  "teacherSubscription.subscription.quotaTutor",
-                                )}
+                          {subscription.plan_type === "group_buy_member" ||
+                          subscription.plan_type === "group_buy_owner" ? (
+                            // Group-buy: backend ships the per-teacher
+                            // monthly quota in quota_total. Showing that
+                            // directly avoids the prior bug where the
+                            // generic "tutor" template said 2000 點/月
+                            // for a 1000-點 group-buy plan.
+                            <>
+                              {(
+                                subscription.subscription_total ||
+                                subscription.quota_total ||
+                                0
+                              ).toLocaleString()}{" "}
+                              點 AI 配額 / 月（團購配給）
+                            </>
+                          ) : subscription.plan === "School Teachers" ? (
+                            t("teacherSubscription.subscription.quotaSchool")
+                          ) : subscription.plan === PLAN_NAMES.FREE_TRIAL ? (
+                            t("teacherSubscription.subscription.quotaTrial")
+                          ) : (
+                            t("teacherSubscription.subscription.quotaTutor")
+                          )}
                         </p>
                       </div>
                       {subscription.plan === PLAN_NAMES.FREE_TRIAL && (
@@ -725,7 +776,19 @@ export default function TeacherSubscription() {
                           <p className="text-sm text-gray-600 mb-2">
                             {t("teacherSubscription.labels.autoRenew")}
                           </p>
-                          {subscription.auto_renew ? (
+                          {subscription.plan_type === "group_buy_member" ||
+                          subscription.plan_type === "group_buy_owner" ? (
+                            // Group-buy members get points from the team
+                            // leader's annual fee — no per-teacher
+                            // auto-renew. Surface this explicitly so the
+                            // teacher doesn't go hunting for a button
+                            // that wouldn't apply to them.
+                            <p className="text-sm text-gray-600">
+                              {subscription.plan_type === "group_buy_owner"
+                                ? "團主：團隊年費於到期時手動續訂；不適用個人自動續訂。"
+                                : "團員：配額由團主年費自動配給，不需個人續訂。"}
+                            </p>
+                          ) : subscription.auto_renew ? (
                             <div className="flex items-center gap-3">
                               <p className="font-semibold text-green-600">
                                 {t("teacherSubscription.labels.enabled")}
@@ -779,17 +842,22 @@ export default function TeacherSubscription() {
                       </div>
                     </div>
 
-                    {!subscription.auto_renew && (
-                      <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
-                        <p className="text-orange-800 text-sm">
-                          {t("teacherSubscription.warnings.renewalCancelled", {
-                            date: subscription.end_date
-                              ? formatDate(subscription.end_date)
-                              : t("teacherSubscription.labels.expiryDate"),
-                          })}
-                        </p>
-                      </div>
-                    )}
+                    {!subscription.auto_renew &&
+                      subscription.plan_type !== "group_buy_member" &&
+                      subscription.plan_type !== "group_buy_owner" && (
+                        <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
+                          <p className="text-orange-800 text-sm">
+                            {t(
+                              "teacherSubscription.warnings.renewalCancelled",
+                              {
+                                date: subscription.end_date
+                                  ? formatDate(subscription.end_date)
+                                  : t("teacherSubscription.labels.expiryDate"),
+                              },
+                            )}
+                          </p>
+                        </div>
+                      )}
 
                     {subscription.days_remaining <= 7 && (
                       <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">

--- a/frontend/src/pages/teacher/TeacherSubscription.tsx
+++ b/frontend/src/pages/teacher/TeacherSubscription.tsx
@@ -541,6 +541,12 @@ export default function TeacherSubscription() {
                 subscription?.plan_type !== "group_buy_owner" && (
                   <div className="space-y-4">
                     <GroupBuyPlanCards
+                      // Plan name is intentionally ignored here — the
+                      // group-buy open page has its own plan-selection
+                      // step (Step 1 of the 3-step wizard) where the
+                      // user can confirm or change their pick. Pre-
+                      // selecting via query param is a future polish,
+                      // tracked for the next iteration.
                       onSelectPlan={() => navigate("/teacher/group-buy/open")}
                     />
                     <div className="text-center">
@@ -655,9 +661,13 @@ export default function TeacherSubscription() {
                             // generic "tutor" template said 2000 點/月
                             // for a 1000-點 group-buy plan.
                             <>
+                              {/* `??` (nullish coalescing) instead of
+                                  `||` so a literal `0` from backend
+                                  isn't treated as falsy and the value
+                                  shown matches the data. */}
                               {(
-                                subscription.subscription_total ||
-                                subscription.quota_total ||
+                                subscription.subscription_total ??
+                                subscription.quota_total ??
                                 0
                               ).toLocaleString()}{" "}
                               點 AI 配額 / 月（團購配給）


### PR DESCRIPTION
## Summary

Address issue #768 comment 4638082532 (staging feedback, 4 items):
1. **Item 4** — `/teacher/subscription` 當前訂閱狀態 panel for group-buy members shows wrong quota (1000→2000), wrong end_date (month-end→annual), wrong auto-renew message.
2. **Item 3** — `/teacher/subscription` should also display the 3 group-buy plan cards (not just a CTA button).
3. **Item 2** — 「團主資訊欄位 連絡電話(必填)」 was the one part of the comment's roster spec not covered by PR #851.
4. **Item 1** — Admin per-teacher view should show group-buy purchase periods (verification on staging — endpoint already returns them).

Related to #768.

## Backend changes

| Endpoint | Change |
|---|---|
| `GET /api/subscription/status` | Detects group-buy membership; overrides `end_date` to `Organization.subscription_end_date` (annual), `auto_renew=False`, and surfaces new `plan_type: "individual" \| "group_buy_member" \| "group_buy_owner"` |
| `POST /api/credit-packages/group-buy-open` | Accepts new optional `leader_phone` field (captured in BigQuery audit `request_data`) |

## Frontend changes

- **NEW** `frontend/src/components/pricing/GroupBuyPlanCards.tsx` — shared component extracted from `PricingPage`. Same fetch + fallback semantics, optional `onSelectPlan` for clickable mode.
- `PricingPage` — uses the new shared component.
- `TeacherSubscription`:
  - Adds `plan_type` to `SubscriptionInfo` type.
  - Quota label uses `quota_total` for group-buy (was hardcoded tutor template).
  - Auto-renew section replaced with clarifying note for group-buy.
  - Hides misleading "您已取消自動續訂" banner for group-buy.
  - Adds `<GroupBuyPlanCards />` inline on the Plans tab (hidden for existing group-buy users).
- `GroupBuyOpenPage`:
  - New 團主資訊 card with email (read-only) + required 連絡電話 input.
  - Phone persisted to localStorage alongside roster.
  - Phone gates the payment button (`allOk` requires `phoneOk`).
  - Ships in TapPay `customPayload.leader_phone`.

## Migration

No new migration. All data is read from existing tables (Teacher / Organization / School / TeacherSchool / TeacherOrganization).

## Test plan

- [ ] Backend tests: `pytest backend/tests/test_subscription_status_group_buy.py` (3 cases)
- [ ] Staging E2E:
  - [ ] Buy a 團購-10席 plan as a group-buy owner
  - [ ] Visit `/teacher/subscription` — quota shows "1000 點 AI 配額 / 月（團購配給）", end date is +1 year, auto-renew section shows 團主 clarifier (not the orange banner)
  - [ ] Login as a group-buy member — same panel shows 團員 clarifier
  - [ ] Login as an individual teacher — old auto-renew UI still works
  - [ ] `/teacher/subscription` Plans tab shows all 3 group-buy plan cards under the individual plans; clicking a card lands on `/teacher/group-buy/open`
  - [ ] `/teacher/group-buy/open` Step 2: 連絡電話 is required; payment button stays disabled until filled; value survives navigation (localStorage)
  - [ ] `/admin` → 訂閱 → 用戶 → 訂閱歷史 — group-buy purchases appear in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)