### PR TITLE
fix(#138): localStorage 佇列樂觀鎖避免並發覆寫

### DIFF
--- a/frontend/src/services/__tests__/azureSpeechService.test.ts
+++ b/frontend/src/services/__tests__/azureSpeechService.test.ts
@@ -200,11 +200,127 @@ describe("AzureSpeechService", () => {
       await service.uploadAnalysisInBackground(mockBlob, {}, 1000);
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "Background upload failed:",
+        "First upload attempt failed:",
         expect.any(Error),
       );
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  // 🎯 Issue #138: Race condition in localStorage queue
+  describe("localStorage Queue Concurrency (Issue #138)", () => {
+    const STORAGE_KEY = "duotopia_pending_uploads";
+    const VERSION_KEY = "duotopia_pending_uploads_version";
+
+    const mkUpload = (id: string, overrides = {}) => ({
+      id,
+      audioBase64: "data:audio/wav;base64,AAAA",
+      analysisResult: {},
+      latencyMs: 100,
+      timestamp: 1000,
+      retryCount: 0,
+      ...overrides,
+    });
+
+    const readQueue = () =>
+      JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]");
+
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it("increments the version counter on each successful save", async () => {
+      await service["savePendingUpload"](mkUpload("A"));
+      expect(localStorage.getItem(VERSION_KEY)).toBe("1");
+
+      await service["savePendingUpload"](mkUpload("B"));
+      expect(localStorage.getItem(VERSION_KEY)).toBe("2");
+
+      expect(readQueue().map((u: { id: string }) => u.id)).toEqual(["A", "B"]);
+    });
+
+    it("retries on a concurrent version bump and keeps both entries (no data loss)", async () => {
+      const orig = localStorage.getItem.bind(localStorage);
+      let versionReads = 0;
+      let injected = false;
+
+      // Simulate another tab committing entry B + bumping the version
+      // right after this context first reads the version (the classic
+      // read-modify-write race window).
+      vi.spyOn(localStorage, "getItem").mockImplementation((key: string) => {
+        if (key === VERSION_KEY) {
+          versionReads++;
+          if (versionReads === 2 && !injected) {
+            injected = true;
+            localStorage.setItem(STORAGE_KEY, JSON.stringify([mkUpload("B")]));
+            localStorage.setItem(VERSION_KEY, "1");
+          }
+        }
+        return orig(key);
+      });
+
+      const result = await service["savePendingUpload"](mkUpload("A"));
+
+      expect(result).toBe(true);
+      const ids = readQueue()
+        .map((u: { id: string }) => u.id)
+        .sort();
+      expect(ids).toEqual(["A", "B"]); // B from the "other tab" survives
+    });
+
+    it("removePendingUpload only removes its target and preserves a concurrent add", async () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([mkUpload("A")]));
+      localStorage.setItem(VERSION_KEY, "1");
+
+      const orig = localStorage.getItem.bind(localStorage);
+      let versionReads = 0;
+      let injected = false;
+
+      vi.spyOn(localStorage, "getItem").mockImplementation((key: string) => {
+        if (key === VERSION_KEY) {
+          versionReads++;
+          if (versionReads === 2 && !injected) {
+            injected = true;
+            // Another tab adds C while we are removing A
+            localStorage.setItem(
+              STORAGE_KEY,
+              JSON.stringify([mkUpload("A"), mkUpload("C")]),
+            );
+            localStorage.setItem(VERSION_KEY, "2");
+          }
+        }
+        return orig(key);
+      });
+
+      service["removePendingUpload"]("A");
+
+      const ids = readQueue()
+        .map((u: { id: string }) => u.id)
+        .sort();
+      expect(ids).toEqual(["C"]); // A removed, concurrently-added C kept
+    });
+
+    it("still prunes oldest entries when over the size limit", async () => {
+      // Each item ~3MB of base64; MAX_QUEUE_SIZE is 10MB → only newest fit
+      const big = "x".repeat(3 * 1024 * 1024);
+      await service["savePendingUpload"](mkUpload("A", { audioBase64: big }));
+      await service["savePendingUpload"](mkUpload("B", { audioBase64: big }));
+      await service["savePendingUpload"](mkUpload("C", { audioBase64: big }));
+      await service["savePendingUpload"](mkUpload("D", { audioBase64: big }));
+
+      const ids = readQueue().map((u: { id: string }) => u.id);
+      expect(ids).not.toContain("A"); // oldest pruned
+      expect(ids).toContain("D"); // newest kept
+    });
+
+    it("rejects a single item larger than the queue limit", async () => {
+      const tooBig = "x".repeat(11 * 1024 * 1024); // > 10MB
+      const result = await service["savePendingUpload"](
+        mkUpload("HUGE", { audioBase64: tooBig }),
+      );
+      expect(result).toBe(false);
+      expect(readQueue()).toEqual([]);
     });
   });
 });

--- a/frontend/src/services/__tests__/azureSpeechService.test.ts
+++ b/frontend/src/services/__tests__/azureSpeechService.test.ts
@@ -228,19 +228,22 @@ describe("AzureSpeechService", () => {
 
     beforeEach(() => {
       localStorage.clear();
+      // Finding 5: restore any localStorage spies left by previous tests so
+      // later tests get the real implementation, not a stale wrapper.
+      vi.restoreAllMocks();
     });
 
-    it("increments the version counter on each successful save", async () => {
-      await service["savePendingUpload"](mkUpload("A"));
+    it("increments the version counter on each successful save", () => {
+      service["savePendingUpload"](mkUpload("A"));
       expect(localStorage.getItem(VERSION_KEY)).toBe("1");
 
-      await service["savePendingUpload"](mkUpload("B"));
+      service["savePendingUpload"](mkUpload("B"));
       expect(localStorage.getItem(VERSION_KEY)).toBe("2");
 
       expect(readQueue().map((u: { id: string }) => u.id)).toEqual(["A", "B"]);
     });
 
-    it("retries on a concurrent version bump and keeps both entries (no data loss)", async () => {
+    it("retries on a concurrent version bump and keeps both entries (no data loss)", () => {
       const orig = localStorage.getItem.bind(localStorage);
       let versionReads = 0;
       let injected = false;
@@ -260,7 +263,7 @@ describe("AzureSpeechService", () => {
         return orig(key);
       });
 
-      const result = await service["savePendingUpload"](mkUpload("A"));
+      const result = service["savePendingUpload"](mkUpload("A"));
 
       expect(result).toBe(true);
       const ids = readQueue()
@@ -301,22 +304,22 @@ describe("AzureSpeechService", () => {
       expect(ids).toEqual(["C"]); // A removed, concurrently-added C kept
     });
 
-    it("still prunes oldest entries when over the size limit", async () => {
+    it("still prunes oldest entries when over the size limit", () => {
       // Each item ~3MB of base64; MAX_QUEUE_SIZE is 10MB → only newest fit
       const big = "x".repeat(3 * 1024 * 1024);
-      await service["savePendingUpload"](mkUpload("A", { audioBase64: big }));
-      await service["savePendingUpload"](mkUpload("B", { audioBase64: big }));
-      await service["savePendingUpload"](mkUpload("C", { audioBase64: big }));
-      await service["savePendingUpload"](mkUpload("D", { audioBase64: big }));
+      service["savePendingUpload"](mkUpload("A", { audioBase64: big }));
+      service["savePendingUpload"](mkUpload("B", { audioBase64: big }));
+      service["savePendingUpload"](mkUpload("C", { audioBase64: big }));
+      service["savePendingUpload"](mkUpload("D", { audioBase64: big }));
 
       const ids = readQueue().map((u: { id: string }) => u.id);
       expect(ids).not.toContain("A"); // oldest pruned
       expect(ids).toContain("D"); // newest kept
     });
 
-    it("rejects a single item larger than the queue limit", async () => {
+    it("rejects a single item larger than the queue limit", () => {
       const tooBig = "x".repeat(11 * 1024 * 1024); // > 10MB
-      const result = await service["savePendingUpload"](
+      const result = service["savePendingUpload"](
         mkUpload("HUGE", { audioBase64: tooBig }),
       );
       expect(result).toBe(false);

--- a/frontend/src/services/azureSpeechService.ts
+++ b/frontend/src/services/azureSpeechService.ts
@@ -279,7 +279,7 @@ export class AzureSpeechService {
       console.error("First upload attempt failed:", error);
 
       // Save to localStorage for later retry
-      const saved = await this.savePendingUpload({
+      const saved = this.savePendingUpload({
         id: uploadId,
         audioBase64: await this.blobToBase64(audioBlob),
         analysisResult: analysisResult as Record<string, unknown>,
@@ -328,7 +328,14 @@ export class AzureSpeechService {
           upload.progressId,
         );
         success.push(upload.id);
-        this.removePendingUpload(upload.id);
+        // 🎯 Issue #138: if removal loses to sustained contention the item
+        // stays queued and will be re-submitted next cycle (backend dedups
+        // via analysis_id) — surface it so it isn't silently swallowed.
+        if (!this.removePendingUpload(upload.id)) {
+          console.warn(
+            `Uploaded ${upload.id} but could not remove from queue; may re-submit`,
+          );
+        }
       } catch (error) {
         console.error(`Retry failed for ${upload.id}:`, error);
         upload.retryCount++;
@@ -403,6 +410,20 @@ export class AzureSpeechService {
    * (e.g. a second browser tab) bumped the version between our read and our
    * write, we re-read and retry instead of clobbering their change.
    *
+   * Known residual risk: localStorage offers no atomic compare-and-swap, so a
+   * narrow undetectable window remains — if two tabs read the same version and
+   * both pass the check before either writes, the later writer silently wins
+   * and bumps the version to the same value, so neither tab can detect the
+   * loss. This shrinks but does not eliminate the race; a complete fix needs a
+   * cross-tab mutex (Web Locks API / BroadcastChannel). Within a single tab JS
+   * is single-threaded, so this path is fully safe there.
+   *
+   * The version write is committed *before* the data write so that a
+   * QuotaExceededError on the second setItem can never leave the data
+   * persisted under a stale version (which would let a later write clobber it
+   * undetected). A failed data write only over-bumps the version, which is
+   * safe: other tabs simply see a conflict and retry.
+   *
    * @param mutator Returns the next queue, or null to abort the write.
    * @returns true if the mutation was committed, false otherwise.
    */
@@ -425,11 +446,13 @@ export class AzureSpeechService {
           continue;
         }
 
-        localStorage.setItem(this.STORAGE_KEY, JSON.stringify(next));
+        // Version first: if the data write below throws (e.g. quota), we never
+        // leave committed data sitting under an unchanged version.
         localStorage.setItem(
           this.VERSION_KEY,
           String(parseInt(versionBefore, 10) + 1),
         );
+        localStorage.setItem(this.STORAGE_KEY, JSON.stringify(next));
         return true;
       } catch (error) {
         console.error("Failed to mutate pending upload queue:", error);
@@ -445,7 +468,7 @@ export class AzureSpeechService {
    * 🎯 Issue #118: Save pending upload to localStorage
    * 🎯 Issue #138: now goes through mutateQueue for concurrency safety
    */
-  private async savePendingUpload(upload: PendingUpload): Promise<boolean> {
+  private savePendingUpload(upload: PendingUpload): boolean {
     const itemSize = new Blob([JSON.stringify(upload)]).size;
 
     // If single item is too large, reject (independent of queue state).
@@ -492,17 +515,19 @@ export class AzureSpeechService {
   /**
    * 🎯 Issue #118: Remove a pending upload from localStorage
    */
-  private removePendingUpload(id: string): void {
-    // 🎯 Issue #138: concurrency-safe removal via mutateQueue
-    this.mutateQueue((pending) => pending.filter((u) => u.id !== id));
+  private removePendingUpload(id: string): boolean {
+    // 🎯 Issue #138: concurrency-safe removal via mutateQueue.
+    // Returns false if the mutation could not be committed (sustained
+    // contention) so callers can react instead of silently dropping it.
+    return this.mutateQueue((pending) => pending.filter((u) => u.id !== id));
   }
 
   /**
    * 🎯 Issue #118: Update a pending upload in localStorage
    */
-  private updatePendingUpload(upload: PendingUpload): void {
+  private updatePendingUpload(upload: PendingUpload): boolean {
     // 🎯 Issue #138: concurrency-safe update via mutateQueue
-    this.mutateQueue((pending) => {
+    return this.mutateQueue((pending) => {
       const index = pending.findIndex((u) => u.id === upload.id);
       if (index < 0) {
         // Entry was concurrently removed elsewhere; don't resurrect it.

--- a/frontend/src/services/azureSpeechService.ts
+++ b/frontend/src/services/azureSpeechService.ts
@@ -31,8 +31,12 @@ export class AzureSpeechService {
 
   // 🎯 Issue #118: localStorage key for pending uploads
   private readonly STORAGE_KEY = "duotopia_pending_uploads";
+  // 🎯 Issue #138: optimistic-locking version counter for the queue
+  private readonly VERSION_KEY = "duotopia_pending_uploads_version";
   private readonly MAX_QUEUE_SIZE = 10 * 1024 * 1024; // 10MB limit
   private readonly MAX_RETRIES = 2;
+  // 🎯 Issue #138: max attempts to commit a queue mutation under contention
+  private readonly QUEUE_MUTATION_RETRIES = 3;
 
   /**
    * 获取 Azure Speech Token（带缓存，提前1分钟过期）
@@ -394,42 +398,83 @@ export class AzureSpeechService {
   // ===== localStorage Management =====
 
   /**
+   * 🎯 Issue #138: Atomically read-modify-write the queue with optimistic
+   * locking. The mutator runs against a fresh snapshot; if another context
+   * (e.g. a second browser tab) bumped the version between our read and our
+   * write, we re-read and retry instead of clobbering their change.
+   *
+   * @param mutator Returns the next queue, or null to abort the write.
+   * @returns true if the mutation was committed, false otherwise.
+   */
+  private mutateQueue(
+    mutator: (queue: PendingUpload[]) => PendingUpload[] | null,
+  ): boolean {
+    for (let attempt = 0; attempt < this.QUEUE_MUTATION_RETRIES; attempt++) {
+      try {
+        const versionBefore = localStorage.getItem(this.VERSION_KEY) || "0";
+        const current = this.getPendingUploads();
+
+        const next = mutator(current);
+        if (next === null) {
+          return false; // mutator chose to abort (e.g. item too large)
+        }
+
+        // Optimistic lock: bail to a retry if anyone wrote since our read.
+        const versionNow = localStorage.getItem(this.VERSION_KEY) || "0";
+        if (versionNow !== versionBefore) {
+          continue;
+        }
+
+        localStorage.setItem(this.STORAGE_KEY, JSON.stringify(next));
+        localStorage.setItem(
+          this.VERSION_KEY,
+          String(parseInt(versionBefore, 10) + 1),
+        );
+        return true;
+      } catch (error) {
+        console.error("Failed to mutate pending upload queue:", error);
+        return false;
+      }
+    }
+
+    console.warn("Queue mutation gave up after version conflicts");
+    return false;
+  }
+
+  /**
    * 🎯 Issue #118: Save pending upload to localStorage
+   * 🎯 Issue #138: now goes through mutateQueue for concurrency safety
    */
   private async savePendingUpload(upload: PendingUpload): Promise<boolean> {
-    try {
-      const existing = this.getPendingUploads();
-      const itemSize = new Blob([JSON.stringify(upload)]).size;
+    const itemSize = new Blob([JSON.stringify(upload)]).size;
 
-      // Check queue size limit
-      let currentSize = this.getQueueSize();
+    // If single item is too large, reject (independent of queue state).
+    if (itemSize > this.MAX_QUEUE_SIZE) {
+      console.warn("Audio file too large for retry queue");
+      return false;
+    }
 
-      // Prune oldest items if over limit
-      while (
-        currentSize + itemSize > this.MAX_QUEUE_SIZE &&
-        existing.length > 0
-      ) {
-        const removed = existing.shift();
+    const saved = this.mutateQueue((existing) => {
+      const queue = [...existing];
+
+      // Prune oldest items until the new item fits under the size limit.
+      let currentSize = new Blob([JSON.stringify(queue)]).size;
+      while (currentSize + itemSize > this.MAX_QUEUE_SIZE && queue.length > 0) {
+        const removed = queue.shift();
         if (removed) {
           console.warn(`Pruning old upload ${removed.id} to make space`);
         }
-        currentSize = new Blob([JSON.stringify(existing)]).size;
+        currentSize = new Blob([JSON.stringify(queue)]).size;
       }
 
-      // If single item is too large, reject
-      if (itemSize > this.MAX_QUEUE_SIZE) {
-        console.warn("Audio file too large for retry queue");
-        return false;
-      }
+      queue.push(upload);
+      return queue;
+    });
 
-      existing.push(upload);
-      localStorage.setItem(this.STORAGE_KEY, JSON.stringify(existing));
+    if (saved) {
       console.log(`Saved pending upload ${upload.id} for retry`);
-      return true;
-    } catch (error) {
-      console.error("Failed to save pending upload:", error);
-      return false;
     }
+    return saved;
   }
 
   /**
@@ -448,32 +493,25 @@ export class AzureSpeechService {
    * 🎯 Issue #118: Remove a pending upload from localStorage
    */
   private removePendingUpload(id: string): void {
-    const pending = this.getPendingUploads().filter((u) => u.id !== id);
-    localStorage.setItem(this.STORAGE_KEY, JSON.stringify(pending));
+    // 🎯 Issue #138: concurrency-safe removal via mutateQueue
+    this.mutateQueue((pending) => pending.filter((u) => u.id !== id));
   }
 
   /**
    * 🎯 Issue #118: Update a pending upload in localStorage
    */
   private updatePendingUpload(upload: PendingUpload): void {
-    const pending = this.getPendingUploads();
-    const index = pending.findIndex((u) => u.id === upload.id);
-    if (index >= 0) {
-      pending[index] = upload;
-      localStorage.setItem(this.STORAGE_KEY, JSON.stringify(pending));
-    }
-  }
-
-  /**
-   * 🎯 Issue #118: Get current queue size in bytes
-   */
-  private getQueueSize(): number {
-    try {
-      const data = localStorage.getItem(this.STORAGE_KEY);
-      return data ? new Blob([data]).size : 0;
-    } catch {
-      return 0;
-    }
+    // 🎯 Issue #138: concurrency-safe update via mutateQueue
+    this.mutateQueue((pending) => {
+      const index = pending.findIndex((u) => u.id === upload.id);
+      if (index < 0) {
+        // Entry was concurrently removed elsewhere; don't resurrect it.
+        return null;
+      }
+      const next = [...pending];
+      next[index] = upload;
+      return next;
+    });
   }
 
   // ===== Utility Methods =====


### PR DESCRIPTION
## 問題 (Fixes #138)

`frontend/src/services/azureSpeechService.ts` 用 localStorage 當待上傳錄音的重試佇列。三個變更函式（`savePendingUpload`、`removePendingUpload`、`updatePendingUpload`）各自做 read-modify-write 卻沒有任何協調。當兩個情境（真實觸發點：**多個瀏覽器分頁共用同一 localStorage**）幾乎同時動到佇列時，後寫者會覆蓋前者的變更，使排隊的錄音被靜默丟失。

> 單一分頁內 JS 是單執行緒、各函式 critical section 無 `await`，本來就原子；真正的損毀視窗在 **跨分頁**。因此修正必須涵蓋全部三個變更函式，而非只改 `savePendingUpload`。

## 解法

集中所有佇列變更走單一樂觀鎖 helper：

- 新增 version key `duotopia_pending_uploads_version`
- 新增 `mutateQueue(mutator)`：讀 version + 快照 → 跑 mutator → 寫入前重查 version 是否未變，變了就重讀重試（最多 3 次）→ 提交並遞增 version
- `savePendingUpload` / `removePendingUpload` / `updatePendingUpload` 全部委派給 `mutateQueue`
- `updatePendingUpload` 對「已被並發移除」的項目回傳 `null`，避免復活
- 移除不再使用的 `getQueueSize`

## 測試

- 新增 5 個並發測試：version 遞增、並發 save 合併不掉資料、並發 remove 保留他者新增、size pruning、單筆過大拒絕
- 修正一個既有過期斷言（程式碼已改記 `"First upload attempt failed:"`）
- ✅ 目標測試檔 12/12 通過、✅ typecheck、✅ lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)