### PR TITLE
feat(#838): Phase C — Email 請款（PDF 附件 + 稽核紀錄）

### DIFF
--- a/backend/routers/organizations.py
+++ b/backend/routers/organizations.py
@@ -26,12 +26,14 @@ from models import (
     TeacherSchool,
     School,
     StudentSchool,
+    InstitutionInvoiceEmail,
 )
 from auth import verify_token, get_password_hash
 from services.casbin_service import get_casbin_service
 from services.email_service import email_service
 from services.institution_billing import compute_monthly_billing
 from services.institution_invoice_pdf import build_invoice_pdf
+from services.institution_invoice_email import send_monthly_invoice_email
 import secrets
 
 
@@ -1627,3 +1629,103 @@ async def get_monthly_billing_pdf(
         media_type="application/pdf",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
+
+
+class SendInvoiceEmailRequest(BaseModel):
+    year: int = Field(..., ge=1, le=9998, description="Calendar year (Taipei)")
+    month: int = Field(..., ge=1, le=12, description="Calendar month (1-12)")
+    cc: Optional[List[str]] = Field(default=None, description="Optional CC emails")
+
+
+@router.post("/{org_id}/billing/monthly/send-email")
+async def send_monthly_billing_email(
+    org_id: uuid.UUID,
+    body: SendInvoiceEmailRequest,
+    db: Session = Depends(get_db),
+    current_teacher: Teacher = Depends(get_current_teacher),
+):
+    """Email the monthly 請款單 (PDF attached) to the org's contact_email and
+    record an append-only audit row (issue #838 Phase C).
+
+    Auth: admin OR org_owner (same as the query/PDF endpoints). 400 if the
+    org has no contact_email set. Repeat sends accumulate audit history and
+    never delete prior rows.
+    """
+    org = _load_billing_org_or_error(org_id, current_teacher, db)
+
+    if not org.contact_email:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="此機構尚未設定聯絡 email，請先於機構設定填寫聯絡 email 後再寄送。",
+        )
+
+    try:
+        billing = compute_monthly_billing(org, body.year, body.month, db)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    try:
+        record = send_monthly_invoice_email(
+            db,
+            org,
+            body.year,
+            body.month,
+            billing,
+            org.contact_email,
+            cc=body.cc,
+            sent_by_id=current_teacher.id,
+            email_service=email_service,
+        )
+    except RuntimeError:
+        # Email transport failed — no audit row written; surface a retryable
+        # error rather than a phantom success.
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="請款 Email 發送失敗，請稍後再試。",
+        )
+
+    return {
+        "success": True,
+        "recipient": record.recipient,
+        "cc": record.cc or [],
+        "sent_at": record.sent_at.isoformat() if record.sent_at else None,
+    }
+
+
+@router.get("/{org_id}/billing/monthly/email-history")
+async def get_monthly_billing_email_history(
+    org_id: uuid.UUID,
+    year: int = Query(..., ge=1, le=9998),
+    month: int = Query(..., ge=1, le=12),
+    db: Session = Depends(get_db),
+    current_teacher: Teacher = Depends(get_current_teacher),
+):
+    """List prior 請款 email sends for (org, year, month), newest first, so
+    the UI can show the last-sent time. Same auth as the billing endpoints.
+    """
+    _load_billing_org_or_error(org_id, current_teacher, db)
+
+    rows = (
+        db.query(InstitutionInvoiceEmail)
+        .filter(
+            InstitutionInvoiceEmail.organization_id == org_id,
+            InstitutionInvoiceEmail.year == year,
+            InstitutionInvoiceEmail.month == month,
+        )
+        .order_by(InstitutionInvoiceEmail.sent_at.desc())
+        .all()
+    )
+    return {
+        "last_sent_at": (
+            rows[0].sent_at.isoformat() if rows and rows[0].sent_at else None
+        ),
+        "history": [
+            {
+                "recipient": r.recipient,
+                "cc": r.cc or [],
+                "sent_at": r.sent_at.isoformat() if r.sent_at else None,
+                "sent_by_admin_id": r.sent_by_admin_id,
+            }
+            for r in rows
+        ],
+    }

--- a/backend/routers/organizations.py
+++ b/backend/routers/organizations.py
@@ -11,7 +11,7 @@ from fastapi.responses import Response
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy import func, distinct, union, select
 from sqlalchemy.orm import Session, joinedload, selectinload, load_only
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field
 from typing import List, Optional
 from datetime import datetime
 import logging
@@ -1634,7 +1634,12 @@ async def get_monthly_billing_pdf(
 class SendInvoiceEmailRequest(BaseModel):
     year: int = Field(..., ge=1, le=9998, description="Calendar year (Taipei)")
     month: int = Field(..., ge=1, le=12, description="Calendar month (1-12)")
-    cc: Optional[List[str]] = Field(default=None, description="Optional CC emails")
+    # EmailStr (not str) so malformed addresses fail with a 422 up front and,
+    # critically, cannot inject CRLF into the raw Cc header built in
+    # email_service._build_message. Capped to avoid a fat-fingered huge list.
+    cc: Optional[List[EmailStr]] = Field(
+        default=None, max_length=50, description="Optional CC emails"
+    )
 
 
 @router.post("/{org_id}/billing/monthly/send-email")

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -4,9 +4,11 @@ import os
 import secrets
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import List, Optional, Tuple
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+from email.mime.base import MIMEBase
+from email import encoders
 import smtplib
 
 from sqlalchemy.orm import Session
@@ -29,26 +31,74 @@ class EmailService:
         self.from_name = os.getenv("FROM_NAME", "Duotopia")
         self.frontend_url = os.getenv("FRONTEND_URL", "http://localhost:5173")
 
-    def send_email(self, to_email: str, subject: str, html_content: str) -> bool:
+    def _build_message(
+        self,
+        to_email: str,
+        subject: str,
+        html_content: str,
+        cc: Optional[List[str]] = None,
+        attachments: Optional[List[Tuple[str, bytes, str]]] = None,
+    ) -> MIMEMultipart:
+        """Assemble the MIME message (pure — no SMTP). Split out so the
+        attachment/cc wiring is unit-testable without a live SMTP server.
+
+        ``attachments`` is a list of (filename, content_bytes, mime_subtype)
+        where mime_subtype is e.g. "pdf" (→ application/pdf).
         """
-        發送通用 HTML 郵件
+        html_part = MIMEText(html_content, "html", "utf-8")
+        if attachments:
+            # "mixed" wrapper carries the html body (as an "alternative"
+            # sub-part) plus the binary attachment parts.
+            msg = MIMEMultipart("mixed")
+            alt = MIMEMultipart("alternative")
+            alt.attach(html_part)
+            msg.attach(alt)
+            for filename, content, subtype in attachments:
+                part = MIMEBase("application", subtype)
+                part.set_payload(content)
+                encoders.encode_base64(part)
+                part.add_header(
+                    "Content-Disposition",
+                    f'attachment; filename="{filename}"',
+                )
+                msg.attach(part)
+        else:
+            msg = MIMEMultipart("alternative")
+            msg.attach(html_part)
+
+        msg["Subject"] = subject
+        msg["From"] = f"{self.from_name} <{self.from_email}>"
+        msg["To"] = to_email
+        if cc:
+            msg["Cc"] = ", ".join(cc)
+        return msg
+
+    def send_email(
+        self,
+        to_email: str,
+        subject: str,
+        html_content: str,
+        cc: Optional[List[str]] = None,
+        attachments: Optional[List[Tuple[str, bytes, str]]] = None,
+    ) -> bool:
+        """
+        發送通用 HTML 郵件（支援 CC 與附件）
 
         Args:
             to_email: 收件者 email
             subject: 郵件主旨
             html_content: HTML 格式的郵件內容
+            cc: 副本收件者 email 清單（可選）
+            attachments: (檔名, 內容 bytes, MIME subtype) 清單（可選），
+                例如 [("invoice.pdf", pdf_bytes, "pdf")]
 
         Returns:
             bool: 是否發送成功
         """
         try:
-            msg = MIMEMultipart("alternative")
-            msg["Subject"] = subject
-            msg["From"] = f"{self.from_name} <{self.from_email}>"
-            msg["To"] = to_email
-
-            html_part = MIMEText(html_content, "html", "utf-8")
-            msg.attach(html_part)
+            msg = self._build_message(
+                to_email, subject, html_content, cc=cc, attachments=attachments
+            )
 
             # 如果 SMTP 未設定，只記錄日誌（開發模式）
             if not self.smtp_user or not self.smtp_password:
@@ -60,6 +110,7 @@ class EmailService:
             with smtplib.SMTP(self.smtp_host, self.smtp_port) as server:
                 server.starttls()
                 server.login(self.smtp_user, self.smtp_password)
+                # send_message derives recipients from To/Cc headers.
                 server.send_message(msg)
 
             logger.info(f"Email sent successfully to {to_email}")

--- a/backend/services/institution_invoice_email.py
+++ b/backend/services/institution_invoice_email.py
@@ -1,0 +1,101 @@
+"""Institution monthly invoice email (issue #838 Phase C).
+
+Sends the monthly 請款單 to an institution's contact email with the Phase B
+PDF attached, and records an append-only audit row in
+``institution_invoice_emails``. Reuses the read-only billing figures and the
+PDF builder; the only DB write is the audit row.
+"""
+
+import html as _html
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+from models import InstitutionInvoiceEmail
+from services.institution_invoice_pdf import build_invoice_pdf, invoice_number
+
+
+def build_subject(org, year: int, month: int) -> str:
+    name = org.display_name or org.name or "機構"
+    return f"[Duotopia] {name} {year} 年 {month:02d} 月請款單"
+
+
+def build_email_html(org, year: int, month: int, billing: dict) -> str:
+    """Plain, self-contained HTML body: 機構名 / 期間 / 金額 / 付款方式 /
+    客服窗口. Org name is HTML-escaped (user-sourced free text)."""
+    name = _html.escape(org.display_name or org.name or "機構")
+    currency = billing.get("currency", "TWD")
+    total = billing.get("total_amount", 0)
+    count = billing.get("billable_student_count", 0)
+    inv_no = invoice_number(org.id, year, month)
+    support = "support@duotopia.com"
+    return f"""\
+<div style="font-family: sans-serif; font-size: 14px; color: #222; line-height: 1.6;">
+  <p>{name} 您好，</p>
+  <p>附件為貴機構 <b>{year} 年 {month:02d} 月</b>的請款單（請款單編號
+     <b>{inv_no}</b>），敬請查收。</p>
+  <table style="border-collapse: collapse; margin: 12px 0;">
+    <tr><td style="padding: 4px 12px; color:#666;">請款期間</td>
+        <td style="padding: 4px 12px;"><b>{year} 年 {month:02d} 月</b></td></tr>
+    <tr><td style="padding: 4px 12px; color:#666;">計費人數</td>
+        <td style="padding: 4px 12px;">{count} 位</td></tr>
+    <tr><td style="padding: 4px 12px; color:#666;">應收總額</td>
+        <td style="padding: 4px 12px; font-size:16px; color:#1a56db;">
+          <b>{currency} {total:,}</b></td></tr>
+  </table>
+  <p>付款方式：請參閱附件請款單所載匯款資訊，並於備註填寫請款單編號以利對帳。</p>
+  <p>如有任何問題，歡迎聯繫客服窗口：<a href="mailto:{support}">{support}</a>。</p>
+  <p style="color:#888; font-size:12px;">
+    本請款單為 Duotopia 內部請款憑證，非統一發票。</p>
+</div>"""
+
+
+def send_monthly_invoice_email(
+    db: Session,
+    org,
+    year: int,
+    month: int,
+    billing: dict,
+    recipient: str,
+    *,
+    cc: list | None,
+    sent_by_id: int | None,
+    email_service,
+    issued_date: date | None = None,
+) -> InstitutionInvoiceEmail:
+    """Render the PDF, email it to ``recipient`` (with optional cc), and
+    append an audit row. Raises RuntimeError if the email send fails so the
+    caller does not record a phantom "sent" row.
+
+    ``email_service`` is injected so the endpoint passes the shared singleton
+    and tests pass a mock.
+    """
+    pdf_bytes = build_invoice_pdf(org, year, month, billing, issued_date=issued_date)
+    inv_no = invoice_number(org.id, year, month)
+    subject = build_subject(org, year, month)
+    html_body = build_email_html(org, year, month, billing)
+    filename = f"{inv_no}.pdf"
+
+    ok = email_service.send_email(
+        recipient,
+        subject,
+        html_body,
+        cc=cc or None,
+        attachments=[(filename, pdf_bytes, "pdf")],
+    )
+    if not ok:
+        raise RuntimeError("email_send_failed")
+
+    # Append-only audit row (no unique key — repeat sends accumulate history).
+    record = InstitutionInvoiceEmail(
+        organization_id=org.id,
+        year=year,
+        month=month,
+        recipient=recipient,
+        cc=cc or None,
+        sent_by_admin_id=sent_by_id,
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record

--- a/backend/tests/test_institution_billing_endpoint.py
+++ b/backend/tests/test_institution_billing_endpoint.py
@@ -10,6 +10,7 @@ import pytest
 
 from auth import create_access_token, get_password_hash
 from models import (
+    InstitutionInvoiceEmail,
     Organization,
     School,
     Student,
@@ -332,3 +333,71 @@ def test_pdf_400_when_org_is_not_institution(test_client, admin, shared_test_ses
         headers=_bearer(admin.id),
     )
     assert r.status_code == 400
+
+
+# ---------- send-email endpoint (issue #838 Phase C) ----------
+
+
+def test_send_email_400_when_no_contact_email(
+    test_client, admin, institution_org_with_one_active_student
+):
+    """The fixture org has no contact_email → 400 with a 'set email' hint."""
+    org, _, _ = institution_org_with_one_active_student
+    r = test_client.post(
+        f"/api/organizations/{org.id}/billing/monthly/send-email",
+        json={"year": 2026, "month": 6},
+        headers=_bearer(admin.id),
+    )
+    assert r.status_code == 400
+    assert "email" in r.json()["detail"].lower() or "聯絡" in r.json()["detail"]
+
+
+def test_send_email_outsider_gets_403(
+    test_client, outsider, institution_org_with_one_active_student
+):
+    org, _, _ = institution_org_with_one_active_student
+    r = test_client.post(
+        f"/api/organizations/{org.id}/billing/monthly/send-email",
+        json={"year": 2026, "month": 6},
+        headers=_bearer(outsider.id),
+    )
+    assert r.status_code == 403
+
+
+def test_send_email_success_writes_audit_and_history(
+    test_client, admin, shared_test_session, institution_org_with_one_active_student
+):
+    org, _, _ = institution_org_with_one_active_student
+    org.contact_email = "finance@acme.example"
+    shared_test_session.commit()
+
+    r = test_client.post(
+        f"/api/organizations/{org.id}/billing/monthly/send-email",
+        json={"year": 2026, "month": 6, "cc": ["cc@acme.example"]},
+        headers=_bearer(admin.id),
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["success"] is True
+    assert body["recipient"] == "finance@acme.example"
+    assert body["cc"] == ["cc@acme.example"]
+    assert body["sent_at"]
+
+    rows = (
+        shared_test_session.query(InstitutionInvoiceEmail)
+        .filter(InstitutionInvoiceEmail.organization_id == org.id)
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].recipient == "finance@acme.example"
+
+    # History endpoint surfaces the last-sent time.
+    h = test_client.get(
+        f"/api/organizations/{org.id}/billing/monthly/email-history"
+        "?year=2026&month=6",
+        headers=_bearer(admin.id),
+    )
+    assert h.status_code == 200
+    hist = h.json()
+    assert hist["last_sent_at"]
+    assert len(hist["history"]) == 1

--- a/backend/tests/test_institution_billing_endpoint.py
+++ b/backend/tests/test_institution_billing_endpoint.py
@@ -401,3 +401,18 @@ def test_send_email_success_writes_audit_and_history(
     hist = h.json()
     assert hist["last_sent_at"]
     assert len(hist["history"]) == 1
+
+
+def test_send_email_422_on_malformed_cc(
+    test_client, admin, institution_org_with_one_active_student
+):
+    """cc is EmailStr-validated → a malformed address is rejected at the
+    request boundary (422), never reaching the raw Cc header."""
+    org, _, _ = institution_org_with_one_active_student
+    org.contact_email = "finance@acme.example"
+    r = test_client.post(
+        f"/api/organizations/{org.id}/billing/monthly/send-email",
+        json={"year": 2026, "month": 6, "cc": ["not-an-email"]},
+        headers=_bearer(admin.id),
+    )
+    assert r.status_code == 422

--- a/backend/tests/test_institution_invoice_email.py
+++ b/backend/tests/test_institution_invoice_email.py
@@ -1,0 +1,179 @@
+"""Tests for services.institution_invoice_email + email attachment wiring
+(issue #838 Phase C).
+
+Service-layer only (no endpoint / permission system): subject/HTML shape,
+the MIME attachment assembly, and that a send writes an append-only audit
+row (and that a transport failure writes none). Endpoint auth/400 paths are
+covered by test_institution_billing_endpoint.py (CI).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from models import InstitutionInvoiceEmail, Organization
+from services.email_service import EmailService
+from services.institution_invoice_email import (
+    build_email_html,
+    build_subject,
+    send_monthly_invoice_email,
+)
+
+
+def _billing(total=200, count=2, per=100, currency="TWD"):
+    return {
+        "per_student_price": per,
+        "billable_student_count": count,
+        "total_amount": total,
+        "currency": currency,
+        "students": [{"student_id": 1, "name": "王小明", "billable": True}],
+    }
+
+
+def _make_org(db, **over):
+    base = dict(
+        name="Acme",
+        org_type="institution",
+        per_student_price=100,
+        contact_email="finance@acme.example",
+        is_active=True,
+    )
+    base.update(over)
+    org = Organization(**base)
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    return org
+
+
+# ---------- subject / html ----------
+
+
+def test_build_subject_format():
+    org = SimpleNamespace(id="a6101f83-0000", name="Acme", display_name="Acme 機構")
+    assert build_subject(org, 2026, 6) == "[Duotopia] Acme 機構 2026 年 06 月請款單"
+
+
+def test_build_email_html_contains_key_fields_and_escapes_name():
+    org = SimpleNamespace(
+        id="a6101f83-0000", name="Acme", display_name="Acme <機構> & Co"
+    )
+    html = build_email_html(org, 2026, 6, _billing(total=300, count=3))
+    assert "2026 年 06 月" in html
+    assert "TWD 300" in html
+    assert "support@duotopia.com" in html
+    # user-sourced name is HTML-escaped
+    assert "&lt;機構&gt;" in html
+    assert "&amp; Co" in html
+
+
+# ---------- MIME attachment wiring ----------
+
+
+def test_email_service_build_message_carries_attachment_and_cc():
+    svc = EmailService()
+    msg = svc._build_message(
+        "to@x.com",
+        "subj",
+        "<p>hi</p>",
+        cc=["c1@x.com", "c2@x.com"],
+        attachments=[("invoice.pdf", b"%PDF-1.4 fake", "pdf")],
+    )
+    assert msg["Cc"] == "c1@x.com, c2@x.com"
+    assert msg.get_content_subtype() == "mixed"
+    filenames = [p.get_filename() for p in msg.walk() if p.get_filename()]
+    assert "invoice.pdf" in filenames
+
+
+def test_email_service_build_message_no_attachment_is_alternative():
+    svc = EmailService()
+    msg = svc._build_message("to@x.com", "s", "<p>hi</p>")
+    assert msg.get_content_subtype() == "alternative"
+
+
+# ---------- send_monthly_invoice_email (audit trail) ----------
+
+
+def test_send_writes_audit_row_and_attaches_pdf(shared_test_session):
+    org = _make_org(shared_test_session)
+    mock_svc = Mock()
+    mock_svc.send_email.return_value = True
+
+    rec = send_monthly_invoice_email(
+        shared_test_session,
+        org,
+        2026,
+        6,
+        _billing(),
+        org.contact_email,
+        cc=["cc@x.com"],
+        sent_by_id=None,
+        email_service=mock_svc,
+    )
+
+    assert rec.id is not None
+    assert rec.recipient == "finance@acme.example"
+    assert rec.cc == ["cc@x.com"]
+    assert rec.sent_at is not None
+
+    # A real PDF was attached (application/pdf) with a .pdf filename.
+    kwargs = mock_svc.send_email.call_args.kwargs
+    fname, content, subtype = kwargs["attachments"][0]
+    assert fname.endswith(".pdf")
+    assert subtype == "pdf"
+    assert content[:4] == b"%PDF"
+
+
+def test_repeat_send_appends_history(shared_test_session):
+    org = _make_org(shared_test_session, contact_email="repeat@acme.example")
+    mock_svc = Mock()
+    mock_svc.send_email.return_value = True
+    for _ in range(3):
+        send_monthly_invoice_email(
+            shared_test_session,
+            org,
+            2026,
+            6,
+            _billing(),
+            org.contact_email,
+            cc=None,
+            sent_by_id=None,
+            email_service=mock_svc,
+        )
+    count = (
+        shared_test_session.query(InstitutionInvoiceEmail)
+        .filter(
+            InstitutionInvoiceEmail.organization_id == org.id,
+            InstitutionInvoiceEmail.year == 2026,
+            InstitutionInvoiceEmail.month == 6,
+        )
+        .count()
+    )
+    assert count == 3
+
+
+def test_send_failure_writes_no_audit_row(shared_test_session):
+    org = _make_org(shared_test_session, contact_email="fail@acme.example")
+    mock_svc = Mock()
+    mock_svc.send_email.return_value = False  # transport failure
+
+    with pytest.raises(RuntimeError):
+        send_monthly_invoice_email(
+            shared_test_session,
+            org,
+            2026,
+            6,
+            _billing(),
+            org.contact_email,
+            cc=None,
+            sent_by_id=None,
+            email_service=mock_svc,
+        )
+
+    count = (
+        shared_test_session.query(InstitutionInvoiceEmail)
+        .filter(InstitutionInvoiceEmail.organization_id == org.id)
+        .count()
+    )
+    assert count == 0

--- a/frontend/src/components/OrgMonthlyBillingPanel.tsx
+++ b/frontend/src/components/OrgMonthlyBillingPanel.tsx
@@ -50,6 +50,8 @@ export default function OrgMonthlyBillingPanel({
   );
   const [loading, setLoading] = React.useState(false);
   const [downloading, setDownloading] = React.useState(false);
+  const [sendingEmail, setSendingEmail] = React.useState(false);
+  const [lastSentAt, setLastSentAt] = React.useState<string | null>(null);
   const [result, setResult] = React.useState<MonthlyBilling | null>(null);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -63,6 +65,17 @@ export default function OrgMonthlyBillingPanel({
         month,
       );
       setResult(data);
+      // Surface the last time a 請款 email was sent for this period.
+      try {
+        const hist = await apiClient.getMonthlyInvoiceEmailHistory(
+          orgId,
+          year,
+          month,
+        );
+        setLastSentAt(hist.last_sent_at);
+      } catch {
+        setLastSentAt(null);
+      }
     } catch (e) {
       const msg =
         e instanceof ApiError
@@ -108,6 +121,32 @@ export default function OrgMonthlyBillingPanel({
     }
   };
 
+  const sendEmail = async () => {
+    const confirmed = window.confirm(
+      `確定要將 ${year} 年 ${month} 月的請款單 Email 寄送給機構聯絡人嗎？` +
+        (lastSentAt
+          ? `\n\n（上次寄送時間：${new Date(lastSentAt).toLocaleString()}）`
+          : ""),
+    );
+    if (!confirmed) return;
+    setSendingEmail(true);
+    try {
+      const res = await apiClient.sendMonthlyInvoiceEmail(orgId, year, month);
+      setLastSentAt(res.sent_at);
+      toast.success(`已寄送請款 Email 至 ${res.recipient}`);
+    } catch (e) {
+      const msg =
+        e instanceof ApiError
+          ? typeof e.detail === "string"
+            ? e.detail
+            : e.message
+          : "寄送請款 Email 失敗";
+      toast.error(msg);
+    } finally {
+      setSendingEmail(false);
+    }
+  };
+
   return (
     <Card className="w-full max-w-3xl">
       <CardHeader>
@@ -149,7 +188,16 @@ export default function OrgMonthlyBillingPanel({
           >
             {downloading ? "產生中…" : "下載 PDF 請款單"}
           </Button>
+          <Button onClick={sendEmail} disabled={sendingEmail} variant="outline">
+            {sendingEmail ? "寄送中…" : "寄送請款 Email"}
+          </Button>
         </div>
+
+        {lastSentAt && (
+          <div className="text-xs text-gray-500">
+            上次寄送請款 Email：{new Date(lastSentAt).toLocaleString()}
+          </div>
+        )}
 
         {error && (
           <div className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">

--- a/frontend/src/components/OrgMonthlyBillingPanel.tsx
+++ b/frontend/src/components/OrgMonthlyBillingPanel.tsx
@@ -73,7 +73,9 @@ export default function OrgMonthlyBillingPanel({
           month,
         );
         setLastSentAt(hist.last_sent_at);
-      } catch {
+      } catch (histErr) {
+        // Informational-only; a transient failure shouldn't block the query.
+        console.warn("Failed to load invoice email history", histErr);
         setLastSentAt(null);
       }
     } catch (e) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1736,6 +1736,46 @@ class ApiClient {
     return { blob, filename };
   }
 
+  /** Email the monthly 請款單 (PDF attached) to the org's contact email
+   * and record an audit row (issue #838 Phase C). */
+  async sendMonthlyInvoiceEmail(
+    orgId: string,
+    year: number,
+    month: number,
+    cc?: string[],
+  ) {
+    return this.request<{
+      success: boolean;
+      recipient: string;
+      cc: string[];
+      sent_at: string | null;
+    }>(`/api/organizations/${orgId}/billing/monthly/send-email`, {
+      method: "POST",
+      body: JSON.stringify({ year, month, cc: cc ?? null }),
+    });
+  }
+
+  /** Prior 請款 email sends for (org, year, month), newest first, so the UI
+   * can show the last-sent time. */
+  async getMonthlyInvoiceEmailHistory(
+    orgId: string,
+    year: number,
+    month: number,
+  ) {
+    return this.request<{
+      last_sent_at: string | null;
+      history: Array<{
+        recipient: string;
+        cc: string[];
+        sent_at: string | null;
+        sent_by_admin_id: number | null;
+      }>;
+    }>(
+      `/api/organizations/${orgId}/billing/monthly/email-history?year=${year}&month=${month}`,
+      { method: "GET" },
+    );
+  }
+
   // ===== Phase 5-2 (issue #768): group-buy plans listing =====
   async listGroupBuyPlans() {
     return this.request<


### PR DESCRIPTION
## 範圍

issue #838 **Phase C**：admin/org_owner 一鍵把機構月度**請款單 Email** 給機構聯絡人，附上 Phase B 的 PDF，並記錄寄送稽核。用到的 `institution_invoice_emails` 表已於 #886 建立。**無 migration。**

## Backend
- **`email_service.send_email` 擴充 `cc` + `attachments`**
  - 抽出可測的 `_build_message()`；有附件時用 `multipart/mixed` 包 `alternative`（HTML body）+ `MIMEBase` base64 附件。
  - 維持既有 3-arg 呼叫相容（其餘 email 通知不受影響）。
- **`services/institution_invoice_email.py`**（新）
  - `build_subject` → `[Duotopia] {display_name} {YYYY} 年 {MM} 月請款單`
  - `build_email_html` → 機構名／期間／金額／付款方式／客服窗口（機構名 HTML-escape）
  - `send_monthly_invoice_email` → 產 PDF → 寄信（PDF 附件）→ 寫 `institution_invoice_emails` 稽核列；**寄送失敗丟 RuntimeError，不寫 phantom 紀錄**。
- **`POST /api/organizations/{id}/billing/monthly/send-email`**（body `{year, month, cc?}`）
  - 沿用 admin/org_owner auth；`contact_email` 為空 → **400** 並提示先設定聯絡 email；寄送失敗 → 502。
- **`GET .../monthly/email-history?year=&month=`** → `last_sent_at` + 歷史清單（給前端顯示上次寄送時間）。

## Frontend
- `api.ts`：`sendMonthlyInvoiceEmail` / `getMonthlyInvoiceEmailHistory`。
- `OrgMonthlyBillingPanel`：新增「**寄送請款 Email**」按鈕（`window.confirm` 確認框）+ 查詢時載入 email-history 顯示「上次寄送請款 Email：…」。

## 驗收對照
- [x] PDF 以附件寄出、可正常開啟（`test_send_writes_audit_row_and_attaches_pdf` 驗附件為 `%PDF`/`application/pdf`）
- [x] 重複寄送累加歷史、不刪除（`test_repeat_send_appends_history`）
- [x] `contact_email` 為 NULL → 400 + 提示（`test_send_email_400_when_no_contact_email`）
- [x] 確認框 + 顯示上次寄送時間（前端）

## 測試
- `test_institution_invoice_email.py` — **7 passed**（subject/html + escape、附件 MIME/cc、寫稽核、重複累加、寄送失敗不寫紀錄）。
- `test_institution_billing_endpoint.py` — 新增 3 個端點測試（無 email 400、outsider 403、成功寫稽核 + history）→ CI 驗證（需 casbin/Postgres）。
- black / flake8 / tsc / prettier clean。

Related to #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)