### PR TITLE
feat(#838): Phase D — 機構應收帳款管理 + 逾期 cron

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -39,6 +39,7 @@ from routers import (
     admin_billing,
     admin_audio_errors,
     admin_promo_codes,
+    institution_invoices,
     teacher_review,
     subscription,
     payment,
@@ -284,6 +285,9 @@ app.include_router(admin_monitoring.router)  # 監控路由（無需認證）
 app.include_router(admin_billing.router)  # Admin 帳單監控路由（Admin only）
 app.include_router(admin_audio_errors.router)  # Admin 錄音錯誤監控路由（Admin only）
 app.include_router(admin_promo_codes.router)  # Admin 推銷碼管理路由（Admin only）
+app.include_router(
+    institution_invoices.router
+)  # Admin 機構應收帳款路由（Admin only, issue #838 Phase D）
 app.include_router(blog.router)  # Blog 管理路由（Admin only）
 app.include_router(cron.router)  # Cron Job 路由
 app.include_router(debug.router)  # Debug 路由

--- a/backend/routers/cron.py
+++ b/backend/routers/cron.py
@@ -25,6 +25,7 @@ from models import (
 from services.email_service import email_service
 from services.tappay_service import TapPayService
 from services.group_buy import grant_monthly_for_group_buy
+from services.institution_invoice_ledger import mark_overdue_invoices
 from google.cloud import bigquery
 
 router = APIRouter(prefix="/api/cron", tags=["cron"])
@@ -1269,6 +1270,36 @@ async def expire_credit_packages_cron(
     except Exception as e:
         db.rollback()
         logger.error(f"Credit package expiry cron failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Cron job failed: {str(e)}")
+
+
+@router.post("/billing-overdue-check")
+async def billing_overdue_check_cron(
+    x_cron_secret: str = Header(None),
+    db: Session = Depends(get_db),
+):
+    """機構應收帳款逾期掃描（issue #838 Phase D）。
+
+    執行時間：每日一次（由 Cloud Scheduler 觸發，建議 09:00 Asia/Taipei）。
+    功能：把所有 status='pending' 且 due_date < 今日（Taipei）的
+    institution_invoices 標記為 'overdue'。冪等 — 同日重跑不會重複處理。
+
+    安全性：需帶正確的 X-Cron-Secret header。
+    """
+    if x_cron_secret != CRON_SECRET:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    try:
+        updated = mark_overdue_invoices(db)
+        logger.info(f"Billing overdue check: marked {updated} invoice(s) overdue")
+        return {
+            "success": True,
+            "marked_overdue": updated,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Billing overdue check cron failed: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Cron job failed: {str(e)}")
 
 

--- a/backend/routers/institution_invoices.py
+++ b/backend/routers/institution_invoices.py
@@ -27,7 +27,10 @@ router = APIRouter(prefix="/api/admin", tags=["admin-institution-invoices"])
 
 class CreateInvoiceRequest(BaseModel):
     organization_id: uuid.UUID
-    year: int = Field(..., ge=1, le=9998)
+    # Bounds match the institution_invoices.year DB CHECK (2000..2099) so an
+    # out-of-range year is a clean 422 up front rather than an IntegrityError
+    # → 500 when upsert_invoice INSERTs.
+    year: int = Field(..., ge=2000, le=2099)
     month: int = Field(..., ge=1, le=12)
 
 
@@ -112,7 +115,7 @@ async def list_institution_invoices(
         default=None, alias="status", description="pending/paid/overdue/cancelled"
     ),
     overdue: Optional[bool] = Query(default=None),
-    year: Optional[int] = Query(default=None, ge=1, le=9998),
+    year: Optional[int] = Query(default=None, ge=2000, le=2099),
     month: Optional[int] = Query(default=None, ge=1, le=12),
     organization_id: Optional[uuid.UUID] = Query(default=None),
     db: Session = Depends(get_db),
@@ -158,8 +161,15 @@ async def update_institution_invoice(
 ):
     """Mark an invoice paid / cancelled (records admin id + timestamp for
     'paid'). 'pending'/'overdue' are system-managed and rejected with 400."""
+    # Row-lock the invoice for the read-modify-write so two concurrent PATCHes
+    # (e.g. one marking paid, one cancelled) serialise instead of last-write-
+    # wins silently dropping an admin's action. No-op on SQLite (tests);
+    # SELECT ... FOR UPDATE on Postgres.
     invoice = (
-        db.query(InstitutionInvoice).filter(InstitutionInvoice.id == invoice_id).first()
+        db.query(InstitutionInvoice)
+        .filter(InstitutionInvoice.id == invoice_id)
+        .with_for_update()
+        .first()
     )
     if invoice is None:
         raise HTTPException(

--- a/backend/routers/institution_invoices.py
+++ b/backend/routers/institution_invoices.py
@@ -122,10 +122,12 @@ async def list_institution_invoices(
     q = db.query(InstitutionInvoice, Organization).join(
         Organization, Organization.id == InstitutionInvoice.organization_id
     )
-    if status_filter:
-        q = q.filter(InstitutionInvoice.status == status_filter)
+    # `overdue=true` is a shorthand for status='overdue' and takes precedence
+    # over `status` so passing both never AND-collapses to an empty result.
     if overdue:
         q = q.filter(InstitutionInvoice.status == "overdue")
+    elif status_filter:
+        q = q.filter(InstitutionInvoice.status == status_filter)
     if year is not None:
         q = q.filter(InstitutionInvoice.year == year)
     if month is not None:

--- a/backend/routers/institution_invoices.py
+++ b/backend/routers/institution_invoices.py
@@ -1,0 +1,173 @@
+"""Admin accounts-receivable endpoints for institution invoices
+(issue #838 Phase D).
+
+All routes are admin-only (`get_current_admin`). The amount is computed
+server-side from `compute_monthly_billing` at lock time — the client never
+supplies it.
+"""
+
+import uuid
+from datetime import date
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import InstitutionInvoice, Organization, Teacher
+from routers.admin import get_current_admin
+from services.institution_billing import compute_monthly_billing
+from services.institution_invoice_ledger import apply_status_change, upsert_invoice
+
+
+router = APIRouter(prefix="/api/admin", tags=["admin-institution-invoices"])
+
+
+class CreateInvoiceRequest(BaseModel):
+    organization_id: uuid.UUID
+    year: int = Field(..., ge=1, le=9998)
+    month: int = Field(..., ge=1, le=12)
+
+
+class UpdateInvoiceRequest(BaseModel):
+    status: str = Field(..., description="'paid' or 'cancelled'")
+    payment_note: Optional[str] = Field(default=None, max_length=1000)
+
+
+class InvoiceResponse(BaseModel):
+    id: int
+    organization_id: str
+    organization_name: Optional[str]
+    year: int
+    month: int
+    amount: int
+    status: str
+    due_date: Optional[date]
+    paid_at: Optional[str]
+    paid_by_admin_id: Optional[int]
+    payment_note: Optional[str]
+    created_at: Optional[str]
+
+
+def _serialize(inv: InstitutionInvoice, org_name: Optional[str]) -> InvoiceResponse:
+    return InvoiceResponse(
+        id=inv.id,
+        organization_id=str(inv.organization_id),
+        organization_name=org_name,
+        year=inv.year,
+        month=inv.month,
+        amount=inv.amount,
+        status=inv.status,
+        due_date=inv.due_date,
+        paid_at=inv.paid_at.isoformat() if inv.paid_at else None,
+        paid_by_admin_id=inv.paid_by_admin_id,
+        payment_note=inv.payment_note,
+        created_at=inv.created_at.isoformat() if inv.created_at else None,
+    )
+
+
+@router.post("/institution-invoices", response_model=InvoiceResponse)
+async def create_institution_invoice(
+    body: CreateInvoiceRequest,
+    db: Session = Depends(get_db),
+    _: Teacher = Depends(get_current_admin),
+):
+    """Lock the (org, year, month) accounts-receivable invoice. Amount is
+    computed server-side and snapshotted. Idempotent: a repeat lock for the
+    same period UPDATEs the pending row rather than creating a duplicate.
+    """
+    org = (
+        db.query(Organization)
+        .filter(
+            Organization.id == body.organization_id,
+            Organization.is_active.is_(True),
+        )
+        .first()
+    )
+    if org is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found"
+        )
+
+    try:
+        billing = compute_monthly_billing(org, body.year, body.month, db)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    invoice, _created = upsert_invoice(
+        db,
+        org.id,
+        body.year,
+        body.month,
+        billing["total_amount"],
+    )
+    return _serialize(invoice, org.display_name or org.name)
+
+
+@router.get("/institution-invoices", response_model=List[InvoiceResponse])
+async def list_institution_invoices(
+    status_filter: Optional[str] = Query(
+        default=None, alias="status", description="pending/paid/overdue/cancelled"
+    ),
+    overdue: Optional[bool] = Query(default=None),
+    year: Optional[int] = Query(default=None, ge=1, le=9998),
+    month: Optional[int] = Query(default=None, ge=1, le=12),
+    organization_id: Optional[uuid.UUID] = Query(default=None),
+    db: Session = Depends(get_db),
+    _: Teacher = Depends(get_current_admin),
+):
+    """List invoices with optional filters, newest period first. `overdue=true`
+    is shorthand for status='overdue'."""
+    q = db.query(InstitutionInvoice, Organization).join(
+        Organization, Organization.id == InstitutionInvoice.organization_id
+    )
+    if status_filter:
+        q = q.filter(InstitutionInvoice.status == status_filter)
+    if overdue:
+        q = q.filter(InstitutionInvoice.status == "overdue")
+    if year is not None:
+        q = q.filter(InstitutionInvoice.year == year)
+    if month is not None:
+        q = q.filter(InstitutionInvoice.month == month)
+    if organization_id is not None:
+        q = q.filter(InstitutionInvoice.organization_id == organization_id)
+
+    rows = q.order_by(
+        InstitutionInvoice.year.desc(),
+        InstitutionInvoice.month.desc(),
+        InstitutionInvoice.id.desc(),
+    ).all()
+    return [_serialize(inv, org.display_name or org.name) for inv, org in rows]
+
+
+@router.patch("/institution-invoices/{invoice_id}", response_model=InvoiceResponse)
+async def update_institution_invoice(
+    invoice_id: int,
+    body: UpdateInvoiceRequest,
+    db: Session = Depends(get_db),
+    current_admin: Teacher = Depends(get_current_admin),
+):
+    """Mark an invoice paid / cancelled (records admin id + timestamp for
+    'paid'). 'pending'/'overdue' are system-managed and rejected with 400."""
+    invoice = (
+        db.query(InstitutionInvoice).filter(InstitutionInvoice.id == invoice_id).first()
+    )
+    if invoice is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found"
+        )
+
+    try:
+        invoice = apply_status_change(
+            db, invoice, body.status, current_admin.id, body.payment_note
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    org = (
+        db.query(Organization)
+        .filter(Organization.id == invoice.organization_id)
+        .first()
+    )
+    return _serialize(invoice, (org.display_name or org.name) if org else None)

--- a/backend/routers/institution_invoices.py
+++ b/backend/routers/institution_invoices.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 
 from database import get_db
 from models import InstitutionInvoice, Organization, Teacher
+from models.institution_invoice import INVOICE_STATUSES
 from routers.admin import get_current_admin
 from services.institution_billing import compute_monthly_billing
 from services.institution_invoice_ledger import apply_status_change, upsert_invoice
@@ -119,6 +120,11 @@ async def list_institution_invoices(
 ):
     """List invoices with optional filters, newest period first. `overdue=true`
     is shorthand for status='overdue'."""
+    if status_filter and status_filter not in INVOICE_STATUSES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"status must be one of {INVOICE_STATUSES}",
+        )
     q = db.query(InstitutionInvoice, Organization).join(
         Organization, Organization.id == InstitutionInvoice.organization_id
     )

--- a/backend/routers/organizations.py
+++ b/backend/routers/organizations.py
@@ -34,6 +34,7 @@ from services.email_service import email_service
 from services.institution_billing import compute_monthly_billing
 from services.institution_invoice_pdf import build_invoice_pdf
 from services.institution_invoice_email import send_monthly_invoice_email
+from services.institution_invoice_ledger import upsert_invoice
 import secrets
 
 
@@ -1688,6 +1689,11 @@ async def send_monthly_billing_email(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="請款 Email 發送失敗，請稍後再試。",
         )
+
+    # issue #838 Phase D — sending the 請款 email also locks a pending
+    # accounts-receivable invoice (idempotent on (org, year, month); a repeat
+    # send does not disturb an already-paid invoice).
+    upsert_invoice(db, org.id, body.year, body.month, billing["total_amount"])
 
     return {
         "success": True,

--- a/backend/routers/organizations.py
+++ b/backend/routers/organizations.py
@@ -1692,8 +1692,17 @@ async def send_monthly_billing_email(
 
     # issue #838 Phase D — sending the 請款 email also locks a pending
     # accounts-receivable invoice (idempotent on (org, year, month); a repeat
-    # send does not disturb an already-paid invoice).
-    upsert_invoice(db, org.id, body.year, body.month, billing["total_amount"])
+    # send does not disturb an already-paid invoice). The email has ALREADY
+    # been sent and audited at this point, so a lock failure must NOT surface
+    # as a request failure (that would wrongly prompt the admin to re-send a
+    # duplicate email) — log and continue.
+    try:
+        upsert_invoice(db, org.id, body.year, body.month, billing["total_amount"])
+    except Exception:  # pragma: no cover - defensive
+        logging.getLogger(__name__).exception(
+            "Invoice lock after send-email failed (email already sent) "
+            f"org={org.id} {body.year}-{body.month:02d}"
+        )
 
     return {
         "success": True,

--- a/backend/services/institution_invoice_ledger.py
+++ b/backend/services/institution_invoice_ledger.py
@@ -145,10 +145,24 @@ def apply_status_change(
     admin_id: int,
     payment_note: Optional[str] = None,
 ) -> InstitutionInvoice:
-    """Route a PATCH status change to the right helper. Only 'paid' and
-    'cancelled' are admin-settable; 'pending'/'overdue' are system-managed.
-    Raises ValueError on an unsupported target status.
+    """Route a PATCH status change to the right helper.
+
+    Guards, in order:
+      - only 'pending'/'overdue' invoices may be transitioned. 'paid' and
+        'cancelled' are terminal — re-marking them would silently overwrite
+        the original payment audit stamp (who/when paid) with no history, so
+        the endpoint refuses. This matches the admin UI, which only offers
+        actions on pending/overdue rows.
+      - the only admin-settable targets are 'paid' and 'cancelled'
+        ('pending'/'overdue' are system-managed).
+
+    Raises ValueError (→ 400) on either violation.
     """
+    if invoice.status not in ("pending", "overdue"):
+        raise ValueError(
+            f"invoice is already {invoice.status!r} (settled); only "
+            "'pending'/'overdue' invoices can be marked paid/cancelled."
+        )
     if new_status == "paid":
         return mark_invoice_paid(db, invoice, admin_id, payment_note)
     if new_status == "cancelled":

--- a/backend/services/institution_invoice_ledger.py
+++ b/backend/services/institution_invoice_ledger.py
@@ -10,6 +10,7 @@ from datetime import date, datetime, timedelta, timezone
 from typing import Optional, Tuple
 from zoneinfo import ZoneInfo
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from models import InstitutionInvoice
@@ -50,22 +51,30 @@ def upsert_invoice(
     if due_date is None:
         due_date = default_due_date(now)
 
-    existing = (
-        db.query(InstitutionInvoice)
-        .filter(
-            InstitutionInvoice.organization_id == organization_id,
-            InstitutionInvoice.year == year,
-            InstitutionInvoice.month == month,
+    def _find():
+        return (
+            db.query(InstitutionInvoice)
+            .filter(
+                InstitutionInvoice.organization_id == organization_id,
+                InstitutionInvoice.year == year,
+                InstitutionInvoice.month == month,
+            )
+            .first()
         )
-        .first()
-    )
-    if existing is not None:
-        if existing.status == "pending":
-            existing.amount = amount
-            existing.due_date = due_date
+
+    def _relock_if_pending(inv):
+        # Only refresh the snapshot while unsettled; never revert a
+        # paid/cancelled/overdue invoice.
+        if inv.status == "pending":
+            inv.amount = amount
+            inv.due_date = due_date
             db.commit()
-            db.refresh(existing)
-        return existing, False
+            db.refresh(inv)
+        return inv
+
+    existing = _find()
+    if existing is not None:
+        return _relock_if_pending(existing), False
 
     invoice = InstitutionInvoice(
         organization_id=organization_id,
@@ -76,7 +85,18 @@ def upsert_invoice(
         due_date=due_date,
     )
     db.add(invoice)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # TOCTOU race: a concurrent call inserted the same (org, year, month)
+        # between our SELECT and INSERT. The UNIQUE constraint rejected us —
+        # roll back and treat it as an idempotent re-lock of the winner's row
+        # instead of surfacing a 500.
+        db.rollback()
+        raced = _find()
+        if raced is None:
+            raise  # not the unique-key race we expected — re-raise
+        return _relock_if_pending(raced), False
     db.refresh(invoice)
     return invoice, True
 

--- a/backend/services/institution_invoice_ledger.py
+++ b/backend/services/institution_invoice_ledger.py
@@ -1,0 +1,155 @@
+"""Institution accounts-receivable ledger (issue #838 Phase D).
+
+CRUD-side helpers for the ``institution_invoices`` table: idempotent
+create/lock, mark paid/cancelled, and the daily overdue sweep. The amount is
+snapshotted from ``compute_monthly_billing`` at lock time so a later change
+to enrolment or per_student_price does not mutate an already-issued invoice.
+"""
+
+from datetime import date, datetime, timedelta, timezone
+from typing import Optional, Tuple
+from zoneinfo import ZoneInfo
+
+from sqlalchemy.orm import Session
+
+from models import InstitutionInvoice
+from models.institution_invoice import INVOICE_STATUSES
+
+
+TAIPEI = ZoneInfo("Asia/Taipei")
+
+# Default payment window: an invoice locked today is due this many days out.
+DEFAULT_DUE_DAYS = 30
+
+
+def default_due_date(now: Optional[datetime] = None) -> date:
+    """Due date for a freshly locked invoice: Taipei-today + 30 days."""
+    base = (now or datetime.now(timezone.utc)).astimezone(TAIPEI).date()
+    return base + timedelta(days=DEFAULT_DUE_DAYS)
+
+
+def upsert_invoice(
+    db: Session,
+    organization_id,
+    year: int,
+    month: int,
+    amount: int,
+    *,
+    due_date: Optional[date] = None,
+    now: Optional[datetime] = None,
+) -> Tuple[InstitutionInvoice, bool]:
+    """Idempotently create-or-refresh the (org, year, month) invoice.
+
+    Returns (invoice, created). The UNIQUE(org, year, month) key guarantees a
+    single row per period, so a repeat "lock" UPDATEs rather than INSERTs.
+
+    Re-locking only refreshes the snapshot (amount + due_date) while the
+    invoice is still ``pending`` — once it is paid / cancelled / overdue it is
+    left untouched so a settled invoice is never silently reverted.
+    """
+    if due_date is None:
+        due_date = default_due_date(now)
+
+    existing = (
+        db.query(InstitutionInvoice)
+        .filter(
+            InstitutionInvoice.organization_id == organization_id,
+            InstitutionInvoice.year == year,
+            InstitutionInvoice.month == month,
+        )
+        .first()
+    )
+    if existing is not None:
+        if existing.status == "pending":
+            existing.amount = amount
+            existing.due_date = due_date
+            db.commit()
+            db.refresh(existing)
+        return existing, False
+
+    invoice = InstitutionInvoice(
+        organization_id=organization_id,
+        year=year,
+        month=month,
+        amount=amount,
+        status="pending",
+        due_date=due_date,
+    )
+    db.add(invoice)
+    db.commit()
+    db.refresh(invoice)
+    return invoice, True
+
+
+def mark_invoice_paid(
+    db: Session,
+    invoice: InstitutionInvoice,
+    admin_id: int,
+    payment_note: Optional[str] = None,
+    *,
+    now: Optional[datetime] = None,
+) -> InstitutionInvoice:
+    """Mark an invoice paid, stamping who/when (invariant: paid ⇒ paid_at set)."""
+    invoice.status = "paid"
+    invoice.paid_at = now or datetime.now(timezone.utc)
+    invoice.paid_by_admin_id = admin_id
+    if payment_note is not None:
+        invoice.payment_note = payment_note
+    db.commit()
+    db.refresh(invoice)
+    return invoice
+
+
+def mark_invoice_cancelled(
+    db: Session,
+    invoice: InstitutionInvoice,
+    payment_note: Optional[str] = None,
+) -> InstitutionInvoice:
+    """Cancel an invoice. paid_* stay NULL (never paid)."""
+    invoice.status = "cancelled"
+    if payment_note is not None:
+        invoice.payment_note = payment_note
+    db.commit()
+    db.refresh(invoice)
+    return invoice
+
+
+def apply_status_change(
+    db: Session,
+    invoice: InstitutionInvoice,
+    new_status: str,
+    admin_id: int,
+    payment_note: Optional[str] = None,
+) -> InstitutionInvoice:
+    """Route a PATCH status change to the right helper. Only 'paid' and
+    'cancelled' are admin-settable; 'pending'/'overdue' are system-managed.
+    Raises ValueError on an unsupported target status.
+    """
+    if new_status == "paid":
+        return mark_invoice_paid(db, invoice, admin_id, payment_note)
+    if new_status == "cancelled":
+        return mark_invoice_cancelled(db, invoice, payment_note)
+    raise ValueError(
+        f"status must be one of ('paid', 'cancelled'); got {new_status!r}. "
+        f"(valid lifecycle states: {INVOICE_STATUSES})"
+    )
+
+
+def mark_overdue_invoices(db: Session, today: Optional[date] = None) -> int:
+    """Daily sweep: flip every still-``pending`` invoice whose due_date has
+    passed to ``overdue``. Returns the number updated. Idempotent — a second
+    run the same day finds nothing left pending-and-past-due.
+    """
+    if today is None:
+        today = datetime.now(TAIPEI).date()
+    updated = (
+        db.query(InstitutionInvoice)
+        .filter(
+            InstitutionInvoice.status == "pending",
+            InstitutionInvoice.due_date.isnot(None),
+            InstitutionInvoice.due_date < today,
+        )
+        .update({InstitutionInvoice.status: "overdue"}, synchronize_session=False)
+    )
+    db.commit()
+    return updated

--- a/backend/services/institution_invoice_ledger.py
+++ b/backend/services/institution_invoice_ledger.py
@@ -125,8 +125,12 @@ def mark_invoice_cancelled(
     invoice: InstitutionInvoice,
     payment_note: Optional[str] = None,
 ) -> InstitutionInvoice:
-    """Cancel an invoice. paid_* stay NULL (never paid)."""
+    """Cancel an invoice. Clears paid_at / paid_by_admin_id so the documented
+    invariant (paid_* set iff status='paid') holds even when cancelling an
+    invoice that had previously been marked paid."""
     invoice.status = "cancelled"
+    invoice.paid_at = None
+    invoice.paid_by_admin_id = None
     if payment_note is not None:
         invoice.payment_note = payment_note
     db.commit()

--- a/backend/tests/test_institution_billing_endpoint.py
+++ b/backend/tests/test_institution_billing_endpoint.py
@@ -391,6 +391,21 @@ def test_send_email_success_writes_audit_and_history(
     assert len(rows) == 1
     assert rows[0].recipient == "finance@acme.example"
 
+    # Phase D — sending the email also locks a pending AR invoice.
+    from models import InstitutionInvoice
+
+    inv = (
+        shared_test_session.query(InstitutionInvoice)
+        .filter(
+            InstitutionInvoice.organization_id == org.id,
+            InstitutionInvoice.year == 2026,
+            InstitutionInvoice.month == 6,
+        )
+        .one()
+    )
+    assert inv.status == "pending"
+    assert inv.amount == 150  # 1 billable student × 150
+
     # History endpoint surfaces the last-sent time.
     h = test_client.get(
         f"/api/organizations/{org.id}/billing/monthly/email-history"

--- a/backend/tests/test_institution_invoice_ledger.py
+++ b/backend/tests/test_institution_invoice_ledger.py
@@ -1,0 +1,169 @@
+"""Tests for services.institution_invoice_ledger (issue #838 Phase D).
+
+Service-layer: idempotent upsert (lock), mark paid/cancelled, status-change
+routing, and the daily overdue sweep. Admin endpoint auth/filters are covered
+by test_institution_invoices_endpoint.py (CI).
+"""
+
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+
+from auth import get_password_hash
+from models import InstitutionInvoice, Organization, Teacher
+from services.institution_invoice_ledger import (
+    apply_status_change,
+    default_due_date,
+    mark_invoice_cancelled,
+    mark_invoice_paid,
+    mark_overdue_invoices,
+    upsert_invoice,
+)
+
+
+def _org(db):
+    o = Organization(
+        name="Acme", org_type="institution", per_student_price=100, is_active=True
+    )
+    db.add(o)
+    db.commit()
+    db.refresh(o)
+    return o
+
+
+def _admin(db, email="ledger-admin@test.com"):
+    t = Teacher(
+        name="Admin", email=email, password_hash=get_password_hash("x"), is_admin=True
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+# ---------- upsert / lock ----------
+
+
+def test_upsert_creates_then_is_idempotent(shared_test_session):
+    org = _org(shared_test_session)
+    inv1, created1 = upsert_invoice(shared_test_session, org.id, 2026, 6, 500)
+    assert created1 is True
+    assert inv1.status == "pending"
+    assert inv1.amount == 500
+    assert inv1.due_date is not None
+
+    # Re-lock same period with a new amount → UPDATE, not a second row.
+    inv2, created2 = upsert_invoice(shared_test_session, org.id, 2026, 6, 900)
+    assert created2 is False
+    assert inv2.id == inv1.id
+    assert inv2.amount == 900
+    count = (
+        shared_test_session.query(InstitutionInvoice)
+        .filter(
+            InstitutionInvoice.organization_id == org.id,
+            InstitutionInvoice.year == 2026,
+            InstitutionInvoice.month == 6,
+        )
+        .count()
+    )
+    assert count == 1
+
+
+def test_upsert_does_not_disturb_a_paid_invoice(shared_test_session):
+    org = _org(shared_test_session)
+    admin = _admin(shared_test_session)
+    inv, _ = upsert_invoice(shared_test_session, org.id, 2026, 7, 500)
+    mark_invoice_paid(shared_test_session, inv, admin.id, "paid via ATM")
+
+    # A later re-lock must NOT revert a settled invoice or change its amount.
+    inv2, created = upsert_invoice(shared_test_session, org.id, 2026, 7, 9999)
+    assert created is False
+    assert inv2.status == "paid"
+    assert inv2.amount == 500
+
+
+def test_default_due_date_is_30_days_out():
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    assert default_due_date(now) == date(2026, 7, 1)
+
+
+# ---------- mark paid / cancelled ----------
+
+
+def test_mark_paid_records_admin_and_time(shared_test_session):
+    org = _org(shared_test_session)
+    admin = _admin(shared_test_session, "paid-admin@test.com")
+    inv, _ = upsert_invoice(shared_test_session, org.id, 2026, 8, 300)
+    out = mark_invoice_paid(shared_test_session, inv, admin.id, "收訖")
+    assert out.status == "paid"
+    assert out.paid_at is not None
+    assert out.paid_by_admin_id == admin.id
+    assert out.payment_note == "收訖"
+
+
+def test_mark_cancelled_leaves_paid_fields_null(shared_test_session):
+    org = _org(shared_test_session)
+    inv, _ = upsert_invoice(shared_test_session, org.id, 2026, 9, 300)
+    out = mark_invoice_cancelled(shared_test_session, inv, "作廢")
+    assert out.status == "cancelled"
+    assert out.paid_at is None
+    assert out.paid_by_admin_id is None
+    assert out.payment_note == "作廢"
+
+
+def test_apply_status_change_rejects_unsupported(shared_test_session):
+    org = _org(shared_test_session)
+    admin = _admin(shared_test_session, "reject-admin@test.com")
+    inv, _ = upsert_invoice(shared_test_session, org.id, 2026, 10, 300)
+    with pytest.raises(ValueError):
+        apply_status_change(shared_test_session, inv, "pending", admin.id)
+    with pytest.raises(ValueError):
+        apply_status_change(shared_test_session, inv, "banana", admin.id)
+
+
+# ---------- overdue sweep ----------
+
+
+def test_mark_overdue_flips_only_past_due_pending(shared_test_session):
+    org = _org(shared_test_session)
+    today = date(2026, 7, 15)
+    # past-due pending → should flip
+    past, _ = upsert_invoice(
+        shared_test_session, org.id, 2026, 5, 100, due_date=date(2026, 7, 1)
+    )
+    # future-due pending → stays pending
+    future, _ = upsert_invoice(
+        shared_test_session, org.id, 2026, 6, 100, due_date=date(2026, 8, 1)
+    )
+    # past-due but already paid → untouched
+    paid, _ = upsert_invoice(
+        shared_test_session, org.id, 2026, 4, 100, due_date=date(2026, 6, 1)
+    )
+    admin = _admin(shared_test_session, "sweep-admin@test.com")
+    mark_invoice_paid(shared_test_session, paid, admin.id)
+
+    updated = mark_overdue_invoices(shared_test_session, today=today)
+    assert updated == 1
+
+    shared_test_session.refresh(past)
+    shared_test_session.refresh(future)
+    shared_test_session.refresh(paid)
+    assert past.status == "overdue"
+    assert future.status == "pending"
+    assert paid.status == "paid"
+
+    # Idempotent: a second run finds nothing new.
+    assert mark_overdue_invoices(shared_test_session, today=today) == 0
+
+
+def test_mark_overdue_ignores_null_due_date(shared_test_session):
+    org = _org(shared_test_session)
+    inv = InstitutionInvoice(
+        organization_id=org.id, year=2026, month=3, amount=100, status="pending"
+    )
+    shared_test_session.add(inv)
+    shared_test_session.commit()
+    updated = mark_overdue_invoices(shared_test_session, today=date(2026, 12, 31))
+    assert updated == 0
+    shared_test_session.refresh(inv)
+    assert inv.status == "pending"

--- a/backend/tests/test_institution_invoice_ledger.py
+++ b/backend/tests/test_institution_invoice_ledger.py
@@ -82,6 +82,54 @@ def test_upsert_does_not_disturb_a_paid_invoice(shared_test_session):
     assert inv2.amount == 500
 
 
+def test_upsert_survives_unique_race(shared_test_session):
+    """If a concurrent insert wins the (org, year, month) UNIQUE key between
+    our SELECT and INSERT, upsert must recover (re-lock the winner) instead
+    of surfacing the IntegrityError as a 500."""
+    org = _org(shared_test_session)
+    # Simulate the race: a row already committed for this period, but our
+    # in-flight call still "sees None" — emulate by pre-inserting then forcing
+    # the insert path via a patched _find that returns None on the first look.
+    from services import institution_invoice_ledger as mod
+
+    pre = InstitutionInvoice(
+        organization_id=org.id, year=2026, month=6, amount=100, status="pending"
+    )
+    shared_test_session.add(pre)
+    shared_test_session.commit()
+
+    calls = {"n": 0}
+    real_query = shared_test_session.query
+
+    def _fake_query(*a, **k):
+        # First .first() in upsert returns None (pretend we didn't see the
+        # winner); subsequent lookups behave normally so the recovery path
+        # re-fetches the real row.
+        q = real_query(*a, **k)
+        if a and a[0] is InstitutionInvoice and calls["n"] == 0:
+            calls["n"] += 1
+
+            class _Wrap:
+                def filter(self, *fa, **fk):
+                    return self
+
+                def first(self):
+                    return None
+
+            return _Wrap()
+        return q
+
+    import unittest.mock as mock
+
+    with mock.patch.object(shared_test_session, "query", _fake_query):
+        inv, created = upsert_invoice(shared_test_session, org.id, 2026, 6, 777)
+
+    assert created is False
+    assert inv.id == pre.id
+    # recovered row re-locked to the new amount (was pending)
+    assert inv.amount == 777
+
+
 def test_default_due_date_is_30_days_out():
     now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
     assert default_due_date(now) == date(2026, 7, 1)

--- a/backend/tests/test_institution_invoice_ledger.py
+++ b/backend/tests/test_institution_invoice_ledger.py
@@ -159,6 +159,22 @@ def test_mark_cancelled_leaves_paid_fields_null(shared_test_session):
     assert out.payment_note == "作廢"
 
 
+def test_cancel_after_paid_clears_paid_fields(shared_test_session):
+    """Invariant: paid_* set iff status='paid'. Cancelling a previously-paid
+    invoice must clear paid_at / paid_by_admin_id (regression for the
+    cancel-after-paid path)."""
+    org = _org(shared_test_session)
+    admin = _admin(shared_test_session, "cancel-after-paid@test.com")
+    inv, _ = upsert_invoice(shared_test_session, org.id, 2026, 11, 300)
+    mark_invoice_paid(shared_test_session, inv, admin.id, "paid then cancelled")
+    assert inv.paid_at is not None and inv.paid_by_admin_id == admin.id
+
+    out = apply_status_change(shared_test_session, inv, "cancelled", admin.id, "退團")
+    assert out.status == "cancelled"
+    assert out.paid_at is None
+    assert out.paid_by_admin_id is None
+
+
 def test_apply_status_change_rejects_unsupported(shared_test_session):
     org = _org(shared_test_session)
     admin = _admin(shared_test_session, "reject-admin@test.com")

--- a/backend/tests/test_institution_invoice_ledger.py
+++ b/backend/tests/test_institution_invoice_ledger.py
@@ -159,17 +159,34 @@ def test_mark_cancelled_leaves_paid_fields_null(shared_test_session):
     assert out.payment_note == "作廢"
 
 
-def test_cancel_after_paid_clears_paid_fields(shared_test_session):
-    """Invariant: paid_* set iff status='paid'. Cancelling a previously-paid
-    invoice must clear paid_at / paid_by_admin_id (regression for the
-    cancel-after-paid path)."""
+def test_apply_status_change_rejects_settled_invoice(shared_test_session):
+    """Settled invoices are terminal: a paid/cancelled invoice cannot be
+    transitioned again via the endpoint (would overwrite the payment audit
+    stamp with no history)."""
     org = _org(shared_test_session)
-    admin = _admin(shared_test_session, "cancel-after-paid@test.com")
-    inv, _ = upsert_invoice(shared_test_session, org.id, 2026, 11, 300)
-    mark_invoice_paid(shared_test_session, inv, admin.id, "paid then cancelled")
-    assert inv.paid_at is not None and inv.paid_by_admin_id == admin.id
+    admin = _admin(shared_test_session, "settled-admin@test.com")
 
-    out = apply_status_change(shared_test_session, inv, "cancelled", admin.id, "退團")
+    paid, _ = upsert_invoice(shared_test_session, org.id, 2026, 11, 300)
+    mark_invoice_paid(shared_test_session, paid, admin.id)
+    with pytest.raises(ValueError, match="settled"):
+        apply_status_change(shared_test_session, paid, "cancelled", admin.id)
+
+    cancelled, _ = upsert_invoice(shared_test_session, org.id, 2026, 12, 300)
+    mark_invoice_cancelled(shared_test_session, cancelled)
+    with pytest.raises(ValueError, match="settled"):
+        apply_status_change(shared_test_session, cancelled, "paid", admin.id)
+
+
+def test_mark_cancelled_direct_clears_paid_fields(shared_test_session):
+    """Defensive: the low-level mark_invoice_cancelled clears paid_* so the
+    'paid_* set iff status=paid' invariant holds even if a paid invoice is
+    cancelled through a direct service call (the endpoint blocks this, but
+    the helper stays self-consistent)."""
+    org = _org(shared_test_session)
+    admin = _admin(shared_test_session, "direct-cancel-admin@test.com")
+    inv, _ = upsert_invoice(shared_test_session, org.id, 2026, 11, 300)
+    mark_invoice_paid(shared_test_session, inv, admin.id)
+    out = mark_invoice_cancelled(shared_test_session, inv, "退團")
     assert out.status == "cancelled"
     assert out.paid_at is None
     assert out.paid_by_admin_id is None

--- a/backend/tests/test_institution_invoices_endpoint.py
+++ b/backend/tests/test_institution_invoices_endpoint.py
@@ -204,6 +204,37 @@ def test_patch_rejects_invalid_status(test_client, admin, institution_with_stude
     assert r.status_code == 400
 
 
+def test_patch_rejects_settled_invoice(test_client, admin, institution_with_student):
+    """A paid invoice is terminal — a second PATCH must be rejected (400)
+    rather than silently overwriting the payment stamp."""
+    org = institution_with_student
+    created = test_client.post(
+        "/api/admin/institution-invoices",
+        json={"organization_id": str(org.id), "year": 2026, "month": 6},
+        headers=_bearer(admin.id),
+    ).json()
+    paid = test_client.patch(
+        f"/api/admin/institution-invoices/{created['id']}",
+        json={"status": "paid"},
+        headers=_bearer(admin.id),
+    )
+    assert paid.status_code == 200
+    # Second transition on a settled invoice → 400.
+    again = test_client.patch(
+        f"/api/admin/institution-invoices/{created['id']}",
+        json={"status": "cancelled"},
+        headers=_bearer(admin.id),
+    )
+    assert again.status_code == 400
+
+
+def test_list_rejects_invalid_status(test_client, admin):
+    r = test_client.get(
+        "/api/admin/institution-invoices?status=bogus", headers=_bearer(admin.id)
+    )
+    assert r.status_code == 400
+
+
 # ---------- overdue cron ----------
 
 

--- a/backend/tests/test_institution_invoices_endpoint.py
+++ b/backend/tests/test_institution_invoices_endpoint.py
@@ -1,0 +1,239 @@
+"""Endpoint tests for the admin institution-invoice ledger + overdue cron
+(issue #838 Phase D).
+
+Covers admin-only auth, server-side amount lock + idempotency, list filters,
+PATCH mark-paid / invalid-status, and the CRON_SECRET-gated overdue sweep.
+"""
+
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+from auth import create_access_token, get_password_hash
+from models import (
+    InstitutionInvoice,
+    Organization,
+    School,
+    Student,
+    StudentSchool,
+    Teacher,
+)
+
+
+def _bearer(teacher_id):
+    return {
+        "Authorization": f"Bearer {create_access_token({'sub': str(teacher_id), 'type': 'teacher'})}"
+    }
+
+
+@pytest.fixture
+def admin(shared_test_session):
+    t = Teacher(
+        email="inv-admin@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="Admin",
+        is_active=True,
+        email_verified=True,
+        is_admin=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+@pytest.fixture
+def non_admin(shared_test_session):
+    t = Teacher(
+        email="inv-teacher@duotopia.com",
+        password_hash=get_password_hash("x"),
+        name="Teacher",
+        is_active=True,
+        email_verified=True,
+    )
+    shared_test_session.add(t)
+    shared_test_session.commit()
+    shared_test_session.refresh(t)
+    return t
+
+
+@pytest.fixture
+def institution_with_student(shared_test_session):
+    org = Organization(
+        name="Acme Institution",
+        org_type="institution",
+        per_student_price=150,
+        is_active=True,
+    )
+    shared_test_session.add(org)
+    shared_test_session.flush()
+    school = School(organization_id=org.id, name="Branch", is_active=True)
+    shared_test_session.add(school)
+    shared_test_session.flush()
+    student = Student(
+        name="Alice",
+        email="alice-inv@example.com",
+        password_hash=get_password_hash("x"),
+        is_active=True,
+    )
+    shared_test_session.add(student)
+    shared_test_session.flush()
+    shared_test_session.add(
+        StudentSchool(student_id=student.id, school_id=school.id, is_active=True)
+    )
+    shared_test_session.commit()
+    return org
+
+
+# ---------- create (lock) ----------
+
+
+def test_create_requires_admin(test_client, non_admin, institution_with_student):
+    r = test_client.post(
+        "/api/admin/institution-invoices",
+        json={
+            "organization_id": str(institution_with_student.id),
+            "year": 2026,
+            "month": 6,
+        },
+        headers=_bearer(non_admin.id),
+    )
+    assert r.status_code == 403
+
+
+def test_create_locks_amount_and_is_idempotent(
+    test_client, admin, shared_test_session, institution_with_student
+):
+    org = institution_with_student
+    payload = {"organization_id": str(org.id), "year": 2026, "month": 6}
+    r1 = test_client.post(
+        "/api/admin/institution-invoices", json=payload, headers=_bearer(admin.id)
+    )
+    assert r1.status_code == 200, r1.text
+    body = r1.json()
+    # 1 billable student × 150
+    assert body["amount"] == 150
+    assert body["status"] == "pending"
+    assert body["organization_name"]
+
+    # Repeat lock → same row (UPDATE, not a duplicate).
+    r2 = test_client.post(
+        "/api/admin/institution-invoices", json=payload, headers=_bearer(admin.id)
+    )
+    assert r2.status_code == 200
+    assert r2.json()["id"] == body["id"]
+    count = (
+        shared_test_session.query(InstitutionInvoice)
+        .filter(InstitutionInvoice.organization_id == org.id)
+        .count()
+    )
+    assert count == 1
+
+
+# ---------- list ----------
+
+
+def test_list_filters_by_status(test_client, admin, institution_with_student):
+    org = institution_with_student
+    test_client.post(
+        "/api/admin/institution-invoices",
+        json={"organization_id": str(org.id), "year": 2026, "month": 6},
+        headers=_bearer(admin.id),
+    )
+    r = test_client.get(
+        "/api/admin/institution-invoices?status=pending", headers=_bearer(admin.id)
+    )
+    assert r.status_code == 200
+    rows = r.json()
+    assert len(rows) >= 1
+    assert all(x["status"] == "pending" for x in rows)
+
+    # A status with no rows returns empty.
+    r2 = test_client.get(
+        "/api/admin/institution-invoices?status=cancelled", headers=_bearer(admin.id)
+    )
+    assert r2.status_code == 200
+    assert r2.json() == []
+
+
+def test_list_requires_admin(test_client, non_admin):
+    r = test_client.get(
+        "/api/admin/institution-invoices", headers=_bearer(non_admin.id)
+    )
+    assert r.status_code == 403
+
+
+# ---------- patch ----------
+
+
+def test_patch_mark_paid_records_admin(
+    test_client, admin, shared_test_session, institution_with_student
+):
+    org = institution_with_student
+    created = test_client.post(
+        "/api/admin/institution-invoices",
+        json={"organization_id": str(org.id), "year": 2026, "month": 6},
+        headers=_bearer(admin.id),
+    ).json()
+    r = test_client.patch(
+        f"/api/admin/institution-invoices/{created['id']}",
+        json={"status": "paid", "payment_note": "ATM 收訖"},
+        headers=_bearer(admin.id),
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "paid"
+    assert body["paid_at"]
+    assert body["paid_by_admin_id"] == admin.id
+    assert body["payment_note"] == "ATM 收訖"
+
+
+def test_patch_rejects_invalid_status(test_client, admin, institution_with_student):
+    org = institution_with_student
+    created = test_client.post(
+        "/api/admin/institution-invoices",
+        json={"organization_id": str(org.id), "year": 2026, "month": 6},
+        headers=_bearer(admin.id),
+    ).json()
+    r = test_client.patch(
+        f"/api/admin/institution-invoices/{created['id']}",
+        json={"status": "pending"},
+        headers=_bearer(admin.id),
+    )
+    assert r.status_code == 400
+
+
+# ---------- overdue cron ----------
+
+
+def test_overdue_cron_requires_secret(test_client):
+    r = test_client.post("/api/cron/billing-overdue-check")
+    assert r.status_code == 401
+
+
+def test_overdue_cron_marks_overdue(
+    test_client, shared_test_session, institution_with_student
+):
+    org = institution_with_student
+    # A pending invoice already past its due date.
+    inv = InstitutionInvoice(
+        organization_id=org.id,
+        year=2026,
+        month=1,
+        amount=150,
+        status="pending",
+        due_date=date(2020, 1, 1),
+    )
+    shared_test_session.add(inv)
+    shared_test_session.commit()
+
+    with patch("routers.cron.CRON_SECRET", "test-secret"):
+        r = test_client.post(
+            "/api/cron/billing-overdue-check",
+            headers={"X-Cron-Secret": "test-secret"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["marked_overdue"] >= 1
+    shared_test_session.refresh(inv)
+    assert inv.status == "overdue"

--- a/backend/tests/test_institution_invoices_endpoint.py
+++ b/backend/tests/test_institution_invoices_endpoint.py
@@ -235,6 +235,18 @@ def test_list_rejects_invalid_status(test_client, admin):
     assert r.status_code == 400
 
 
+def test_create_rejects_out_of_range_year(test_client, admin, institution_with_student):
+    """year is bounded to the DB CHECK (2000..2099) so an out-of-range value
+    is a clean 422, not an IntegrityError → 500."""
+    org = institution_with_student
+    r = test_client.post(
+        "/api/admin/institution-invoices",
+        json={"organization_id": str(org.id), "year": 1999, "month": 6},
+        headers=_bearer(admin.id),
+    )
+    assert r.status_code == 422
+
+
 # ---------- overdue cron ----------
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,6 +43,7 @@ import AdminMonitoringPage from "./pages/admin/AdminMonitoringPage";
 import AdminDashboard from "./pages/admin/AdminDashboard";
 import CreateOrganization from "./pages/admin/CreateOrganization";
 import AdminOrgMonthlyBilling from "./pages/admin/AdminOrgMonthlyBilling";
+import AdminInstitutionInvoices from "./pages/admin/AdminInstitutionInvoices";
 import GroupBuyOpenPage from "./pages/teacher/GroupBuyOpenPage";
 import { ENABLE_GROUP_BUY } from "./config/featureFlags";
 import BlogListPage from "./pages/BlogListPage";
@@ -372,6 +373,16 @@ function App() {
             element={
               <ProtectedRoute requireAdmin>
                 <AdminOrgMonthlyBilling />
+              </ProtectedRoute>
+            }
+          />
+        )}
+        {ENABLE_GROUP_BUY && (
+          <Route
+            path="/admin/billing/institutions"
+            element={
+              <ProtectedRoute requireAdmin>
+                <AdminInstitutionInvoices />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/components/OrgMonthlyBillingPanel.tsx
+++ b/frontend/src/components/OrgMonthlyBillingPanel.tsx
@@ -51,6 +51,7 @@ export default function OrgMonthlyBillingPanel({
   const [loading, setLoading] = React.useState(false);
   const [downloading, setDownloading] = React.useState(false);
   const [sendingEmail, setSendingEmail] = React.useState(false);
+  const [creatingInvoice, setCreatingInvoice] = React.useState(false);
   const [lastSentAt, setLastSentAt] = React.useState<string | null>(null);
   const [result, setResult] = React.useState<MonthlyBilling | null>(null);
   const [error, setError] = React.useState<string | null>(null);
@@ -149,6 +150,26 @@ export default function OrgMonthlyBillingPanel({
     }
   };
 
+  const createInvoice = async () => {
+    setCreatingInvoice(true);
+    try {
+      const inv = await apiClient.createInstitutionInvoice(orgId, year, month);
+      toast.success(
+        `已建立/更新應收帳款：${inv.year} 年 ${inv.month} 月，金額 ${inv.amount.toLocaleString()}`,
+      );
+    } catch (e) {
+      const msg =
+        e instanceof ApiError
+          ? typeof e.detail === "string"
+            ? e.detail
+            : e.message
+          : "建立應收帳款失敗";
+      toast.error(msg);
+    } finally {
+      setCreatingInvoice(false);
+    }
+  };
+
   return (
     <Card className="w-full max-w-3xl">
       <CardHeader>
@@ -192,6 +213,13 @@ export default function OrgMonthlyBillingPanel({
           </Button>
           <Button onClick={sendEmail} disabled={sendingEmail} variant="outline">
             {sendingEmail ? "寄送中…" : "寄送請款 Email"}
+          </Button>
+          <Button
+            onClick={createInvoice}
+            disabled={creatingInvoice}
+            variant="outline"
+          >
+            {creatingInvoice ? "建立中…" : "建立應收帳款"}
           </Button>
         </div>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -112,6 +112,22 @@ export interface LoginRequest {
   password: string;
 }
 
+/** Institution accounts-receivable invoice (issue #838 Phase D). */
+export interface InstitutionInvoiceDto {
+  id: number;
+  organization_id: string;
+  organization_name: string | null;
+  year: number;
+  month: number;
+  amount: number;
+  status: "pending" | "paid" | "overdue" | "cancelled";
+  due_date: string | null;
+  paid_at: string | null;
+  paid_by_admin_id: number | null;
+  payment_note: string | null;
+  created_at: string | null;
+}
+
 export interface LoginResponse {
   access_token: string;
   token_type: string;
@@ -1773,6 +1789,58 @@ class ApiClient {
     }>(
       `/api/organizations/${orgId}/billing/monthly/email-history?year=${year}&month=${month}`,
       { method: "GET" },
+    );
+  }
+
+  // ===== issue #838 Phase D: institution accounts-receivable ledger =====
+
+  /** Lock the (org, year, month) accounts-receivable invoice (amount is
+   * computed server-side). Idempotent. Admin only. */
+  async createInstitutionInvoice(orgId: string, year: number, month: number) {
+    return this.request<InstitutionInvoiceDto>(
+      `/api/admin/institution-invoices`,
+      {
+        method: "POST",
+        body: JSON.stringify({ organization_id: orgId, year, month }),
+      },
+    );
+  }
+
+  /** List AR invoices with optional filters (admin only). */
+  async listInstitutionInvoices(
+    params: {
+      status?: string;
+      overdue?: boolean;
+      year?: number;
+      month?: number;
+      organizationId?: string;
+    } = {},
+  ) {
+    const q = new URLSearchParams();
+    if (params.status) q.set("status", params.status);
+    if (params.overdue) q.set("overdue", "true");
+    if (params.year) q.set("year", String(params.year));
+    if (params.month) q.set("month", String(params.month));
+    if (params.organizationId) q.set("organization_id", params.organizationId);
+    const qs = q.toString();
+    return this.request<InstitutionInvoiceDto[]>(
+      `/api/admin/institution-invoices${qs ? `?${qs}` : ""}`,
+      { method: "GET" },
+    );
+  }
+
+  /** Mark an AR invoice paid / cancelled (admin only). */
+  async updateInstitutionInvoice(
+    id: number,
+    status: "paid" | "cancelled",
+    paymentNote?: string,
+  ) {
+    return this.request<InstitutionInvoiceDto>(
+      `/api/admin/institution-invoices/${id}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify({ status, payment_note: paymentNote ?? null }),
+      },
     );
   }
 

--- a/frontend/src/pages/admin/AdminInstitutionInvoices.tsx
+++ b/frontend/src/pages/admin/AdminInstitutionInvoices.tsx
@@ -66,11 +66,13 @@ export default function AdminInstitutionInvoices() {
   ) => {
     const verb = next === "paid" ? "標記已收款" : "作廢";
     if (!window.confirm(`確定要將此帳款${verb}嗎？`)) return;
-    const note =
-      window.prompt(`備註（選填）：`, inv.payment_note ?? "") ?? undefined;
+    // null = prompt cancelled → keep the existing note (send undefined);
+    // "" = admin cleared it on purpose → clear the note (send "").
+    const raw = window.prompt(`備註（選填）：`, inv.payment_note ?? "");
+    const note = raw === null ? undefined : raw;
     setBusyId(inv.id);
     try {
-      await apiClient.updateInstitutionInvoice(inv.id, next, note || undefined);
+      await apiClient.updateInstitutionInvoice(inv.id, next, note);
       toast.success(`已${verb}`);
       await load();
     } catch (e) {

--- a/frontend/src/pages/admin/AdminInstitutionInvoices.tsx
+++ b/frontend/src/pages/admin/AdminInstitutionInvoices.tsx
@@ -1,0 +1,197 @@
+/**
+ * Admin page: institution accounts-receivable dashboard (issue #838 Phase D).
+ *
+ * Route: /admin/billing/institutions
+ * Auth: requires admin (ProtectedRoute requireAdmin).
+ *
+ * Lists institution_invoices with status filtering + "標記已收款" / "作廢"
+ * actions. The overdue status is set by the daily cron; here admins mark
+ * payment received or cancel an invoice.
+ */
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { apiClient, ApiError, InstitutionInvoiceDto } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+
+const STATUS_FILTERS = [
+  { value: "", label: "全部" },
+  { value: "pending", label: "待收款" },
+  { value: "overdue", label: "逾期" },
+  { value: "paid", label: "已收款" },
+  { value: "cancelled", label: "已作廢" },
+];
+
+const STATUS_BADGE: Record<string, { label: string; className: string }> = {
+  pending: { label: "待收款", className: "bg-yellow-100 text-yellow-800" },
+  overdue: { label: "逾期", className: "bg-red-100 text-red-800" },
+  paid: { label: "已收款", className: "bg-green-100 text-green-800" },
+  cancelled: { label: "已作廢", className: "bg-gray-100 text-gray-500" },
+};
+
+export default function AdminInstitutionInvoices() {
+  const navigate = useNavigate();
+  const [invoices, setInvoices] = React.useState<InstitutionInvoiceDto[]>([]);
+  const [loading, setLoading] = React.useState(false);
+  const [status, setStatus] = React.useState("");
+  const [busyId, setBusyId] = React.useState<number | null>(null);
+
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    try {
+      const rows = await apiClient.listInstitutionInvoices(
+        status ? { status } : {},
+      );
+      setInvoices(rows);
+    } catch (e) {
+      const msg =
+        e instanceof ApiError
+          ? typeof e.detail === "string"
+            ? e.detail
+            : e.message
+          : "載入應收帳款失敗";
+      toast.error(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, [status]);
+
+  React.useEffect(() => {
+    load();
+  }, [load]);
+
+  const update = async (
+    inv: InstitutionInvoiceDto,
+    next: "paid" | "cancelled",
+  ) => {
+    const verb = next === "paid" ? "標記已收款" : "作廢";
+    if (!window.confirm(`確定要將此帳款${verb}嗎？`)) return;
+    const note =
+      window.prompt(`備註（選填）：`, inv.payment_note ?? "") ?? undefined;
+    setBusyId(inv.id);
+    try {
+      await apiClient.updateInstitutionInvoice(inv.id, next, note || undefined);
+      toast.success(`已${verb}`);
+      await load();
+    } catch (e) {
+      const msg =
+        e instanceof ApiError
+          ? typeof e.detail === "string"
+            ? e.detail
+            : e.message
+          : `${verb}失敗`;
+      toast.error(msg);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4 p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">機構應收帳款</h1>
+        <Button variant="ghost" onClick={() => navigate("/admin")}>
+          ← 返回
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {STATUS_FILTERS.map((f) => (
+          <Button
+            key={f.value || "all"}
+            size="sm"
+            variant={status === f.value ? "default" : "outline"}
+            onClick={() => setStatus(f.value)}
+          >
+            {f.label}
+          </Button>
+        ))}
+        <Button size="sm" variant="ghost" onClick={load} disabled={loading}>
+          {loading ? "載入中…" : "重新整理"}
+        </Button>
+      </div>
+
+      <div className="overflow-x-auto rounded border border-gray-200">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="px-3 py-2 text-left">機構</th>
+              <th className="px-3 py-2 text-left">期間</th>
+              <th className="px-3 py-2 text-right">金額</th>
+              <th className="px-3 py-2 text-left">狀態</th>
+              <th className="px-3 py-2 text-left">到期日</th>
+              <th className="px-3 py-2 text-left">收款時間</th>
+              <th className="px-3 py-2 text-left">動作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {invoices.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-3 py-6 text-center text-gray-500">
+                  {loading ? "載入中…" : "沒有符合條件的應收帳款"}
+                </td>
+              </tr>
+            )}
+            {invoices.map((inv) => {
+              const badge = STATUS_BADGE[inv.status] ?? {
+                label: inv.status,
+                className: "bg-gray-100 text-gray-700",
+              };
+              const actionable =
+                inv.status === "pending" || inv.status === "overdue";
+              return (
+                <tr key={inv.id} className="border-t border-gray-200">
+                  <td className="px-3 py-2">
+                    {inv.organization_name ?? inv.organization_id}
+                  </td>
+                  <td className="px-3 py-2">
+                    {inv.year} 年 {inv.month} 月
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    {inv.amount.toLocaleString()}
+                  </td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={`rounded px-2 py-0.5 text-xs ${badge.className}`}
+                    >
+                      {badge.label}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2">{inv.due_date ?? "—"}</td>
+                  <td className="px-3 py-2">
+                    {inv.paid_at
+                      ? new Date(inv.paid_at).toLocaleDateString()
+                      : "—"}
+                  </td>
+                  <td className="px-3 py-2">
+                    {actionable ? (
+                      <div className="flex gap-2">
+                        <Button
+                          size="sm"
+                          disabled={busyId === inv.id}
+                          onClick={() => update(inv, "paid")}
+                        >
+                          標記已收款
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={busyId === inv.id}
+                          onClick={() => update(inv, "cancelled")}
+                        >
+                          作廢
+                        </Button>
+                      </div>
+                    ) : (
+                      <span className="text-gray-400">—</span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminOrganizations.tsx
+++ b/frontend/src/pages/admin/AdminOrganizations.tsx
@@ -357,13 +357,25 @@ export default function AdminOrganizations() {
               <Building className="h-6 w-6 text-blue-600" />
               <CardTitle className="text-2xl font-bold">組織管理</CardTitle>
             </div>
-            <Button
-              onClick={() => navigate("/admin/organizations/create")}
-              className="flex items-center gap-2"
-            >
-              <Building className="h-4 w-4" />
-              創建組織
-            </Button>
+            <div className="flex items-center gap-2">
+              {ENABLE_GROUP_BUY && (
+                <Button
+                  variant="outline"
+                  onClick={() => navigate("/admin/billing/institutions")}
+                  className="flex items-center gap-2"
+                  title="機構應收帳款管理"
+                >
+                  機構應收帳款
+                </Button>
+              )}
+              <Button
+                onClick={() => navigate("/admin/organizations/create")}
+                className="flex items-center gap-2"
+              >
+                <Building className="h-4 w-4" />
+                創建組織
+              </Button>
+            </div>
           </div>
         </CardHeader>
 


### PR DESCRIPTION
## 範圍

issue #838 **Phase D（最後一塊）**：應收帳款 ledger 的 CRUD、admin 儀表板、每日逾期掃描 cron。用到的 `institution_invoices` 表已於 #886 建立，**無 migration**。

## Backend
- **`services/institution_invoice_ledger.py`**（新）
  - `upsert_invoice` — 對 `(org, year, month)` **冪等鎖定**；`amount` 由後端 `compute_monthly_billing` **snapshot**（客戶端不傳）。重複鎖定 **UPDATE 而非 INSERT**；已 `paid`/`cancelled`/`overdue` 的帳款不被還原/改額。
  - `mark_invoice_paid` / `mark_invoice_cancelled` / `apply_status_change` — 僅 `paid`/`cancelled` 可由 admin 設定（`pending`/`overdue` 系統管理）；`paid` 記錄 admin id + 時間。
  - `mark_overdue_invoices` — `pending` 且 `due_date < 今日(Taipei)` → `overdue`，冪等。
- **`routers/institution_invoices.py`**（`/api/admin`，admin only）
  - `POST /institution-invoices`（鎖金額，冪等）
  - `GET /institution-invoices?status=&overdue=&year=&month=&organization_id=`（篩選、newest first）
  - `PATCH /institution-invoices/{id}`（標記 paid/cancelled + note）
  - main.py 註冊。
- **`routers/cron.py`**：`POST /api/cron/billing-overdue-check`（`CRON_SECRET` header 保護；建議每日 09:00 Asia/Taipei）。
- **`organizations.py` send-email 端點**：寄送成功後 **自動 upsert 一筆 pending 應收帳款**（idempotent，不干擾已 paid）。

## Frontend
- `api.ts`：`createInstitutionInvoice` / `listInstitutionInvoices` / `updateInstitutionInvoice` + `InstitutionInvoiceDto`。
- `OrgMonthlyBillingPanel`：新增「**建立應收帳款**」按鈕（鎖金額）。
- 新 admin 頁 **`/admin/billing/institutions`**（`AdminInstitutionInvoices.tsx`）：狀態篩選 + badge + 「**標記已收款**」/「作廢」action；App.tsx 註冊路由（`requireAdmin`）。

## 驗收對照
- [x] 同月份對同 org 重複建立會 UPDATE 而非 INSERT（`test_upsert_creates_then_is_idempotent` + 端點 `test_create_locks_amount_and_is_idempotent`）
- [x] 標記 paid 後 admin 名字/時間正確記錄（`test_mark_paid_records_admin_and_time` + `test_patch_mark_paid_records_admin`）
- [x] 逾期 cron 可跑（`test_overdue_cron_marks_overdue`；手動觸發：`POST /api/cron/billing-overdue-check` 帶 `X-Cron-Secret`）
- [x] 列表頁狀態篩選（`test_list_filters_by_status` + 前端 filter）
- [x] Phase C 寄 email 時自動建立 pending 帳款

## 測試
- Service 層：`test_institution_invoice_ledger.py` **8 passed**（含既有 models 共 28 passed）。
- 端點/cron：`test_institution_invoices_endpoint.py` 8 個（admin auth、鎖金額冪等、篩選、mark paid、非法 status 400、cron 需 secret + 標記 overdue）→ CI 驗證（需 casbin/Postgres）。
- black / flake8 / tsc / prettier clean。

## Cloud Scheduler 設定（部署後）
每日觸發 `POST {backend}/api/cron/billing-overdue-check`，header `X-Cron-Secret: {CRON_SECRET}`，排程 `0 9 * * * Asia/Taipei`。

Related to #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)