### PR TITLE
fix(#335): 教師端作業提交 ownership 驗證 + assignment_id 過濾 + timezone

### DIFF
--- a/backend/routers/assignments/grading.py
+++ b/backend/routers/assignments/grading.py
@@ -102,7 +102,7 @@ async def ai_grade_assignment(
     AI 自動批改作業
     只有教師可以觸發批改
     """
-    start_time = datetime.now()
+    start_time = datetime.now(timezone.utc)
     perf = PerformanceSnapshot(f"AI_Grade_Assignment_{assignment_id}")
 
     # 1. 取得作業並驗證權限
@@ -253,7 +253,7 @@ async def ai_grade_assignment(
             perf.checkpoint("Database Update Complete")
 
         # 8. 計算處理時間
-        processing_time = (datetime.now() - start_time).total_seconds()
+        processing_time = (datetime.now(timezone.utc) - start_time).total_seconds()
         perf.finish()
 
         return AIGradingResponse(
@@ -262,7 +262,7 @@ async def ai_grade_assignment(
             overall_score=overall_score,
             feedback=feedback,
             detailed_feedback=detailed_results,
-            graded_at=datetime.now(),
+            graded_at=datetime.now(timezone.utc),
             processing_time_seconds=round(processing_time, 2),
         )
 
@@ -279,22 +279,33 @@ async def get_assignment_submissions(
     db: Session = Depends(get_db),
 ):
     """獲取作業的所有提交（教師用）"""
-    # 獲取基礎作業資訊
+    # 獲取基礎作業資訊，並驗證此作業屬於登入教師（避免跨班級枚舉）
     base_assignment = (
         db.query(StudentAssignment)
-        .filter(StudentAssignment.id == assignment_id)
+        .join(Classroom)
+        .filter(
+            and_(
+                StudentAssignment.id == assignment_id,
+                Classroom.teacher_id == current_teacher.id,
+            )
+        )
         .first()
     )
 
     if not base_assignment:
-        raise HTTPException(status_code=404, detail="Assignment not found")
+        raise HTTPException(
+            status_code=404,
+            detail="Assignment not found or you don't have permission",
+        )
 
-    # 獲取同一內容的所有學生作業
+    # 獲取「同一份作業」的所有學生提交
+    # 需同時過濾 classroom_id 與 assignment_id，否則會回傳整個班級其他作業的提交
     submissions = (
         db.query(StudentAssignment)
         .join(Student)
         .filter(
             StudentAssignment.classroom_id == base_assignment.classroom_id,
+            StudentAssignment.assignment_id == base_assignment.assignment_id,
         )
         .all()
     )

--- a/backend/routers/assignments/submission.py
+++ b/backend/routers/assignments/submission.py
@@ -176,6 +176,6 @@ async def submit_assignment(
     return {
         "success": True,
         "message": "作業提交成功" + ("（遲交）" if is_late else ""),
-        "submission_time": datetime.now().isoformat(),
+        "submission_time": datetime.now(timezone.utc).isoformat(),
         "is_late": is_late,
     }


### PR DESCRIPTION
## 背景

Issue #335（來自 PR #323 round-4 review）列了教師端作業 router 的 11 項。本 PR 只處理**兩個真 bug（含安全性）+ timezone**；其餘為程式品質項目，另行處理。

## 變更

### 🔴 Item 1（安全性 / IDOR）— `GET /teachers/assignments/{id}/submissions`
原本只用 `StudentAssignment.id == assignment_id` 查詢，**未驗證該作業屬於登入教師** → 教師可枚舉 ID 讀取其他班級的學生提交。
修法：`.join(Classroom).filter(Classroom.teacher_id == current_teacher.id)`，比照同檔 `ai_grade_assignment` 既有的權限驗證寫法；不符回 404。

### 🔴 Item 2（資料外洩 / logic bug）— 同一支查詢
submissions query 原本只用 `classroom_id` 過濾，**漏了 `assignment_id`** → 回傳整個班級**所有**作業的提交，而非指定那份。
修法：加上 `StudentAssignment.assignment_id == base_assignment.assignment_id`。

### 🟡 Item 4（timezone-naive datetime）
- `grading.py`：`start_time`、`processing_time` 相減、`graded_at` 三處 `datetime.now()` → `datetime.now(timezone.utc)`（start_time 與相減一起改，避免 naive/aware 混用）
- `submission.py`：`submission_time` 一處

## 驗證

- `py_compile` 通過；兩檔已無殘留 naive `datetime.now()`
- 已確認 `StudentAssignment.assignment_id` 欄位存在於 model
- Ownership 寫法直接沿用同檔 `ai_grade_assignment` 的既有 pattern

⚠️ **回歸測試延後**：後端測試 harness 目前在本地無法啟動（`TestClient(app)` 觸發 Casbin startup → 連 Postgres 失敗 → `RuntimeError: Failed to initialize permission system`），這正是 **#314** 的範圍。待 #314 修好 test 環境後補上跨教師 403 / 只回目標作業 的回歸測試。CI（GH Actions 有真 Postgres）會實際跑既有測試。

## #335 其餘項目狀態
- 已完成：Item 3（無 print）、7（無 mock 資料）、11（score_category 後端 resolve）
- 仍待處理（品質）：Item 5（dict→Pydantic）、6（dead code）、8、9（inline imports）、10（submit 未更新 progress）

Related to #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)