### PR TITLE
fix(#873): 單字集例句翻譯缺漏補齊 + 例句翻譯「中文」按鈕無反應

### DIFF
--- a/backend/services/translation.py
+++ b/backend/services/translation.py
@@ -829,6 +829,35 @@ IMPORTANT: Each English sentence MUST contain the exact target word."""
                 if "word" not in sentence:
                     sentence["word"] = words[i]
 
+            # Issue #873: 有要求翻譯時，確保每個句子都帶 translation。
+            # AI 偶爾會漏掉某些句子的 translation 欄位（魔術貼上時觀察到第一個
+            # 單字最常缺漏），導致前端例句翻譯空白。對缺漏者用 translate_text 補齊
+            # （與例句翻譯按鈕走同一條 /translate 路徑，行為一致）。
+            if translate_to:
+                missing = [
+                    i
+                    for i, s in enumerate(sentences)
+                    if s.get("sentence") and not (s.get("translation") or "").strip()
+                ]
+                if missing:
+                    fallback = await asyncio.gather(
+                        *[
+                            self.translate_text(sentences[i]["sentence"], translate_to)
+                            for i in missing
+                        ],
+                        return_exceptions=True,
+                    )
+                    for i, result in zip(missing, fallback):
+                        if isinstance(result, Exception):
+                            logger.warning(
+                                "Fallback translation failed for '%s': %s",
+                                sentences[i].get("sentence"),
+                                result,
+                            )
+                            sentences[i].setdefault("translation", "")
+                        else:
+                            sentences[i]["translation"] = result
+
             return sentences
 
         except Exception as e:

--- a/backend/services/translation.py
+++ b/backend/services/translation.py
@@ -854,7 +854,7 @@ IMPORTANT: Each English sentence MUST contain the exact target word."""
                                 sentences[i].get("sentence"),
                                 result,
                             )
-                            sentences[i].setdefault("translation", "")
+                            sentences[i]["translation"] = ""
                         else:
                             sentences[i]["translation"] = result
 

--- a/backend/tests/test_sentence_generation_misalignment.py
+++ b/backend/tests/test_sentence_generation_misalignment.py
@@ -407,3 +407,122 @@ class TestSentenceGenerationChunking:
         for i, result in enumerate(results):
             assert result["word"] == words[i]
             assert "Vertex example" in result["sentence"]
+
+
+@pytest.mark.unit
+class TestSentenceTranslationBackfill:
+    """Issue #873: ensure every sentence has a translation when translate_to is set.
+
+    The AI intermittently omits the ``translation`` field for some sentences
+    (most often the first word during magic-paste), which left the example
+    sentence translation blank in the UI. The service must backfill any missing
+    translation via ``translate_text``.
+    """
+
+    @pytest.fixture
+    def service(self):
+        svc = TranslationService()
+        svc.use_vertex_ai = False
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_missing_translation_is_backfilled(self, service):
+        """When AI omits translation for the first word, it is filled via translate_text."""
+        words = ["grape", "passionfruit"]
+
+        # AI response: first sentence has NO translation, second one does.
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[
+            0
+        ].message.content = """[
+            {"sentence": "I ate a grape.", "word": "grape"},
+            {"sentence": "Passionfruit is sweet.", "translation": "百香果很甜。", "word": "passionfruit"}
+        ]"""
+
+        mock_client = Mock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        service.client = mock_client
+
+        # Mock the fallback single-sentence translator.
+        service.translate_text = AsyncMock(return_value="我吃了一顆葡萄。")
+
+        results = await service.generate_sentences(words=words, translate_to="zh-TW")
+
+        # Fallback called exactly once, for the missing (first) sentence.
+        service.translate_text.assert_awaited_once_with("I ate a grape.", "zh-TW")
+
+        # Both sentences now have a non-empty translation.
+        assert results[0]["translation"] == "我吃了一顆葡萄。"
+        assert results[1]["translation"] == "百香果很甜。"
+
+    @pytest.mark.asyncio
+    async def test_empty_string_translation_is_backfilled(self, service):
+        """A present-but-empty translation is also treated as missing."""
+        words = ["grape"]
+
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[
+            0
+        ].message.content = """[
+            {"sentence": "I ate a grape.", "translation": "  ", "word": "grape"}
+        ]"""
+
+        mock_client = Mock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        service.client = mock_client
+        service.translate_text = AsyncMock(return_value="我吃了一顆葡萄。")
+
+        results = await service.generate_sentences(words=words, translate_to="zh-TW")
+
+        service.translate_text.assert_awaited_once_with("I ate a grape.", "zh-TW")
+        assert results[0]["translation"] == "我吃了一顆葡萄。"
+
+    @pytest.mark.asyncio
+    async def test_no_backfill_when_translate_to_is_none(self, service):
+        """When no translation is requested, no fallback runs and no translation key is added."""
+        words = ["grape", "passionfruit"]
+
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[
+            0
+        ].message.content = """[
+            {"sentence": "I ate a grape.", "word": "grape"},
+            {"sentence": "Passionfruit is sweet.", "word": "passionfruit"}
+        ]"""
+
+        mock_client = Mock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        service.client = mock_client
+        service.translate_text = AsyncMock(return_value="should-not-be-used")
+
+        results = await service.generate_sentences(words=words, translate_to=None)
+
+        service.translate_text.assert_not_awaited()
+        for result in results:
+            assert "translation" not in result
+
+    @pytest.mark.asyncio
+    async def test_backfill_failure_leaves_empty_translation(self, service):
+        """If the fallback translate_text raises, the sentence keeps an empty translation
+        rather than propagating the error."""
+        words = ["grape"]
+
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[
+            0
+        ].message.content = """[
+            {"sentence": "I ate a grape.", "word": "grape"}
+        ]"""
+
+        mock_client = Mock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        service.client = mock_client
+        service.translate_text = AsyncMock(side_effect=Exception("translate down"))
+
+        results = await service.generate_sentences(words=words, translate_to="zh-TW")
+
+        assert results[0]["translation"] == ""

--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -1305,7 +1305,7 @@ function SortableRowInner({
   handleGenerateSingleDefinition,
   handleGenerateSingleDefinitionWithLang:
     _handleGenerateSingleDefinitionWithLang,
-  handleGenerateExampleTranslation: _handleGenerateExampleTranslation,
+  handleGenerateExampleTranslation,
   handleGenerateExampleTranslationWithLang:
     _handleGenerateExampleTranslationWithLang,
   handleOpenAIGenerateModal,
@@ -1318,8 +1318,8 @@ function SortableRowInner({
   showOptionImages = false,
   duplicateReasons,
   customTranslationLang = "",
-  sentenceTranslationLang = "",
-  customSentenceTranslationLang: customSentenceLang = "",
+  sentenceTranslationLang: _sentenceTranslationLang = "",
+  customSentenceTranslationLang: _customSentenceLang = "",
 }: SortableRowInnerProps) {
   const { t } = useTranslation();
   const {
@@ -1774,13 +1774,19 @@ function SortableRowInner({
           maxLength={500}
         />
         <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center">
-          <span className="text-xs text-gray-400">
-            {sentenceTranslationLang === "other"
-              ? customSentenceLang || "..."
-              : SENTENCE_TRANSLATION_LANGUAGES.find(
-                  (l) => l.value === sentenceTranslationLang,
-                )?.label || ""}
-          </span>
+          <button
+            onClick={() => handleGenerateExampleTranslation(index)}
+            className="text-xs text-gray-400 hover:text-blue-500 hover:underline cursor-pointer transition-colors"
+            title={t("vocabularySet.tooltips.generateExampleTranslation", {
+              lang: SENTENCE_TRANSLATION_LANGUAGES.find(
+                (l) => l.value === (row.selectedSentenceLanguage || "chinese"),
+              )?.label,
+            })}
+          >
+            {SENTENCE_TRANSLATION_LANGUAGES.find(
+              (l) => l.value === (row.selectedSentenceLanguage || "chinese"),
+            )?.label || ""}
+          </button>
         </div>
       </div>
 

--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -1775,6 +1775,7 @@ function SortableRowInner({
         />
         <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center">
           <button
+            type="button"
             onClick={() => handleGenerateExampleTranslation(index)}
             className="text-xs text-gray-400 hover:text-blue-500 hover:underline cursor-pointer transition-colors"
             title={t("vocabularySet.tooltips.generateExampleTranslation", {


### PR DESCRIPTION
Fixes #873

## 問題

單字集編輯頁兩個 bug：

### Bug 1 — 魔術貼上多單字時，第一張卡片例句缺中文翻譯
魔術貼上時每個單字各自呼叫 `/generate-sentences`，AI 偶爾會漏回 `translation` 欄位（觀察到批次中第一個單字最常見），前端因 `if (sentencesData[0].translation)` 守衛而把例句翻譯留白 → `grape` 沒翻譯、`passionfruit` 有。

### Bug 2 — 「中文例句翻譯（選填）」右邊的「中文」按鈕點了沒反應
該按鈕原本是個**靜態 `<span>`，完全沒綁事件**；對應的 handler `handleGenerateExampleTranslation` 其實早就存在、也能用，只是沒接上。（上方「中文單字翻譯」的按鈕是正常的 `<button>`。）

## 修法

**Bug 1（後端，根因處理）** — [`backend/services/translation.py`](backend/services/translation.py) `_generate_sentences_batch`：解析 AI 回應後，若有要求翻譯（`translate_to`）卻有句子缺/空 `translation`，用既有的 `translate_text` 並行補齊。與「例句翻譯」按鈕走同一條 `/translate` 路徑，行為一致；一次涵蓋魔術貼上、補齊模式、單字 AI 產句三個呼叫點，且為決定性結果。

**Bug 2（前端）** — [`frontend/src/components/VocabularySetPanel.tsx`](frontend/src/components/VocabularySetPanel.tsx)：把 `<span>` 換成 `<button onClick={() => handleGenerateExampleTranslation(index)}>`，並還原被以底線標記為「未使用」的 prop。label 改讀 `row.selectedSentenceLanguage`，與正上方的輸入框顯示語言一致。

## 測試

- 後端新增 `TestSentenceTranslationBackfill` 4 例：缺漏補齊、空字串視為缺漏、未要求翻譯時不觸發 fallback、fallback 失敗保留空字串。
- `pytest tests/test_sentence_generation_misalignment.py` → **15 passed**
- 後端 `black --check` / `flake8` 乾淨
- 前端 `npm run typecheck` 乾淨、`npm run build` 成功

## 測試建議（人工）
1. 單字集輸入多個英文單字（如 `grape` / `passionfruit`）→ 魔術貼上（勾選產例句+翻譯）→ 兩張卡片例句皆應有中文翻譯。
2. 任一卡片在「中文例句翻譯（選填）」先填入例句，點右邊「中文」按鈕 → 應產生例句翻譯。

🤖 Generated with [Claude Code](https://claude.com/claude-code)