### PR TITLE
fix(#874): generate_sentences 與 distractors 補上 disable_thinking=True

### DIFF
--- a/backend/services/translation.py
+++ b/backend/services/translation.py
@@ -791,6 +791,7 @@ IMPORTANT: Each English sentence MUST contain the exact target word."""
                     max_tokens=dynamic_max_tokens,
                     temperature=0.7,  # Match GPT temperature for consistent quality
                     system_instruction=system_prompt,
+                    disable_thinking=True,
                 )
             else:
                 response = await self.client.chat.completions.create(
@@ -927,6 +928,7 @@ JSON 陣列，只包含 {count} 個干擾項：
                     max_tokens=200,
                     temperature=0.2,  # Very low temperature to strictly follow prompt rules
                     system_instruction=system_instruction,
+                    disable_thinking=True,
                 )
             else:
                 response = await self.client.chat.completions.create(
@@ -1058,6 +1060,7 @@ JSON 陣列，每個元素是一個包含 {count} 個干擾項的陣列。
                     max_tokens=1000,
                     temperature=0.2,  # Very low temperature to strictly follow prompt rules
                     system_instruction=system_instruction,
+                    disable_thinking=True,
                 )
             else:
                 response = await self.client.chat.completions.create(

--- a/backend/tests/test_vertex_disable_thinking.py
+++ b/backend/tests/test_vertex_disable_thinking.py
@@ -1,0 +1,72 @@
+"""
+Test for Issue #874: generate_sentences 與 distractors 補上 disable_thinking=True
+
+When USE_VERTEX_AI=true, gemini-2.5-flash runs with thinking ENABLED by default,
+and max_output_tokens is shared between thinking and output tokens. The three AI
+paths below previously omitted disable_thinking=True, which caused:
+  1. 3~13x slower latency (model spends time thinking)
+  2. JSON truncation ("Unterminated string") — thinking ate the token budget
+
+These tests assert that every Vertex AI generate_json call made by the
+sentence/distractor paths passes disable_thinking=True, matching the already-correct
+translation paths.
+"""
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest  # noqa: E402
+from services.translation import TranslationService  # noqa: E402
+
+
+@pytest.mark.unit
+class TestVertexDisableThinking:
+    """Issue #874: Vertex AI 生成路徑必須關閉 thinking"""
+
+    @pytest.fixture
+    def vertex_service(self):
+        """Service forced into Vertex AI mode with a mocked vertex client."""
+        service = TranslationService()
+        service.use_vertex_ai = True
+        service.vertex_ai = AsyncMock()
+        # _ensure_client() must not try to (re)initialise the real client
+        service._ensure_client = lambda: None
+        return service
+
+    @pytest.mark.asyncio
+    async def test_generate_sentences_disables_thinking(self, vertex_service):
+        vertex_service.vertex_ai.generate_json = AsyncMock(
+            return_value=[{"sentence": "I eat an apple.", "translation": "我吃蘋果。"}]
+        )
+
+        await vertex_service.generate_sentences(words=["apple"], level="A1")
+
+        vertex_service.vertex_ai.generate_json.assert_awaited()
+        kwargs = vertex_service.vertex_ai.generate_json.call_args.kwargs
+        assert kwargs.get("disable_thinking") is True
+
+    @pytest.mark.asyncio
+    async def test_generate_distractors_disables_thinking(self, vertex_service):
+        vertex_service.vertex_ai.generate_json = AsyncMock(return_value=["香蕉", "橘子"])
+
+        await vertex_service.generate_distractors(
+            word="apple", translation="蘋果", count=2
+        )
+
+        vertex_service.vertex_ai.generate_json.assert_awaited()
+        kwargs = vertex_service.vertex_ai.generate_json.call_args.kwargs
+        assert kwargs.get("disable_thinking") is True
+
+    @pytest.mark.asyncio
+    async def test_batch_generate_distractors_disables_thinking(self, vertex_service):
+        vertex_service.vertex_ai.generate_json = AsyncMock(return_value=[["香蕉", "橘子"]])
+
+        await vertex_service.batch_generate_distractors(
+            words=[{"word": "apple", "translation": "蘋果"}], count=2
+        )
+
+        vertex_service.vertex_ai.generate_json.assert_awaited()
+        kwargs = vertex_service.vertex_ai.generate_json.call_args.kwargs
+        assert kwargs.get("disable_thinking") is True


### PR DESCRIPTION
Fixes #874

## 問題
Prod 因 OpenAI key 失效切到 Vertex AI (`gemini-2.5-flash`) 後，`generate_sentences` 與兩條 distractors 路徑漏設 `disable_thinking=True`：

- `gemini-2.5-flash` thinking 預設開啟，`max_output_tokens` 為 thinking + 輸出**共用預算**
- 結果：延遲 3~13 倍（vs 翻譯路徑 ~1.4s），且 thinking 吃光 token 預算造成 JSON 截斷

Prod log 實證：
```
Failed to parse JSON from Vertex AI response: Unterminated string
Raw response: [{"sentence": "...", "translation": "我昨天   <- 斷在字串中間
```

## 修改
[translation.py](backend/services/translation.py) 三處 `vertex_ai.generate_json(...)` 補上 `disable_thinking=True`，與既有翻譯路徑一致：
- `generate_sentences`
- `generate_distractors`
- `batch_generate_distractors`

不動 `max_tokens`、不換 model（flash-lite / 區域另案評估）。

## 測試
- 新增 `tests/test_vertex_disable_thinking.py`：3 個回歸測試，斷言三條路徑皆以 `disable_thinking=True` 呼叫 Vertex — **3 passed**
- 既有 `test_sentence_generation_misalignment.py` — **11 passed**（無 regression）
- Black / Flake8 — 通過

## 驗收
- [ ] generate-sentences 延遲掉回 ~1.4s 級別
- [ ] 不再出現 `Unterminated string` 截斷錯誤

🤖 Generated with [Claude Code](https://claude.com/claude-code)