### PR TITLE
refactor(#331,#332,#337): 共用 AssignmentData 型別 + 狀態白名單 + useCallback

### DIFF
--- a/frontend/src/pages/student/StudentAssignmentDetail.tsx
+++ b/frontend/src/pages/student/StudentAssignmentDetail.tsx
@@ -24,6 +24,7 @@ import {
   StudentAssignment,
   StudentContentProgress,
   AssignmentStatusEnum,
+  AssignmentData,
 } from "@/types";
 import { useTranslation } from "react-i18next";
 
@@ -63,21 +64,6 @@ export default function StudentAssignmentDetail() {
         throw new Error(`HTTP error! status: ${assignmentsResponse.status}`);
       }
 
-      interface AssignmentData {
-        id: number;
-        assignment_id?: number;
-        student_number: number;
-        classroom_id: number;
-        title: string;
-        status?: string;
-        score?: number;
-        feedback?: string;
-        is_active?: boolean;
-        assigned_at?: string;
-        created_at?: string;
-        due_date?: string;
-        submitted_at?: string;
-      }
       const assignments = await assignmentsResponse.json();
       const foundAssignment = assignments.find(
         (a: AssignmentData) => a.id === parseInt(id!),

--- a/frontend/src/pages/student/StudentAssignmentList.tsx
+++ b/frontend/src/pages/student/StudentAssignmentList.tsx
@@ -25,7 +25,11 @@ import {
   ArrowUpDown,
   Filter,
 } from "lucide-react";
-import { StudentAssignmentCard, AssignmentStatusEnum } from "@/types";
+import {
+  StudentAssignmentCard,
+  AssignmentStatusEnum,
+  AssignmentData,
+} from "@/types";
 import { useTranslation } from "react-i18next";
 import {
   practiceModeIcon,
@@ -42,6 +46,18 @@ const SCORE_CATEGORY_COLORS: Record<string, string> = {
   writing: "bg-blue-100 text-blue-700 border-blue-200",
   reading: "bg-pink-100 text-pink-700 border-pink-200",
 };
+
+// Issue #332: statuses for which the assignment action button stays enabled.
+// Whitelist instead of a negated AND chain, so a newly-added status doesn't
+// silently disable the button.
+const ACTIONABLE_STATUSES = new Set<string>([
+  "NOT_STARTED",
+  "IN_PROGRESS",
+  "SUBMITTED",
+  "GRADED",
+  "RETURNED",
+  "RESUBMITTED",
+]);
 
 export default function StudentAssignmentList() {
   const { t } = useTranslation();
@@ -104,25 +120,6 @@ export default function StudentAssignmentList() {
         }
 
         const data = await response.json();
-
-        interface AssignmentData {
-          id: number;
-          title: string;
-          status?: string;
-          due_date?: string;
-          assigned_at?: string;
-          submitted_at?: string;
-          score?: number;
-          feedback?: string;
-          classroom_id: number;
-          content_type?: string;
-          practice_mode?: string;
-          score_category?: string;
-          content_count?: number;
-          is_live_quiz?: boolean;
-          quiz_opened_at?: string | null;
-          quiz_closed_at?: string | null;
-        }
 
         const assignmentCards: StudentAssignmentCard[] = data.map(
           (a: AssignmentData) => ({
@@ -363,13 +360,7 @@ export default function StudentAssignmentList() {
     return (
       <Button
         onClick={() => handleStartAssignment(assignment.id)}
-        disabled={
-          !canStart &&
-          assignment.status !== "GRADED" &&
-          assignment.status !== "SUBMITTED" &&
-          assignment.status !== "RETURNED" &&
-          assignment.status !== "RESUBMITTED"
-        }
+        disabled={!ACTIONABLE_STATUSES.has(assignment.status)}
         size="sm"
         className={`crayon-texture text-xs sm:text-sm font-medium ${
           canStart || assignment.status === "RETURNED"

--- a/frontend/src/pages/teacher/TeacherSubscription.tsx
+++ b/frontend/src/pages/teacher/TeacherSubscription.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { PLAN_NAMES } from "@/constants/plans";
@@ -260,27 +260,7 @@ export default function TeacherSubscription() {
 
   const currentPlanId = getCurrentPlanId();
 
-  useEffect(() => {
-    fetchSubscriptionData();
-
-    const handleSubscriptionChanged = () => {
-      fetchSubscriptionData();
-    };
-
-    window.addEventListener(
-      "subscriptionStatusChanged",
-      handleSubscriptionChanged,
-    );
-
-    return () => {
-      window.removeEventListener(
-        "subscriptionStatusChanged",
-        handleSubscriptionChanged,
-      );
-    };
-  }, []);
-
-  const fetchSubscriptionData = async () => {
+  const fetchSubscriptionData = useCallback(async () => {
     try {
       setLoading(true);
 
@@ -321,7 +301,27 @@ export default function TeacherSubscription() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [t]);
+
+  useEffect(() => {
+    fetchSubscriptionData();
+
+    const handleSubscriptionChanged = () => {
+      fetchSubscriptionData();
+    };
+
+    window.addEventListener(
+      "subscriptionStatusChanged",
+      handleSubscriptionChanged,
+    );
+
+    return () => {
+      window.removeEventListener(
+        "subscriptionStatusChanged",
+        handleSubscriptionChanged,
+      );
+    };
+  }, [fetchSubscriptionData]);
 
   const fetchAnalytics = async () => {
     try {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -254,6 +254,32 @@ export interface StudentAssignmentCard {
   quiz_closed_at?: string | null;
 }
 
+// Raw assignment row as returned by the student assignments API.
+// Shared by StudentAssignmentList and StudentAssignmentDetail (Issue #331).
+// Superset of both call sites — fields that only one page uses are optional.
+export interface AssignmentData {
+  id: number;
+  assignment_id?: number;
+  title: string;
+  status?: string;
+  score?: number;
+  feedback?: string;
+  classroom_id: number;
+  student_number?: number;
+  is_active?: boolean;
+  assigned_at?: string;
+  created_at?: string;
+  due_date?: string;
+  submitted_at?: string;
+  content_type?: string;
+  practice_mode?: string;
+  score_category?: string;
+  content_count?: number;
+  is_live_quiz?: boolean;
+  quiz_opened_at?: string | null;
+  quiz_closed_at?: string | null;
+}
+
 // Student Dashboard specific data
 export interface StudentDashboard {
   active_assignments: StudentAssignmentCard[];


### PR DESCRIPTION
## 背景

三個來自 PR #323/#322 review 的低風險前端清理，合併為一個 PR。

## 變更

### #331 — `AssignmentData` 移到共用 types
原本這個 interface 分別**定義在兩個檔案的 function body 內**（`StudentAssignmentList.tsx`、`StudentAssignmentDetail.tsx`，內容還略有差異）。改為在 `types/index.ts` export 單一 `AssignmentData`（兩份的 superset，各頁專屬欄位設為 optional），兩處改用 import。

### #332 — 作業按鈕 disabled 改白名單
原本用 negated AND chain（`!canStart && status !== "GRADED" && ...`），新增狀態時會 silently 讓按鈕失效。改為：
```ts
const ACTIONABLE_STATUSES = new Set(["NOT_STARTED","IN_PROGRESS","SUBMITTED","GRADED","RETURNED","RESUBMITTED"]);
disabled={!ACTIONABLE_STATUSES.has(assignment.status)}
```
邏輯等價（白名單 = 原本 canStart ∪ 四個 status），且與專案既有 pattern（`StudentStatusPanel` 的 `RETURNABLE_STATUSES`）一致。

### #337 — `fetchSubscriptionData` 包 useCallback
原本在空 deps `[]` 的 useEffect 內呼叫、未列入 deps，觸發 `react-hooks/exhaustive-deps`。改為 `useCallback(async () => {...}, [t])`（其餘相依 `apiClient`/`toast` 為 module import、setter 皆穩定），並把定義移到 useEffect 之前（避免 const TDZ），deps 補上 `fetchSubscriptionData`。

## 驗證（本地）

- ✅ `tsc --noEmit` 無錯
- ✅ eslint 改動的 4 個檔案乾淨（`TeacherSubscription.tsx` 的 exhaustive-deps 已消除）；`StudentAssignmentDetail.tsx` 殘留的 `loadAssignmentDetail` warning 為 **pre-existing 且與本次無關**（不在我的 diff 內）
- ✅ `prettier --check` 通過
- ✅ `vite build` 成功

Related to #331, #332, #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)