### PR TITLE
feat(#838): 機構請款工具 — 資料表 migration (請款/應收帳款 data layer)

### DIFF
--- a/backend/alembic/versions/20260626_1000_add_institution_invoice_tables.py
+++ b/backend/alembic/versions/20260626_1000_add_institution_invoice_tables.py
@@ -1,0 +1,108 @@
+"""Add institution billing invoice tables (issue #838 data layer)
+
+Revision ID: 20260626_1000
+Revises: 20260608_1000
+Create Date: 2026-06-26 10:00:00
+
+Creates the two tables backing the manual 請款 / 收款 workflow that follows
+the read-only monthly billing query from issue #768:
+
+  - institution_invoices        — accounts-receivable ledger, one row per
+    (organization, year, month). UNIQUE(organization_id, year, month) is the
+    idempotency anchor for the Phase D upsert endpoint.
+  - institution_invoice_emails  — append-only 請款 email audit trail (no
+    unique key: repeat sends must append, never overwrite).
+
+Idempotent (per專案 migration 鐵則):
+  - CREATE TABLE IF NOT EXISTS — constraints + PK declared inline so they are
+    created atomically with the (brand-new) table; re-running is a no-op.
+  - CREATE INDEX IF NOT EXISTS for every index.
+  - No DROP / RENAME / ALTER TYPE on existing tables; FKs reference existing
+    organizations(id) (UUID) and teachers(id) (INTEGER).
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "20260626_1000"
+down_revision: Union[str, None] = "20260608_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ---- institution_invoices (accounts-receivable ledger) --------------
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS institution_invoices (
+            id SERIAL PRIMARY KEY,
+            organization_id UUID NOT NULL
+                REFERENCES organizations(id) ON DELETE CASCADE,
+            year INTEGER NOT NULL,
+            month INTEGER NOT NULL,
+            amount INTEGER NOT NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'pending',
+            due_date DATE,
+            paid_at TIMESTAMP WITH TIME ZONE,
+            paid_by_admin_id INTEGER
+                REFERENCES teachers(id) ON DELETE SET NULL,
+            payment_note TEXT,
+            created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            updated_at TIMESTAMP WITH TIME ZONE,
+            CONSTRAINT uq_institution_invoices_org_year_month
+                UNIQUE (organization_id, year, month),
+            CONSTRAINT ck_institution_invoices_status_valid
+                CHECK (status IN ('pending', 'paid', 'overdue', 'cancelled')),
+            CONSTRAINT ck_institution_invoices_month_valid
+                CHECK (month BETWEEN 1 AND 12),
+            CONSTRAINT ck_institution_invoices_amount_nonneg
+                CHECK (amount >= 0)
+        );
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_institution_invoices_status "
+        "ON institution_invoices (status);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_institution_invoices_org "
+        "ON institution_invoices (organization_id);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_institution_invoices_due_date "
+        "ON institution_invoices (due_date);"
+    )
+
+    # ---- institution_invoice_emails (append-only audit trail) -----------
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS institution_invoice_emails (
+            id SERIAL PRIMARY KEY,
+            organization_id UUID NOT NULL
+                REFERENCES organizations(id) ON DELETE CASCADE,
+            year INTEGER NOT NULL,
+            month INTEGER NOT NULL,
+            recipient VARCHAR(200) NOT NULL,
+            cc TEXT,
+            sent_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            sent_by_admin_id INTEGER
+                REFERENCES teachers(id) ON DELETE SET NULL,
+            created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            CONSTRAINT ck_institution_invoice_emails_month_valid
+                CHECK (month BETWEEN 1 AND 12)
+        );
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_institution_invoice_emails_lookup "
+        "ON institution_invoice_emails (organization_id, year, month);"
+    )
+
+
+def downgrade() -> None:
+    # Both tables are brand-new in this revision and hold no pre-existing
+    # business data, so dropping them on downgrade is safe.
+    op.execute("DROP TABLE IF EXISTS institution_invoice_emails;")
+    op.execute("DROP TABLE IF EXISTS institution_invoices;")

--- a/backend/alembic/versions/20260626_1000_add_institution_invoice_tables.py
+++ b/backend/alembic/versions/20260626_1000_add_institution_invoice_tables.py
@@ -1,7 +1,7 @@
 """Add institution billing invoice tables (issue #838 data layer)
 
 Revision ID: 20260626_1000
-Revises: 20260608_1000
+Revises: 20260624_1000
 Create Date: 2026-06-26 10:00:00
 
 Creates the two tables backing the manual 請款 / 收款 workflow that follows
@@ -17,6 +17,10 @@ Idempotent (per專案 migration 鐵則):
   - CREATE TABLE IF NOT EXISTS — constraints + PK declared inline so they are
     created atomically with the (brand-new) table; re-running is a no-op.
   - CREATE INDEX IF NOT EXISTS for every index.
+  - updated_at trigger uses CREATE OR REPLACE FUNCTION + DROP TRIGGER IF
+    EXISTS before CREATE TRIGGER (mirrors 20260518_1000), so re-running is
+    safe and raw-SQL UPDATEs (e.g. the Phase D overdue cron) refresh
+    updated_at without relying on the ORM onupdate hook.
   - No DROP / RENAME / ALTER TYPE on existing tables; FKs reference existing
     organizations(id) (UUID) and teachers(id) (INTEGER).
 """
@@ -27,7 +31,7 @@ from alembic import op
 
 
 revision: str = "20260626_1000"
-down_revision: Union[str, None] = "20260608_1000"
+down_revision: Union[str, None] = "20260624_1000"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -50,13 +54,15 @@ def upgrade() -> None:
                 REFERENCES teachers(id) ON DELETE SET NULL,
             payment_note TEXT,
             created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-            updated_at TIMESTAMP WITH TIME ZONE,
+            updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
             CONSTRAINT uq_institution_invoices_org_year_month
                 UNIQUE (organization_id, year, month),
             CONSTRAINT ck_institution_invoices_status_valid
                 CHECK (status IN ('pending', 'paid', 'overdue', 'cancelled')),
             CONSTRAINT ck_institution_invoices_month_valid
                 CHECK (month BETWEEN 1 AND 12),
+            CONSTRAINT ck_institution_invoices_year_valid
+                CHECK (year BETWEEN 2000 AND 2099),
             CONSTRAINT ck_institution_invoices_amount_nonneg
                 CHECK (amount >= 0)
         );
@@ -75,6 +81,35 @@ def upgrade() -> None:
         "ON institution_invoices (due_date);"
     )
 
+    # DB-level trigger to refresh updated_at on every UPDATE, including
+    # raw-SQL writes that bypass SQLAlchemy's ORM-only onupdate=func.now()
+    # — notably the Phase D overdue cron that bulk-UPDATEs status. Function
+    # uses CREATE OR REPLACE; trigger is dropped + re-created so the
+    # migration stays idempotent (mirrors 20260518_1000).
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION set_institution_invoices_updated_at()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            NEW.updated_at = now();
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_institution_invoices_updated_at "
+        "ON institution_invoices"
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_institution_invoices_updated_at
+        BEFORE UPDATE ON institution_invoices
+        FOR EACH ROW
+        EXECUTE FUNCTION set_institution_invoices_updated_at();
+        """
+    )
+
     # ---- institution_invoice_emails (append-only audit trail) -----------
     op.execute(
         """
@@ -85,13 +120,15 @@ def upgrade() -> None:
             year INTEGER NOT NULL,
             month INTEGER NOT NULL,
             recipient VARCHAR(200) NOT NULL,
-            cc TEXT,
+            cc JSONB,
             sent_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
             sent_by_admin_id INTEGER
                 REFERENCES teachers(id) ON DELETE SET NULL,
             created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
             CONSTRAINT ck_institution_invoice_emails_month_valid
-                CHECK (month BETWEEN 1 AND 12)
+                CHECK (month BETWEEN 1 AND 12),
+            CONSTRAINT ck_institution_invoice_emails_year_valid
+                CHECK (year BETWEEN 2000 AND 2099)
         );
         """
     )
@@ -103,6 +140,12 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     # Both tables are brand-new in this revision and hold no pre-existing
-    # business data, so dropping them on downgrade is safe.
+    # business data, so dropping them (and the trigger/function) on
+    # downgrade is safe.
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_institution_invoices_updated_at "
+        "ON institution_invoices"
+    )
+    op.execute("DROP FUNCTION IF EXISTS set_institution_invoices_updated_at();")
     op.execute("DROP TABLE IF EXISTS institution_invoice_emails;")
     op.execute("DROP TABLE IF EXISTS institution_invoices;")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -60,6 +60,12 @@ from .organization import (
 # Student status history (issue #768 — per-head billing trail)
 from .student_status_history import StudentStatusHistory
 
+# Institution billing invoices (issue #838 — 請款 / 應收帳款 data layer)
+from .institution_invoice import (
+    InstitutionInvoice,
+    InstitutionInvoiceEmail,
+)
+
 # Classroom models
 from .classroom import Classroom, ClassroomStudent
 
@@ -135,6 +141,9 @@ __all__ = [
     "StudentSchool",
     # Student status history
     "StudentStatusHistory",
+    # Institution billing invoices
+    "InstitutionInvoice",
+    "InstitutionInvoiceEmail",
     # Classrooms
     "Classroom",
     "ClassroomStudent",

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -64,6 +64,7 @@ from .student_status_history import StudentStatusHistory
 from .institution_invoice import (
     InstitutionInvoice,
     InstitutionInvoiceEmail,
+    INVOICE_STATUSES,
 )
 
 # Classroom models
@@ -144,6 +145,7 @@ __all__ = [
     # Institution billing invoices
     "InstitutionInvoice",
     "InstitutionInvoiceEmail",
+    "INVOICE_STATUSES",
     # Classrooms
     "Classroom",
     "ClassroomStudent",

--- a/backend/models/institution_invoice.py
+++ b/backend/models/institution_invoice.py
@@ -10,6 +10,13 @@ read-only monthly billing query shipped in issue #768:
     already-issued invoice. The UNIQUE (organization_id, year, month) key is
     the idempotency anchor for the Phase D upsert endpoint.
 
+    Cross-field invariant (enforced by the Phase D service layer, NOT yet at
+    the DB): ``paid_at`` and ``paid_by_admin_id`` are set iff
+    ``status == 'paid'``. The "mark paid" endpoint must stamp both together;
+    marking any other status must leave them NULL. A hard DB CHECK is
+    deliberately deferred until that endpoint exists so the constraint can be
+    designed against real cancel/refund flows rather than guessed here.
+
   - ``InstitutionInvoiceEmail``  — append-only audit trail of 請款 emails
     sent. Deliberately has NO unique key: resending the same month must be
     recorded as a new row, never overwrite history.
@@ -34,13 +41,27 @@ from sqlalchemy import (
 from sqlalchemy.sql import func
 
 from database import Base
-from .base import UUID
+from .base import UUID, JSONType
 
 
-# Valid invoice lifecycle states. Kept in sync with the CHECK constraint
-# below and the migration; the Phase D PATCH endpoint will validate against
-# this same set.
+# Valid invoice lifecycle states. This is the single source of truth: the
+# status CHECK constraint below is derived from it, and the Phase D PATCH
+# endpoint will validate against this same set. Adding a state here
+# propagates to the DB constraint automatically (a new migration is still
+# required to alter the constraint on already-created tables).
 INVOICE_STATUSES = ("pending", "paid", "overdue", "cancelled")
+
+# Reasonable calendar-year guard for billing rows. Wide enough to never
+# reject a real invoice, tight enough to catch a 0 / negative / 5-digit typo
+# on the Phase D write path before that endpoint's own validation exists.
+_MIN_INVOICE_YEAR = 2000
+_MAX_INVOICE_YEAR = 2099
+
+
+def _status_in_clause() -> str:
+    """SQL ``status IN ('a', 'b', ...)`` body derived from INVOICE_STATUSES,
+    so the CHECK constraint can never silently drift from the constant."""
+    return "status IN (" + ", ".join(repr(s) for s in INVOICE_STATUSES) + ")"
 
 
 class InstitutionInvoice(Base):
@@ -67,6 +88,8 @@ class InstitutionInvoice(Base):
     )
 
     due_date = Column(Date, nullable=True)
+    # paid_at / paid_by_admin_id: see the module-level invariant note — set
+    # together with status='paid' by the Phase D endpoint.
     paid_at = Column(DateTime(timezone=True), nullable=True)
     paid_by_admin_id = Column(
         Integer,
@@ -78,7 +101,14 @@ class InstitutionInvoice(Base):
     created_at = Column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
-    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+    # server_default + a BEFORE UPDATE trigger (in the migration) keep this
+    # fresh even for raw-SQL writers — notably the Phase D overdue cron that
+    # bulk-UPDATEs status without going through the ORM's onupdate hook.
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
 
     __table_args__ = (
         UniqueConstraint(
@@ -88,12 +118,16 @@ class InstitutionInvoice(Base):
             name="uq_institution_invoices_org_year_month",
         ),
         CheckConstraint(
-            "status IN ('pending', 'paid', 'overdue', 'cancelled')",
+            _status_in_clause(),
             name="ck_institution_invoices_status_valid",
         ),
         CheckConstraint(
             "month BETWEEN 1 AND 12",
             name="ck_institution_invoices_month_valid",
+        ),
+        CheckConstraint(
+            f"year BETWEEN {_MIN_INVOICE_YEAR} AND {_MAX_INVOICE_YEAR}",
+            name="ck_institution_invoices_year_valid",
         ),
         CheckConstraint(
             "amount >= 0",
@@ -105,9 +139,13 @@ class InstitutionInvoice(Base):
     )
 
     def __repr__(self):
+        # Guard the month formatter: SQLAlchemy exposes un-set NOT NULL
+        # columns as None before flush, so `:02d` would TypeError on a
+        # partially-built object — exactly when repr() is used for debugging.
+        month = f"{self.month:02d}" if self.month is not None else "??"
         return (
             f"<InstitutionInvoice(id={self.id}, org={self.organization_id}, "
-            f"{self.year}-{self.month:02d}, {self.status}, amount={self.amount})>"
+            f"{self.year}-{month}, {self.status}, amount={self.amount})>"
         )
 
 
@@ -127,9 +165,10 @@ class InstitutionInvoiceEmail(Base):
     month = Column(Integer, nullable=False)
 
     recipient = Column(String(200), nullable=False)
-    # Optional CC list, stored as a comma-separated string (the send-email
-    # endpoint accepts cc?: string[] and joins it).
-    cc = Column(Text, nullable=True)
+    # Optional CC list stored as a JSON array of email strings, matching the
+    # project convention for list-type columns (JSONType → JSONB on Postgres,
+    # JSON on SQLite). The send-email endpoint accepts cc?: string[] verbatim.
+    cc = Column(JSONType, nullable=True)
 
     sent_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     sent_by_admin_id = Column(
@@ -146,6 +185,10 @@ class InstitutionInvoiceEmail(Base):
             "month BETWEEN 1 AND 12",
             name="ck_institution_invoice_emails_month_valid",
         ),
+        CheckConstraint(
+            f"year BETWEEN {_MIN_INVOICE_YEAR} AND {_MAX_INVOICE_YEAR}",
+            name="ck_institution_invoice_emails_year_valid",
+        ),
         Index(
             "idx_institution_invoice_emails_lookup",
             "organization_id",
@@ -155,7 +198,8 @@ class InstitutionInvoiceEmail(Base):
     )
 
     def __repr__(self):
+        month = f"{self.month:02d}" if self.month is not None else "??"
         return (
             f"<InstitutionInvoiceEmail(id={self.id}, org={self.organization_id}, "
-            f"{self.year}-{self.month:02d}, to={self.recipient})>"
+            f"{self.year}-{month}, to={self.recipient})>"
         )

--- a/backend/models/institution_invoice.py
+++ b/backend/models/institution_invoice.py
@@ -1,0 +1,161 @@
+"""
+Institution billing invoice models (issue #838).
+
+Two tables backing the manual 請款 / 收款 workflow that follows the
+read-only monthly billing query shipped in issue #768:
+
+  - ``InstitutionInvoice``       — accounts-receivable ledger. One row per
+    (organization, year, month); ``amount`` is snapshotted at 請款 time so a
+    later change to ``per_student_price`` or enrolment does not mutate an
+    already-issued invoice. The UNIQUE (organization_id, year, month) key is
+    the idempotency anchor for the Phase D upsert endpoint.
+
+  - ``InstitutionInvoiceEmail``  — append-only audit trail of 請款 emails
+    sent. Deliberately has NO unique key: resending the same month must be
+    recorded as a new row, never overwrite history.
+
+This module is the data layer only — the PDF (Phase B), email send
+(Phase C) and AR-management endpoints + overdue cron (Phase D) land in
+follow-up PRs once this migration is merged to staging.
+"""
+
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.sql import func
+
+from database import Base
+from .base import UUID
+
+
+# Valid invoice lifecycle states. Kept in sync with the CHECK constraint
+# below and the migration; the Phase D PATCH endpoint will validate against
+# this same set.
+INVOICE_STATUSES = ("pending", "paid", "overdue", "cancelled")
+
+
+class InstitutionInvoice(Base):
+    """機構應收帳款 (accounts-receivable ledger)."""
+
+    __tablename__ = "institution_invoices"
+
+    id = Column(Integer, primary_key=True)
+
+    organization_id = Column(
+        UUID,
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    year = Column(Integer, nullable=False)
+    month = Column(Integer, nullable=False)
+
+    # Amount (NT$) snapshotted at 請款 time — intentionally NOT recomputed
+    # from per_student_price on read.
+    amount = Column(Integer, nullable=False)
+
+    status = Column(
+        String(20), nullable=False, default="pending", server_default="pending"
+    )
+
+    due_date = Column(Date, nullable=True)
+    paid_at = Column(DateTime(timezone=True), nullable=True)
+    paid_by_admin_id = Column(
+        Integer,
+        ForeignKey("teachers.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    payment_note = Column(Text, nullable=True)
+
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    __table_args__ = (
+        UniqueConstraint(
+            "organization_id",
+            "year",
+            "month",
+            name="uq_institution_invoices_org_year_month",
+        ),
+        CheckConstraint(
+            "status IN ('pending', 'paid', 'overdue', 'cancelled')",
+            name="ck_institution_invoices_status_valid",
+        ),
+        CheckConstraint(
+            "month BETWEEN 1 AND 12",
+            name="ck_institution_invoices_month_valid",
+        ),
+        CheckConstraint(
+            "amount >= 0",
+            name="ck_institution_invoices_amount_nonneg",
+        ),
+        Index("idx_institution_invoices_status", "status"),
+        Index("idx_institution_invoices_org", "organization_id"),
+        Index("idx_institution_invoices_due_date", "due_date"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<InstitutionInvoice(id={self.id}, org={self.organization_id}, "
+            f"{self.year}-{self.month:02d}, {self.status}, amount={self.amount})>"
+        )
+
+
+class InstitutionInvoiceEmail(Base):
+    """請款 email 寄送稽核紀錄 (append-only)."""
+
+    __tablename__ = "institution_invoice_emails"
+
+    id = Column(Integer, primary_key=True)
+
+    organization_id = Column(
+        UUID,
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    year = Column(Integer, nullable=False)
+    month = Column(Integer, nullable=False)
+
+    recipient = Column(String(200), nullable=False)
+    # Optional CC list, stored as a comma-separated string (the send-email
+    # endpoint accepts cc?: string[] and joins it).
+    cc = Column(Text, nullable=True)
+
+    sent_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    sent_by_admin_id = Column(
+        Integer,
+        ForeignKey("teachers.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "month BETWEEN 1 AND 12",
+            name="ck_institution_invoice_emails_month_valid",
+        ),
+        Index(
+            "idx_institution_invoice_emails_lookup",
+            "organization_id",
+            "year",
+            "month",
+        ),
+    )
+
+    def __repr__(self):
+        return (
+            f"<InstitutionInvoiceEmail(id={self.id}, org={self.organization_id}, "
+            f"{self.year}-{self.month:02d}, to={self.recipient})>"
+        )

--- a/backend/models/institution_invoice.py
+++ b/backend/models/institution_invoice.py
@@ -108,6 +108,7 @@ class InstitutionInvoice(Base):
         DateTime(timezone=True),
         server_default=func.now(),
         onupdate=func.now(),
+        nullable=False,
     )
 
     __table_args__ = (

--- a/backend/tests/test_institution_invoice_models.py
+++ b/backend/tests/test_institution_invoice_models.py
@@ -1,0 +1,178 @@
+"""
+Issue #838 — data-layer tests for the institution billing invoice tables.
+
+Covers the two new tables shipped in the migration-only PR:
+  - institution_invoices        (應收帳款 / accounts-receivable ledger)
+  - institution_invoice_emails  (請款 email 寄送稽核紀錄)
+
+No endpoint / PDF / email behaviour here (Phases B/C/D land after this
+migration merges); this only proves schema, constraints, defaults, and the
+unique (org, year, month) idempotency key the upsert flow will rely on.
+"""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from models import (
+    Teacher,
+    Organization,
+    InstitutionInvoice,
+    InstitutionInvoiceEmail,
+)
+
+
+def _make_org(db):
+    o = Organization(
+        name="Acme",
+        org_type="institution",
+        per_student_price=100,
+        is_active=True,
+    )
+    db.add(o)
+    db.commit()
+    db.refresh(o)
+    return o
+
+
+def _make_admin(db, email="invoice-admin@test.com"):
+    t = Teacher(name="Admin", email=email, password_hash="x", is_admin=True)
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+# ---------------------------------------------------- institution_invoices
+
+
+def test_invoice_defaults_status_pending(test_db_session):
+    org = _make_org(test_db_session)
+    inv = InstitutionInvoice(organization_id=org.id, year=2026, month=6, amount=500)
+    test_db_session.add(inv)
+    test_db_session.commit()
+    test_db_session.refresh(inv)
+    assert inv.status == "pending"
+    assert inv.id is not None
+    assert inv.created_at is not None
+    assert inv.paid_at is None
+    assert inv.paid_by_admin_id is None
+
+
+def test_invoice_unique_org_year_month(test_db_session):
+    """The (org, year, month) key is the idempotency anchor for the
+    Phase D upsert — a second row for the same period must be rejected."""
+    org = _make_org(test_db_session)
+    test_db_session.add(
+        InstitutionInvoice(organization_id=org.id, year=2026, month=6, amount=500)
+    )
+    test_db_session.commit()
+    test_db_session.add(
+        InstitutionInvoice(organization_id=org.id, year=2026, month=6, amount=999)
+    )
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()
+
+
+def test_invoice_rejects_invalid_status(test_db_session):
+    org = _make_org(test_db_session)
+    test_db_session.add(
+        InstitutionInvoice(
+            organization_id=org.id, year=2026, month=7, amount=1, status="banana"
+        )
+    )
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()
+
+
+def test_invoice_rejects_bad_month(test_db_session):
+    org = _make_org(test_db_session)
+    test_db_session.add(
+        InstitutionInvoice(organization_id=org.id, year=2026, month=13, amount=1)
+    )
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()
+
+
+def test_invoice_rejects_negative_amount(test_db_session):
+    org = _make_org(test_db_session)
+    test_db_session.add(
+        InstitutionInvoice(organization_id=org.id, year=2026, month=8, amount=-1)
+    )
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()
+
+
+def test_invoice_records_paid_fields(test_db_session):
+    org = _make_org(test_db_session)
+    admin = _make_admin(test_db_session)
+    inv = InstitutionInvoice(
+        organization_id=org.id,
+        year=2026,
+        month=9,
+        amount=300,
+        status="paid",
+        paid_by_admin_id=admin.id,
+        payment_note="ATM 匯款 末五碼 12345",
+    )
+    test_db_session.add(inv)
+    test_db_session.commit()
+    test_db_session.refresh(inv)
+    assert inv.status == "paid"
+    assert inv.paid_by_admin_id == admin.id
+    assert inv.payment_note == "ATM 匯款 末五碼 12345"
+
+
+# ----------------------------------------------- institution_invoice_emails
+
+
+def test_email_audit_row_inserts(test_db_session):
+    org = _make_org(test_db_session)
+    admin = _make_admin(test_db_session, "audit-admin@test.com")
+    rec = InstitutionInvoiceEmail(
+        organization_id=org.id,
+        year=2026,
+        month=6,
+        recipient="finance@org.com",
+        sent_by_admin_id=admin.id,
+    )
+    test_db_session.add(rec)
+    test_db_session.commit()
+    test_db_session.refresh(rec)
+    assert rec.id is not None
+    assert rec.sent_at is not None
+    assert rec.recipient == "finance@org.com"
+
+
+def test_email_audit_allows_repeat_sends(test_db_session):
+    """Resending the same month must append history, not collide on a
+    unique key — there is intentionally NO unique constraint here."""
+    org = _make_org(test_db_session)
+    for _ in range(3):
+        test_db_session.add(
+            InstitutionInvoiceEmail(
+                organization_id=org.id, year=2026, month=6, recipient="f@org.com"
+            )
+        )
+        test_db_session.commit()
+    count = (
+        test_db_session.query(InstitutionInvoiceEmail)
+        .filter_by(organization_id=org.id, year=2026, month=6)
+        .count()
+    )
+    assert count == 3
+
+
+def test_email_audit_rejects_bad_month(test_db_session):
+    org = _make_org(test_db_session)
+    test_db_session.add(
+        InstitutionInvoiceEmail(
+            organization_id=org.id, year=2026, month=0, recipient="f@org.com"
+        )
+    )
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()

--- a/backend/tests/test_institution_invoice_models.py
+++ b/backend/tests/test_institution_invoice_models.py
@@ -10,6 +10,8 @@ migration merges); this only proves schema, constraints, defaults, and the
 unique (org, year, month) idempotency key the upsert flow will rely on.
 """
 
+from datetime import datetime, timezone
+
 import pytest
 from sqlalchemy.exc import IntegrityError
 
@@ -18,6 +20,7 @@ from models import (
     Organization,
     InstitutionInvoice,
     InstitutionInvoiceEmail,
+    INVOICE_STATUSES,
 )
 
 
@@ -109,12 +112,15 @@ def test_invoice_rejects_negative_amount(test_db_session):
 def test_invoice_records_paid_fields(test_db_session):
     org = _make_org(test_db_session)
     admin = _make_admin(test_db_session)
+    # Reflects the documented invariant: status='paid' rows carry paid_at
+    # AND paid_by_admin_id together (the Phase D endpoint stamps all three).
     inv = InstitutionInvoice(
         organization_id=org.id,
         year=2026,
         month=9,
         amount=300,
         status="paid",
+        paid_at=datetime.now(timezone.utc),
         paid_by_admin_id=admin.id,
         payment_note="ATM 匯款 末五碼 12345",
     )
@@ -122,8 +128,52 @@ def test_invoice_records_paid_fields(test_db_session):
     test_db_session.commit()
     test_db_session.refresh(inv)
     assert inv.status == "paid"
+    assert inv.paid_at is not None
     assert inv.paid_by_admin_id == admin.id
     assert inv.payment_note == "ATM 匯款 末五碼 12345"
+
+
+def test_invoice_rejects_bad_year(test_db_session):
+    org = _make_org(test_db_session)
+    test_db_session.add(
+        InstitutionInvoice(organization_id=org.id, year=1999, month=6, amount=1)
+    )
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()
+
+
+def test_invoice_status_check_matches_constant(test_db_session):
+    """The status CHECK is derived from INVOICE_STATUSES — every declared
+    status must be insertable, proving the constant and constraint agree."""
+    org = _make_org(test_db_session)
+    for i, status in enumerate(INVOICE_STATUSES, start=1):
+        inv = InstitutionInvoice(
+            organization_id=org.id, year=2026, month=i, amount=0, status=status
+        )
+        test_db_session.add(inv)
+        test_db_session.commit()
+        test_db_session.refresh(inv)
+        assert inv.status == status
+
+
+def test_invoice_updated_at_populated_on_insert(test_db_session):
+    """server_default keeps updated_at non-NULL even without an UPDATE, so
+    raw-SQL writers never see a NULL (the DB trigger keeps it fresh after)."""
+    org = _make_org(test_db_session)
+    inv = InstitutionInvoice(organization_id=org.id, year=2026, month=11, amount=100)
+    test_db_session.add(inv)
+    test_db_session.commit()
+    test_db_session.refresh(inv)
+    assert inv.updated_at is not None
+
+
+def test_invoice_repr_survives_preflush_none_month():
+    """Regression: repr() on a partially-built object (month unset → None)
+    must not TypeError on the :02d formatter."""
+    inv = InstitutionInvoice(organization_id="x", year=2026, amount=500)
+    # month is None here; repr must degrade gracefully.
+    assert "??" in repr(inv)
 
 
 # ----------------------------------------------- institution_invoice_emails
@@ -137,6 +187,7 @@ def test_email_audit_row_inserts(test_db_session):
         year=2026,
         month=6,
         recipient="finance@org.com",
+        cc=["cc1@org.com", "cc2@org.com"],
         sent_by_admin_id=admin.id,
     )
     test_db_session.add(rec)
@@ -145,6 +196,8 @@ def test_email_audit_row_inserts(test_db_session):
     assert rec.id is not None
     assert rec.sent_at is not None
     assert rec.recipient == "finance@org.com"
+    # cc round-trips as a JSON list (JSONType), not a comma-joined string.
+    assert rec.cc == ["cc1@org.com", "cc2@org.com"]
 
 
 def test_email_audit_allows_repeat_sends(test_db_session):


### PR DESCRIPTION
## 範圍

issue #838（機構月度請款工具）的**第一階段：純資料表 migration**。
依需求拆分，本 PR 只建立 Phase C / Phase D 需要的兩張表 + ORM models + data-layer 測試。**不含任何 endpoint / PDF / email / 前端 UI** — 那些在此 PR merge 到 staging 後接續（B → C → D）。

> 註：依 owner 留言「A 不必要，有 B+C+D 就足夠」，Phase A（CSV）已捨棄。

## 新增資料表

### `institution_invoices`（應收帳款 ledger，Phase D）
- `UNIQUE (organization_id, year, month)` — Phase D upsert 端點的**冪等 anchor**
- `amount` 於請款當下 **snapshot**，不隨 `per_student_price` 或在籍人數變動而改變已開立金額
- `status` CHECK ∈ `(pending, paid, overdue, cancelled)`，預設 `pending`
- `month BETWEEN 1 AND 12`、`amount >= 0` CHECK
- FK：`organization_id → organizations(id)` ON DELETE CASCADE、`paid_by_admin_id → teachers(id)` ON DELETE SET NULL
- index：status / organization_id / due_date

### `institution_invoice_emails`（請款 email 寄送稽核，Phase C）
- **append-only**，刻意**不設 unique key** — 重複寄送同月份須累加歷史，不覆蓋
- index：`(organization_id, year, month)`（查「上次寄送時間」）

## Migration 冪等性（遵守專案鐵則）
- `CREATE TABLE / INDEX IF NOT EXISTS`
- constraint 以 inline 方式隨建表原子建立（兩張表皆為全新表，各環境首次建立）
- **無** DROP / RENAME / ALTER TYPE 等破壞性操作
- FK 指向既有 `organizations(id)`（UUID）與 `teachers(id)`（INTEGER）
- 已用 Postgres SQL parser 驗證 8 條 DDL 語法皆合法
- 單一 alembic head：`20260626_1000`（revises `20260608_1000`）

## 測試
`backend/tests/test_institution_invoice_models.py` — 9 個 data-layer 測試全綠：
- 預設 status=pending、`(org, year, month)` unique、status / month / amount CHCEK 拒絕非法值
- 已收款欄位（paid_by_admin_id / payment_note）正確記錄
- email 稽核可重複寄送累加、bad month 拒絕

相關 billing/endpoint 既有測試（`test_institution_billing*`）24 passed，無回歸。

## 後續（待此 PR merge）
- **Phase B** PDF 請款單 endpoint + 下載按鈕
- **Phase C** Email 請款（重用 PDF、寫入 `institution_invoice_emails`）
- **Phase D** 應收帳款管理 endpoints + admin 頁 + 逾期 cron（寫入 `institution_invoices`）

Related to #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)