### PR TITLE
fix(#139): Azure Speech token 端點加上 per-user rate limiting

### DIFF
--- a/backend/core/limiter.py
+++ b/backend/core/limiter.py
@@ -66,8 +66,8 @@ def get_authenticated_user_identifier(request: Request) -> str:
 
     # 兩個 @limiter.limit 裝飾器會對同一 request 都呼叫本函式，
     # 用 request.state 快取結果，避免重複解碼 JWT
-    if hasattr(request.state, "_rate_limit_user_key"):
-        return request.state._rate_limit_user_key
+    if hasattr(request.state, "_duotopia_rate_limit_user_key"):
+        return request.state._duotopia_rate_limit_user_key
 
     auth_header = request.headers.get("Authorization", "")
     if auth_header.startswith("Bearer "):
@@ -78,12 +78,12 @@ def get_authenticated_user_identifier(request: Request) -> str:
             # sub 只要存在就用 user 桶；空字串也是合法 sub，不可掉進 IP 桶
             if sub is not None:
                 key = f"user:{sub}"
-                request.state._rate_limit_user_key = key
+                request.state._duotopia_rate_limit_user_key = key
                 return key
 
     # 無有效 token → 回到既有識別策略（body email/id 或 IP）
     key = get_user_identifier(request)
-    request.state._rate_limit_user_key = key
+    request.state._duotopia_rate_limit_user_key = key
     return key
 
 

--- a/backend/core/limiter.py
+++ b/backend/core/limiter.py
@@ -60,18 +60,31 @@ def get_authenticated_user_identifier(request: Request) -> str:
     無有效 token 時 fallback 到 get_user_identifier（最後到 IP），
     確保未驗證的請求不會被歸到同一個 user 桶互相干擾。
     """
-    # 延遲 import 避免 circular import（auth 依賴其他模組）
+    # 延遲 import 以避免 import limiter 時就 eager-load 整個 ORM stack
+    # （auth → models → database），同時讓單元測試與啟動更輕量
     from auth import verify_token
+
+    # 兩個 @limiter.limit 裝飾器會對同一 request 都呼叫本函式，
+    # 用 request.state 快取結果，避免重複解碼 JWT
+    if hasattr(request.state, "_rate_limit_user_key"):
+        return request.state._rate_limit_user_key
 
     auth_header = request.headers.get("Authorization", "")
     if auth_header.startswith("Bearer "):
         token = auth_header[len("Bearer ") :]
         payload = verify_token(token)
-        if payload and payload.get("sub"):
-            return f"user:{payload['sub']}"
+        if payload:
+            sub = payload.get("sub")
+            # sub 只要存在就用 user 桶；空字串也是合法 sub，不可掉進 IP 桶
+            if sub is not None:
+                key = f"user:{sub}"
+                request.state._rate_limit_user_key = key
+                return key
 
     # 無有效 token → 回到既有識別策略（body email/id 或 IP）
-    return get_user_identifier(request)
+    key = get_user_identifier(request)
+    request.state._rate_limit_user_key = key
+    return key
 
 
 # 🔐 Create limiter with smart identifier

--- a/backend/core/limiter.py
+++ b/backend/core/limiter.py
@@ -70,8 +70,9 @@ def get_authenticated_user_identifier(request: Request) -> str:
         return request.state._duotopia_rate_limit_user_key
 
     auth_header = request.headers.get("Authorization", "")
-    if auth_header.startswith("Bearer "):
-        token = auth_header[len("Bearer ") :]
+    # RFC 7235：auth-scheme 不分大小寫，bearer/BEARER 都合法
+    if auth_header.lower().startswith("bearer "):
+        token = auth_header[len("bearer ") :]
         payload = verify_token(token)
         if payload:
             sub = payload.get("sub")

--- a/backend/core/limiter.py
+++ b/backend/core/limiter.py
@@ -50,5 +50,29 @@ def get_user_identifier(request: Request) -> str:
     return f"ip:{get_remote_address(request)}"
 
 
+def get_authenticated_user_identifier(request: Request) -> str:
+    """
+    以「登入身分」為基準的 rate-limit key。
+
+    從 Authorization: Bearer header 解析 JWT，回傳 user:<sub>，
+    讓單一帳號的請求數受限，無法靠輪換 IP/proxy 繞過（Issue #139）。
+
+    無有效 token 時 fallback 到 get_user_identifier（最後到 IP），
+    確保未驗證的請求不會被歸到同一個 user 桶互相干擾。
+    """
+    # 延遲 import 避免 circular import（auth 依賴其他模組）
+    from auth import verify_token
+
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        token = auth_header[len("Bearer ") :]
+        payload = verify_token(token)
+        if payload and payload.get("sub"):
+            return f"user:{payload['sub']}"
+
+    # 無有效 token → 回到既有識別策略（body email/id 或 IP）
+    return get_user_identifier(request)
+
+
 # 🔐 Create limiter with smart identifier
 limiter = Limiter(key_func=get_user_identifier)

--- a/backend/routers/azure_speech_token.py
+++ b/backend/routers/azure_speech_token.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from auth import get_current_user
-from core.limiter import limiter
+from core.limiter import limiter, get_authenticated_user_identifier
 from services.azure_speech_token import get_azure_speech_token_service
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,10 @@ class TokenResponse(BaseModel):
 
 
 @router.post("/token", response_model=TokenResponse)
-@limiter.limit("10/minute")  # 每分鐘最多 10 次請求
+@limiter.limit("10/minute")  # 每 IP 每分鐘最多 10 次（防爆量）
+@limiter.limit(
+    "60/hour", key_func=get_authenticated_user_identifier
+)  # 每使用者每小時最多 60 次（防輪換 IP 繞過，Issue #139）
 async def get_speech_token(
     request: Request, current_user: dict = Depends(get_current_user)
 ):
@@ -44,7 +47,7 @@ async def get_speech_token(
 
     安全措施：
     - ✅ 需要用戶身份驗證（get_current_user dependency）
-    - ✅ Rate limiting（每分鐘最多 10 次請求）
+    - ✅ Rate limiting（每 IP 每分鐘 10 次 + 每使用者每小時 60 次）
     - ✅ Token server-side cache（減少 Azure API 調用）
     - ✅ Subscription Key 不外泄（只在後端使用）
 

--- a/backend/tests/unit/test_limiter.py
+++ b/backend/tests/unit/test_limiter.py
@@ -1,0 +1,66 @@
+"""
+Tests for rate-limit key functions (core/limiter.py)
+
+Focus: get_authenticated_user_identifier — derives a per-user rate-limit key
+from the JWT in the Authorization header, so a malicious user cannot bypass
+limits by rotating IPs/proxies (Issue #139).
+"""
+from starlette.requests import Request
+
+from auth import create_access_token
+from core.limiter import get_authenticated_user_identifier
+
+
+def _make_request(headers=None, client_host="1.2.3.4"):
+    """Build a minimal Starlette Request for key-function testing."""
+    headers = headers or {}
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in headers.items()]
+    scope = {
+        "type": "http",
+        "headers": raw_headers,
+        "client": (client_host, 12345),
+    }
+    return Request(scope)
+
+
+class TestAuthenticatedUserIdentifier:
+    def test_valid_token_returns_user_key(self):
+        """有效 JWT → 以 user:<sub> 作為 key"""
+        token = create_access_token(data={"sub": "42", "type": "teacher"})
+        request = _make_request({"Authorization": f"Bearer {token}"})
+
+        assert get_authenticated_user_identifier(request) == "user:42"
+
+    def test_different_users_get_different_keys(self):
+        """不同使用者 → 不同 key（即使同 IP）"""
+        token_a = create_access_token(data={"sub": "1", "type": "student"})
+        token_b = create_access_token(data={"sub": "2", "type": "student"})
+
+        key_a = get_authenticated_user_identifier(
+            _make_request({"Authorization": f"Bearer {token_a}"}, client_host="9.9.9.9")
+        )
+        key_b = get_authenticated_user_identifier(
+            _make_request({"Authorization": f"Bearer {token_b}"}, client_host="9.9.9.9")
+        )
+
+        assert key_a == "user:1"
+        assert key_b == "user:2"
+        assert key_a != key_b
+
+    def test_no_auth_header_falls_back_to_ip(self):
+        """沒有 Authorization header → fallback 到 IP，不可是 user 桶"""
+        request = _make_request(client_host="5.6.7.8")
+
+        key = get_authenticated_user_identifier(request)
+        assert "5.6.7.8" in key
+        assert not key.startswith("user:")
+
+    def test_invalid_token_falls_back_to_ip(self):
+        """無效 token → fallback 到 IP，不可當成單一 user 共用桶"""
+        request = _make_request(
+            {"Authorization": "Bearer not-a-real-token"}, client_host="5.6.7.8"
+        )
+
+        key = get_authenticated_user_identifier(request)
+        assert "5.6.7.8" in key
+        assert not key.startswith("user:")

--- a/backend/tests/unit/test_limiter.py
+++ b/backend/tests/unit/test_limiter.py
@@ -47,6 +47,18 @@ class TestAuthenticatedUserIdentifier:
         assert key_b == "user:2"
         assert key_a != key_b
 
+    def test_cache_hit_reuses_request_state_key(self):
+        """同一 request 第二次呼叫 → 直接讀 request.state 快取，不再重新解碼"""
+        token = create_access_token(data={"sub": "7", "type": "teacher"})
+        request = _make_request({"Authorization": f"Bearer {token}"})
+
+        # 第一次呼叫會把 key 寫進 request.state
+        assert get_authenticated_user_identifier(request) == "user:7"
+
+        # 竄改快取值；若第二次有讀快取，就會回傳竄改後的值
+        request.state._duotopia_rate_limit_user_key = "user:cached"
+        assert get_authenticated_user_identifier(request) == "user:cached"
+
     def test_empty_string_sub_still_uses_user_bucket(self):
         """sub 為空字串也是合法身分 → 仍走 user 桶，不可掉進共用 IP 桶"""
         token = create_access_token(data={"sub": "", "type": "teacher"})

--- a/backend/tests/unit/test_limiter.py
+++ b/backend/tests/unit/test_limiter.py
@@ -47,6 +47,14 @@ class TestAuthenticatedUserIdentifier:
         assert key_b == "user:2"
         assert key_a != key_b
 
+    def test_lowercase_bearer_still_uses_user_bucket(self):
+        """RFC 7235：scheme 不分大小寫，bearer/BEARER 仍要走 user 桶"""
+        token = create_access_token(data={"sub": "42", "type": "teacher"})
+
+        for scheme in ("bearer", "BEARER", "BeArEr"):
+            request = _make_request({"Authorization": f"{scheme} {token}"})
+            assert get_authenticated_user_identifier(request) == "user:42"
+
     def test_cache_hit_reuses_request_state_key(self):
         """同一 request 第二次呼叫 → 直接讀 request.state 快取，不再重新解碼"""
         token = create_access_token(data={"sub": "7", "type": "teacher"})

--- a/backend/tests/unit/test_limiter.py
+++ b/backend/tests/unit/test_limiter.py
@@ -47,6 +47,13 @@ class TestAuthenticatedUserIdentifier:
         assert key_b == "user:2"
         assert key_a != key_b
 
+    def test_empty_string_sub_still_uses_user_bucket(self):
+        """sub 為空字串也是合法身分 → 仍走 user 桶，不可掉進共用 IP 桶"""
+        token = create_access_token(data={"sub": "", "type": "teacher"})
+        request = _make_request({"Authorization": f"Bearer {token}"})
+
+        assert get_authenticated_user_identifier(request) == "user:"
+
     def test_no_auth_header_falls_back_to_ip(self):
         """沒有 Authorization header → fallback 到 IP，不可是 user 桶"""
         request = _make_request(client_host="5.6.7.8")


### PR DESCRIPTION
Fixes #139

## 問題
[backend/routers/azure_speech_token.py](backend/routers/azure_speech_token.py) 的 `/token` 端點原本只有 `10/minute` 限制，且共用的 `limiter` 是從 request body 讀 email/id 識別 —— 但此端點沒有 body，實際上 fallback 成**純 IP 限制**。攻擊者輪換 proxy（換 IP）即可完全繞過。

## 修正
- **`core/limiter.py`**：新增 `get_authenticated_user_identifier`，從 `Authorization: Bearer` 解析 JWT 回傳 `user:<sub>`；無有效 token 時 fallback 既有識別策略（最後到 IP），避免未驗證請求被歸進同一個 user 桶互相干擾。
- **`routers/azure_speech_token.py`**：疊加 `@limiter.limit("60/hour", key_func=get_authenticated_user_identifier)` per-user 限制，保留 `10/minute` per-IP 防爆量。
- **測試**：新增 `tests/unit/test_limiter.py`（4 tests）覆蓋 key function —— 有效 token 回傳 user key、不同使用者分桶、無/無效 token fallback。

## 與 issue 原提案的差異
Issue 範例是手刻 `user_token_requests = {}` 字典。本 PR **不採用** —— 那會記憶體洩漏（無上限、無清除機制）且重複造輪子。改用既有 slowapi limiter + JWT key function，無洩漏、與現有架構一致。per-user 上限依討論設為 **60/hour**（原範例 20/hour）。

## 測試
- 新 limiter 測試：4 passed
- Azure Speech 服務測試：12 passed
- Black / Flake8：clean

## 注意
per-user 限制用 slowapi 預設 in-memory 儲存，Cloud Run 多實例下各實例獨立計數（與現有 limiter 行為一致）。跨實例精準限制需接 Redis backend，不在本 issue 範圍。

🤖 Generated with [Claude Code](https://claude.com/claude-code)