### PR TITLE
fix(#314 Part 1): 解鎖測試 — Casbin best-effort sync + SQLite fallback

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -146,33 +146,49 @@ async def startup_event():
 
     logger = logging.getLogger(__name__)
 
-    MAX_RETRIES = 3
-    RETRY_DELAY = 2  # seconds
-
-    for attempt in range(MAX_RETRIES):
+    # In the test suite, Casbin sync must never abort startup. Instantiating
+    # TestClient(app) fires this startup event; when the DB is unreachable (local
+    # SQLite runs with no Postgres) sync_from_database() used to retry and then
+    # raise "Failed to initialize permission system", aborting every
+    # TestClient-based test at setup. In TESTING mode we make it best-effort:
+    # try once, keep any grants we can load (e.g. CI's real Postgres still syncs
+    # exactly as before), but swallow failures instead of crashing. (Issue #314)
+    if os.getenv("TESTING", "").lower() == "true":
         try:
             from services.casbin_service import get_casbin_service
 
-            casbin_service = get_casbin_service()
-            casbin_service.sync_from_database()
-            logger.info("✅ Casbin roles synced from database")
-            break
+            get_casbin_service().sync_from_database()
+            logger.info("✅ Casbin roles synced from database (test mode)")
         except Exception as e:
-            if attempt == MAX_RETRIES - 1:
-                # Last attempt failed - this is critical
-                logger.critical(
-                    f"🚨 CRITICAL: Failed to sync Casbin roles after {MAX_RETRIES} attempts: {e}",
-                    exc_info=True,
-                )
-                raise RuntimeError(
-                    "Failed to initialize permission system. Cannot start application."
-                ) from e
-            else:
-                logger.warning(
-                    f"⚠️ Casbin sync attempt {attempt + 1}/{MAX_RETRIES} failed: {e}. Retrying in {RETRY_DELAY}s..."
-                )
-                time.sleep(RETRY_DELAY)
-                RETRY_DELAY *= 2  # Exponential backoff
+            logger.warning(f"⏭️  TESTING: Casbin sync skipped — DB not reachable ({e})")
+    else:
+        MAX_RETRIES = 3
+        RETRY_DELAY = 2  # seconds
+
+        for attempt in range(MAX_RETRIES):
+            try:
+                from services.casbin_service import get_casbin_service
+
+                casbin_service = get_casbin_service()
+                casbin_service.sync_from_database()
+                logger.info("✅ Casbin roles synced from database")
+                break
+            except Exception as e:
+                if attempt == MAX_RETRIES - 1:
+                    # Last attempt failed - this is critical
+                    logger.critical(
+                        f"🚨 CRITICAL: Failed to sync Casbin roles after {MAX_RETRIES} attempts: {e}",
+                        exc_info=True,
+                    )
+                    raise RuntimeError(
+                        "Failed to initialize permission system. Cannot start application."
+                    ) from e
+                else:
+                    logger.warning(
+                        f"⚠️ Casbin sync attempt {attempt + 1}/{MAX_RETRIES} failed: {e}. Retrying in {RETRY_DELAY}s..."
+                    )
+                    time.sleep(RETRY_DELAY)
+                    RETRY_DELAY *= 2  # Exponential backoff
 
     print(
         "🚀 Application startup complete - "

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,6 +2,19 @@
 Global pytest configuration
 統一的測試配置，確保所有測試使用相同的資料庫設置
 """
+import os
+
+# Boot the app in test mode BEFORE importing database/main below.
+# - TESTING=true makes the startup event treat Casbin sync_from_database as
+#   best-effort: it no longer retries-then-raises when the DB is unreachable,
+#   which used to abort every TestClient-based test at setup (Issue #314).
+# - DATABASE_URL defaults the app's engine to the local SQLite test DB, so any
+#   code path that bypasses the get_db override fails safe to SQLite instead of
+#   a remote Postgres/Supabase host. setdefault() preserves an explicit
+#   DATABASE_URL (e.g. a Postgres service in CI).
+os.environ.setdefault("TESTING", "true")
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test_org.db")
+
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker

--- a/backend/tests/unit/test_assignment_models.py
+++ b/backend/tests/unit/test_assignment_models.py
@@ -17,6 +17,7 @@ from models import (
     Student,
     Classroom,
     Content,
+    ContentItem,
     Lesson,
     Program,
     AssignmentStatus,
@@ -109,9 +110,9 @@ def sample_content(db_session, sample_lesson):
         lesson_id=sample_lesson.id,
         type=ContentType.EXAMPLE_SENTENCES,
         title="Test Content",
-        items=[
-            {"text": "Hello", "translation": "你好"},
-            {"text": "World", "translation": "世界"},
+        content_items=[
+            ContentItem(order_index=0, text="Hello", translation="你好"),
+            ContentItem(order_index=1, text="World", translation="世界"),
         ],
     )
     db_session.add(content)
@@ -217,7 +218,7 @@ class TestAssignmentContentModel:
                 lesson_id=sample_lesson.id,
                 type=ContentType.EXAMPLE_SENTENCES,
                 title=f"Content {i+1}",
-                items=[],
+                content_items=[],
             )
             contents.append(content)
         db_session.add_all(contents)


### PR DESCRIPTION
## 背景

#314 Part 1 的**最高槓桿切片**。過去所有用 `TestClient(app)` 的測試都在 setup 就爆掉：FastAPI startup event 會跑 Casbin `sync_from_database()`，連不到 DB 時重試 3 次後 `raise RuntimeError("Failed to initialize permission system")`，導致本地測試根本跑不起來（前兩輪 #273/#335 都撞到）。

## 變更

1. **`main.py`** — TESTING 模式下 Casbin sync 改為 **best-effort**：試一次、失敗就吞掉（log warning），不再 retry-then-raise。
   - ✅ **CI 的真 Postgres 行為不變**（sync 照樣成功）；只有本地/SQLite 連不到 DB 時不再 crash。這是刻意選 best-effort 而非直接 skip 的原因——避免改動 CI 既有行為。
2. **`tests/conftest.py`** — 在 import `database`/`main` **之前**設 `TESTING=true` 與 SQLite `DATABASE_URL`（`DATABASE_URL` 在 database.py import 時就綁定）。用 `setdefault()`，所以 CI 明確設定的 Postgres URL 會被保留。
3. **`tests/unit/test_assignment_models.py`** — 修 `Content(items=...)` kwarg：`items` 欄位已被 `content_items` 關聯取代，改用 `ContentItem(order_index, text, translation)`。

## 影響（本地 `pytest tests/unit/`，未設 DATABASE_URL）

| | 結果 |
|---|---|
| **修改前** | 幾乎所有 TestClient 測試在 setup **ERROR**（連 DB / Casbin RuntimeError），單一 setup ~6s |
| **修改後** | **936 passed**, 158 failed, 22 errors；setup ~0.02s |

## 本 PR **不含**的後續（誠實列出）

- **22 errors**：4 個 module-level `app.dependency_overrides` 檔案（`test_content_crud_api` / `test_lesson_crud_api` / `test_program_crud_api` / `test_content_update_with_practice_answers`）在整個 suite 跑時 override 會被別的 fixture 清掉，屬 order-dependent 污染 → 需改用 conftest 的 `test_client` fixture。
- **158 failed**：測試終於能跑之後浮現的個別 test bug（硬編碼 `test_token`→401、`Content(created_by_teacher_id=)`、缺 optional 套件 `google.cloud.aiplatform` 等）。
- **Part 3**（移除 CI `continue-on-error`）：等 suite 全綠才能收，維持 gated。

## 驗證
- ✅ black / flake8 clean（改動的 3 檔）
- ✅ `test_assignment_models.py` 現在全綠（10 passed）
- ✅ 抽樣整合測試 setup 從 ~6s 降到 ~0.02s，無 DB 連線錯誤

Related to #314 (Part 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)