### PR TITLE
refactor(#335): 教師批改 router 品質項（items 5/6/8/9）

### DIFF
--- a/backend/routers/assignments/grading.py
+++ b/backend/routers/assignments/grading.py
@@ -4,6 +4,7 @@ Grading operations (AI and manual)
 
 import json
 import logging
+from collections import defaultdict
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException
@@ -37,6 +38,10 @@ from .validators import (
     StudentBatchGradingResult,
     BatchGradeFinalizeRequest,
     BatchGradeFinalizeResponse,
+    GradeStudentAssignmentRequest,
+    SetAssignmentInProgressRequest,
+    ReturnForRevisionRequest,
+    ManualGradeAssignmentRequest,
 )
 from .dependencies import get_current_teacher
 from .detail import (
@@ -135,10 +140,7 @@ async def ai_grade_assignment(
             )
         perf.checkpoint("Status Validation")
 
-    # 3. 簡化版 - 不查詢 Content
-    content = None
-
-    # 4. 取得提交資料（新架構從 StudentContentProgress 取得）
+    # 3. 取得提交資料（新架構從 StudentContentProgress 取得）
     # 暫時簡化處理
 
     try:
@@ -151,12 +153,11 @@ async def ai_grade_assignment(
         else:
             # 準備預期文字
             with start_span("Prepare Expected Texts"):
+                # This simplified path intentionally does not load Content, so
+                # there are no expected texts to prepare. (Issue #335 item 6:
+                # removed dead `hasattr(content, ...)` block that was always
+                # False because content was unconditionally None.)
                 expected_texts = []
-                if hasattr(content, "content_items"):
-                    for item in content.content_items:
-                        expected_texts.append(
-                            item.text if hasattr(item, "text") else ""
-                        )
                 perf.checkpoint("Text Preparation")
 
             # 呼叫 Whisper API（這裡最可能慢）
@@ -317,8 +318,6 @@ async def get_assignment_submissions(
     }
 
     submission_ids = [sub.id for sub in submissions]
-    from collections import defaultdict
-
     progress_dict = defaultdict(list)
     for progress in (
         db.query(StudentContentProgress)
@@ -770,12 +769,14 @@ def _is_quiz_assignment(
 @router.post("/{assignment_id}/grade")
 async def grade_student_assignment(
     assignment_id: int,
-    grade_data: dict,
+    payload: GradeStudentAssignmentRequest,
     current_teacher: Teacher = Depends(get_current_teacher),
     db: Session = Depends(get_db),
 ):
     """教師批改學生作業"""
-    import logging
+    # Issue #335 item 5: validated body bridged to the existing dict logic
+    # (exclude_none keeps the original ``"key" in grade_data`` semantics).
+    grade_data = payload.model_dump(exclude_none=True)
 
     # 獲取學生ID
     student_id = grade_data.get("student_id")
@@ -976,11 +977,13 @@ async def grade_student_assignment(
 @router.post("/{assignment_id}/set-in-progress")
 async def set_assignment_in_progress(
     assignment_id: int,
-    data: dict,
+    payload: SetAssignmentInProgressRequest,
     current_teacher: Teacher = Depends(get_current_teacher),
     db: Session = Depends(get_db),
 ):
     """設定為批改中狀態"""
+    # Issue #335 item 5: validated body bridged to the existing dict logic.
+    data = payload.model_dump(exclude_none=True)
     # 獲取學生ID
     student_id = data.get("student_id")
     if not student_id:
@@ -1156,11 +1159,13 @@ def _do_return_for_revision(
 @router.post("/{assignment_id}/return-for-revision")
 async def return_for_revision(
     assignment_id: int,
-    data: dict,
+    payload: ReturnForRevisionRequest,
     current_teacher: Teacher = Depends(get_current_teacher),
     db: Session = Depends(get_db),
 ):
     """要求訂正 - 要求學生修改作業（單筆）"""
+    # Issue #335 item 5: validated body bridged to the existing dict logic.
+    data = payload.model_dump(exclude_none=True)
     student_id = data.get("student_id")
     if not student_id:
         raise HTTPException(status_code=400, detail="Student ID is required")
@@ -1377,11 +1382,13 @@ async def batch_reset_not_started(
 @router.post("/{assignment_id}/manual-grade")
 async def manual_grade_assignment(
     assignment_id: int,
-    grade_data: dict,
+    payload: ManualGradeAssignmentRequest,
     current_teacher: Teacher = Depends(get_current_teacher),
     db: Session = Depends(get_db),
 ):
     """手動評分（教師用）"""
+    # Issue #335 item 5: validated body bridged to the existing dict logic.
+    grade_data = payload.model_dump(exclude_none=True)
     # 獲取作業
     assignment = (
         db.query(StudentAssignment)
@@ -1420,7 +1427,7 @@ async def manual_grade_assignment(
     if "detailed_scores" in grade_data:
         progress_records = (
             db.query(StudentContentProgress)
-            .filter(StudentContentProgress.student_assignment_id == assignment_id)
+            .filter(StudentContentProgress.student_assignment_id == assignment.id)
             .all()
         )
 

--- a/backend/routers/assignments/validators.py
+++ b/backend/routers/assignments/validators.py
@@ -4,7 +4,7 @@ Pydantic models and validators for assignments
 
 from typing import List, Optional, Dict, Any
 from datetime import datetime
-from pydantic import BaseModel, model_validator, field_validator
+from pydantic import BaseModel, Field, model_validator, field_validator
 
 from utils.practice_mode import validate_practice_mode
 
@@ -262,3 +262,48 @@ class BatchGradeFinalizeResponse(BaseModel):
     graded_count: int
     unchanged_count: int
     total_count: int
+
+
+# Issue #335 item 5: typed request bodies for the manual/teacher grading
+# endpoints that previously accepted raw ``dict`` (no validation, no score
+# bounds). Endpoints bridge these back to a dict via
+# ``model_dump(exclude_none=True)`` so existing body logic is unchanged while
+# input is now validated at the boundary.
+class TeacherItemGradeResult(BaseModel):
+    """Per-item teacher grade inside GradeStudentAssignmentRequest."""
+
+    item_index: int
+    feedback: Optional[str] = None
+    passed: Optional[bool] = None
+    score: Optional[float] = Field(default=None, ge=0, le=100)
+
+
+class GradeStudentAssignmentRequest(BaseModel):
+    """Body for POST /{assignment_id}/grade."""
+
+    student_id: int
+    score: Optional[float] = Field(default=None, ge=0, le=100)
+    feedback: Optional[str] = None
+    update_status: bool = True
+    item_results: Optional[List[TeacherItemGradeResult]] = None
+
+
+class SetAssignmentInProgressRequest(BaseModel):
+    """Body for POST /{assignment_id}/set-in-progress."""
+
+    student_id: int
+
+
+class ReturnForRevisionRequest(BaseModel):
+    """Body for POST /{assignment_id}/return-for-revision."""
+
+    student_id: int
+    message: Optional[str] = None
+
+
+class ManualGradeAssignmentRequest(BaseModel):
+    """Body for POST /{assignment_id}/manual-grade."""
+
+    score: Optional[float] = Field(default=None, ge=0, le=100)
+    feedback: Optional[str] = None
+    detailed_scores: Optional[Dict[str, Any]] = None

--- a/backend/tests/integration/api/test_grading_request_validation_335.py
+++ b/backend/tests/integration/api/test_grading_request_validation_335.py
@@ -1,0 +1,107 @@
+"""Issue #335 item 5: the teacher grading endpoints now validate their request
+bodies via Pydantic models instead of accepting a raw dict. This covers the
+new score bounds check and the required-field validation.
+"""
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from auth import create_access_token
+from models import (
+    Teacher,
+    Student,
+    Classroom,
+    Assignment,
+    StudentAssignment,
+    AssignmentStatus,
+)
+
+
+def _seed(db_session: Session):
+    teacher = Teacher(email="grade_t@test.com", name="Grade T", password_hash="x")
+    student = Student(email="grade_s@test.com", name="Grade S")
+    db_session.add_all([teacher, student])
+    db_session.commit()
+
+    classroom = Classroom(name="Grade Class", teacher_id=teacher.id)
+    db_session.add(classroom)
+    db_session.commit()
+
+    parent = Assignment(
+        title="Grade Assignment",
+        classroom_id=classroom.id,
+        teacher_id=teacher.id,
+        is_archived=False,
+    )
+    db_session.add(parent)
+    db_session.commit()
+
+    sa = StudentAssignment(
+        assignment_id=parent.id,
+        student_id=student.id,
+        classroom_id=classroom.id,
+        title="SA",
+        status=AssignmentStatus.SUBMITTED,
+    )
+    db_session.add(sa)
+    db_session.commit()
+    return teacher, student, parent, sa
+
+
+def _headers(teacher: Teacher) -> dict:
+    token = create_access_token({"sub": str(teacher.id), "type": "teacher"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestGradingRequestValidation:
+    def test_score_above_100_is_rejected(
+        self, test_client: TestClient, db_session: Session
+    ):
+        teacher, student, parent, _ = _seed(db_session)
+        resp = test_client.post(
+            f"/api/teachers/assignments/{parent.id}/grade",
+            headers=_headers(teacher),
+            json={"student_id": student.id, "score": 150},
+        )
+        assert resp.status_code == 422
+
+    def test_negative_score_is_rejected(
+        self, test_client: TestClient, db_session: Session
+    ):
+        teacher, student, parent, _ = _seed(db_session)
+        resp = test_client.post(
+            f"/api/teachers/assignments/{parent.id}/grade",
+            headers=_headers(teacher),
+            json={"student_id": student.id, "score": -5},
+        )
+        assert resp.status_code == 422
+
+    def test_valid_grade_is_accepted_and_persisted(
+        self, test_client: TestClient, db_session: Session
+    ):
+        teacher, student, parent, sa = _seed(db_session)
+        resp = test_client.post(
+            f"/api/teachers/assignments/{parent.id}/grade",
+            headers=_headers(teacher),
+            json={
+                "student_id": student.id,
+                "score": 85,
+                "feedback": "good",
+                "update_status": True,
+            },
+        )
+        assert resp.status_code == 200
+        db_session.refresh(sa)
+        assert sa.score == 85
+        assert sa.feedback == "good"
+
+    def test_return_for_revision_requires_student_id(
+        self, test_client: TestClient, db_session: Session
+    ):
+        teacher, _, parent, _ = _seed(db_session)
+        resp = test_client.post(
+            f"/api/teachers/assignments/{parent.id}/return-for-revision",
+            headers=_headers(teacher),
+            json={},  # missing required student_id
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## 背景

#335 教師端作業 router 稽核的剩餘品質項。安全性/邏輯 bug（items 1/2/4）已於 PR #896 修復；本 PR 處理 **items 5、6、8、9**。（item 10 是功能缺口，另開 PR。）

## 變更

### Item 5 — 4 個 endpoint 從 raw `dict` → Pydantic（含驗證）
- 在 `validators.py` 新增 4 個 request model（`grade_student_assignment` / `set_assignment_in_progress` / `return_for_revision` / `manual_grade_assignment`）。
- **score 加上 0..100 bounds**，`student_id` 等必填欄位強制驗證（原本 raw dict 完全沒驗證，score 無界）。
- 每個 endpoint 用 `model_dump(exclude_none=True)` 把驗證後的 model 橋接回 dict → **既有 body 邏輯完全不動**（保留 `"key" in data` / `.get()` 語意），只在邊界加驗證。風險最小化。
- 事前用 agent 完整比對「後端讀的 key」vs「前端送的 key」→ **無 mismatch**，不會破壞任何現有 caller。

### Item 6 — 移除 `ai_grade_assignment` dead code
`content` 被無條件設成 None，故 `hasattr(content, \"content_items\")` 永遠 False、整段是死碼。移除後 `expected_texts` 維持 `[]`（行為不變）。

### Item 8 — `manual_grade_assignment` 進度查詢
改用 `assignment.id`（查出來的 row）而非 raw URL path param。

### Item 9 — inline import 移到 module top
`from collections import defaultdict` 與函式內重複的 `import logging`（json/logging 已在 module 頂層）。**刻意保留** `utils.py` 中為避免循環 import 的 lazy import。

## 測試

新增 `test_grading_request_validation_335.py`（拜 #900 測試 infra 修復，本地可跑）：
- ✅ score > 100 → 422
- ✅ score < 0 → 422
- ✅ 合法 grade → 200 且分數/評語落地
- ✅ return-for-revision 缺 student_id → 422

4 個全綠。

## 驗證
- ✅ Backend：新測試 4 passed；black / flake8 clean
- ✅ 已用 `git stash` 確認既有 grading 測試的 failure（`created_by_teacher_id` / `test_token` 401 / `reading_assessment` enum）在**乾淨 staging baseline 也一樣 fail** → 屬 #314 backlog，非本 PR regression

Related to #335（items 5, 6, 8, 9）

🤖 Generated with [Claude Code](https://claude.com/claude-code)