### PR TITLE
fix(#838): 團購開團 — 發起人 email 暫存 + 同一發起人可加開分校

### DIFF
--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -1109,20 +1109,23 @@ async def open_group_buy(
     )
 
     # F2 — Race-safe concurrent-request guard: acquire a Postgres advisory
-    # xact-lock keyed on (teacher_id, plan_name) BEFORE the recent-transaction
-    # lookup so two concurrent requests (mobile retry, double-tap) can't both
-    # pass the check and double-charge. Lock auto-releases at request end.
+    # xact-lock keyed on teacher_id BEFORE the recent-transaction lookup so
+    # two concurrent requests (mobile retry, double-tap) can't both pass the
+    # check and double-charge. Lock auto-releases at request end.
     # SQLite tests are single-threaded; the dialect guard is a no-op there.
     # Use db.get_bind() (SQLAlchemy 2.x idiom) instead of db.bind.
     #
-    # NOTE: lock key intentionally scopes by (teacher_id, plan_name) only.
-    # Two concurrent requests for DIFFERENT plans from the same teacher
-    # would not serialise on this lock. That edge is covered by the
-    # R2-F2 single-org-per-teacher guard below: the first request to
-    # commit creates the TeacherOrganization, and the second request's
-    # R2-F2 check finds it and returns 409.
+    # issue #838 — The lock key is scoped by teacher_id ONLY (previously
+    # (teacher_id, plan_name)). Now that a repeat open accretes a new 分校
+    # onto the teacher's single group-buy org, ALL of a teacher's concurrent
+    # opens must serialise — otherwise two different-plan requests could race
+    # `find_owned_group_buy_org` and either create two orphaned orgs or lose
+    # an `org.teacher_limit` read-modify-write update. Serialising per-teacher
+    # replaces the old R2-F2 409 guard that used to cover this edge. The 60s
+    # idempotency shortcut below (keyed on teacher+plan) still prevents a
+    # same-plan double-tap from double-charging once the lock is held.
     if db.get_bind().dialect.name == "postgresql":
-        lock_key = f"group_buy_open:{current_teacher.id}:{plan.name}"
+        lock_key = f"group_buy_open:{current_teacher.id}"
         locked = db.execute(
             text("SELECT pg_try_advisory_xact_lock(hashtext(:k))"),
             {"k": lock_key},
@@ -1140,8 +1143,9 @@ async def open_group_buy(
     # Instead it is treated as 新增一個分校: the provisioning block below
     # reuses the teacher's existing group-buy org and adds a new School.
     # Double-charge on an accidental double-submit is still prevented by the
-    # advisory xact-lock above (same plan) plus the 60s idempotency shortcut
-    # below (returns the original transaction without re-charging).
+    # per-teacher advisory xact-lock above (serialises all of a teacher's
+    # concurrent opens) plus the 60s idempotency shortcut below (returns the
+    # original transaction without re-charging).
 
     # Idempotency (post-lock): a recent SUCCESS transaction for this
     # (teacher, plan) within 60s means the previous request already opened

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -33,9 +33,11 @@ from routers.teachers import get_current_teacher
 from services.tappay_service import TapPayService
 from services.topup_discount import get_teacher_topup_discount
 from services.group_buy import (
+    add_group_buy_school_to_org,
     compute_group_buy_total,
     create_group_buy_org_and_school,
     create_group_buy_period,
+    find_owned_group_buy_org,
     validate_group_buy_plan,
 )
 from config.plans import (
@@ -1134,29 +1136,12 @@ async def open_group_buy(
                 ),
             )
 
-    # R2-F2 — Long-term guard: a teacher already owning an active group-buy
-    # org (role='org_owner') cannot open another. Filtered to orgs created
-    # more than 60 seconds ago so a same-submission retry (network timeout,
-    # mobile re-send) falls through to the idempotency-shortcut block below
-    # and returns the original transaction id, instead of getting 409.
-    existing_owned = (
-        db.query(TeacherOrganization)
-        .join(Organization, Organization.id == TeacherOrganization.organization_id)
-        .filter(
-            TeacherOrganization.teacher_id == current_teacher.id,
-            TeacherOrganization.role == "org_owner",
-            TeacherOrganization.is_active.is_(True),
-            Organization.org_type == "group_buy",
-            Organization.is_active.is_(True),
-            Organization.created_at < now - timedelta(seconds=60),
-        )
-        .first()
-    )
-    if existing_owned is not None:
-        raise HTTPException(
-            status_code=409,
-            detail="您已開設一個團購方案，不可重複開設。",
-        )
+    # issue #838 — A repeat open by the same 發起人 is NO LONGER rejected.
+    # Instead it is treated as 新增一個分校: the provisioning block below
+    # reuses the teacher's existing group-buy org and adds a new School.
+    # Double-charge on an accidental double-submit is still prevented by the
+    # advisory xact-lock above (same plan) plus the 60s idempotency shortcut
+    # below (returns the original transaction without re-charging).
 
     # Idempotency (post-lock): a recent SUCCESS transaction for this
     # (teacher, plan) within 60s means the previous request already opened
@@ -1324,9 +1309,30 @@ async def open_group_buy(
         # provision) — we cannot silently 500 and swallow the rec_trade_id.
         external_transaction_id = gateway_response.get("rec_trade_id")
         try:
-            org, school, _, _ = create_group_buy_org_and_school(
-                current_teacher, plan, db, now=now
-            )
+            # issue #838 — reuse-or-create. If the 發起人 already owns a
+            # group-buy org, this repeat open adds a new 分校 (School) under
+            # it; otherwise a fresh org+school is created. Either way the
+            # 發起人 contact info (email + leader_phone) is persisted on the
+            # org.
+            existing_org = find_owned_group_buy_org(current_teacher, db)
+            if existing_org is not None:
+                org = existing_org
+                school, _ = add_group_buy_school_to_org(
+                    current_teacher,
+                    org,
+                    plan,
+                    db,
+                    now=now,
+                    leader_phone=open_request.leader_phone,
+                )
+            else:
+                org, school, _, _ = create_group_buy_org_and_school(
+                    current_teacher,
+                    plan,
+                    db,
+                    now=now,
+                    leader_phone=open_request.leader_phone,
+                )
             create_group_buy_period(
                 current_teacher,
                 plan,

--- a/backend/services/group_buy.py
+++ b/backend/services/group_buy.py
@@ -7,7 +7,7 @@ All amount/quota computations are server-side from the Plan row — never
 trust the frontend.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Tuple
 from zoneinfo import ZoneInfo
 
@@ -32,6 +32,13 @@ GROUP_BUY_MONTHLY_QUOTA = 1000
 
 
 # ---------- pure helpers ----------
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Normalise a datetime to tz-aware UTC. SQLite strips tzinfo on
+    TIMESTAMPTZ load (naive), Postgres preserves it (aware); coercing both
+    sides before comparison avoids a naive/aware TypeError."""
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
 
 
 def validate_group_buy_plan(plan_name: str, db: Session) -> Plan:
@@ -93,6 +100,7 @@ def create_group_buy_org_and_school(
     db: Session,
     *,
     now: datetime,
+    leader_phone: str | None = None,
 ) -> Tuple[Organization, School, TeacherSchool, TeacherOrganization]:
     """Atomically create the Organization, School, owner TeacherSchool, AND
     owner TeacherOrganization (role='org_owner') for a new group-buy
@@ -101,6 +109,11 @@ def create_group_buy_org_and_school(
     TeacherOrganization is required so the opener can use the existing
     /org-purchase and /org-renew endpoints, both of which gate on
     `TeacherOrganization.role == 'org_owner'`.
+
+    issue #838 comment — the initiator's contact info is persisted onto the
+    org (`contact_email` = the opener's email, `contact_phone` =
+    `leader_phone`) so admins can identify/contact the 發起人 instead of the
+    field being left NULL.
     """
     owner_label = owner.name or owner.email
     org = Organization(
@@ -111,6 +124,9 @@ def create_group_buy_org_and_school(
         display_name=f"{owner_label}'s 團購-{plan.teacher_seats}位",
         org_type="group_buy",
         teacher_limit=plan.teacher_seats,
+        # issue #838 — persist 發起人 contact info (was previously NULL).
+        contact_email=owner.email,
+        contact_phone=leader_phone,
         subscription_start_date=now,
         # relativedelta(years=1) handles Feb 29 → Feb 28 edge correctly;
         # `timedelta(days=365)` would produce an off-by-one in leap years.
@@ -148,6 +164,97 @@ def create_group_buy_org_and_school(
     db.flush()
 
     return org, school, teacher_school, teacher_org
+
+
+def find_owned_group_buy_org(owner: Teacher, db: Session) -> Organization | None:
+    """Return the active group-buy Organization this teacher owns
+    (role='org_owner'), or None. Earliest-created wins so repeat opens keep
+    accreting 分校 under the teacher's first org rather than spawning new
+    orgs. Used by the open endpoint to decide reuse-vs-create (issue #838).
+    """
+    return (
+        db.query(Organization)
+        .join(
+            TeacherOrganization,
+            TeacherOrganization.organization_id == Organization.id,
+        )
+        .filter(
+            TeacherOrganization.teacher_id == owner.id,
+            TeacherOrganization.role == "org_owner",
+            TeacherOrganization.is_active.is_(True),
+            Organization.org_type == "group_buy",
+            Organization.is_active.is_(True),
+        )
+        .order_by(Organization.created_at.asc())
+        .first()
+    )
+
+
+def add_group_buy_school_to_org(
+    owner: Teacher,
+    org: Organization,
+    plan: Plan,
+    db: Session,
+    *,
+    now: datetime,
+    leader_phone: str | None = None,
+) -> Tuple[School, TeacherSchool]:
+    """Add a new 分校 (School) under an EXISTING group-buy org for a repeat
+    open by the same 發起人 (issue #838).
+
+    Per product decision, a repeat open is equivalent to 新增一個分校:
+      - a new School (its own Plan / seat limit) is created under `org`;
+      - the owner is bound to it as school_admin (they already have the
+        org-level org_owner TeacherOrganization, so no new one is made);
+      - the org's teacher_limit grows by this plan's seats (aggregate cap
+        across all 分校);
+      - the org subscription is extended to cover the new cohort's year
+        (keep the later end date so the newest purchase never shortens an
+        existing cohort's grant window);
+      - contact info is refreshed to the latest 發起人 email/phone.
+
+    Returns the new (School, owner TeacherSchool). The caller creates the
+    owner/member SubscriptionPeriods and roster bindings against the
+    returned school, mirroring the fresh-org path.
+    """
+    school = School(
+        organization_id=org.id,
+        name=f"{org.name} School",
+        plan_id=plan.id,
+        teacher_seat_limit=plan.teacher_seats,
+        is_active=True,
+    )
+    db.add(school)
+    db.flush()  # need school.id for FK
+
+    teacher_school = TeacherSchool(
+        teacher_id=owner.id,
+        school_id=school.id,
+        roles=["school_admin"],
+        is_active=True,
+    )
+    db.add(teacher_school)
+
+    # Aggregate the seat cap across all 分校.
+    org.teacher_limit = (org.teacher_limit or 0) + int(plan.teacher_seats)
+
+    # Extend the org subscription to cover this cohort's year, but never
+    # shorten an existing later end date. SQLite strips tzinfo on
+    # TIMESTAMPTZ load while Postgres preserves it, so normalise both sides
+    # to tz-aware UTC before comparing to avoid a naive/aware TypeError.
+    new_end = now + relativedelta(years=1)
+    existing_end = org.subscription_end_date
+    if existing_end is None or _as_utc(existing_end) < _as_utc(new_end):
+        org.subscription_end_date = new_end
+
+    # Refresh 發起人 contact info (latest wins); backfills orgs opened before
+    # the issue #838 fix that still have NULL contact_email.
+    org.contact_email = owner.email
+    if leader_phone:
+        org.contact_phone = leader_phone
+
+    db.flush()
+    return school, teacher_school
 
 
 def create_group_buy_period(

--- a/backend/services/group_buy.py
+++ b/backend/services/group_buy.py
@@ -217,9 +217,13 @@ def add_group_buy_school_to_org(
     owner/member SubscriptionPeriods and roster bindings against the
     returned school, mirroring the fresh-org path.
     """
+    # Ordinal suffix so repeated 分校 are distinguishable in the admin UI
+    # (the fresh-org path names its first school "{org.name} School"; the
+    # 2nd/3rd accretions become "... School 2", "... School 3", ...).
+    existing_count = db.query(School).filter(School.organization_id == org.id).count()
     school = School(
         organization_id=org.id,
-        name=f"{org.name} School",
+        name=f"{org.name} School {existing_count + 1}",
         plan_id=plan.id,
         teacher_seat_limit=plan.teacher_seats,
         is_active=True,

--- a/backend/tests/test_group_buy_open_endpoint.py
+++ b/backend/tests/test_group_buy_open_endpoint.py
@@ -150,6 +150,9 @@ def test_happy_path_creates_org_school_binding_period(
         .one()
     )
     assert org.org_type == "group_buy"
+    # issue #838 Bug 1 — the 發起人's email is persisted onto the org so
+    # admins can identify/contact the initiator (was previously NULL).
+    assert org.contact_email == teacher.email
     school = (
         shared_test_session.query(School).filter(School.id == body["school_id"]).one()
     )
@@ -196,25 +199,37 @@ def test_happy_path_creates_org_school_binding_period(
     assert txn.subscription_type == gb_plan.name
 
 
-def test_rejects_when_teacher_already_owns_a_group_buy_org(
+def test_repeat_open_adds_school_to_existing_org(
     test_client, auth_header, teacher, gb_plan, shared_test_session
 ):
-    """R2-F2 — A teacher who already owns a group-buy organization (older
-    than the 60s retry window) must not be able to open another (would
-    result in a second NT$X charge and 2x monthly grants)."""
+    """issue #838 Bug 2 — A repeat open by the same 發起人 is no longer
+    rejected: it reuses the teacher's existing group-buy org and adds a new
+    分校 (School) under it, charging normally. Seat cap aggregates across
+    分校 and the 發起人 contact info is backfilled onto the org."""
     from datetime import datetime, timedelta, timezone
 
-    # Seed an existing owned group-buy org for this teacher, created
-    # well outside the 60s same-submission window.
+    now = datetime.now(timezone.utc)
+    # Seed an existing owned group-buy org + its first school, created well
+    # outside the 60s retry window (no recent SUCCESS txn ⇒ not idempotent).
     org = Organization(
         name="Pre-existing 團",
         org_type="group_buy",
+        teacher_limit=gb_plan.teacher_seats,
+        subscription_start_date=now - timedelta(days=10),
+        subscription_end_date=now + timedelta(days=355),
         is_active=True,
-        created_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        created_at=now - timedelta(hours=1),
     )
     shared_test_session.add(org)
-    shared_test_session.commit()
-    shared_test_session.refresh(org)
+    shared_test_session.flush()
+    first_school = School(
+        organization_id=org.id,
+        name="Pre-existing 團 School",
+        plan_id=gb_plan.id,
+        teacher_seat_limit=gb_plan.teacher_seats,
+        is_active=True,
+    )
+    shared_test_session.add(first_school)
     shared_test_session.add(
         TeacherOrganization(
             teacher_id=teacher.id,
@@ -224,20 +239,76 @@ def test_rejects_when_teacher_already_owns_a_group_buy_org(
         )
     )
     shared_test_session.commit()
+    org_id = org.id
+    first_school_id = first_school.id
 
+    mock_tappay = Mock()
+    mock_tappay.process_payment.return_value = {
+        "status": 0,
+        "rec_trade_id": "REC-OPEN-2ND",
+        "card_secret": {},
+    }
     with patch("routers.credit_packages.ENABLE_PAYMENT", True), patch(
-        "routers.credit_packages.TapPayService"
-    ) as mock_tappay_class:
+        "routers.credit_packages.TapPayService", return_value=mock_tappay
+    ):
         r = test_client.post(
             "/api/credit-packages/group-buy-open",
-            json={"prime": "prime-x", "plan_name": gb_plan.name},
+            json={
+                "prime": "prime-x",
+                "plan_name": gb_plan.name,
+                "leader_phone": "0912345678",
+            },
             headers=auth_header,
         )
 
-    assert r.status_code == 409
-    assert "團購方案" in r.json()["detail"]
-    # TapPay must NOT be charged
-    mock_tappay_class.assert_not_called()
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    assert body["success"] is True
+    # Charged again (repeat open is a real purchase).
+    mock_tappay.process_payment.assert_called_once()
+
+    # Reused the SAME org, but created a NEW 分校.
+    assert body["organization_id"] == str(org_id)
+    assert body["school_id"] != str(first_school_id)
+
+    shared_test_session.expire_all()
+    schools = (
+        shared_test_session.query(School).filter(School.organization_id == org_id).all()
+    )
+    assert len(schools) == 2, "a new 分校 should be added under the existing org"
+
+    reused_org = (
+        shared_test_session.query(Organization).filter(Organization.id == org_id).one()
+    )
+    # Seat cap aggregates across 分校.
+    assert reused_org.teacher_limit == gb_plan.teacher_seats * 2
+    # 發起人 contact info backfilled onto the org.
+    assert reused_org.contact_email == teacher.email
+    assert reused_org.contact_phone == "0912345678"
+
+    # Owner bound as school_admin of the new 分校.
+    new_school_id = body["school_id"]
+    ts = (
+        shared_test_session.query(TeacherSchool)
+        .filter(
+            TeacherSchool.teacher_id == teacher.id,
+            TeacherSchool.school_id == new_school_id,
+        )
+        .one()
+    )
+    assert ts.roles == ["school_admin"]
+
+    # Only ONE org owned by this teacher — repeat opens accrete 分校, they
+    # do not spawn a second org.
+    owned_orgs = (
+        shared_test_session.query(TeacherOrganization)
+        .filter(
+            TeacherOrganization.teacher_id == teacher.id,
+            TeacherOrganization.role == "org_owner",
+        )
+        .count()
+    )
+    assert owned_orgs == 1
 
 
 def test_idempotent_within_60s_returns_existing_transaction(

--- a/backend/tests/test_group_buy_service.py
+++ b/backend/tests/test_group_buy_service.py
@@ -28,9 +28,11 @@ from models import (
 )
 from services.group_buy import (
     GROUP_BUY_MONTHLY_QUOTA,
+    add_group_buy_school_to_org,
     compute_group_buy_total,
     create_group_buy_org_and_school,
     create_group_buy_period,
+    find_owned_group_buy_org,
     grant_monthly_for_group_buy,
     month_end_taipei,
     validate_group_buy_plan,
@@ -189,6 +191,92 @@ def test_open_creates_org_school_and_owner_binding(shared_test_session, owner):
     owner_label = owner.name or owner.email
     assert org.display_name == f"{owner_label}'s 團購-{plan.teacher_seats}位"
     assert org.teacher_limit == plan.teacher_seats
+
+
+# ---------- issue #838: 發起人 contact + repeat-open 分校 ----------
+
+
+def test_open_persists_initiator_contact_email_and_phone(shared_test_session, owner):
+    """Bug 1 — the create flow persists the 發起人's email onto the org's
+    contact_email, and leader_phone onto contact_phone (were NULL before)."""
+    plan = _make_group_buy_plan(shared_test_session)
+    now = datetime.now(timezone.utc)
+    org, _, _, _ = create_group_buy_org_and_school(
+        owner, plan, shared_test_session, now=now, leader_phone="0912345678"
+    )
+    shared_test_session.commit()
+    assert org.contact_email == owner.email
+    assert org.contact_phone == "0912345678"
+
+
+def test_find_owned_group_buy_org_returns_owned_or_none(shared_test_session, owner):
+    plan = _make_group_buy_plan(shared_test_session)
+    # No org yet.
+    assert find_owned_group_buy_org(owner, shared_test_session) is None
+    org, _, _, _ = create_group_buy_org_and_school(
+        owner, plan, shared_test_session, now=datetime.now(timezone.utc)
+    )
+    shared_test_session.commit()
+    found = find_owned_group_buy_org(owner, shared_test_session)
+    assert found is not None and found.id == org.id
+
+
+def test_add_group_buy_school_adds_branch_and_aggregates(shared_test_session, owner):
+    """Bug 2 — a repeat open adds a new 分校 under the existing org:
+    aggregates teacher_limit, extends subscription, binds owner as
+    school_admin, and backfills contact info."""
+    plan = _make_group_buy_plan(shared_test_session, seats=30)
+    now = datetime.now(timezone.utc)
+    org, first_school, _, _ = create_group_buy_org_and_school(
+        owner, plan, shared_test_session, now=now - relativedelta(days=10)
+    )
+    shared_test_session.commit()
+    original_end = org.subscription_end_date
+
+    school2, ts2 = add_group_buy_school_to_org(
+        owner, org, plan, shared_test_session, now=now, leader_phone="0900111222"
+    )
+    shared_test_session.commit()
+
+    # New 分校 distinct from the first, both under the same org.
+    assert school2.id != first_school.id
+    assert school2.organization_id == org.id
+    schools = (
+        shared_test_session.query(School).filter(School.organization_id == org.id).all()
+    )
+    assert len(schools) == 2
+    # Seat cap aggregates across 分校.
+    assert org.teacher_limit == 30 * 2
+    # Subscription extended to cover the newest cohort's year.
+    assert _naive(org.subscription_end_date) == _naive(now + relativedelta(years=1))
+    assert org.subscription_end_date >= original_end
+    # Owner bound as school_admin of the new 分校.
+    assert ts2.teacher_id == owner.id
+    assert ts2.school_id == school2.id
+    assert ts2.roles == ["school_admin"]
+    # Contact info backfilled to latest.
+    assert org.contact_email == owner.email
+    assert org.contact_phone == "0900111222"
+
+
+def test_add_group_buy_school_does_not_shorten_later_subscription(
+    shared_test_session, owner
+):
+    """Extending the org subscription must never shorten an existing later
+    end date (keep the max)."""
+    plan = _make_group_buy_plan(shared_test_session)
+    now = datetime.now(timezone.utc)
+    org, _, _, _ = create_group_buy_org_and_school(
+        owner, plan, shared_test_session, now=now
+    )
+    # Force a far-future end date, then add a school "now".
+    far_future = now + relativedelta(years=5)
+    org.subscription_end_date = far_future
+    shared_test_session.commit()
+
+    add_group_buy_school_to_org(owner, org, plan, shared_test_session, now=now)
+    shared_test_session.commit()
+    assert _naive(org.subscription_end_date) == _naive(far_future)
 
 
 # ---------- create_group_buy_period ----------

--- a/backend/tests/test_group_buy_service.py
+++ b/backend/tests/test_group_buy_service.py
@@ -238,9 +238,11 @@ def test_add_group_buy_school_adds_branch_and_aggregates(shared_test_session, ow
     )
     shared_test_session.commit()
 
-    # New 分校 distinct from the first, both under the same org.
+    # New 分校 distinct from the first, both under the same org, and named
+    # with an ordinal suffix so admins can tell 分校 apart.
     assert school2.id != first_school.id
     assert school2.organization_id == org.id
+    assert school2.name == f"{org.name} School 2"
     schools = (
         shared_test_session.query(School).filter(School.organization_id == org.id).all()
     )


### PR DESCRIPTION
## 範圍

修正 issue #838 [comment](https://github.com/myduotopia/duotopia/issues/838#issuecomment-4838883506) 回報的兩個 `/teacher/group-buy/open` 團購開團問題。與 billing Phase B/C/D 無關，獨立 PR。

## Bug 1 — 發起人的 Email 沒有被暫存
開團時 `create_group_buy_org_and_school` 從未設定 `org.contact_email` / `contact_phone`，前端送出的 `leader_phone` 也被丟棄 → org 上完全沒有發起人聯絡資訊（admin 只能繞 FK 反查）。

**修正**：`create_group_buy_org_and_school` 新增 `leader_phone` 參數，開團時：
- `org.contact_email = 發起人 email`（`current_teacher.email`）
- `org.contact_phone = leader_phone`

## Bug 2 — 同一發起人無法發起多個團購（預期＝新增一個分校）
`credit_packages.py` 的 **R2-F2 guard** 會在教師已擁有 group_buy org 時回 `409「您已開設一個團購方案，不可重複開設。」`，完全擋掉重複開團。

**修正**：改為「reuse-or-create」——
- 移除 R2-F2 409 guard。
- 新增 `find_owned_group_buy_org()`：找出教師已擁有的 group_buy org。
- 新增 `add_group_buy_school_to_org()`：於既有 org 下新增一個 **School（分校）**，綁定發起人為 `school_admin`；`teacher_limit` 依新方案席次**累加**；訂閱 `end_date` 延長到涵蓋新一期（取較晚者，**不縮短**既有 cohort 的配點窗口）；回填最新聯絡資訊。
- 端點依「是否已擁有 org」決定 reuse（加分校）或 create（首次開團）。

**不會重複扣款**：同一方案的誤觸雙擊仍由既有的 advisory `pg_try_advisory_xact_lock`（同 teacher+plan 串行化）+ 60s idempotency shortcut（回傳原交易、不再扣款）擋住。真正的第二次開團（>60s 或不同方案）才會建立新分校。

## 測試
- **Service 層**（本機可跑，已全綠）新增 5 個：
  - `test_open_persists_initiator_contact_email_and_phone`（Bug 1）
  - `test_find_owned_group_buy_org_returns_owned_or_none`
  - `test_add_group_buy_school_adds_branch_and_aggregates`（加分校 + 席次累加 + 訂閱延長 + school_admin 綁定 + 聯絡回填）
  - `test_add_group_buy_school_does_not_shorten_later_subscription`
  - `test_group_buy_service.py` 全部 23 passed
- **端點層**：既有 `test_rejects_when_teacher_already_owns_a_group_buy_org`（斷言 409）改寫為 `test_repeat_open_adds_school_to_existing_org`（斷言 reuse org + 新分校 + 扣款 + 席次累加 + 聯絡回填 + 只有一個 org）。happy-path 加驗 `org.contact_email`。
  > 註：端點測試需 casbin 權限系統（需 Postgres），本機環境無法啟動 `test_client`，由 CI 執行驗證。

Black + Flake8 clean。無 migration、無前端變更（前端已送 `leader_phone`；且無程式碼依賴舊 409 訊息）。

Related to #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)