### PR TITLE
feat(#330): 學生作業列表後端分頁 + status 篩選（opt-in）

### DIFF
--- a/backend/routers/students/assignments.py
+++ b/backend/routers/students/assignments.py
@@ -94,75 +94,24 @@ def _tier_counts(mastery_result) -> Dict[str, int]:
     }
 
 
-@router.get("/assignments")
-async def get_student_assignments(
-    sort_by: Literal[
-        "due_date_asc", "due_date_desc", "assigned_at_desc", "status"
-    ] = Query("due_date_asc"),
-    practice_mode: Optional[
-        Literal[
-            "reading",
-            "rearrangement",
-            "word_selection",
-            "word_reading",
-            "word_spelling",
-            "word_cloze",
-            # Issue #843: 對齊前端 registry（含三種小考與 tug_of_war），
-            # 否則學生端篩選這些模式會 422，前端誤跳「載入失敗」。
-            # 無對應作業時回空陣列，前端顯示空狀態而非報錯。
-            "word_selection_quiz",
-            "word_spelling_quiz",
-            "word_cloze_quiz",
-            "tug_of_war",
-        ]
-    ] = None,
-    current_student: Dict[str, Any] = Depends(get_current_student),
-    db: Session = Depends(get_db),
-):
-    """取得學生作業列表"""
-    student_id = current_student.get("sub")
+# Issue #330: student assignment-list tab keys → StudentAssignment status groups,
+# used for optional server-side filtering + pagination of the list endpoint.
+_STATUS_TAB_MAP = {
+    "todo": [AssignmentStatus.NOT_STARTED, AssignmentStatus.IN_PROGRESS],
+    "submitted": [AssignmentStatus.SUBMITTED],
+    "returned": [AssignmentStatus.RETURNED],
+    "resubmitted": [AssignmentStatus.RESUBMITTED],
+    "graded": [AssignmentStatus.GRADED],
+}
 
-    # Base query: always join Assignment to filter archived and eager-load
-    query = (
-        db.query(StudentAssignment)
-        .join(Assignment, StudentAssignment.assignment_id == Assignment.id)
-        .options(contains_eager(StudentAssignment.assignment))
-        .filter(
-            StudentAssignment.student_id == int(student_id),
-            Assignment.is_archived.is_(False),
-        )
-    )
 
-    # Filter by practice_mode
-    if practice_mode:
-        query = query.filter(Assignment.practice_mode == practice_mode)
+def _serialize_student_assignments(
+    db: Session, assignments: List[StudentAssignment]
+) -> List[Dict[str, Any]]:
+    """Serialize StudentAssignment rows into the student-facing card shape.
 
-    # Sorting
-    if sort_by == "due_date_desc":
-        query = query.order_by(StudentAssignment.due_date.desc().nullslast())
-    elif sort_by == "assigned_at_desc":
-        query = query.order_by(StudentAssignment.assigned_at.desc().nullslast())
-    elif sort_by == "status":
-        # Priority: returned > in_progress > not_started > submitted > resubmitted > graded
-        status_order = case(
-            (StudentAssignment.status == AssignmentStatus.RETURNED, 0),
-            (StudentAssignment.status == AssignmentStatus.IN_PROGRESS, 1),
-            (StudentAssignment.status == AssignmentStatus.NOT_STARTED, 2),
-            (StudentAssignment.status == AssignmentStatus.SUBMITTED, 3),
-            (StudentAssignment.status == AssignmentStatus.RESUBMITTED, 4),
-            (StudentAssignment.status == AssignmentStatus.GRADED, 5),
-            else_=6,
-        )
-        query = query.order_by(
-            status_order, StudentAssignment.due_date.asc().nullslast()
-        )
-    else:
-        # Default: due_date_asc (nearest deadline first)
-        query = query.order_by(StudentAssignment.due_date.asc().nullslast())
-
-    assignments = query.all()
-
-    # Batch query: count content items per assignment to avoid N+1
+    Batches the content-item count query to avoid N+1.
+    """
     parent_ids = [sa.assignment_id for sa in assignments if sa.assignment_id]
     count_map: Dict[int, int] = {}
     if parent_ids:
@@ -219,8 +168,139 @@ async def get_student_assignments(
                 ),
             }
         )
-
     return result
+
+
+def _compute_status_tab_stats(
+    db: Session, student_id: int, practice_mode: Optional[str]
+) -> Dict[str, int]:
+    """Per-tab assignment counts for the student, independent of the active tab.
+
+    Keeps every tab badge populated when the list is served page-by-page.
+    Respects the same student + not-archived (+ practice_mode) scope as the list.
+    """
+    stats_query = (
+        db.query(StudentAssignment.status, func.count(StudentAssignment.id))
+        .join(Assignment, StudentAssignment.assignment_id == Assignment.id)
+        .filter(
+            StudentAssignment.student_id == student_id,
+            Assignment.is_archived.is_(False),
+        )
+    )
+    if practice_mode:
+        stats_query = stats_query.filter(Assignment.practice_mode == practice_mode)
+
+    counts = {
+        row[0]: row[1] for row in stats_query.group_by(StudentAssignment.status).all()
+    }
+    return {
+        "todo": counts.get(AssignmentStatus.NOT_STARTED, 0)
+        + counts.get(AssignmentStatus.IN_PROGRESS, 0),
+        "submitted": counts.get(AssignmentStatus.SUBMITTED, 0),
+        "returned": counts.get(AssignmentStatus.RETURNED, 0),
+        "resubmitted": counts.get(AssignmentStatus.RESUBMITTED, 0),
+        "graded": counts.get(AssignmentStatus.GRADED, 0),
+    }
+
+
+@router.get("/assignments")
+async def get_student_assignments(
+    sort_by: Literal[
+        "due_date_asc", "due_date_desc", "assigned_at_desc", "status"
+    ] = Query("due_date_asc"),
+    practice_mode: Optional[
+        Literal[
+            "reading",
+            "rearrangement",
+            "word_selection",
+            "word_reading",
+            "word_spelling",
+            "word_cloze",
+            # Issue #843: 對齊前端 registry（含三種小考與 tug_of_war），
+            # 否則學生端篩選這些模式會 422，前端誤跳「載入失敗」。
+            # 無對應作業時回空陣列，前端顯示空狀態而非報錯。
+            "word_selection_quiz",
+            "word_spelling_quiz",
+            "word_cloze_quiz",
+            "tug_of_war",
+        ]
+    ] = None,
+    # Issue #330: optional server-side status filtering + pagination. When
+    # page_size is omitted the endpoint stays backward-compatible and returns a
+    # bare list (StudentDashboard and StudentAssignmentDetail rely on that).
+    status_tab: Optional[
+        Literal["todo", "submitted", "returned", "resubmitted", "graded"]
+    ] = Query(None, alias="status"),
+    page: int = Query(1, ge=1),
+    page_size: Optional[int] = Query(None, ge=1, le=100),
+    current_student: Dict[str, Any] = Depends(get_current_student),
+    db: Session = Depends(get_db),
+):
+    """取得學生作業列表
+
+    - 不帶 ``page_size``：回傳完整 list（向後相容，Dashboard/Detail 使用）。
+    - 帶 ``page_size``：回傳 ``{items, total, page, page_size, stats}``，
+      status 分頁與 tab 計數都在後端完成。
+    """
+    student_id = current_student.get("sub")
+
+    # Base query: always join Assignment to filter archived and eager-load
+    query = (
+        db.query(StudentAssignment)
+        .join(Assignment, StudentAssignment.assignment_id == Assignment.id)
+        .options(contains_eager(StudentAssignment.assignment))
+        .filter(
+            StudentAssignment.student_id == int(student_id),
+            Assignment.is_archived.is_(False),
+        )
+    )
+
+    # Filter by practice_mode
+    if practice_mode:
+        query = query.filter(Assignment.practice_mode == practice_mode)
+
+    # Issue #330: optional server-side status-tab filter
+    if status_tab:
+        query = query.filter(StudentAssignment.status.in_(_STATUS_TAB_MAP[status_tab]))
+
+    # Sorting
+    if sort_by == "due_date_desc":
+        query = query.order_by(StudentAssignment.due_date.desc().nullslast())
+    elif sort_by == "assigned_at_desc":
+        query = query.order_by(StudentAssignment.assigned_at.desc().nullslast())
+    elif sort_by == "status":
+        # Priority: returned > in_progress > not_started > submitted > resubmitted > graded
+        status_order = case(
+            (StudentAssignment.status == AssignmentStatus.RETURNED, 0),
+            (StudentAssignment.status == AssignmentStatus.IN_PROGRESS, 1),
+            (StudentAssignment.status == AssignmentStatus.NOT_STARTED, 2),
+            (StudentAssignment.status == AssignmentStatus.SUBMITTED, 3),
+            (StudentAssignment.status == AssignmentStatus.RESUBMITTED, 4),
+            (StudentAssignment.status == AssignmentStatus.GRADED, 5),
+            else_=6,
+        )
+        query = query.order_by(
+            status_order, StudentAssignment.due_date.asc().nullslast()
+        )
+    else:
+        # Default: due_date_asc (nearest deadline first)
+        query = query.order_by(StudentAssignment.due_date.asc().nullslast())
+
+    # Issue #330: paginate on the server only when page_size is provided;
+    # otherwise return the full list (backward-compatible).
+    if page_size is None:
+        return _serialize_student_assignments(db, query.all())
+
+    total = query.count()
+    stats = _compute_status_tab_stats(db, int(student_id), practice_mode)
+    page_assignments = query.offset((page - 1) * page_size).limit(page_size).all()
+    return {
+        "items": _serialize_student_assignments(db, page_assignments),
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "stats": stats,
+    }
 
 
 @router.get("/assignments/{assignment_id}/activities")

--- a/backend/tests/integration/api/test_student_assignments_pagination.py
+++ b/backend/tests/integration/api/test_student_assignments_pagination.py
@@ -1,0 +1,145 @@
+"""Issue #330: server-side pagination + status filtering for the student
+assignment list endpoint (GET /api/students/assignments).
+
+Covers:
+- backward compatibility (no page_size -> bare list),
+- the paginated envelope shape + per-tab stats,
+- server-side status-tab filtering with paging.
+"""
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from auth import create_access_token
+from models import (
+    Teacher,
+    Student,
+    Classroom,
+    Assignment,
+    StudentAssignment,
+    AssignmentStatus,
+)
+
+
+# Status distribution used across the tests below.
+#   todo = NOT_STARTED + IN_PROGRESS = 7
+#   submitted = 3, returned = 1, resubmitted = 1, graded = 4
+#   total = 16
+_DISTRIBUTION = (
+    [AssignmentStatus.NOT_STARTED] * 5
+    + [AssignmentStatus.IN_PROGRESS] * 2
+    + [AssignmentStatus.SUBMITTED] * 3
+    + [AssignmentStatus.RETURNED] * 1
+    + [AssignmentStatus.RESUBMITTED] * 1
+    + [AssignmentStatus.GRADED] * 4
+)
+
+
+def _seed(db_session: Session) -> Student:
+    teacher = Teacher(email="pg_teacher@test.com", name="PG Teacher", password_hash="x")
+    student = Student(email="pg_student@test.com", name="PG Student")
+    db_session.add_all([teacher, student])
+    db_session.commit()
+
+    classroom = Classroom(name="PG Class", teacher_id=teacher.id)
+    db_session.add(classroom)
+    db_session.commit()
+
+    parent = Assignment(
+        title="PG Assignment",
+        classroom_id=classroom.id,
+        teacher_id=teacher.id,
+        is_archived=False,
+    )
+    db_session.add(parent)
+    db_session.commit()
+
+    for i, status in enumerate(_DISTRIBUTION):
+        db_session.add(
+            StudentAssignment(
+                assignment_id=parent.id,
+                student_id=student.id,
+                classroom_id=classroom.id,
+                title=f"SA {i}",
+                status=status,
+            )
+        )
+    db_session.commit()
+    return student
+
+
+def _headers(student: Student) -> dict:
+    token = create_access_token({"sub": str(student.id), "type": "student"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestStudentAssignmentsPagination:
+    def test_no_page_size_returns_bare_list(
+        self, test_client: TestClient, db_session: Session
+    ):
+        """Backward compatible: without page_size the endpoint returns a list."""
+        student = _seed(db_session)
+        resp = test_client.get("/api/students/assignments", headers=_headers(student))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert isinstance(body, list)
+        assert len(body) == len(_DISTRIBUTION)  # 16
+
+    def test_paginated_envelope_and_stats(
+        self, test_client: TestClient, db_session: Session
+    ):
+        """With page_size the endpoint returns an envelope with total + stats."""
+        student = _seed(db_session)
+        resp = test_client.get(
+            "/api/students/assignments?page=1&page_size=8",
+            headers=_headers(student),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert isinstance(body, dict)
+        assert body["total"] == 16
+        assert body["page"] == 1
+        assert body["page_size"] == 8
+        assert len(body["items"]) == 8
+        # stats are independent of the current page / active tab
+        assert body["stats"] == {
+            "todo": 7,
+            "submitted": 3,
+            "returned": 1,
+            "resubmitted": 1,
+            "graded": 4,
+        }
+
+        # Page 2 returns the remaining 8 items.
+        resp2 = test_client.get(
+            "/api/students/assignments?page=2&page_size=8",
+            headers=_headers(student),
+        )
+        assert resp2.status_code == 200
+        assert len(resp2.json()["items"]) == 8
+
+    def test_status_tab_filter_with_paging(
+        self, test_client: TestClient, db_session: Session
+    ):
+        """status filter narrows results server-side; total reflects the tab."""
+        student = _seed(db_session)
+        resp = test_client.get(
+            "/api/students/assignments?status=todo&page=1&page_size=5",
+            headers=_headers(student),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 7  # only NOT_STARTED + IN_PROGRESS
+        assert len(body["items"]) == 5
+        assert all(
+            item["status"] in ("NOT_STARTED", "IN_PROGRESS") for item in body["items"]
+        )
+        # stats stay full-scope even when a tab is active
+        assert body["stats"]["graded"] == 4
+
+        # Second page of the todo tab has the remaining 2.
+        resp2 = test_client.get(
+            "/api/students/assignments?status=todo&page=2&page_size=5",
+            headers=_headers(student),
+        )
+        assert len(resp2.json()["items"]) == 2

--- a/frontend/src/pages/student/StudentAssignmentList.tsx
+++ b/frontend/src/pages/student/StudentAssignmentList.tsx
@@ -81,6 +81,8 @@ export default function StudentAssignmentList() {
   const [filterMode, setFilterMode] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const PAGE_SIZE = 8;
+  // Issue #330: total count for the active tab, from the server (drives paging).
+  const [totalCount, setTotalCount] = useState(0);
   const [stats, setStats] = useState({
     totalAssignments: 0,
     todo: 0,
@@ -97,7 +99,15 @@ export default function StudentAssignmentList() {
         if (!silent) setLoading(true);
         const apiUrl = import.meta.env.VITE_API_URL || "";
 
-        const params = new URLSearchParams({ sort_by: sortBy });
+        // Issue #330: server-side pagination + status filtering. Request only
+        // the active tab's current page; the backend also returns per-tab
+        // counts so every tab badge stays populated.
+        const params = new URLSearchParams({
+          sort_by: sortBy,
+          status: activeTab,
+          page: String(currentPage),
+          page_size: String(PAGE_SIZE),
+        });
         if (filterMode) {
           params.set("practice_mode", filterMode);
         }
@@ -121,7 +131,7 @@ export default function StudentAssignmentList() {
 
         const data = await response.json();
 
-        const assignmentCards: StudentAssignmentCard[] = data.map(
+        const assignmentCards: StudentAssignmentCard[] = data.items.map(
           (a: AssignmentData) => ({
             id: a.id,
             title: a.title,
@@ -144,31 +154,23 @@ export default function StudentAssignmentList() {
         );
 
         setAssignments(assignmentCards);
+        setTotalCount(data.total ?? assignmentCards.length);
 
-        // Calculate stats
-        const todo = assignmentCards.filter(
-          (a) => a.status === "NOT_STARTED" || a.status === "IN_PROGRESS",
-        ).length;
-        const submitted = assignmentCards.filter(
-          (a) => a.status === "SUBMITTED",
-        ).length;
-        const graded = assignmentCards.filter(
-          (a) => a.status === "GRADED",
-        ).length;
-        const returned = assignmentCards.filter(
-          (a) => a.status === "RETURNED",
-        ).length;
-        const resubmitted = assignmentCards.filter(
-          (a) => a.status === "RESUBMITTED",
-        ).length;
-
+        // Stats are computed server-side over the full set (all tabs), so the
+        // badges stay correct even though only one page is fetched.
+        const s = data.stats || {};
         setStats({
-          totalAssignments: assignmentCards.length,
-          todo,
-          submitted,
-          graded,
-          returned,
-          resubmitted,
+          totalAssignments:
+            (s.todo || 0) +
+            (s.submitted || 0) +
+            (s.graded || 0) +
+            (s.returned || 0) +
+            (s.resubmitted || 0),
+          todo: s.todo || 0,
+          submitted: s.submitted || 0,
+          graded: s.graded || 0,
+          returned: s.returned || 0,
+          resubmitted: s.resubmitted || 0,
         });
       } catch (error) {
         console.error("Failed to load assignments:", error);
@@ -178,7 +180,7 @@ export default function StudentAssignmentList() {
         if (!silent) setLoading(false);
       }
     },
-    [token, sortBy, filterMode, t],
+    [token, sortBy, filterMode, activeTab, currentPage, t],
   );
 
   useEffect(() => {
@@ -475,25 +477,6 @@ export default function StudentAssignmentList() {
     );
   };
 
-  const filterAssignments = (statusFilter: string) => {
-    switch (statusFilter) {
-      case "todo":
-        return assignments.filter(
-          (a) => a.status === "NOT_STARTED" || a.status === "IN_PROGRESS",
-        );
-      case "submitted":
-        return assignments.filter((a) => a.status === "SUBMITTED");
-      case "graded":
-        return assignments.filter((a) => a.status === "GRADED");
-      case "returned":
-        return assignments.filter((a) => a.status === "RETURNED");
-      case "resubmitted":
-        return assignments.filter((a) => a.status === "RESUBMITTED");
-      default:
-        return assignments;
-    }
-  };
-
   const renderEmptyState = (tab: string) => {
     const iconMap: Record<string, React.ReactNode> = {
       todo: <Clock className="h-12 w-12 text-gray-300 mx-auto mb-3" />,
@@ -523,18 +506,18 @@ export default function StudentAssignmentList() {
   };
 
   const renderTabContent = (tab: string) => {
-    const filtered = filterAssignments(tab);
-    if (filtered.length === 0) return renderEmptyState(tab);
+    // Issue #330: the server already returns just this tab's current page and
+    // the tab's total count, so render `assignments` directly and derive the
+    // page count from totalCount.
+    if (assignments.length === 0) return renderEmptyState(tab);
 
-    const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+    const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
     const safeCurrentPage = Math.min(currentPage, totalPages);
-    const startIdx = (safeCurrentPage - 1) * PAGE_SIZE;
-    const paged = filtered.slice(startIdx, startIdx + PAGE_SIZE);
 
     return (
       <>
         <div className="grid grid-cols-1 md:grid-cols-2 2xl:grid-cols-3 gap-3 sm:gap-4">
-          {paged.map(renderAssignmentCard)}
+          {assignments.map(renderAssignmentCard)}
         </div>
         {totalPages > 1 && (
           <div className="flex items-center justify-center gap-3 mt-6">


### PR DESCRIPTION
## 背景

`GET /api/students/assignments` 過去回傳**全部**作業，前端 `StudentAssignmentList` 再用 tab client-side 篩選 + `.slice()` 分頁。#330 要把分頁/篩選移到後端。

## 關鍵設計：opt-in（向後相容）

此端點有 **3 個 consumer**：`StudentAssignmentList`（要分頁）、`StudentAssignmentDetail`（抓整包 list 再 `.find()` 一筆）、`StudentDashboard`（抓整包）。若直接改成分頁 envelope 會**破壞後兩者**。

→ 採 **opt-in**：帶 `page_size` 才分頁，不帶則維持原本 bare list。Dashboard / Detail 完全不動。

## Backend（`routers/students/assignments.py`）

- 新增 optional query params：`status`（tab：todo/submitted/returned/resubmitted/graded，用 `alias=\"status\"` 避免和 fastapi 的 `status` import 撞名）、`page`、`page_size`。
- 不帶 `page_size`：回傳原本的 bare list（向後相容）。
- 帶 `page_size`：回傳 `{items, total, page, page_size, stats}`。
  - `stats` 是**跨全體**（student + 未封存 + practice_mode）的 per-tab 計數 → 即使只抓一頁，5 個 tab badge 仍正確。
- 抽出 row 序列化為共用 helper；新增 stats helper。

## Frontend（`StudentAssignmentList.tsx`）

- 只請求 active tab 的當前頁（`status`+`page`+`page_size`），直接 render 回傳的 items，分頁數由 server `total` 推導。
- tab badge 改吃 server `stats`（不再從已變成「一頁」的 client list 數）。
- 移除 client-side `filterAssignments` / `.slice()`。

## 測試（新增 `test_student_assignments_pagination.py`）

拜 **#900**（測試 infra 修復）所賜，後端測試現在本地跑得起來：
- ✅ 向後相容 bare list
- ✅ 分頁 envelope + stats 正確
- ✅ status tab 篩選跨頁

三個測試本地全綠。

## 驗證
- ✅ Backend：新測試 3 passed；black / flake8 clean
- ✅ Frontend：tsc / eslint / prettier / vite build 全通過
- ℹ️ 註：`test_student_assignment_activities_fixed.py` 有 1 個 failure，但那是**另一個端點**（`/activities`）的 pre-existing test bug（#314 backlog），不在本 PR 範圍、我也沒動到該端點

Related to #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)