### PR TITLE
Release: staging → main (6 commits)

### DIFF
--- a/backend/routers/students/assignments.py
+++ b/backend/routers/students/assignments.py
@@ -107,6 +107,13 @@ async def get_student_assignments(
             "word_reading",
             "word_spelling",
             "word_cloze",
+            # Issue #843: 對齊前端 registry（含三種小考與 tug_of_war），
+            # 否則學生端篩選這些模式會 422，前端誤跳「載入失敗」。
+            # 無對應作業時回空陣列，前端顯示空狀態而非報錯。
+            "word_selection_quiz",
+            "word_spelling_quiz",
+            "word_cloze_quiz",
+            "tug_of_war",
         ]
     ] = None,
     current_student: Dict[str, Any] = Depends(get_current_student),

--- a/backend/services/translation.py
+++ b/backend/services/translation.py
@@ -791,6 +791,7 @@ IMPORTANT: Each English sentence MUST contain the exact target word."""
                     max_tokens=dynamic_max_tokens,
                     temperature=0.7,  # Match GPT temperature for consistent quality
                     system_instruction=system_prompt,
+                    disable_thinking=True,
                 )
             else:
                 response = await self.client.chat.completions.create(
@@ -956,6 +957,7 @@ JSON 陣列，只包含 {count} 個干擾項：
                     max_tokens=200,
                     temperature=0.2,  # Very low temperature to strictly follow prompt rules
                     system_instruction=system_instruction,
+                    disable_thinking=True,
                 )
             else:
                 response = await self.client.chat.completions.create(
@@ -1087,6 +1089,7 @@ JSON 陣列，每個元素是一個包含 {count} 個干擾項的陣列。
                     max_tokens=1000,
                     temperature=0.2,  # Very low temperature to strictly follow prompt rules
                     system_instruction=system_instruction,
+                    disable_thinking=True,
                 )
             else:
                 response = await self.client.chat.completions.create(

--- a/backend/services/translation.py
+++ b/backend/services/translation.py
@@ -829,6 +829,35 @@ IMPORTANT: Each English sentence MUST contain the exact target word."""
                 if "word" not in sentence:
                     sentence["word"] = words[i]
 
+            # Issue #873: 有要求翻譯時，確保每個句子都帶 translation。
+            # AI 偶爾會漏掉某些句子的 translation 欄位（魔術貼上時觀察到第一個
+            # 單字最常缺漏），導致前端例句翻譯空白。對缺漏者用 translate_text 補齊
+            # （與例句翻譯按鈕走同一條 /translate 路徑，行為一致）。
+            if translate_to:
+                missing = [
+                    i
+                    for i, s in enumerate(sentences)
+                    if s.get("sentence") and not (s.get("translation") or "").strip()
+                ]
+                if missing:
+                    fallback = await asyncio.gather(
+                        *[
+                            self.translate_text(sentences[i]["sentence"], translate_to)
+                            for i in missing
+                        ],
+                        return_exceptions=True,
+                    )
+                    for i, result in zip(missing, fallback):
+                        if isinstance(result, Exception):
+                            logger.warning(
+                                "Fallback translation failed for '%s': %s",
+                                sentences[i].get("sentence"),
+                                result,
+                            )
+                            sentences[i]["translation"] = ""
+                        else:
+                            sentences[i]["translation"] = result
+
             return sentences
 
         except Exception as e:

--- a/backend/tests/test_sentence_generation_misalignment.py
+++ b/backend/tests/test_sentence_generation_misalignment.py
@@ -407,3 +407,122 @@ class TestSentenceGenerationChunking:
         for i, result in enumerate(results):
             assert result["word"] == words[i]
             assert "Vertex example" in result["sentence"]
+
+
+@pytest.mark.unit
+class TestSentenceTranslationBackfill:
+    """Issue #873: ensure every sentence has a translation when translate_to is set.
+
+    The AI intermittently omits the ``translation`` field for some sentences
+    (most often the first word during magic-paste), which left the example
+    sentence translation blank in the UI. The service must backfill any missing
+    translation via ``translate_text``.
+    """
+
+    @pytest.fixture
+    def service(self):
+        svc = TranslationService()
+        svc.use_vertex_ai = False
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_missing_translation_is_backfilled(self, service):
+        """When AI omits translation for the first word, it is filled via translate_text."""
+        words = ["grape", "passionfruit"]
+
+        # AI response: first sentence has NO translation, second one does.
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[
+            0
+        ].message.content = """[
+            {"sentence": "I ate a grape.", "word": "grape"},
+            {"sentence": "Passionfruit is sweet.", "translation": "百香果很甜。", "word": "passionfruit"}
+        ]"""
+
+        mock_client = Mock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        service.client = mock_client
+
+        # Mock the fallback single-sentence translator.
+        service.translate_text = AsyncMock(return_value="我吃了一顆葡萄。")
+
+        results = await service.generate_sentences(words=words, translate_to="zh-TW")
+
+        # Fallback called exactly once, for the missing (first) sentence.
+        service.translate_text.assert_awaited_once_with("I ate a grape.", "zh-TW")
+
+        # Both sentences now have a non-empty translation.
+        assert results[0]["translation"] == "我吃了一顆葡萄。"
+        assert results[1]["translation"] == "百香果很甜。"
+
+    @pytest.mark.asyncio
+    async def test_empty_string_translation_is_backfilled(self, service):
+        """A present-but-empty translation is also treated as missing."""
+        words = ["grape"]
+
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[
+            0
+        ].message.content = """[
+            {"sentence": "I ate a grape.", "translation": "  ", "word": "grape"}
+        ]"""
+
+        mock_client = Mock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        service.client = mock_client
+        service.translate_text = AsyncMock(return_value="我吃了一顆葡萄。")
+
+        results = await service.generate_sentences(words=words, translate_to="zh-TW")
+
+        service.translate_text.assert_awaited_once_with("I ate a grape.", "zh-TW")
+        assert results[0]["translation"] == "我吃了一顆葡萄。"
+
+    @pytest.mark.asyncio
+    async def test_no_backfill_when_translate_to_is_none(self, service):
+        """When no translation is requested, no fallback runs and no translation key is added."""
+        words = ["grape", "passionfruit"]
+
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[
+            0
+        ].message.content = """[
+            {"sentence": "I ate a grape.", "word": "grape"},
+            {"sentence": "Passionfruit is sweet.", "word": "passionfruit"}
+        ]"""
+
+        mock_client = Mock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        service.client = mock_client
+        service.translate_text = AsyncMock(return_value="should-not-be-used")
+
+        results = await service.generate_sentences(words=words, translate_to=None)
+
+        service.translate_text.assert_not_awaited()
+        for result in results:
+            assert "translation" not in result
+
+    @pytest.mark.asyncio
+    async def test_backfill_failure_leaves_empty_translation(self, service):
+        """If the fallback translate_text raises, the sentence keeps an empty translation
+        rather than propagating the error."""
+        words = ["grape"]
+
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[
+            0
+        ].message.content = """[
+            {"sentence": "I ate a grape.", "word": "grape"}
+        ]"""
+
+        mock_client = Mock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        service.client = mock_client
+        service.translate_text = AsyncMock(side_effect=Exception("translate down"))
+
+        results = await service.generate_sentences(words=words, translate_to="zh-TW")
+
+        assert results[0]["translation"] == ""

--- a/backend/tests/test_vertex_disable_thinking.py
+++ b/backend/tests/test_vertex_disable_thinking.py
@@ -1,0 +1,72 @@
+"""
+Test for Issue #874: generate_sentences 與 distractors 補上 disable_thinking=True
+
+When USE_VERTEX_AI=true, gemini-2.5-flash runs with thinking ENABLED by default,
+and max_output_tokens is shared between thinking and output tokens. The three AI
+paths below previously omitted disable_thinking=True, which caused:
+  1. 3~13x slower latency (model spends time thinking)
+  2. JSON truncation ("Unterminated string") — thinking ate the token budget
+
+These tests assert that every Vertex AI generate_json call made by the
+sentence/distractor paths passes disable_thinking=True, matching the already-correct
+translation paths.
+"""
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest  # noqa: E402
+from services.translation import TranslationService  # noqa: E402
+
+
+@pytest.mark.unit
+class TestVertexDisableThinking:
+    """Issue #874: Vertex AI 生成路徑必須關閉 thinking"""
+
+    @pytest.fixture
+    def vertex_service(self):
+        """Service forced into Vertex AI mode with a mocked vertex client."""
+        service = TranslationService()
+        service.use_vertex_ai = True
+        service.vertex_ai = AsyncMock()
+        # _ensure_client() must not try to (re)initialise the real client
+        service._ensure_client = lambda: None
+        return service
+
+    @pytest.mark.asyncio
+    async def test_generate_sentences_disables_thinking(self, vertex_service):
+        vertex_service.vertex_ai.generate_json = AsyncMock(
+            return_value=[{"sentence": "I eat an apple.", "translation": "我吃蘋果。"}]
+        )
+
+        await vertex_service.generate_sentences(words=["apple"], level="A1")
+
+        vertex_service.vertex_ai.generate_json.assert_awaited()
+        kwargs = vertex_service.vertex_ai.generate_json.call_args.kwargs
+        assert kwargs.get("disable_thinking") is True
+
+    @pytest.mark.asyncio
+    async def test_generate_distractors_disables_thinking(self, vertex_service):
+        vertex_service.vertex_ai.generate_json = AsyncMock(return_value=["香蕉", "橘子"])
+
+        await vertex_service.generate_distractors(
+            word="apple", translation="蘋果", count=2
+        )
+
+        vertex_service.vertex_ai.generate_json.assert_awaited()
+        kwargs = vertex_service.vertex_ai.generate_json.call_args.kwargs
+        assert kwargs.get("disable_thinking") is True
+
+    @pytest.mark.asyncio
+    async def test_batch_generate_distractors_disables_thinking(self, vertex_service):
+        vertex_service.vertex_ai.generate_json = AsyncMock(return_value=[["香蕉", "橘子"]])
+
+        await vertex_service.batch_generate_distractors(
+            words=[{"word": "apple", "translation": "蘋果"}], count=2
+        )
+
+        vertex_service.vertex_ai.generate_json.assert_awaited()
+        kwargs = vertex_service.vertex_ai.generate_json.call_args.kwargs
+        assert kwargs.get("disable_thinking") is True

--- a/frontend/src/components/AssignmentDialog.tsx
+++ b/frontend/src/components/AssignmentDialog.tsx
@@ -68,6 +68,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { apiClient, ApiError } from "@/lib/api";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import type { PracticeMode } from "@/lib/practiceMode";
 import { useTranslation } from "react-i18next";
 import { useWorkspaceSafe } from "@/contexts/WorkspaceContext";
 import { getScoreCategory, type ScoreCategory } from "@/utils/scoreCategory";
@@ -482,17 +483,8 @@ export function AssignmentDialog({
     due_date: undefined as Date | undefined,
     start_date: undefined as Date | undefined,
     // ===== 例句集作答模式設定 =====
-    practice_mode: "word_selection" as
-      | ""
-      | "reading"
-      | "rearrangement"
-      | "word_reading"
-      | "word_selection"
-      | "word_spelling"
-      | "word_cloze"
-      | "word_selection_quiz"
-      | "word_spelling_quiz"
-      | "word_cloze_quiz", // 作答模式（預設單字選擇）
+    // Issue #843: 型別統一由 @/lib/practiceMode 提供（含 tug_of_war 與三種小考）
+    practice_mode: "word_selection" as "" | PracticeMode, // 作答模式（預設單字選擇）
     time_limit_per_question: 30 as 0 | 10 | 20 | 30 | 40, // 每題時間限制 (0 = 不限時)
     // Issue #828: 小考整卷限時（秒）；null/0 不限時，預設 0
     quiz_time_limit_seconds: 0 as 0 | 180 | 300 | 600 | 900 | 1200 | 1800,

--- a/frontend/src/components/StudentStatusPanel.tsx
+++ b/frontend/src/components/StudentStatusPanel.tsx
@@ -12,6 +12,7 @@
  */
 import { useState, useMemo, useEffect, useCallback, forwardRef } from "react";
 import { useTranslation } from "react-i18next";
+import { isQuizMode, isGradableMode } from "@/lib/practiceMode";
 import {
   LayoutGrid,
   List,
@@ -94,8 +95,7 @@ type ViewMode = "grid" | "list";
 type TabValue = "all" | "assigned" | "unassigned";
 type SortMode = "number" | "name" | "score" | "status";
 
-const GRADABLE_MODES = new Set(["reading", "word_reading", "rearrangement"]);
-
+// 可由老師點姓名開批改頁的模式（isGradableMode）：reading / word_reading / rearrangement
 // revision 模式可被退回訂正的狀態（有作答可訂正）
 const RETURNABLE_STATUSES = new Set(["SUBMITTED", "GRADED", "RESUBMITTED"]);
 
@@ -781,7 +781,7 @@ const StudentStatusPanel = forwardRef<HTMLDivElement, StudentStatusPanelProps>(
     // 批改 hub（revision 模式）依作業類型決定分數區欄位；assign 模式維持單一分數（不變）。
     const metricMode: MetricMode = !isRevision
       ? "score"
-      : practiceMode?.endsWith("_quiz")
+      : isQuizMode(practiceMode)
         ? "quiz"
         : practiceMode === "reading" || practiceMode === "word_reading"
           ? "reading"
@@ -807,7 +807,7 @@ const StudentStatusPanel = forwardRef<HTMLDivElement, StudentStatusPanelProps>(
     const [rangeMin, setRangeMin] = useState("0");
     const [rangeMax, setRangeMax] = useState("80");
 
-    const isGradable = practiceMode ? GRADABLE_MODES.has(practiceMode) : false;
+    const isGradable = isGradableMode(practiceMode);
 
     // Clear selection when parent resets editing state (e.g. after save)
     // revision 模式不受 isEditingStudents 影響（避免清掉退回勾選）
@@ -1008,7 +1008,7 @@ const StudentStatusPanel = forwardRef<HTMLDivElement, StudentStatusPanelProps>(
     }, [rangeMin, rangeMax, selectReturnableBy]);
 
     // ---- Navigation ----
-    // Gradable modes (see GRADABLE_MODES): open grading page for this student in a new tab.
+    // Gradable modes (isGradableMode): open grading page for this student in a new tab.
     // Skip unassigned and NOT_STARTED — nothing to grade yet.
     const isGradableStudent = useCallback(
       (s: StudentProgress) =>
@@ -1016,7 +1016,7 @@ const StudentStatusPanel = forwardRef<HTMLDivElement, StudentStatusPanelProps>(
       [isGradable],
     );
 
-    // revision 模式解除 GRADABLE_MODES 限制:任何可退回學生點姓名都能開批改頁
+    // revision 模式解除 isGradableMode 限制:任何可退回學生點姓名都能開批改頁
     const isClickableStudent = useCallback(
       (s: StudentProgress) =>
         isRevision

--- a/frontend/src/components/TeacherLayout.tsx
+++ b/frontend/src/components/TeacherLayout.tsx
@@ -395,11 +395,18 @@ function TeacherLayoutInner({
         return true;
       })
       .map((group) => {
-        // 個人模式下過濾掉「機構教材」item
-        if (mode === "personal" && group.id === "class-management") {
+        // 依視圖過濾教材 item，避免在錯的視圖選錯目的地：
+        // 個人視圖隱藏「機構教材」，機構視圖隱藏「我的教材」
+        if (group.id === "class-management") {
           return {
             ...group,
-            items: group.items.filter((item) => item.id !== "org-materials"),
+            items: group.items.filter((item) => {
+              if (mode === "personal" && item.id === "org-materials")
+                return false;
+              if (mode === "organization" && item.id === "programs")
+                return false;
+              return true;
+            }),
           };
         }
         return group;

--- a/frontend/src/components/VocabularySetPanel.tsx
+++ b/frontend/src/components/VocabularySetPanel.tsx
@@ -1305,7 +1305,7 @@ function SortableRowInner({
   handleGenerateSingleDefinition,
   handleGenerateSingleDefinitionWithLang:
     _handleGenerateSingleDefinitionWithLang,
-  handleGenerateExampleTranslation: _handleGenerateExampleTranslation,
+  handleGenerateExampleTranslation,
   handleGenerateExampleTranslationWithLang:
     _handleGenerateExampleTranslationWithLang,
   handleOpenAIGenerateModal,
@@ -1318,8 +1318,8 @@ function SortableRowInner({
   showOptionImages = false,
   duplicateReasons,
   customTranslationLang = "",
-  sentenceTranslationLang = "",
-  customSentenceTranslationLang: customSentenceLang = "",
+  sentenceTranslationLang: _sentenceTranslationLang = "",
+  customSentenceTranslationLang: _customSentenceLang = "",
 }: SortableRowInnerProps) {
   const { t } = useTranslation();
   const {
@@ -1774,13 +1774,20 @@ function SortableRowInner({
           maxLength={500}
         />
         <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center">
-          <span className="text-xs text-gray-400">
-            {sentenceTranslationLang === "other"
-              ? customSentenceLang || "..."
-              : SENTENCE_TRANSLATION_LANGUAGES.find(
-                  (l) => l.value === sentenceTranslationLang,
-                )?.label || ""}
-          </span>
+          <button
+            type="button"
+            onClick={() => handleGenerateExampleTranslation(index)}
+            className="text-xs text-gray-400 hover:text-blue-500 hover:underline cursor-pointer transition-colors"
+            title={t("vocabularySet.tooltips.generateExampleTranslation", {
+              lang: SENTENCE_TRANSLATION_LANGUAGES.find(
+                (l) => l.value === (row.selectedSentenceLanguage || "chinese"),
+              )?.label,
+            })}
+          >
+            {SENTENCE_TRANSLATION_LANGUAGES.find(
+              (l) => l.value === (row.selectedSentenceLanguage || "chinese"),
+            )?.label || ""}
+          </button>
         </div>
       </div>
 

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -46,6 +46,7 @@ import VirtualKeyboard from "./shared/VirtualKeyboard";
 import QuizAnswerInput, {
   type QuizAnswerInputHandle,
 } from "./shared/QuizAnswerInput";
+import ClozeBlankText from "./shared/ClozeBlankText";
 import { WordCard } from "./shared/WordCard";
 import { useInputDeviceMode } from "@/hooks/useInputDeviceMode";
 import { aggregateTierCounts, weightedMastery } from "./wordFamiliarity";
@@ -895,7 +896,7 @@ export default function WordClozeActivity({
                     </div>
                   )}
                   <p className="quiz-question-font leading-relaxed text-gray-800 font-semibold px-4 tracking-wide">
-                    {currentQ.blanked_sentence}
+                    <ClozeBlankText text={currentQ.blanked_sentence} />
                   </p>
                   {showTranslation && currentQ.sentence_translation && (
                     <p className="quiz-translation-font text-gray-500">

--- a/frontend/src/components/activities/WordClozeActivity.tsx
+++ b/frontend/src/components/activities/WordClozeActivity.tsx
@@ -140,10 +140,9 @@ export default function WordClozeActivity({
 
   const [showTranslation, setShowTranslation] = useState(true);
   const [audioOnlyMode, setAudioOnlyMode] = useState(false);
-  // Issue #828: placeholder 提示移除；setter 保留以維持載入時 effect 相容。
-  const [, setShowAnswerOnWrong] = useState(false);
-  // Issue #716: 答錯後改用 placeholder 顯示正解，需要記錄上一次是否答錯
-  const [, setLastAttemptWrong] = useState(false);
+  // Issue #867: 老師開「答錯顯示答案」(或播放音檔模式強制) 時，答錯後以紅色
+  // placeholder 在 input 顯示正解；學生再次輸入即消失（#828 重構時誤刪，此處還原）。
+  const [showAnswerOnWrong, setShowAnswerOnWrong] = useState(false);
 
   const [proficiency, setProficiency] = useState<ProficiencyStatus>({
     current_mastery: 0,
@@ -459,12 +458,10 @@ export default function WordClozeActivity({
       setShowResult(true);
       if (correct) {
         setCorrectCount((prev) => prev + 1);
-        setLastAttemptWrong(false);
         // Issue #715: 答對 → 翻面（不立刻顯示 ScoreOverlay）→ onFlipped 後才顯示
         setCardFace("front");
       } else {
-        setLastAttemptWrong(true);
-        // Issue #716: 清空 input 讓正解 placeholder 露出來
+        // Issue #716/#867: 清空 input 讓正解 placeholder 露出來
         setTypedAnswer("");
       }
       recordPreviewAnswer(currentQ.content_item_id, correct);
@@ -489,12 +486,10 @@ export default function WordClozeActivity({
       setShowResult(true);
       if (correct) {
         setCorrectCount((prev) => prev + 1);
-        setLastAttemptWrong(false);
         // Issue #715: 答對 → 翻面（不立刻顯示 ScoreOverlay）→ onFlipped 後才顯示
         setCardFace("front");
       } else {
-        setLastAttemptWrong(true);
-        // Issue #716: 清空 input 讓正解 placeholder 露出來
+        // Issue #716/#867: 清空 input 讓正解 placeholder 露出來
         setTypedAnswer("");
       }
       await fetchProficiency();
@@ -527,7 +522,6 @@ export default function WordClozeActivity({
     setCardFace("back");
     setShowResult(false);
     setTypedAnswer("");
-    setLastAttemptWrong(false);
     if (timeLimit) setTimeRemaining(timeLimit);
 
     if (currentIndex < questions.length - 1) {
@@ -923,6 +917,7 @@ export default function WordClozeActivity({
                   disabled={showResult && isCorrect}
                   useVirtualKeyboard={useVirtualKeyboard}
                   hideSubmitButton={showResult && isCorrect}
+                  revealAnswer={showResult && !isCorrect && showAnswerOnWrong}
                   state={
                     showResult && isCorrect
                       ? "correct"

--- a/frontend/src/components/activities/WordClozeQuizActivity.tsx
+++ b/frontend/src/components/activities/WordClozeQuizActivity.tsx
@@ -36,6 +36,7 @@ import CountdownRing from "./shared/CountdownRing";
 import QuizAnswerInput, {
   type QuizAnswerInputHandle,
 } from "./shared/QuizAnswerInput";
+import ClozeBlankText from "./shared/ClozeBlankText";
 import VirtualKeyboard from "./shared/VirtualKeyboard";
 import CardNavArrow from "./shared/CardNavArrow";
 import QuizReviewView, {
@@ -515,7 +516,7 @@ export default function WordClozeQuizActivity({
                 </span>
               )}
               <p className="quiz-question-font leading-relaxed text-gray-800 font-semibold tracking-wide">
-                {blanked}
+                <ClozeBlankText text={blanked} />
               </p>
               {w.example_sentence_translation && (
                 <p className="quiz-translation-font text-gray-500">
@@ -555,7 +556,7 @@ export default function WordClozeQuizActivity({
         {t("wordQuiz.questionNav") || "題號"}
       </span>
       {/* #844：題號多時不換行，改水平捲動；標題／計數／計時器留在外面不被推走 */}
-      <div className="flex gap-1 sm:gap-1.5 items-center overflow-x-auto min-w-0 flex-1 py-0.5">
+      <div className="flex gap-1 sm:gap-1.5 items-center overflow-x-auto min-w-0 flex-1 py-1">
         {words.map((w, idx) => {
           const answered = (typedByItem[w.content_item_id] || "").trim() !== "";
           const isCurrent = idx === currentIndex;
@@ -565,7 +566,7 @@ export default function WordClozeQuizActivity({
               type="button"
               onClick={() => goTo(idx)}
               className={cn(
-                "h-7 min-w-[28px] px-2 rounded text-xs font-medium border transition",
+                "h-8 min-w-8 shrink-0 inline-flex items-center justify-center rounded text-sm font-medium border transition",
                 isCurrent
                   ? "bg-pink-500 text-white border-pink-500"
                   : !answered
@@ -703,7 +704,7 @@ export default function WordClozeQuizActivity({
                     </div>
                   )}
                   <p className="quiz-question-font leading-relaxed text-gray-800 font-semibold px-4 tracking-wide">
-                    {blanked}
+                    <ClozeBlankText text={blanked} />
                   </p>
                   {settings.show_translation &&
                     currentWord.example_sentence_translation && (

--- a/frontend/src/components/activities/WordSelectionQuizActivity.tsx
+++ b/frontend/src/components/activities/WordSelectionQuizActivity.tsx
@@ -515,7 +515,7 @@ export default function WordSelectionQuizActivity({
         {t("wordQuiz.questionNav") || "題號"}
       </span>
       {/* #844：題號多時不換行，改水平捲動；標題／計數／計時器留在外面不被推走 */}
-      <div className="flex gap-1 sm:gap-1.5 items-center overflow-x-auto min-w-0 flex-1 py-0.5">
+      <div className="flex gap-1 sm:gap-1.5 items-center overflow-x-auto min-w-0 flex-1 py-1">
         {words.map((w, idx) => {
           const answered =
             (selectedByItem[w.content_item_id] || "").trim() !== "";
@@ -526,7 +526,7 @@ export default function WordSelectionQuizActivity({
               type="button"
               onClick={() => goTo(idx)}
               className={cn(
-                "h-7 min-w-[28px] px-2 rounded text-xs font-medium border transition",
+                "h-8 min-w-8 shrink-0 inline-flex items-center justify-center rounded text-sm font-medium border transition",
                 isCurrent
                   ? "bg-emerald-500 text-white border-emerald-500"
                   : !answered

--- a/frontend/src/components/activities/WordSpellingActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingActivity.tsx
@@ -140,11 +140,9 @@ export default function WordSpellingActivity({
   // True when teacher chose "播放音檔" mode — translation is hidden and the
   // audio button becomes the primary hint, so make it visually prominent.
   const [audioOnlyMode, setAudioOnlyMode] = useState(false);
-  // Issue #828: show-answer-on-wrong placeholder 移除（不再以 placeholder 顯示
-  // 正解；setter 保留為 no-op 以維持載入時設定相容性）。
-  const [, setShowAnswerOnWrong] = useState(false);
-  // Issue #828: placeholder 提示移除，setter 保留以最小變動現有呼叫點。
-  const [, setLastAttemptWrong] = useState(false);
+  // Issue #867: 老師開「答錯顯示答案」(或播放音檔模式強制) 時，答錯後以紅色
+  // placeholder 在 input 顯示正解；學生再次輸入即消失（#828 重構時誤刪，此處還原）。
+  const [showAnswerOnWrong, setShowAnswerOnWrong] = useState(false);
 
   // Proficiency
   const [proficiency, setProficiency] = useState<ProficiencyStatus>({
@@ -465,12 +463,10 @@ export default function WordSpellingActivity({
     setSubmitting(true);
 
     if (correct) {
-      setLastAttemptWrong(false);
       // Issue #715: 答對 → 翻面（不立刻顯示 ScoreOverlay）→ onFlipped 後才顯示
       setCardFace("front");
     } else {
-      setLastAttemptWrong(true);
-      // Issue #716: 清空 input 讓正解 placeholder 露出來
+      // Issue #716/#867: 清空 input 讓正解 placeholder 露出來
       setTypedAnswer("");
     }
 
@@ -521,7 +517,6 @@ export default function WordSpellingActivity({
     setCardFace("back");
     setShowResult(false);
     setTypedAnswer("");
-    setLastAttemptWrong(false);
     if (timeLimit) setTimeRemaining(timeLimit);
 
     if (currentIndex < words.length - 1) {
@@ -917,6 +912,7 @@ export default function WordSpellingActivity({
                   disabled={showResult && isCorrect}
                   useVirtualKeyboard={useVirtualKeyboard}
                   hideSubmitButton={showResult && isCorrect}
+                  revealAnswer={showResult && !isCorrect && showAnswerOnWrong}
                   state={
                     showResult && isCorrect
                       ? "correct"

--- a/frontend/src/components/activities/WordSpellingQuizActivity.tsx
+++ b/frontend/src/components/activities/WordSpellingQuizActivity.tsx
@@ -570,7 +570,7 @@ export default function WordSpellingQuizActivity({
         {t("wordQuiz.questionNav") || "題號"}
       </span>
       {/* #844：題號多時不換行，改水平捲動；標題／計數／計時器留在外面不被推走 */}
-      <div className="flex gap-1 sm:gap-1.5 items-center overflow-x-auto min-w-0 flex-1 py-0.5">
+      <div className="flex gap-1 sm:gap-1.5 items-center overflow-x-auto min-w-0 flex-1 py-1">
         {words.map((w, idx) => {
           const answered = (typedByItem[w.content_item_id] || "").trim() !== "";
           const isCurrent = idx === currentIndex;
@@ -580,7 +580,7 @@ export default function WordSpellingQuizActivity({
               type="button"
               onClick={() => goTo(idx)}
               className={cn(
-                "h-7 min-w-[28px] px-2 rounded text-xs font-medium border transition",
+                "h-8 min-w-8 shrink-0 inline-flex items-center justify-center rounded text-sm font-medium border transition",
                 isCurrent
                   ? "bg-amber-500 text-white border-amber-500"
                   : !answered

--- a/frontend/src/components/activities/shared/ClozeBlankText.tsx
+++ b/frontend/src/components/activities/shared/ClozeBlankText.tsx
@@ -1,0 +1,39 @@
+/**
+ * ClozeBlankText — 克漏字句子的挑空渲染元件
+ *
+ * #867：把句子裡的底線挑空（連續的 `_`，如 `_____`）換成圓角淡色方塊，
+ * 取代生硬的底線字元，視覺更好看。方塊為「非互動」（無內容、無 caret），
+ * 明確不是輸入框；實際作答仍在下方的 QuizAnswerInput。
+ *
+ * 用法：放在原本顯示 blanked_sentence 的 <p> 內，取代純文字 `{sentence}`。
+ */
+import React from "react";
+
+interface Props {
+  /** 含底線挑空的句子，例如 "I want to _____ photos." */
+  text: string;
+}
+
+export default function ClozeBlankText({ text }: Props) {
+  if (!text) return null;
+
+  // 以「連續底線」為分隔切開，底線段換成方塊，其餘維持原文字
+  const parts = text.split(/(_+)/);
+  return (
+    <>
+      {parts.map((part, i) =>
+        /^_+$/.test(part) ? (
+          <span
+            key={i}
+            aria-hidden="true"
+            className="inline-block rounded-md bg-indigo-50 border border-indigo-200 px-[3.125rem] py-0.5 mx-1 align-middle select-none"
+          >
+            {" "}
+          </span>
+        ) : (
+          <React.Fragment key={i}>{part}</React.Fragment>
+        ),
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/activities/shared/QuizAnswerInput.tsx
+++ b/frontend/src/components/activities/shared/QuizAnswerInput.tsx
@@ -11,7 +11,9 @@
  *   - VirtualKeyboard Space 鍵 → 跳到下一個 slot（#844，見 appendChar）。
  *   - 過濾允許字元：英文字母、連字號、撇號、句號、逗號、問號、驚嘆號。
  *     （單字 slot 內不允許空格 — 空格是分隔，不該由學生輸入）
- *   - 完整支援標準編輯（Backspace、刪除、游標移動、選取重打）。
+ *   - 支援標準編輯（Backspace、刪除、游標移動、中間插入/刪改、可全選清除）。
+ *   - #867 防查字：允許選取，但禁止複製/剪下/右鍵/拖曳帶出（全裝置）；
+ *     每格 maxLength = 答案長度 + 2；寬度加長（+6 ch）。
  *   - 透過 ref 暴露 VirtualKeyboard 整合：appendChar / backspace / submit /
  *     focusFirst 由父元件的 VK 觸發，作用在當前 focused slot 上。
  *   - revealAnswer（#867）：艾賓浩斯答錯且老師開「答錯顯示答案」時，以紅色
@@ -246,17 +248,26 @@ const QuizAnswerInput = forwardRef<QuizAnswerInputHandle, Props>(
                   }}
                   onPaste={(e) => e.preventDefault()}
                   onDrop={(e) => e.preventDefault()}
+                  // #867: 允許選取（方便全選清除重打），但全裝置禁止複製/帶出，
+                  //   避免學生把答案複製/右鍵搜尋/拖去搜尋列查字。
+                  onCopy={(e) => e.preventDefault()}
+                  onCut={(e) => e.preventDefault()}
+                  onContextMenu={(e) => e.preventDefault()}
+                  onDragStart={(e) => e.preventDefault()}
+                  // #867: 限制每格字母數 = 該格答案長度 + 2 緩衝
+                  maxLength={slotExpected.length + 2}
                   disabled={disabled}
                   autoComplete="off"
                   autoCapitalize="off"
                   autoCorrect="off"
                   spellCheck={false}
-                  // Issue #828: 寬度依答案長度自適應，+4 ch 預留 padding + 較寬字元
+                  // Issue #828: 寬度依答案長度自適應，預留 padding + 較寬字元
                   // #844: 末格內含送出鍵時右側多留 padding，避免文字被圖示蓋住
+                  // #867: 加長寬度（+6 ch），輸入更從容
                   style={
                     multi
-                      ? { width: `${Math.max(slotExpected.length + 4, 6)}ch` }
-                      : { width: `${Math.max(slotExpected.length + 4, 8)}ch` }
+                      ? { width: `${Math.max(slotExpected.length + 6, 8)}ch` }
+                      : { width: `${Math.max(slotExpected.length + 6, 10)}ch` }
                   }
                   className={cn(
                     "text-center quiz-input-font h-14 bg-transparent shadow-none rounded-none border-0 border-b-2 transition-colors",

--- a/frontend/src/components/activities/shared/QuizAnswerInput.tsx
+++ b/frontend/src/components/activities/shared/QuizAnswerInput.tsx
@@ -14,6 +14,8 @@
  *   - 完整支援標準編輯（Backspace、刪除、游標移動、選取重打）。
  *   - 透過 ref 暴露 VirtualKeyboard 整合：appendChar / backspace / submit /
  *     focusFirst 由父元件的 VK 觸發，作用在當前 focused slot 上。
+ *   - revealAnswer（#867）：艾賓浩斯答錯且老師開「答錯顯示答案」時，以紅色
+ *     placeholder 在每個 slot 顯示正解；學生一打字該 slot placeholder 即消失。
  */
 
 import {
@@ -61,6 +63,10 @@ interface Props {
   useVirtualKeyboard?: boolean;
   /** Hide the inline Send button (parent might trigger submit elsewhere). */
   hideSubmitButton?: boolean;
+  /** #867: show the correct answer as a (red) placeholder per slot — used by
+   * Ebbinghaus modes when the student answers wrong and the teacher enabled
+   * "show answer on wrong". Disappears as soon as the student types. */
+  revealAnswer?: boolean;
   onChange: (next: string) => void;
   /** Called when student presses Enter or clicks the Send button. */
   onSubmit?: () => void;
@@ -84,6 +90,7 @@ const QuizAnswerInput = forwardRef<QuizAnswerInputHandle, Props>(
       autoFocus = false,
       useVirtualKeyboard = false,
       hideSubmitButton = false,
+      revealAnswer = false,
       onChange,
       onSubmit,
     },
@@ -205,7 +212,7 @@ const QuizAnswerInput = forwardRef<QuizAnswerInputHandle, Props>(
       state === "correct"
         ? "border-green-500 text-green-700"
         : state === "wrong"
-          ? "border-red-500 text-red-600"
+          ? "border-red-500 text-red-600 placeholder:text-red-400"
           : "border-gray-300 focus:border-indigo-500";
 
     const showSubmit = !hideSubmitButton && !!onSubmit;
@@ -226,6 +233,8 @@ const QuizAnswerInput = forwardRef<QuizAnswerInputHandle, Props>(
                   type="text"
                   inputMode={useVirtualKeyboard ? "none" : "text"}
                   value={currentSlots[idx] || ""}
+                  // #867: 答錯時以 placeholder 顯示該 slot 的正解，學生打字即消失
+                  placeholder={revealAnswer ? slotExpected : undefined}
                   onChange={(e) => writeSlot(idx, e.target.value)}
                   onKeyDown={handleKeyDown(idx)}
                   onFocus={() => setFocusedIdx(idx)}

--- a/frontend/src/hooks/useInputDeviceMode.ts
+++ b/frontend/src/hooks/useInputDeviceMode.ts
@@ -6,11 +6,16 @@
  * spelling/cloze activities. Desktops keep the native keyboard.
  *
  * Detection strategy (avoids UA sniffing):
- *   isTouch  = (pointer: coarse) AND maxTouchPoints > 0
- *   isTablet = viewport width >= 1024px
+ *   isDesktop = (any-pointer: fine)  — has a mouse / trackpad → physical
+ *               keyboard is available, so never force the virtual keyboard.
+ *               (#867: touchscreen Windows laptops/PCs were wrongly forced
+ *               into the VK because they also report a coarse pointer.)
+ *   isTouch   = (pointer: coarse) AND maxTouchPoints > 0
+ *   isTablet  = viewport width >= 1024px
  *
  * Reactively updates on resize / pointer change so iPad rotation between
- * portrait (mobile-ish) and landscape (tablet) switches modes correctly.
+ * portrait (mobile-ish) and landscape (tablet) switches modes correctly,
+ * and so plugging/unplugging a mouse re-evaluates desktop vs touch.
  */
 
 import { useEffect, useState } from "react";
@@ -21,6 +26,9 @@ const TABLET_BREAKPOINT = 1024;
 
 function detect(): InputDeviceMode {
   if (typeof window === "undefined") return "desktop";
+  // #867: a fine pointer (mouse / trackpad) means the student can use a
+  // physical keyboard → treat as desktop and never force the virtual keyboard.
+  if (window.matchMedia("(any-pointer: fine)").matches) return "desktop";
   const coarse = window.matchMedia("(pointer: coarse)").matches;
   const touchPoints = navigator.maxTouchPoints ?? 0;
   const isTouch = coarse && touchPoints > 0;
@@ -34,13 +42,16 @@ export function useInputDeviceMode(): InputDeviceMode {
   useEffect(() => {
     const update = () => setMode(detect());
     const pointerMq = window.matchMedia("(pointer: coarse)");
+    const finePointerMq = window.matchMedia("(any-pointer: fine)");
     const widthMq = window.matchMedia(`(min-width: ${TABLET_BREAKPOINT}px)`);
     pointerMq.addEventListener("change", update);
+    finePointerMq.addEventListener("change", update);
     widthMq.addEventListener("change", update);
     window.addEventListener("resize", update);
     window.addEventListener("orientationchange", update);
     return () => {
       pointerMq.removeEventListener("change", update);
+      finePointerMq.removeEventListener("change", update);
       widthMq.removeEventListener("change", update);
       window.removeEventListener("resize", update);
       window.removeEventListener("orientationchange", update);

--- a/frontend/src/lib/practiceMode.ts
+++ b/frontend/src/lib/practiceMode.ts
@@ -7,7 +7,23 @@
  * 這裡集中定義，各顯示點改用 helper，避免再漂移。
  *
  * 標籤鍵對應 i18n 的 `classroomDetail.contentTypes.*`；顏色沿用既有 badge 配色。
+ *
+ * 注意：成績類別（聽說讀寫 score_category）刻意「不」放進這裡 —— 它不是
+ * practice_mode 的純函式（還要看 play_audio），且唯一真相在後端
+ * `backend/utils/score_category.py`，前端只讀後端算好的值。詳見
+ * `docs/design/score-category-mapping.md`。
  */
+
+import {
+  Mic,
+  Shuffle,
+  MousePointerClick,
+  Volume2,
+  Keyboard,
+  FileText,
+  BookOpen,
+  type LucideIcon,
+} from "lucide-react";
 
 export type PracticeMode =
   | "reading"
@@ -83,4 +99,129 @@ export function practiceModeLabelKey(mode?: string | null): string {
 /** 回傳該 practice_mode 的 badge className（未知回中性灰）。 */
 export function practiceModeBadgeClass(mode?: string | null): string {
   return (mode && BADGE_CLASS[mode as PracticeMode]) || BADGE_CLASS_DEFAULT;
+}
+
+/**
+ * practice_mode → 學生卡 lucide 圖示（component 參照，由呼叫端決定尺寸 className）。
+ * 小考沿用其 base 模式圖示；tug_of_war 目前無專屬圖示，沿用既有 BookOpen fallback。
+ */
+const MODE_ICON: Record<PracticeMode, LucideIcon> = {
+  reading: Mic,
+  rearrangement: Shuffle,
+  word_reading: Volume2,
+  word_selection: MousePointerClick,
+  word_selection_quiz: MousePointerClick,
+  word_spelling: Keyboard,
+  word_spelling_quiz: Keyboard,
+  word_cloze: FileText,
+  word_cloze_quiz: FileText,
+  tug_of_war: BookOpen,
+};
+
+const MODE_ICON_DEFAULT: LucideIcon = BookOpen;
+
+/** 回傳該 practice_mode 的 lucide 圖示 component（未知回 BookOpen）。 */
+export function practiceModeIcon(mode?: string | null): LucideIcon {
+  return (mode && MODE_ICON[mode as PracticeMode]) || MODE_ICON_DEFAULT;
+}
+
+/**
+ * practice_mode → 學生卡左側圖示區「蠟筆」底色 class。
+ * 小考沿用其 base 模式底色；tug_of_war 目前無專屬底色，沿用既有灰底 fallback（行為不變）。
+ */
+const CRAYON_BG_DEFAULT = "bg-gray-50 text-gray-600";
+
+const CRAYON_BG: Record<PracticeMode, string> = {
+  reading:
+    "crayon-texture bg-gradient-to-b from-orange-100 to-orange-200 text-orange-600",
+  rearrangement:
+    "crayon-texture bg-gradient-to-b from-blue-100 to-blue-200 text-blue-600",
+  word_selection:
+    "crayon-texture bg-gradient-to-b from-emerald-100 to-emerald-200 text-emerald-600",
+  word_selection_quiz:
+    "crayon-texture bg-gradient-to-b from-emerald-100 to-emerald-200 text-emerald-600",
+  word_reading:
+    "crayon-texture bg-gradient-to-b from-purple-100 to-purple-200 text-purple-600",
+  word_spelling:
+    "crayon-texture bg-gradient-to-b from-amber-100 to-amber-200 text-amber-600",
+  word_spelling_quiz:
+    "crayon-texture bg-gradient-to-b from-amber-100 to-amber-200 text-amber-600",
+  word_cloze:
+    "crayon-texture bg-gradient-to-b from-pink-100 to-pink-200 text-pink-600",
+  word_cloze_quiz:
+    "crayon-texture bg-gradient-to-b from-pink-100 to-pink-200 text-pink-600",
+  tug_of_war: CRAYON_BG_DEFAULT,
+};
+
+/** 回傳該 practice_mode 的學生卡蠟筆底色 class（未知回灰底）。 */
+export function practiceModeCrayonBg(mode?: string | null): string {
+  return (mode && CRAYON_BG[mode as PracticeMode]) || CRAYON_BG_DEFAULT;
+}
+
+/**
+ * 篩選/顯示用的標準順序（含三種小考）。每個 base 模式後緊接其小考變體，
+ * 篩選下拉、按鈕清單都應依此產生，避免各頁各自硬寫且遺漏小考。
+ */
+export const PRACTICE_MODE_ORDER: PracticeMode[] = [
+  "reading",
+  "word_reading",
+  "rearrangement",
+  "word_selection",
+  "word_selection_quiz",
+  "word_spelling",
+  "word_spelling_quiz",
+  "word_cloze",
+  "word_cloze_quiz",
+  "tug_of_war",
+];
+
+export interface PracticeModeFilterOption {
+  /** 原始 practice_mode 值（作為 select value / 後端 query 參數） */
+  mode: PracticeMode;
+  /** i18n key（`classroomDetail.contentTypes.*`） */
+  labelKey: string;
+}
+
+/**
+ * 產生作業模式篩選下拉/按鈕的選項清單（依 PRACTICE_MODE_ORDER，含小考）。
+ * 不含「全部」選項 —— 由各頁自行加上（key 各自既有）。
+ */
+export function practiceModeFilterOptions(): PracticeModeFilterOption[] {
+  return PRACTICE_MODE_ORDER.map((mode) => ({
+    mode,
+    labelKey: practiceModeLabelKey(mode),
+  }));
+}
+
+/**
+ * 自動計分模式：系統自動判分、不需 AI 發音批改的模式。
+ * = {rearrangement, word_selection, word_spelling, word_cloze, tug_of_war} ∪ 三種小考。
+ * 補集為朗讀類（reading / word_reading）—— 需 AI 批改。
+ */
+const AUTO_SCORED_MODES: ReadonlySet<PracticeMode> = new Set([
+  "rearrangement",
+  "word_selection",
+  "word_spelling",
+  "word_cloze",
+  "tug_of_war",
+]);
+
+export function isAutoScoredMode(mode?: string | null): boolean {
+  if (!mode) return false;
+  return AUTO_SCORED_MODES.has(mode as PracticeMode) || isQuizMode(mode);
+}
+
+/**
+ * 可由老師「點進去手動批改/檢視」的模式（StudentStatusPanel 既有 GRADABLE_MODES）。
+ * = {reading, word_reading, rearrangement}。語意與 isAutoScoredMode 補集「不」相同，
+ * 故獨立定義，維持各自既有行為。
+ */
+const GRADABLE_MODES: ReadonlySet<PracticeMode> = new Set([
+  "reading",
+  "word_reading",
+  "rearrangement",
+]);
+
+export function isGradableMode(mode?: string | null): boolean {
+  return !!mode && GRADABLE_MODES.has(mode as PracticeMode);
 }

--- a/frontend/src/pages/student/StudentActivityPageContent.tsx
+++ b/frontend/src/pages/student/StudentActivityPageContent.tsx
@@ -27,6 +27,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
+import { isQuizMode as resolveIsQuizMode } from "@/lib/practiceMode";
 import { QuizNavSlotContext } from "@/contexts/QuizNavSlotContext";
 import ReadingAssessmentTemplate from "@/components/activities/ReadingAssessmentTemplate";
 import ListeningClozeTemplate from "@/components/activities/ListeningClozeTemplate";
@@ -332,10 +333,7 @@ export default function StudentActivityPageContent({
   const [currentActivityIndex, setCurrentActivityIndex] = useState(0);
   // Quiz 題號 bar 的 Portal slot — Page 保留 DOM，Activity 投放 nav JSX
   const [quizNavSlot, setQuizNavSlot] = useState<HTMLDivElement | null>(null);
-  const isQuizMode =
-    practiceMode === "word_selection_quiz" ||
-    practiceMode === "word_spelling_quiz" ||
-    practiceMode === "word_cloze_quiz";
+  const isQuizMode = resolveIsQuizMode(practiceMode);
   const [currentSubQuestionIndex, setCurrentSubQuestionIndex] = useState(0);
   const [answers, setAnswers] = useState<Map<number, Answer>>(new Map());
   const [saving] = useState(false);

--- a/frontend/src/pages/student/StudentActivityPageContent.tsx
+++ b/frontend/src/pages/student/StudentActivityPageContent.tsx
@@ -2838,7 +2838,10 @@ export default function StudentActivityPageContent({
               </CardHeader>
             )}
 
-            <CardContent className="p-2 sm:p-3">
+            {/* #867: select-none 禁止反白選取作答內容（題目/翻譯/單字卡），
+                防學生反白後搜尋/翻譯查字。此容器涵蓋所有 practice_mode，
+                未來新模式自動繼承；input 答案另在 QuizAnswerInput 處理。 */}
+            <CardContent className="p-2 sm:p-3 select-none">
               {renderActivityContent(currentActivity)}
 
               {/* Navigation buttons */}

--- a/frontend/src/pages/student/StudentAssignmentList.tsx
+++ b/frontend/src/pages/student/StudentAssignmentList.tsx
@@ -14,7 +14,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useStudentAuthStore } from "@/stores/studentAuthStore";
 import { toast } from "sonner";
 import {
-  BookOpen,
   Clock,
   Calendar,
   CheckCircle,
@@ -23,30 +22,17 @@ import {
   ChevronLeft,
   ChevronRight,
   ArrowRight,
-  Mic,
-  Shuffle,
-  MousePointerClick,
-  Volume2,
   ArrowUpDown,
-  Keyboard,
-  FileText,
+  Filter,
 } from "lucide-react";
 import { StudentAssignmentCard, AssignmentStatusEnum } from "@/types";
 import { useTranslation } from "react-i18next";
-
-// Practice mode icon mapping
-const PRACTICE_MODE_ICONS: Record<string, React.ReactNode> = {
-  reading: <Mic className="h-7 w-7 sm:h-8 sm:w-8" />,
-  rearrangement: <Shuffle className="h-7 w-7 sm:h-8 sm:w-8" />,
-  word_selection: <MousePointerClick className="h-7 w-7 sm:h-8 sm:w-8" />,
-  word_reading: <Volume2 className="h-7 w-7 sm:h-8 sm:w-8" />,
-  word_spelling: <Keyboard className="h-7 w-7 sm:h-8 sm:w-8" />,
-  word_cloze: <FileText className="h-7 w-7 sm:h-8 sm:w-8" />,
-  // 小考沿用其 base 模式圖示
-  word_selection_quiz: <MousePointerClick className="h-7 w-7 sm:h-8 sm:w-8" />,
-  word_spelling_quiz: <Keyboard className="h-7 w-7 sm:h-8 sm:w-8" />,
-  word_cloze_quiz: <FileText className="h-7 w-7 sm:h-8 sm:w-8" />,
-};
+import {
+  practiceModeIcon,
+  practiceModeCrayonBg,
+  practiceModeLabelKey,
+  practiceModeFilterOptions,
+} from "@/lib/practiceMode";
 
 // Score category colors — keys must match ScoreCategory enum values
 // (see docs/design/score-category-mapping.md)
@@ -57,31 +43,13 @@ const SCORE_CATEGORY_COLORS: Record<string, string> = {
   reading: "bg-pink-100 text-pink-700 border-pink-200",
 };
 
-// Practice mode background colors for left icon area (crayon style)
-const PRACTICE_MODE_BG: Record<string, string> = {
-  reading:
-    "crayon-texture bg-gradient-to-b from-orange-100 to-orange-200 text-orange-600",
-  rearrangement:
-    "crayon-texture bg-gradient-to-b from-blue-100 to-blue-200 text-blue-600",
-  word_selection:
-    "crayon-texture bg-gradient-to-b from-emerald-100 to-emerald-200 text-emerald-600",
-  word_reading:
-    "crayon-texture bg-gradient-to-b from-purple-100 to-purple-200 text-purple-600",
-  word_spelling:
-    "crayon-texture bg-gradient-to-b from-amber-100 to-amber-200 text-amber-600",
-  word_cloze:
-    "crayon-texture bg-gradient-to-b from-pink-100 to-pink-200 text-pink-600",
-  // 小考沿用其 base 模式底色
-  word_selection_quiz:
-    "crayon-texture bg-gradient-to-b from-emerald-100 to-emerald-200 text-emerald-600",
-  word_spelling_quiz:
-    "crayon-texture bg-gradient-to-b from-amber-100 to-amber-200 text-amber-600",
-  word_cloze_quiz:
-    "crayon-texture bg-gradient-to-b from-pink-100 to-pink-200 text-pink-600",
-};
-
 export default function StudentAssignmentList() {
   const { t } = useTranslation();
+  // 標籤集中由 @/lib/practiceMode 推導（classroomDetail.contentTypes，含三種小考）
+  const getPracticeModeLabel = (mode?: string) => {
+    const key = practiceModeLabelKey(mode);
+    return key ? t(key) : mode || "—";
+  };
   const navigate = useNavigate();
   const { token, user } = useStudentAuthStore();
   const [searchParams] = useSearchParams();
@@ -345,10 +313,8 @@ export default function StudentAssignmentList() {
     const dueDateInfo = formatDueDate(assignment.due_date);
     const practiceMode = assignment.practice_mode || "reading";
     const scoreCategory = assignment.score_category;
-    const modeIcon = PRACTICE_MODE_ICONS[practiceMode] || (
-      <BookOpen className="h-5 w-5" />
-    );
-    const modeBg = PRACTICE_MODE_BG[practiceMode] || "bg-gray-50 text-gray-600";
+    const ModeIcon = practiceModeIcon(practiceMode);
+    const modeBg = practiceModeCrayonBg(practiceMode);
     const categoryColor = scoreCategory
       ? SCORE_CATEGORY_COLORS[scoreCategory] || "bg-gray-100 text-gray-600"
       : null;
@@ -365,7 +331,7 @@ export default function StudentAssignmentList() {
             <div
               className={`flex items-center justify-center w-16 sm:w-20 flex-shrink-0 rounded-l-lg ${modeBg}`}
             >
-              {modeIcon}
+              <ModeIcon className="h-7 w-7 sm:h-8 sm:w-8" />
             </div>
 
             {/* Right: Content */}
@@ -395,7 +361,7 @@ export default function StudentAssignmentList() {
 
               {/* Practice mode label */}
               <p className="text-[10px] sm:text-xs text-gray-500 mt-0.5">
-                {t(`studentAssignmentList.practiceMode.${practiceMode}`)}
+                {getPracticeModeLabel(practiceMode)}
               </p>
 
               {/* Bottom row: due date + score + action */}
@@ -549,15 +515,6 @@ export default function StudentAssignmentList() {
     );
   }
 
-  const practiceModes = [
-    "reading",
-    "rearrangement",
-    "word_selection",
-    "word_reading",
-    "word_spelling",
-    "word_cloze",
-  ];
-
   return (
     <div className="p-4 sm:p-6 lg:p-8">
       {/* Assignment Flow Status — full width */}
@@ -701,33 +658,30 @@ export default function StudentAssignmentList() {
             </Select>
           </div>
 
-          {/* Practice mode filter */}
-          <div className="flex items-center gap-1.5 flex-wrap">
-            <Button
-              variant={filterMode === null ? "default" : "outline"}
-              size="sm"
-              className="h-7 text-xs px-2.5"
-              onClick={() => {
-                setFilterMode(null);
+          {/* Practice mode filter（含三種小考，選項由 @/lib/practiceMode 產生） */}
+          <div className="flex items-center gap-2">
+            <Filter className="h-4 w-4 text-gray-500" />
+            <Select
+              value={filterMode ?? "all"}
+              onValueChange={(v) => {
+                setFilterMode(v === "all" ? null : v);
                 setCurrentPage(1);
               }}
             >
-              {t("studentAssignmentList.practiceMode.all")}
-            </Button>
-            {practiceModes.map((mode) => (
-              <Button
-                key={mode}
-                variant={filterMode === mode ? "default" : "outline"}
-                size="sm"
-                className="h-7 text-xs px-2.5"
-                onClick={() => {
-                  setFilterMode(filterMode === mode ? null : mode);
-                  setCurrentPage(1);
-                }}
-              >
-                {t(`studentAssignmentList.practiceMode.${mode}`)}
-              </Button>
-            ))}
+              <SelectTrigger className="w-[200px] h-8 text-xs sm:text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">
+                  {t("studentAssignmentList.practiceMode.all")}
+                </SelectItem>
+                {practiceModeFilterOptions().map((opt) => (
+                  <SelectItem key={opt.mode} value={opt.mode}>
+                    {t(opt.labelKey)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
         </div>
 

--- a/frontend/src/pages/teacher/AssignmentManagementPage.tsx
+++ b/frontend/src/pages/teacher/AssignmentManagementPage.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next";
 import {
   practiceModeLabelKey,
   practiceModeBadgeClass,
+  practiceModeFilterOptions,
 } from "@/lib/practiceMode";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -388,27 +389,12 @@ export default function AssignmentManagementPage() {
           className="h-9 rounded-md border border-input bg-background px-3 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200"
         >
           <option value="">{t("classroomDetail.filters.allTypes")}</option>
-          <option value="reading">
-            {t("classroomDetail.contentTypes.SPEAKING")}
-          </option>
-          <option value="rearrangement">
-            {t("classroomDetail.contentTypes.REARRANGEMENT")}
-          </option>
-          <option value="word_reading">
-            {t("classroomDetail.contentTypes.WORD_READING")}
-          </option>
-          <option value="word_selection">
-            {t("classroomDetail.contentTypes.WORD_SELECTION")}
-          </option>
-          <option value="word_spelling">
-            {t("classroomDetail.contentTypes.WORD_SPELLING")}
-          </option>
-          <option value="word_cloze">
-            {t("classroomDetail.contentTypes.WORD_CLOZE")}
-          </option>
-          <option value="tug_of_war">
-            {t("classroomDetail.contentTypes.TUG_OF_WAR")}
-          </option>
+          {/* Issue #843: 選項由 @/lib/practiceMode 產生（含三種小考），不再硬寫 */}
+          {practiceModeFilterOptions().map((opt) => (
+            <option key={opt.mode} value={opt.mode}>
+              {t(opt.labelKey)}
+            </option>
+          ))}
         </select>
 
         <div className="relative w-full md:w-[250px]">

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -4,7 +4,8 @@ import { useTranslation } from "react-i18next";
 import {
   practiceModeLabelKey,
   practiceModeBadgeClass,
-  isQuizMode,
+  practiceModeFilterOptions,
+  isAutoScoredMode,
 } from "@/lib/practiceMode";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -249,12 +250,72 @@ export default function ClassroomDetail({
     "" | "completed" | "in_progress" | "overdue"
   >("");
 
-  // Filter type → practice_mode mapping
-  const filterTypeMap: Record<string, string> = {
-    WORD_READING: "word_reading",
-    WORD_SELECTION: "word_selection",
-    SPEAKING: "reading",
-    REARRANGEMENT: "rearrangement",
+  // Issue #843: 作業卡「類型標籤/顏色」單一來源。
+  // VOCABULARY_SET / SENTENCE_MAKING → 由 practice_mode 查 registry（含三種小考），
+  // 未知模式退回單字朗讀；EXAMPLE_SENTENCES / READING_ASSESSMENT 與其他 content_type
+  // 維持原內容型別語意。桌機/手機兩處作業卡共用此函式（原本是兩段相同的 getTypeInfo）。
+  const getAssignmentTypeInfo = (assignment: Assignment) => {
+    const contentType = assignment.content_type?.toUpperCase();
+    const practiceMode = assignment.practice_mode;
+
+    if (contentType === "VOCABULARY_SET" || contentType === "SENTENCE_MAKING") {
+      const key = practiceModeLabelKey(practiceMode);
+      if (key) {
+        return { label: t(key), color: practiceModeBadgeClass(practiceMode) };
+      }
+      return {
+        label: t("classroomDetail.contentTypes.WORD_READING"),
+        color:
+          "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
+      };
+    }
+
+    if (
+      contentType === "EXAMPLE_SENTENCES" ||
+      contentType === "READING_ASSESSMENT"
+    ) {
+      if (practiceMode === "rearrangement") {
+        return {
+          label: t("classroomDetail.contentTypes.REARRANGEMENT"),
+          color:
+            "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+        };
+      }
+      return {
+        label: t("classroomDetail.contentTypes.SPEAKING"),
+        color:
+          "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+      };
+    }
+
+    const otherTypeLabels: Record<string, { label: string; color: string }> = {
+      SPEAKING_PRACTICE: {
+        label: t("classroomDetail.contentTypes.speakingPractice"),
+        color:
+          "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
+      },
+      SPEAKING_SCENARIO: {
+        label: t("classroomDetail.contentTypes.speakingScenario"),
+        color:
+          "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+      },
+      LISTENING_CLOZE: {
+        label: t("classroomDetail.contentTypes.listeningCloze"),
+        color:
+          "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+      },
+      SPEAKING_QUIZ: {
+        label: t("classroomDetail.contentTypes.speakingQuiz"),
+        color: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+      },
+    };
+
+    return (
+      otherTypeLabels[contentType || ""] || {
+        label: t("classroomDetail.labels.unknownType"),
+        color: "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300",
+      }
+    );
   };
 
   // Archive states
@@ -272,8 +333,7 @@ export default function ClassroomDetail({
       !a.title.toLowerCase().includes(filterKeyword.toLowerCase())
     )
       return false;
-    if (filterType && a.practice_mode !== filterTypeMap[filterType])
-      return false;
+    if (filterType && a.practice_mode !== filterType) return false;
     if (filterDateFrom && a.created_at) {
       if (new Date(a.created_at) < new Date(filterDateFrom)) return false;
     }
@@ -2203,18 +2263,13 @@ export default function ClassroomDetail({
                           <option value="">
                             {t("classroomDetail.filters.allTypes")}
                           </option>
-                          <option value="WORD_READING">
-                            {t("classroomDetail.contentTypes.WORD_READING")}
-                          </option>
-                          <option value="WORD_SELECTION">
-                            {t("classroomDetail.contentTypes.WORD_SELECTION")}
-                          </option>
-                          <option value="SPEAKING">
-                            {t("classroomDetail.contentTypes.SPEAKING")}
-                          </option>
-                          <option value="REARRANGEMENT">
-                            {t("classroomDetail.contentTypes.REARRANGEMENT")}
-                          </option>
+                          {/* Issue #843: 選項由 @/lib/practiceMode 產生（含三種小考），
+                              value 直接用 practice_mode，不再經 filterTypeMap 轉換 */}
+                          {practiceModeFilterOptions().map((opt) => (
+                            <option key={opt.mode} value={opt.mode}>
+                              {t(opt.labelKey)}
+                            </option>
+                          ))}
                         </select>
                         <div className="relative w-full md:w-[35%]">
                           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
@@ -2289,159 +2344,7 @@ export default function ClassroomDetail({
                             const completionRate =
                               assignment.completion_rate || 0;
                             // 🎯 Issue #118: 根據 content_type + practice_mode 決定顯示標籤
-                            const getTypeInfo = () => {
-                              const contentType =
-                                assignment.content_type?.toUpperCase();
-                              const practiceMode = assignment.practice_mode;
-
-                              // VOCABULARY_SET 或 SENTENCE_MAKING → 根據 practice_mode
-                              if (
-                                contentType === "VOCABULARY_SET" ||
-                                contentType === "SENTENCE_MAKING"
-                              ) {
-                                if (practiceMode === "word_selection") {
-                                  return {
-                                    label: t(
-                                      "classroomDetail.contentTypes.WORD_SELECTION",
-                                    ),
-                                    color:
-                                      "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300",
-                                  };
-                                }
-                                if (practiceMode === "word_spelling") {
-                                  return {
-                                    label: t(
-                                      "classroomDetail.contentTypes.WORD_SPELLING",
-                                    ),
-                                    color:
-                                      "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
-                                  };
-                                }
-                                if (practiceMode === "word_cloze") {
-                                  return {
-                                    label: t(
-                                      "classroomDetail.contentTypes.WORD_CLOZE",
-                                    ),
-                                    color:
-                                      "bg-pink-100 text-pink-800 dark:bg-pink-900/30 dark:text-pink-300",
-                                  };
-                                }
-                                if (practiceMode === "tug_of_war") {
-                                  return {
-                                    label: t(
-                                      "classroomDetail.contentTypes.TUG_OF_WAR",
-                                    ),
-                                    color:
-                                      "bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-300",
-                                  };
-                                }
-                                if (practiceMode === "rearrangement") {
-                                  return {
-                                    label: t(
-                                      "classroomDetail.contentTypes.REARRANGEMENT",
-                                    ),
-                                    color:
-                                      "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-                                  };
-                                }
-                                if (practiceMode === "reading") {
-                                  return {
-                                    label: t(
-                                      "classroomDetail.contentTypes.SPEAKING",
-                                    ),
-                                    color:
-                                      "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-                                  };
-                                }
-                                // 其餘（含三種小考）由 registry 推導；未知才退回單字朗讀
-                                {
-                                  const key =
-                                    practiceModeLabelKey(practiceMode);
-                                  if (key)
-                                    return {
-                                      label: t(key),
-                                      color:
-                                        practiceModeBadgeClass(practiceMode),
-                                    };
-                                }
-                                return {
-                                  label: t(
-                                    "classroomDetail.contentTypes.WORD_READING",
-                                  ),
-                                  color:
-                                    "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
-                                };
-                              }
-
-                              // EXAMPLE_SENTENCES 或 READING_ASSESSMENT → 根據 practice_mode
-                              if (
-                                contentType === "EXAMPLE_SENTENCES" ||
-                                contentType === "READING_ASSESSMENT"
-                              ) {
-                                if (practiceMode === "rearrangement") {
-                                  return {
-                                    label: t(
-                                      "classroomDetail.contentTypes.REARRANGEMENT",
-                                    ),
-                                    color:
-                                      "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-                                  };
-                                }
-                                return {
-                                  label: t(
-                                    "classroomDetail.contentTypes.SPEAKING",
-                                  ),
-                                  color:
-                                    "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-                                };
-                              }
-
-                              // 其他類型保持原有邏輯
-                              const otherTypeLabels: Record<
-                                string,
-                                { label: string; color: string }
-                              > = {
-                                SPEAKING_PRACTICE: {
-                                  label: t(
-                                    "classroomDetail.contentTypes.speakingPractice",
-                                  ),
-                                  color:
-                                    "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
-                                },
-                                SPEAKING_SCENARIO: {
-                                  label: t(
-                                    "classroomDetail.contentTypes.speakingScenario",
-                                  ),
-                                  color:
-                                    "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-                                },
-                                LISTENING_CLOZE: {
-                                  label: t(
-                                    "classroomDetail.contentTypes.listeningCloze",
-                                  ),
-                                  color:
-                                    "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
-                                },
-                                SPEAKING_QUIZ: {
-                                  label: t(
-                                    "classroomDetail.contentTypes.speakingQuiz",
-                                  ),
-                                  color:
-                                    "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
-                                },
-                              };
-
-                              return (
-                                otherTypeLabels[contentType || ""] || {
-                                  label: t(
-                                    "classroomDetail.labels.unknownType",
-                                  ),
-                                  color:
-                                    "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300",
-                                }
-                              );
-                            };
-                            const typeInfo = getTypeInfo();
+                            const typeInfo = getAssignmentTypeInfo(assignment);
 
                             return (
                               <div
@@ -2476,15 +2379,9 @@ export default function ClassroomDetail({
                                       word_spelling / word_cloze / tug_of_war / 三種小考)
                                       不顯示 AI 批改按鈕。#830：列表入口暫時隱藏，改由 hub 內觸發 */}
                                   {SHOW_LIST_AI_GRADE &&
-                                    assignment.practice_mode !==
-                                      "rearrangement" &&
-                                    assignment.practice_mode !==
-                                      "word_selection" &&
-                                    assignment.practice_mode !==
-                                      "word_spelling" &&
-                                    assignment.practice_mode !== "word_cloze" &&
-                                    assignment.practice_mode !== "tug_of_war" &&
-                                    !isQuizMode(assignment.practice_mode) &&
+                                    !isAutoScoredMode(
+                                      assignment.practice_mode,
+                                    ) &&
                                     canUseAiGrading && (
                                       <div className="flex flex-col items-end flex-shrink-0">
                                         <Button
@@ -2689,161 +2586,8 @@ export default function ClassroomDetail({
                                 const completionRate =
                                   assignment.completion_rate || 0;
                                 // 🎯 Issue #118: 根據 content_type + practice_mode 決定顯示標籤
-                                const getTypeInfo = () => {
-                                  const contentType =
-                                    assignment.content_type?.toUpperCase();
-                                  const practiceMode = assignment.practice_mode;
-
-                                  // VOCABULARY_SET 或 SENTENCE_MAKING → 根據 practice_mode
-                                  if (
-                                    contentType === "VOCABULARY_SET" ||
-                                    contentType === "SENTENCE_MAKING"
-                                  ) {
-                                    if (practiceMode === "word_selection") {
-                                      return {
-                                        label: t(
-                                          "classroomDetail.contentTypes.WORD_SELECTION",
-                                        ),
-                                        color:
-                                          "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300",
-                                      };
-                                    }
-                                    if (practiceMode === "word_spelling") {
-                                      return {
-                                        label: t(
-                                          "classroomDetail.contentTypes.WORD_SPELLING",
-                                        ),
-                                        color:
-                                          "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
-                                      };
-                                    }
-                                    if (practiceMode === "word_cloze") {
-                                      return {
-                                        label: t(
-                                          "classroomDetail.contentTypes.WORD_CLOZE",
-                                        ),
-                                        color:
-                                          "bg-pink-100 text-pink-800 dark:bg-pink-900/30 dark:text-pink-300",
-                                      };
-                                    }
-                                    if (practiceMode === "tug_of_war") {
-                                      return {
-                                        label: t(
-                                          "classroomDetail.contentTypes.TUG_OF_WAR",
-                                        ),
-                                        color:
-                                          "bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-300",
-                                      };
-                                    }
-                                    if (practiceMode === "rearrangement") {
-                                      return {
-                                        label: t(
-                                          "classroomDetail.contentTypes.REARRANGEMENT",
-                                        ),
-                                        color:
-                                          "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-                                      };
-                                    }
-                                    if (practiceMode === "reading") {
-                                      return {
-                                        label: t(
-                                          "classroomDetail.contentTypes.SPEAKING",
-                                        ),
-                                        color:
-                                          "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-                                      };
-                                    }
-                                    // 其餘（含三種小考）由 registry 推導；未知才退回單字朗讀
-                                    {
-                                      const key =
-                                        practiceModeLabelKey(practiceMode);
-                                      if (key)
-                                        return {
-                                          label: t(key),
-                                          color:
-                                            practiceModeBadgeClass(
-                                              practiceMode,
-                                            ),
-                                        };
-                                    }
-                                    return {
-                                      label: t(
-                                        "classroomDetail.contentTypes.WORD_READING",
-                                      ),
-                                      color:
-                                        "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
-                                    };
-                                  }
-
-                                  // EXAMPLE_SENTENCES 或 READING_ASSESSMENT → 根據 practice_mode
-                                  if (
-                                    contentType === "EXAMPLE_SENTENCES" ||
-                                    contentType === "READING_ASSESSMENT"
-                                  ) {
-                                    if (practiceMode === "rearrangement") {
-                                      return {
-                                        label: t(
-                                          "classroomDetail.contentTypes.REARRANGEMENT",
-                                        ),
-                                        color:
-                                          "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-                                      };
-                                    }
-                                    return {
-                                      label: t(
-                                        "classroomDetail.contentTypes.SPEAKING",
-                                      ),
-                                      color:
-                                        "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-                                    };
-                                  }
-
-                                  // 其他類型
-                                  const otherTypeLabels: Record<
-                                    string,
-                                    { label: string; color: string }
-                                  > = {
-                                    SPEAKING_PRACTICE: {
-                                      label: t(
-                                        "classroomDetail.contentTypes.speakingPractice",
-                                      ),
-                                      color:
-                                        "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
-                                    },
-                                    SPEAKING_SCENARIO: {
-                                      label: t(
-                                        "classroomDetail.contentTypes.speakingScenario",
-                                      ),
-                                      color:
-                                        "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-                                    },
-                                    LISTENING_CLOZE: {
-                                      label: t(
-                                        "classroomDetail.contentTypes.listeningCloze",
-                                      ),
-                                      color:
-                                        "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
-                                    },
-                                    SPEAKING_QUIZ: {
-                                      label: t(
-                                        "classroomDetail.contentTypes.speakingQuiz",
-                                      ),
-                                      color:
-                                        "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
-                                    },
-                                  };
-
-                                  return (
-                                    otherTypeLabels[contentType || ""] || {
-                                      label: t(
-                                        "classroomDetail.labels.unknownType",
-                                      ),
-                                      color:
-                                        "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300",
-                                    }
-                                  );
-                                };
-                                const typeInfo = getTypeInfo();
+                                const typeInfo =
+                                  getAssignmentTypeInfo(assignment);
 
                                 return (
                                   <tr
@@ -2967,17 +2711,7 @@ export default function ClassroomDetail({
                                             word_spelling / word_cloze / tug_of_war / 三種小考)
                                             不顯示 AI 批改按鈕。#830：列表入口暫時隱藏，改由 hub 內觸發 */}
                                         {SHOW_LIST_AI_GRADE &&
-                                          assignment.practice_mode !==
-                                            "rearrangement" &&
-                                          assignment.practice_mode !==
-                                            "word_selection" &&
-                                          assignment.practice_mode !==
-                                            "word_spelling" &&
-                                          assignment.practice_mode !==
-                                            "word_cloze" &&
-                                          assignment.practice_mode !==
-                                            "tug_of_war" &&
-                                          !isQuizMode(
+                                          !isAutoScoredMode(
                                             assignment.practice_mode,
                                           ) &&
                                           canUseAiGrading && (

--- a/frontend/src/pages/teacher/GradingPage.tsx
+++ b/frontend/src/pages/teacher/GradingPage.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from "react-i18next";
 import { apiClient } from "@/lib/api";
 import { toast } from "sonner";
 import { Assignment } from "@/types";
+import type { PracticeMode } from "@/lib/practiceMode";
 import {
   GradingHeader,
   StudentListPanel,
@@ -122,15 +123,9 @@ export interface SubmissionItem {
   time_spent_seconds?: number;
 }
 
-export type PracticeMode =
-  | "reading"
-  | "rearrangement"
-  | "word_reading"
-  | "word_selection"
-  // Issue #830: 小考變體（自動判分，批改頁走 QuizGradingPanel 顯示逐題對錯）
-  | "word_selection_quiz"
-  | "word_spelling_quiz"
-  | "word_cloze_quiz";
+// Issue #843: practice_mode 型別統一由 @/lib/practiceMode 提供（含全部模式與三種小考），
+// 不再各頁硬寫發散的 union（此頁原本缺 word_spelling / word_cloze / tug_of_war）。
+export type { PracticeMode };
 
 export interface StudentSubmission {
   student_number: number;

--- a/frontend/src/pages/teacher/ResourceMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/ResourceMaterialsPage.tsx
@@ -5,6 +5,7 @@ import {
   ResourceMaterial,
   ResourceMaterialDetail,
 } from "@/hooks/useResourceMaterialsAPI";
+import { useWorkspace } from "@/contexts/WorkspaceContext";
 import ResourceFolderView from "@/components/shared/ResourceFolderView";
 import type { ResourceContentItem } from "@/components/shared/ResourceFolderView";
 import MaterialsToolbar from "@/components/shared/MaterialsToolbar";
@@ -152,6 +153,13 @@ function ResourceMaterialsInner() {
   const { loading, listMaterials, getMaterialDetail, copyMaterial } =
     useResourceMaterialsAPI();
 
+  // 機構視圖（含校內視圖）時，資源包複製/列表改用機構 scope。
+  // 後端複製 API 僅支援 individual/organization，故只要 selectedOrganization
+  // 存在就一律歸到該機構。沿用 TeacherClassrooms 等頁的 workspace 分流慣例。
+  const { mode, selectedOrganization } = useWorkspace();
+  const orgScope = mode === "organization" && !!selectedOrganization;
+  const orgId = selectedOrganization?.id;
+
   const [materials, setMaterials] = useState<ResourceMaterial[]>([]);
   const [viewMode, setViewMode] = useState<ViewMode>("folder");
   const [searchQuery, setSearchQuery] = useState("");
@@ -178,9 +186,12 @@ function ResourceMaterialsInner() {
   const [copying, setCopying] = useState(false);
 
   const fetchMaterials = useCallback(async () => {
-    const result = await listMaterials("individual");
+    const result = await listMaterials(
+      orgScope ? "organization" : "individual",
+      orgScope ? orgId : undefined,
+    );
     setMaterials(result.materials);
-  }, [listMaterials]);
+  }, [listMaterials, orgScope, orgId]);
 
   useEffect(() => {
     fetchMaterials();
@@ -232,9 +243,18 @@ function ResourceMaterialsInner() {
     if (!copyTarget) return;
     setCopying(true);
     try {
-      await copyMaterial(copyTarget.id, "individual");
+      await copyMaterial(
+        copyTarget.id,
+        orgScope ? "organization" : "individual",
+        orgScope ? orgId : undefined,
+      );
       toast.success(
-        t("resourceMaterials.toast.copySuccess", { name: copyTarget.name }),
+        t(
+          orgScope
+            ? "resourceMaterials.toast.copySuccessOrg"
+            : "resourceMaterials.toast.copySuccess",
+          { name: copyTarget.name },
+        ),
       );
       setMaterials((prev) =>
         prev.map((m) => {

--- a/frontend/src/pages/teacher/TeacherAssignmentDetailPage.tsx
+++ b/frontend/src/pages/teacher/TeacherAssignmentDetailPage.tsx
@@ -18,6 +18,7 @@ import ReadingAssessmentPanel from "@/components/ReadingAssessmentPanel";
 import VocabularySetPanel from "@/components/VocabularySetPanel";
 import BatchGradingModal from "@/components/BatchGradingModal";
 import { apiClient } from "@/lib/api";
+import type { PracticeMode } from "@/lib/practiceMode";
 import { toast } from "sonner";
 import {
   ArrowLeft,
@@ -64,17 +65,7 @@ interface AssignmentDetail extends Assignment {
   content_id: number;
   assigned_date?: string; // Alternative field name
   students?: number[]; // Alternative field name
-  practice_mode?:
-    | "reading"
-    | "rearrangement"
-    | "word_reading"
-    | "word_selection"
-    | "word_selection_quiz"
-    | "word_spelling"
-    | "word_spelling_quiz"
-    | "word_cloze"
-    | "word_cloze_quiz"
-    | "tug_of_war"; // 練習模式
+  practice_mode?: PracticeMode; // 練習模式（型別統一由 @/lib/practiceMode 提供）
   content?: {
     title: string;
     type: string;


### PR DESCRIPTION
## Release: staging → main

將 staging 已驗證的修復合併至 production（main）。本批次共 6 個 commit、無 DB migration。

### 內容

| Issue | 說明 |
|---|---|
| #876 (#873) | 單字集：魔術貼上例句缺中文翻譯補齊（後端 fallback）+ 例句翻譯「中文」按鈕無反應 |
| #875 (#874) | `generate_sentences` 與 distractors 補上 `disable_thinking=True` |
| #871 (#867) | 單字集（作業模式：單字拼寫-艾賓浩斯）答案送出無反應；答錯顯示正解、桌機不強制虛擬鍵盤 |
| #870 (#843) | 統一 `practice_mode` 顯示邏輯到單一 registry，消除前端重複 |
| #869 (#853) | 資源教材包複製至機構教材顯示失敗、機構教材新增錯誤 |

關閉 issues：#843 #853 #867 #873 #874

### 範圍
- 24 files changed（前端為主，含 `ClassroomDetail.tsx` 大幅精簡、`GradingPage.tsx`、`ResourceMaterialsPage.tsx` 等）
- **無 database migration**
- 所有 commit 皆已於 staging 通過 CI 並 merge

### 部署前確認
- [ ] CI 全綠
- [ ] 確認無 migration → 不需特別 DB 步驟

🤖 Generated with [Claude Code](https://claude.com/claude-code)