### PR TITLE
feat(#838): Phase B — 機構月度 PDF 請款單下載

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -49,6 +49,10 @@ tenacity==8.2.3
 # Excel export (issue #708 — class & student grade reports)
 openpyxl==3.1.5
 
+# PDF generation (issue #838 — institution monthly 請款單; Chinese via
+# built-in STSong-Light CID font, no TTF shipped)
+reportlab==5.0.0
+
 # =============================================
 # Development Dependencies
 # =============================================

--- a/backend/routers/organizations.py
+++ b/backend/routers/organizations.py
@@ -7,6 +7,7 @@ Note: Per-issue deploy now includes database migrations (2026-01-11 v4 - upgrade
 """
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import Response
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy import func, distinct, union, select
 from sqlalchemy.orm import Session, joinedload, selectinload, load_only
@@ -14,6 +15,7 @@ from pydantic import BaseModel, Field
 from typing import List, Optional
 from datetime import datetime
 import logging
+import re
 import uuid
 
 from database import get_db
@@ -29,6 +31,7 @@ from auth import verify_token, get_password_hash
 from services.casbin_service import get_casbin_service
 from services.email_service import email_service
 from services.institution_billing import compute_monthly_billing
+from services.institution_invoice_pdf import build_invoice_pdf
 import secrets
 
 
@@ -1517,28 +1520,14 @@ class MonthlyBillingResponse(BaseModel):
     students: List[StudentBillingBreakdown]
 
 
-@router.get("/{org_id}/billing/monthly", response_model=MonthlyBillingResponse)
-async def get_monthly_billing(
-    org_id: uuid.UUID,
-    year: int = Query(..., ge=1, le=9998, description="Calendar year (Taipei)"),
-    month: int = Query(..., ge=1, le=12, description="Calendar month (1-12)"),
-    db: Session = Depends(get_db),
-    current_teacher: Teacher = Depends(get_current_teacher),
-):
-    """Compute the institution's monthly invoice for a given (year, month).
-
-    Auth: platform admin OR an org_owner of this org.
-    Validation: org must be `org_type='institution'` with `per_student_price`
-    set. 400 otherwise.
-
-    Billing rule (issue #768 五.5): a student is billable for the month iff
-    they were 'active' at any moment during the Taipei month window. See
-    `services.institution_billing` for the detailed derivation.
+def _load_billing_org_or_error(
+    org_id: uuid.UUID, current_teacher: Teacher, db: Session
+) -> Organization:
+    """Load an active org and enforce billing auth: platform admin OR the
+    org's `org_owner` specifically. Billing exposes PII (student names +
+    billable status) so org_admin / teacher roles are excluded. Shared by
+    the JSON and PDF billing endpoints. Raises 404 / 403.
     """
-    # Auth: admin bypasses org-membership check; otherwise must be the
-    # org's `org_owner` specifically (NOT just any member). Billing exposes
-    # PII (student names + billable status) so org_admin / teacher roles
-    # are explicitly excluded.
     org = (
         db.query(Organization)
         .filter(Organization.id == org_id, Organization.is_active.is_(True))
@@ -1566,6 +1555,36 @@ async def get_monthly_billing(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Only org_owner can query monthly billing.",
             )
+    return org
+
+
+def _billing_filename_slug(org: Organization) -> str:
+    """ASCII slug of the org name for the download filename (Content-
+    Disposition needs ASCII). Chinese-only names collapse to 'invoice'."""
+    base = org.name or org.display_name or "invoice"
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", base).strip("-").lower()
+    return slug or "invoice"
+
+
+@router.get("/{org_id}/billing/monthly", response_model=MonthlyBillingResponse)
+async def get_monthly_billing(
+    org_id: uuid.UUID,
+    year: int = Query(..., ge=1, le=9998, description="Calendar year (Taipei)"),
+    month: int = Query(..., ge=1, le=12, description="Calendar month (1-12)"),
+    db: Session = Depends(get_db),
+    current_teacher: Teacher = Depends(get_current_teacher),
+):
+    """Compute the institution's monthly invoice for a given (year, month).
+
+    Auth: platform admin OR an org_owner of this org.
+    Validation: org must be `org_type='institution'` with `per_student_price`
+    set. 400 otherwise.
+
+    Billing rule (issue #768 五.5): a student is billable for the month iff
+    they were 'active' at any moment during the Taipei month window. See
+    `services.institution_billing` for the detailed derivation.
+    """
+    org = _load_billing_org_or_error(org_id, current_teacher, db)
 
     try:
         result = compute_monthly_billing(org, year, month, db)
@@ -1577,3 +1596,34 @@ async def get_monthly_billing(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     return result
+
+
+@router.get("/{org_id}/billing/monthly.pdf")
+async def get_monthly_billing_pdf(
+    org_id: uuid.UUID,
+    year: int = Query(..., ge=1, le=9998, description="Calendar year (Taipei)"),
+    month: int = Query(..., ge=1, le=12, description="Calendar month (1-12)"),
+    db: Session = Depends(get_db),
+    current_teacher: Teacher = Depends(get_current_teacher),
+):
+    """Render the monthly 請款單 as a downloadable PDF (issue #838 Phase B).
+
+    Same auth + validation as the JSON endpoint (admin OR org_owner). Reuses
+    `compute_monthly_billing`; the PDF is presentation-only (no DB writes).
+    Deterministic 請款單編號 (INV-{org 前8碼}-{YYYYMM}); remittance account
+    comes from env config so it differs per environment.
+    """
+    org = _load_billing_org_or_error(org_id, current_teacher, db)
+
+    try:
+        billing = compute_monthly_billing(org, year, month, db)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    pdf_bytes = build_invoice_pdf(org, year, month, billing)
+    filename = f"{_billing_filename_slug(org)}-{year:04d}-{month:02d}.pdf"
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/backend/services/institution_invoice_pdf.py
+++ b/backend/services/institution_invoice_pdf.py
@@ -13,6 +13,7 @@ correctly.
 import os
 from datetime import date, datetime
 from io import BytesIO
+from xml.sax.saxutils import escape
 from zoneinfo import ZoneInfo
 
 from reportlab.lib import colors
@@ -72,6 +73,15 @@ def get_bank_info() -> dict:
 
 def _fmt_amount(amount: int, currency: str) -> str:
     return f"{currency} {amount:,}"
+
+
+def _esc(value) -> str:
+    """XML-escape a DB/user-sourced value before it is interpolated into a
+    ReportLab ``Paragraph`` (which parses its input as XML-like markup, so a
+    literal ``&``/``<``/``>`` in an org name, address or student name would
+    otherwise raise a parse error and 500 the PDF endpoint). Static labels
+    and the ``<br/>``/``<b>`` tags we add ourselves stay unescaped."""
+    return escape("" if value is None else str(value))
 
 
 def build_invoice_pdf(
@@ -136,10 +146,10 @@ def build_invoice_pdf(
         f"請款期間 Period：{year} 年 {month:02d} 月",
     ]
     org_lines = [
-        f"機構名稱：{org_display}",
-        f"統一編號：{org.tax_id or '—'}",
-        f"聯絡 Email：{org.contact_email or '—'}",
-        f"地址：{org.address or '—'}",
+        f"機構名稱：{_esc(org_display)}",
+        f"統一編號：{_esc(org.tax_id or '—')}",
+        f"聯絡 Email：{_esc(org.contact_email or '—')}",
+        f"地址：{_esc(org.address or '—')}",
     ]
     header_tbl = Table(
         [
@@ -180,8 +190,8 @@ def build_invoice_pdf(
             unit = _fmt_amount(per_price, currency) if billable else "—"
             rows.append(
                 [
-                    Paragraph(str(s.get("student_id", "")), cell_c),
-                    Paragraph(str(s.get("name", "")), cell),
+                    Paragraph(_esc(s.get("student_id", "")), cell_c),
+                    Paragraph(_esc(s.get("name", "")), cell),
                     Paragraph("是" if billable else "否", cell_c),
                     Paragraph(unit, cell_c),
                 ]
@@ -227,9 +237,9 @@ def build_invoice_pdf(
     # ---- remittance + notes ----
     bank_lines = [
         "匯款資訊 Remittance",
-        f"銀行 Bank：{bank['bank_name']}",
-        f"帳號 Account：{bank['account']}",
-        f"戶名 Account Holder：{bank['holder']}",
+        f"銀行 Bank：{_esc(bank['bank_name'])}",
+        f"帳號 Account：{_esc(bank['account'])}",
+        f"戶名 Account Holder：{_esc(bank['holder'])}",
     ]
     story.append(Paragraph("<br/>".join(bank_lines), normal))
     story.append(Spacer(1, 4 * mm))

--- a/backend/services/institution_invoice_pdf.py
+++ b/backend/services/institution_invoice_pdf.py
@@ -1,0 +1,256 @@
+"""Institution monthly invoice PDF generation (issue #838 Phase B).
+
+Renders a 請款單 (internal billing statement — NOT a 統一發票) for an
+institution org's monthly per-head billing. Reuses the read-only figures
+from ``services.institution_billing.compute_monthly_billing``; this module
+is presentation only and performs no DB writes.
+
+Chinese text is embedded via ReportLab's built-in ``STSong-Light`` CID font,
+so no TTF file needs to be shipped and both Chinese and English render
+correctly.
+"""
+
+import os
+from datetime import date, datetime
+from io import BytesIO
+from zoneinfo import ZoneInfo
+
+from reportlab.lib import colors
+from reportlab.lib.enums import TA_CENTER, TA_RIGHT
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import mm
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.cidfonts import UnicodeCIDFont
+from reportlab.platypus import (
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+
+TAIPEI = ZoneInfo("Asia/Taipei")
+
+# ReportLab's built-in Adobe CID font for Simplified/Traditional Chinese.
+# Registering it (idempotently) lets us embed CJK glyphs without bundling a
+# TTF. The same font name is used for every style below.
+_CJK_FONT = "STSong-Light"
+_font_registered = False
+
+
+def _ensure_font() -> None:
+    global _font_registered
+    if not _font_registered:
+        pdfmetrics.registerFont(UnicodeCIDFont(_CJK_FONT))
+        _font_registered = True
+
+
+def invoice_number(org_id, year: int, month: int) -> str:
+    """Deterministic 請款單編號: ``INV-{org_id 前 8 碼}-{YYYYMM}``.
+
+    Same (org, year, month) → identical number on every download, so the
+    statement can be referenced consistently. Uses the first 8 chars of the
+    org UUID string (its first hex block).
+    """
+    short = str(org_id)[:8]
+    return f"INV-{short}-{year:04d}{month:02d}"
+
+
+def get_bank_info() -> dict:
+    """Remittance account shown on the statement, overridable per environment
+    via env vars so staging/prod use different accounts and tests never show
+    a real one. Defaults are obvious placeholders (never a real account).
+    """
+    return {
+        "bank_name": os.getenv("INVOICE_BANK_NAME", "（範例）測試銀行 001"),
+        "account": os.getenv("INVOICE_BANK_ACCOUNT", "0000-0000-0000-0000（範例）"),
+        "holder": os.getenv("INVOICE_BANK_HOLDER", "Duotopia（範例收款戶名）"),
+    }
+
+
+def _fmt_amount(amount: int, currency: str) -> str:
+    return f"{currency} {amount:,}"
+
+
+def build_invoice_pdf(
+    org,
+    year: int,
+    month: int,
+    billing: dict,
+    *,
+    issued_date: date | None = None,
+) -> bytes:
+    """Render the monthly 請款單 PDF and return its bytes.
+
+    ``org`` is duck-typed: it must expose ``id``, ``name``, ``display_name``,
+    ``tax_id``, ``contact_email`` and ``address``. ``billing`` is the dict
+    returned by ``compute_monthly_billing`` (keys: per_student_price,
+    billable_student_count, total_amount, currency, students[]).
+
+    ``issued_date`` defaults to today in Taipei; passing it fixed makes the
+    output reproducible for tests.
+    """
+    _ensure_font()
+    if issued_date is None:
+        issued_date = datetime.now(TAIPEI).date()
+
+    currency = billing.get("currency", "TWD")
+    per_price = billing.get("per_student_price", 0)
+    students = billing.get("students", [])
+    total_amount = billing.get("total_amount", 0)
+    inv_no = invoice_number(org.id, year, month)
+    bank = get_bank_info()
+
+    # ---- styles ----
+    base = getSampleStyleSheet()
+    normal = ParagraphStyle(
+        "cjk", parent=base["Normal"], fontName=_CJK_FONT, fontSize=10, leading=15
+    )
+    title = ParagraphStyle(
+        "cjkTitle",
+        parent=base["Title"],
+        fontName=_CJK_FONT,
+        fontSize=20,
+        leading=26,
+    )
+    right = ParagraphStyle("cjkRight", parent=normal, alignment=TA_RIGHT)
+    total_style = ParagraphStyle(
+        "cjkTotal", parent=normal, fontSize=16, leading=22, alignment=TA_RIGHT
+    )
+    cell = ParagraphStyle("cjkCell", parent=normal, fontSize=9, leading=12)
+    cell_c = ParagraphStyle("cjkCellC", parent=cell, alignment=TA_CENTER)
+
+    org_display = org.display_name or org.name or ""
+
+    story = []
+    story.append(Paragraph("Duotopia 請款單", title))
+    story.append(Paragraph("Institution Monthly Billing Statement", right))
+    story.append(Spacer(1, 6 * mm))
+
+    # ---- header: invoice meta + org info (two columns) ----
+    meta_lines = [
+        f"請款單編號 Invoice No.：{inv_no}",
+        f"開立日期 Issued：{issued_date.isoformat()}",
+        f"請款期間 Period：{year} 年 {month:02d} 月",
+    ]
+    org_lines = [
+        f"機構名稱：{org_display}",
+        f"統一編號：{org.tax_id or '—'}",
+        f"聯絡 Email：{org.contact_email or '—'}",
+        f"地址：{org.address or '—'}",
+    ]
+    header_tbl = Table(
+        [
+            [
+                Paragraph("<br/>".join(meta_lines), normal),
+                Paragraph("<br/>".join(org_lines), normal),
+            ]
+        ],
+        colWidths=[85 * mm, 85 * mm],
+    )
+    header_tbl.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("BOX", (0, 0), (-1, -1), 0.5, colors.grey),
+                ("INNERGRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                ("LEFTPADDING", (0, 0), (-1, -1), 6),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+                ("TOPPADDING", (0, 0), (-1, -1), 6),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+            ]
+        )
+    )
+    story.append(header_tbl)
+    story.append(Spacer(1, 6 * mm))
+
+    # ---- line-item table ----
+    header_row = [
+        Paragraph("學生 ID", cell_c),
+        Paragraph("姓名", cell_c),
+        Paragraph("是否計費", cell_c),
+        Paragraph("單價", cell_c),
+    ]
+    rows = [header_row]
+    if students:
+        for s in students:
+            billable = bool(s.get("billable"))
+            unit = _fmt_amount(per_price, currency) if billable else "—"
+            rows.append(
+                [
+                    Paragraph(str(s.get("student_id", "")), cell_c),
+                    Paragraph(str(s.get("name", "")), cell),
+                    Paragraph("是" if billable else "否", cell_c),
+                    Paragraph(unit, cell_c),
+                ]
+            )
+    else:
+        rows.append([Paragraph("（本月無學生資料）", cell_c), "", "", ""])
+
+    item_tbl = Table(
+        rows,
+        colWidths=[30 * mm, 70 * mm, 30 * mm, 40 * mm],
+        repeatRows=1,
+    )
+    item_style = [
+        ("FONTNAME", (0, 0), (-1, -1), _CJK_FONT),
+        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#f0f0f0")),
+        ("GRID", (0, 0), (-1, -1), 0.4, colors.grey),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+    ]
+    if not students:
+        item_style.append(("SPAN", (0, 1), (-1, 1)))
+    item_tbl.setStyle(TableStyle(item_style))
+    story.append(item_tbl)
+    story.append(Spacer(1, 4 * mm))
+
+    # ---- totals ----
+    story.append(
+        Paragraph(
+            f"計費人數 Billable：{billing.get('billable_student_count', 0)} 位"
+            f"　×　單價 {_fmt_amount(per_price, currency)}",
+            right,
+        )
+    )
+    story.append(
+        Paragraph(
+            f"<b>應收總額 Total Due：{_fmt_amount(total_amount, currency)}</b>",
+            total_style,
+        )
+    )
+    story.append(Spacer(1, 8 * mm))
+
+    # ---- remittance + notes ----
+    bank_lines = [
+        "匯款資訊 Remittance",
+        f"銀行 Bank：{bank['bank_name']}",
+        f"帳號 Account：{bank['account']}",
+        f"戶名 Account Holder：{bank['holder']}",
+    ]
+    story.append(Paragraph("<br/>".join(bank_lines), normal))
+    story.append(Spacer(1, 4 * mm))
+    story.append(
+        Paragraph(
+            "注意事項：本請款單為 Duotopia 內部請款憑證，非統一發票。"
+            "如需統一發票請另行聯繫。請於收到後 30 日內完成匯款，"
+            "並於備註填寫請款單編號以利對帳。",
+            normal,
+        )
+    )
+
+    buf = BytesIO()
+    doc = SimpleDocTemplate(
+        buf,
+        pagesize=A4,
+        leftMargin=18 * mm,
+        rightMargin=18 * mm,
+        topMargin=18 * mm,
+        bottomMargin=18 * mm,
+        title=f"{inv_no} {org_display}",
+    )
+    doc.build(story)
+    return buf.getvalue()

--- a/backend/tests/test_institution_billing_endpoint.py
+++ b/backend/tests/test_institution_billing_endpoint.py
@@ -278,3 +278,57 @@ def test_happy_path_full_response(
     assert body["students"][0]["student_id"] == student.id
     assert body["students"][0]["name"] == "Alice"
     assert body["students"][0]["billable"] is True
+
+
+# ---------- PDF endpoint (issue #838 Phase B) ----------
+
+
+def test_pdf_outsider_teacher_gets_403(
+    test_client, outsider, institution_org_with_one_active_student
+):
+    org, _, _ = institution_org_with_one_active_student
+    r = test_client.get(
+        f"/api/organizations/{org.id}/billing/monthly.pdf?year=2026&month=6",
+        headers=_bearer(outsider.id),
+    )
+    assert r.status_code == 403
+
+
+def test_pdf_owner_downloads_valid_pdf(
+    test_client, owner, institution_org_with_one_active_student
+):
+    org, _, _ = institution_org_with_one_active_student
+    r = test_client.get(
+        f"/api/organizations/{org.id}/billing/monthly.pdf?year=2026&month=6",
+        headers=_bearer(owner.id),
+    )
+    assert r.status_code == 200, r.text
+    assert r.headers["content-type"] == "application/pdf"
+    # Valid PDF payload + attachment disposition with the org-slug filename.
+    assert r.content[:4] == b"%PDF"
+    cd = r.headers.get("content-disposition", "")
+    assert "attachment" in cd
+    assert "acme-institution-2026-06.pdf" in cd
+
+
+def test_pdf_admin_can_download_any_org(
+    test_client, admin, institution_org_with_one_active_student
+):
+    org, _, _ = institution_org_with_one_active_student
+    r = test_client.get(
+        f"/api/organizations/{org.id}/billing/monthly.pdf?year=2026&month=6",
+        headers=_bearer(admin.id),
+    )
+    assert r.status_code == 200
+    assert r.content[:4] == b"%PDF"
+
+
+def test_pdf_400_when_org_is_not_institution(test_client, admin, shared_test_session):
+    org = Organization(name="Group Buy", org_type="group_buy", is_active=True)
+    shared_test_session.add(org)
+    shared_test_session.commit()
+    r = test_client.get(
+        f"/api/organizations/{org.id}/billing/monthly.pdf?year=2026&month=6",
+        headers=_bearer(admin.id),
+    )
+    assert r.status_code == 400

--- a/backend/tests/test_institution_invoice_pdf.py
+++ b/backend/tests/test_institution_invoice_pdf.py
@@ -1,0 +1,129 @@
+"""Tests for services.institution_invoice_pdf (issue #838 Phase B).
+
+Covers the deterministic invoice number, env-driven bank info, and that the
+PDF renders (valid %PDF bytes) across the populated / zero-student / mixed
+billable cases. No DB or endpoint here — pure presentation layer.
+"""
+
+from datetime import date
+from types import SimpleNamespace
+
+from services.institution_invoice_pdf import (
+    build_invoice_pdf,
+    get_bank_info,
+    invoice_number,
+)
+
+
+def _org(**over):
+    base = dict(
+        id="a6101f83-5f13-4a2b-9c7d-000000000000",
+        name="Acme Institution",
+        display_name="Acme 機構",
+        tax_id="12345678",
+        contact_email="finance@acme.example",
+        address="台北市中正區測試路 1 號",
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _billing(students, per_price=100, currency="TWD"):
+    billable = sum(1 for s in students if s["billable"])
+    return {
+        "org_id": "a6101f83-5f13-4a2b-9c7d-000000000000",
+        "year": 2026,
+        "month": 6,
+        "per_student_price": per_price,
+        "billable_student_count": billable,
+        "total_amount": billable * per_price,
+        "currency": currency,
+        "students": students,
+    }
+
+
+# ---------- invoice_number ----------
+
+
+def test_invoice_number_format_and_determinism():
+    oid = "a6101f83-5f13-4a2b-9c7d-000000000000"
+    n1 = invoice_number(oid, 2026, 6)
+    n2 = invoice_number(oid, 2026, 6)
+    assert n1 == "INV-a6101f83-202606"
+    assert n1 == n2  # deterministic
+
+
+def test_invoice_number_zero_pads_month():
+    assert invoice_number("abcdef12-0000", 2026, 1).endswith("-202601")
+
+
+# ---------- bank info ----------
+
+
+def test_bank_info_defaults_are_placeholders(monkeypatch):
+    monkeypatch.delenv("INVOICE_BANK_ACCOUNT", raising=False)
+    info = get_bank_info()
+    # Default must be an obvious placeholder, never a real account.
+    assert "範例" in info["account"] or "0000" in info["account"]
+
+
+def test_bank_info_reads_env(monkeypatch):
+    monkeypatch.setenv("INVOICE_BANK_NAME", "玉山銀行 808")
+    monkeypatch.setenv("INVOICE_BANK_ACCOUNT", "1234-5678")
+    monkeypatch.setenv("INVOICE_BANK_HOLDER", "杜拓比亞股份有限公司")
+    info = get_bank_info()
+    assert info["bank_name"] == "玉山銀行 808"
+    assert info["account"] == "1234-5678"
+    assert info["holder"] == "杜拓比亞股份有限公司"
+
+
+# ---------- build_invoice_pdf ----------
+
+
+def test_pdf_renders_valid_bytes_with_students():
+    students = [
+        {"student_id": 1, "name": "王小明", "billable": True},
+        {"student_id": 2, "name": "Jane Doe", "billable": False},
+        {"student_id": 3, "name": "李四", "billable": True},
+    ]
+    data = build_invoice_pdf(
+        _org(), 2026, 6, _billing(students), issued_date=date(2026, 7, 1)
+    )
+    assert isinstance(data, bytes)
+    assert data[:4] == b"%PDF"
+    assert len(data) > 1000
+
+
+def test_pdf_renders_with_zero_students():
+    data = build_invoice_pdf(
+        _org(), 2026, 6, _billing([]), issued_date=date(2026, 7, 1)
+    )
+    assert data[:4] == b"%PDF"
+
+
+def test_pdf_handles_missing_org_optional_fields():
+    org = _org(display_name=None, tax_id=None, contact_email=None, address=None)
+    data = build_invoice_pdf(
+        org,
+        2026,
+        6,
+        _billing([{"student_id": 1, "name": "王小明", "billable": True}]),
+        issued_date=date(2026, 7, 1),
+    )
+    assert data[:4] == b"%PDF"
+
+
+def test_pdf_uses_env_bank_account(monkeypatch):
+    """The remittance account on the statement comes from env config so
+    staging/prod can differ and tests never surface a real account."""
+    monkeypatch.setenv("INVOICE_BANK_ACCOUNT", "SENTINEL-ACCT")
+    # Sanity: the value the PDF will render is the env one, not a default.
+    assert get_bank_info()["account"] == "SENTINEL-ACCT"
+    data = build_invoice_pdf(
+        _org(),
+        2026,
+        6,
+        _billing([{"student_id": 1, "name": "王小明", "billable": True}]),
+        issued_date=date(2026, 7, 1),
+    )
+    assert data[:4] == b"%PDF"

--- a/backend/tests/test_institution_invoice_pdf.py
+++ b/backend/tests/test_institution_invoice_pdf.py
@@ -101,6 +101,25 @@ def test_pdf_renders_with_zero_students():
     assert data[:4] == b"%PDF"
 
 
+def test_pdf_handles_xml_special_chars_in_free_text():
+    """Regression: ReportLab Paragraph parses XML-like markup, so a literal
+    &/</> in an org name, address, or student name must be escaped or PDF
+    generation raises a parse error (500)."""
+    org = _org(
+        name="Fun & Learn <Institute>",
+        display_name="Fun & Learn <機構>",
+        address="3F, No. 5 <Building B> & Co.",
+    )
+    students = [
+        {"student_id": 1, "name": "A & B <script>", "billable": True},
+        {"student_id": 2, "name": "李 <四> & 王", "billable": False},
+    ]
+    data = build_invoice_pdf(
+        org, 2026, 6, _billing(students), issued_date=date(2026, 7, 1)
+    )
+    assert data[:4] == b"%PDF"
+
+
 def test_pdf_handles_missing_org_optional_fields():
     org = _org(display_name=None, tax_id=None, contact_email=None, address=None)
     data = build_invoice_pdf(

--- a/frontend/src/components/OrgMonthlyBillingPanel.tsx
+++ b/frontend/src/components/OrgMonthlyBillingPanel.tsx
@@ -49,6 +49,7 @@ export default function OrgMonthlyBillingPanel({
     defaultMonth ?? today.getMonth() + 1,
   );
   const [loading, setLoading] = React.useState(false);
+  const [downloading, setDownloading] = React.useState(false);
   const [result, setResult] = React.useState<MonthlyBilling | null>(null);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -74,6 +75,36 @@ export default function OrgMonthlyBillingPanel({
       toast.error(msg);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const downloadPdf = async () => {
+    setDownloading(true);
+    try {
+      const { blob, filename } =
+        await apiClient.downloadOrganizationMonthlyInvoicePdf(
+          orgId,
+          year,
+          month,
+        );
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (e) {
+      const msg =
+        e instanceof ApiError
+          ? typeof e.detail === "string"
+            ? e.detail
+            : e.message
+          : "下載 PDF 請款單失敗";
+      toast.error(msg);
+    } finally {
+      setDownloading(false);
     }
   };
 
@@ -110,6 +141,13 @@ export default function OrgMonthlyBillingPanel({
           </div>
           <Button onClick={fetchBilling} disabled={loading}>
             {loading ? "查詢中…" : "查詢"}
+          </Button>
+          <Button
+            onClick={downloadPdf}
+            disabled={downloading}
+            variant="outline"
+          >
+            {downloading ? "產生中…" : "下載 PDF 請款單"}
           </Button>
         </div>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1700,6 +1700,42 @@ class ApiClient {
     );
   }
 
+  /**
+   * Download the monthly 請款單 PDF (issue #838 Phase B). Returns the raw
+   * Blob so the caller can trigger a browser download; the filename is taken
+   * from the server's Content-Disposition when present.
+   */
+  async downloadOrganizationMonthlyInvoicePdf(
+    orgId: string,
+    year: number,
+    month: number,
+  ): Promise<{ blob: Blob; filename: string }> {
+    const currentToken = this.getToken();
+    const headers: Record<string, string> = {};
+    if (currentToken) {
+      headers["Authorization"] = `Bearer ${currentToken}`;
+    }
+    const response = await fetch(
+      `${this.baseUrl}/api/organizations/${orgId}/billing/monthly.pdf?year=${year}&month=${month}`,
+      { method: "GET", headers },
+    );
+    if (!response.ok) {
+      let detail = `下載 PDF 失敗 (${response.status})`;
+      try {
+        const body = await response.json();
+        if (body?.detail) detail = body.detail;
+      } catch {
+        // non-JSON error body; keep the default message
+      }
+      throw new ApiError(response.status, detail);
+    }
+    const blob = await response.blob();
+    const cd = response.headers.get("content-disposition") || "";
+    const match = cd.match(/filename="?([^"]+)"?/);
+    const filename = match ? match[1] : `invoice-${year}-${month}.pdf`;
+    return { blob, filename };
+  }
+
   // ===== Phase 5-2 (issue #768): group-buy plans listing =====
   async listGroupBuyPlans() {
     return this.request<


### PR DESCRIPTION
## 範圍

issue #838 **Phase B**：機構月度**請款單 PDF** 產生與下載。建立在已 merge 的 billing 資料表/查詢之上；本 PR 為呈現層，**無 migration、無 DB 寫入**。

> Phase A（CSV）依 owner 留言略過；Phase C（Email）、D（應收帳款）為後續 PR。

## Backend
- **`services/institution_invoice_pdf.py`**（新）
  - `build_invoice_pdf(org, year, month, billing)` → A4 請款單 PDF bytes。中文用 reportlab 內建 **STSong-Light CID font**（免 embed TTF，中英文皆正常）。
  - 版面：Duotopia 抬頭、機構資訊（名稱／統編／聯絡 email／地址）、請款期間、明細表（學生 ID／姓名／是否計費／單價）、**應收總額（粗體大字）**、匯款資訊、注意事項（註明非統一發票）。
  - `invoice_number()` → **deterministic** `INV-{org 前8碼}-{YYYYMM}`（同 org 同月每次一致）。
  - `get_bank_info()` → 匯款帳號由 `INVOICE_BANK_NAME/ACCOUNT/HOLDER` env 切換；**預設為明顯範例值**，測試/未設定不會顯示真實帳號。
- **`GET /api/organizations/{org_id}/billing/monthly.pdf?year=&month=`**
  - 沿用月結查詢的 `compute_monthly_billing` 與 auth（**admin 或 org_owner**）。
  - 回 `application/pdf` + `Content-Disposition: attachment; filename="{org-slug}-{YYYY}-{MM}.pdf"`。
  - 抽出 `_load_billing_org_or_error()` 共用 org 查詢＋auth，避免與 JSON 端點重複。
- `requirements.txt` 新增 `reportlab==5.0.0`。

## Frontend
- `api.ts`：`downloadOrganizationMonthlyInvoicePdf()` — 帶 auth header 的 blob 下載，讀 `Content-Disposition` 檔名。
- `OrgMonthlyBillingPanel.tsx`：新增「**下載 PDF 請款單**」按鈕。

## 驗收對照
- [x] PDF 中英文皆正常（中文字體 embed via CID font）
- [x] 請款單編號 deterministic（`test_invoice_number_format_and_determinism`）
- [x] 匯款資訊可經 env 切換、預設非真實帳號（`test_bank_info_*`）
- [x] 0 學生情境可產生（`test_pdf_renders_with_zero_students`）

## 測試
- `test_institution_invoice_pdf.py` — **8 passed**（編號 deterministic、env 帳號、含學生／0 學生／缺欄位皆產生有效 `%PDF`）。
- `test_institution_billing_endpoint.py` — 新增 4 個 PDF 端點測試（outsider 403、owner 下載、admin 下載、非機構 400）。
  > 端點測試需 casbin 權限系統（Postgres），本機 `test_client` 無法啟動 → 由 CI 驗證（與既有 billing 端點測試同路徑）。
- black / flake8 / tsc / prettier clean。

Related to #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)