### PR TITLE
refactor(#291): 移除已棄用的 Pydantic from_orm shim，改用 model_validate

### DIFF
--- a/backend/routers/programs.py
+++ b/backend/routers/programs.py
@@ -1301,7 +1301,7 @@ async def copy_program(
             detail="Failed to copy program. Please try again later.",
         )
 
-    program_data = ProgramResponse.from_orm(new_program)
+    program_data = ProgramResponse.model_validate(new_program)
     program_data.lessons = []
 
     for lesson in sorted(new_program.lessons, key=lambda x: x.order_index):
@@ -1388,7 +1388,7 @@ async def create_program(
             school_id=sch_uuid,
         )
 
-        return ProgramResponse.from_orm(program)
+        return ProgramResponse.model_validate(program)
 
     except PermissionError as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
@@ -1508,7 +1508,7 @@ async def update_program(
             db=db,
         )
 
-        return ProgramResponse.from_orm(program)
+        return ProgramResponse.model_validate(program)
 
     except PermissionError as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
@@ -1617,7 +1617,7 @@ async def update_lesson(
             db=db,
         )
 
-        return LessonResponse.from_orm(lesson)
+        return LessonResponse.model_validate(lesson)
 
     except PermissionError as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))

--- a/backend/routers/teachers.py
+++ b/backend/routers/teachers.py
@@ -505,7 +505,7 @@ async def get_teacher_dashboard(
     )
 
     return TeacherDashboard(
-        teacher=TeacherProfile.from_orm(current_teacher),
+        teacher=TeacherProfile.model_validate(current_teacher),
         classroom_count=len(classrooms),
         student_count=total_students,
         program_count=program_count,

--- a/backend/routers/teachers/dashboard.py
+++ b/backend/routers/teachers/dashboard.py
@@ -262,7 +262,7 @@ async def get_teacher_dashboard(
     )
 
     return TeacherDashboard(
-        teacher=TeacherProfile.from_orm(current_teacher),
+        teacher=TeacherProfile.model_validate(current_teacher),
         classroom_count=len(classrooms),
         student_count=total_students,
         program_count=program_count,


### PR DESCRIPTION
## 背景

Issue #291（來自 PR #288 code review 的 tech debt 整理）item 2：Pydantic v2 已棄用 `.from_orm()`，v3 會直接移除。需改用 `.model_validate()`。

## 分析後的實際範圍

原 issue 說「全部 21 處」，但實測後發現只有 **6 處**是真正會在 v3 壞掉的棄用 shim。其餘 15 處是**自訂的 `from_orm` classmethod override**（例如 `OrganizationResponse.from_orm(org, owner)` 會多帶參數，內部用 `cls(...)` 建構），只是剛好同名，並非 Pydantic 的 shim，v3 不受影響，**刻意保留**。

## 本 PR 變更（6 處）

| 檔案 | 轉換 |
|------|------|
| `routers/programs.py` | `ProgramResponse` ×3、`LessonResponse` ×1 |
| `routers/teachers.py` | `TeacherProfile` ×1 |
| `routers/teachers/dashboard.py` | `TeacherProfile` ×1 |

全部目標 schema 皆為 `from_attributes=True`。已在 Pydantic 層驗證 `model_validate` 輸出與 `from_orm` **完全一致**（行為不變）。

## #291 其他兩項狀態
- Item 1（重複 `check_manage_materials_permission`）：✅ 早已修復
- Item 3（RLS migration 不一致）：✅ 早已修復（兩個 migration 皆有 idempotent DO-block guard）

Related to #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)