### PR TITLE
test(#314): 3 個 module-level TestClient unit 檔改用 conftest fixtures

### DIFF
--- a/backend/tests/unit/test_content_crud_api.py
+++ b/backend/tests/unit/test_content_crud_api.py
@@ -1,108 +1,67 @@
 """
 Unit Tests for Content CRUD API Endpoints
 測試 Content 的 Create, Read, Update, Delete API 端點
+
+Issue #314: uses the shared conftest test_client/db_session fixtures instead of
+a module-level TestClient + app.dependency_overrides (which got wiped by the
+conftest fixture's override cleanup mid-suite).
 """
 
 import pytest
 from fastapi.testclient import TestClient
-from main import app
-from database import get_db
+from sqlalchemy.orm import Session
+
+from auth import create_access_token
 from models import Teacher, Program, Classroom, Lesson, ProgramLevel
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from passlib.context import CryptContext
-
-# 密碼雜湊
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
-# 測試資料庫連接
-SQLALCHEMY_DATABASE_URL = "sqlite:///./test_content_crud.db"
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
-)
-TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-client = TestClient(app)
-
-
-def override_get_db():
-    """Override database dependency for testing"""
-    db = TestingSessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
-
-
-app.dependency_overrides[get_db] = override_get_db
-
-
-@pytest.fixture(scope="module", autouse=True)
-def setup_database():
-    """Setup test database before tests"""
-    from models import Base
-
-    Base.metadata.create_all(bind=engine)
-
-    # 創建測試老師
-    db = TestingSessionLocal()
-    teacher = Teacher(
-        email="test@teacher.com",
-        name="Test Teacher",
-        password_hash=pwd_context.hash("test123"),
-        email_verified=True,
-    )
-    db.add(teacher)
-
-    # 創建測試班級
-    classroom = Classroom(name="Test Classroom", teacher_id=1, grade="Grade 1")
-    db.add(classroom)
-
-    # 創建測試課程
-    program = Program(
-        name="Test Program",
-        description="Test Program Description",
-        teacher_id=1,
-        classroom_id=1,
-    )
-    db.add(program)
-
-    # 創建測試單元
-    lesson = Lesson(
-        name="Test Lesson",
-        description="Test Lesson Description",
-        program_id=1,
-        order_index=1,
-        estimated_minutes=30,
-    )
-    db.add(lesson)
-
-    db.commit()
-    db.close()
-
-    yield
-
-    # Cleanup
-    Base.metadata.drop_all(bind=engine)
 
 
 @pytest.fixture
-def auth_token():
-    """Get authentication token for testing"""
-    response = client.post(
-        "/api/auth/teacher/login",
-        json={"email": "test@teacher.com", "password": "test123"},
+def auth_token(db_session: Session):
+    """Seed teacher + classroom + program + lesson (all id=1) and return a token.
+
+    conftest cleans every table between tests, so the seeded rows get id=1.
+    """
+    teacher = Teacher(
+        email="test@teacher.com",
+        name="Test Teacher",
+        password_hash="x",
+        email_verified=True,
     )
-    assert response.status_code == 200
-    return response.json()["access_token"]
+    db_session.add(teacher)
+    db_session.commit()
+
+    classroom = Classroom(name="Test Classroom", teacher_id=teacher.id, grade="Grade 1")
+    db_session.add(classroom)
+    db_session.commit()
+
+    program = Program(
+        name="Test Program",
+        description="Test Program Description",
+        teacher_id=teacher.id,
+        classroom_id=classroom.id,
+    )
+    db_session.add(program)
+    db_session.commit()
+
+    lesson = Lesson(
+        name="Test Lesson",
+        description="Test Lesson Description",
+        program_id=program.id,
+        order_index=1,
+        estimated_minutes=30,
+    )
+    db_session.add(lesson)
+    db_session.commit()
+
+    return create_access_token({"sub": str(teacher.id), "type": "teacher"})
 
 
 class TestContentCRUD:
     """測試 Content CRUD API"""
 
-    def test_create_content(self, auth_token):
+    def test_create_content(self, test_client: TestClient, auth_token):
         """測試創建 Content (CREATE)"""
-        response = client.post(
+        response = test_client.post(
             "/api/teachers/lessons/1/contents",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -125,10 +84,10 @@ class TestContentCRUD:
         assert len(data["items"]) == 2
         assert "id" in data
 
-    def test_read_content(self, auth_token):
+    def test_read_content(self, test_client: TestClient, auth_token):
         """測試讀取 Content (READ)"""
         # 先創建一個 content
-        create_response = client.post(
+        create_response = test_client.post(
             "/api/teachers/lessons/1/contents",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -142,7 +101,7 @@ class TestContentCRUD:
         content_id = create_response.json()["id"]
 
         # 讀取 content
-        response = client.get(
+        response = test_client.get(
             f"/api/teachers/contents/{content_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
         )
@@ -153,10 +112,10 @@ class TestContentCRUD:
         assert data["title"] == "Read Test Content"
         assert data["target_wpm"] == 120
 
-    def test_update_content(self, auth_token):
+    def test_update_content(self, test_client: TestClient, auth_token):
         """測試更新 Content (UPDATE)"""
         # 先創建一個 content
-        create_response = client.post(
+        create_response = test_client.post(
             "/api/teachers/lessons/1/contents",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -170,7 +129,7 @@ class TestContentCRUD:
         content_id = create_response.json()["id"]
 
         # 更新 content
-        response = client.put(
+        response = test_client.put(
             f"/api/teachers/contents/{content_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -186,10 +145,10 @@ class TestContentCRUD:
         assert data["target_wpm"] == 150
         assert data["target_accuracy"] == 95.0
 
-    def test_delete_content(self, auth_token):
+    def test_delete_content(self, test_client: TestClient, auth_token):
         """測試刪除 Content (DELETE) - 軟刪除"""
         # 先創建一個 content
-        create_response = client.post(
+        create_response = test_client.post(
             "/api/teachers/lessons/1/contents",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -203,7 +162,7 @@ class TestContentCRUD:
         content_id = create_response.json()["id"]
 
         # 刪除 content
-        response = client.delete(
+        response = test_client.delete(
             f"/api/teachers/contents/{content_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
         )
@@ -211,14 +170,14 @@ class TestContentCRUD:
         assert response.status_code == 200
 
         # 驗證軟刪除：嘗試讀取應該返回 404
-        get_response = client.get(
+        get_response = test_client.get(
             f"/api/teachers/contents/{content_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
         )
         assert get_response.status_code == 404
 
         # 驗證軟刪除：嘗試更新應該返回 404
-        update_response = client.put(
+        update_response = test_client.put(
             f"/api/teachers/contents/{content_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -229,10 +188,11 @@ class TestContentCRUD:
         )
         assert update_response.status_code == 404
 
-    def test_cannot_create_content_in_deleted_lesson(self, auth_token):
+    def test_cannot_create_content_in_deleted_lesson(
+        self, test_client: TestClient, db_session: Session, auth_token
+    ):
         """測試無法在已刪除的 Lesson 中創建 Content"""
         # 創建一個新 lesson
-        db = TestingSessionLocal()
         lesson = Lesson(
             name="To Delete Lesson",
             description="Will be deleted",
@@ -240,19 +200,18 @@ class TestContentCRUD:
             order_index=2,
             estimated_minutes=30,
         )
-        db.add(lesson)
-        db.commit()
+        db_session.add(lesson)
+        db_session.commit()
         lesson_id = lesson.id
-        db.close()
 
         # 刪除 lesson
-        client.delete(
+        test_client.delete(
             f"/api/teachers/lessons/{lesson_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
         )
 
         # 嘗試在已刪除的 lesson 中創建 content
-        response = client.post(
+        response = test_client.post(
             f"/api/teachers/lessons/{lesson_id}/contents",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -266,10 +225,10 @@ class TestContentCRUD:
 
         assert response.status_code == 404
 
-    def test_unauthorized_access(self):
+    def test_unauthorized_access(self, test_client: TestClient):
         """測試未授權存取"""
         # 沒有 token
-        response = client.post(
+        response = test_client.post(
             "/api/teachers/lessons/1/contents",
             json={
                 "title": "Test",
@@ -282,13 +241,15 @@ class TestContentCRUD:
         assert response.status_code == 401
 
         # 錯誤的 token
-        response = client.get(
+        response = test_client.get(
             "/api/teachers/contents/1",
             headers={"Authorization": "Bearer invalid_token"},
         )
         assert response.status_code == 401
 
-    def test_content_inherits_program_level(self, auth_token):
+    def test_content_inherits_program_level(
+        self, test_client: TestClient, db_session: Session, auth_token
+    ):
         """測試 Content 正確繼承 Program 的 level (#250)
 
         驗證：
@@ -297,7 +258,6 @@ class TestContentCRUD:
         3. ProgramLevel Enum 應該正確轉換為字串存入 Content.level
         """
         # 創建一個 B2 級別的 Program
-        db = TestingSessionLocal()
         program_b2 = Program(
             name="B2 Test Program",
             description="B2 Level Program",
@@ -305,8 +265,8 @@ class TestContentCRUD:
             classroom_id=1,
             level=ProgramLevel.B2,  # 設定為 B2
         )
-        db.add(program_b2)
-        db.commit()
+        db_session.add(program_b2)
+        db_session.commit()
         program_b2_id = program_b2.id
 
         # 創建一個 Lesson
@@ -317,13 +277,12 @@ class TestContentCRUD:
             order_index=1,
             estimated_minutes=30,
         )
-        db.add(lesson_b2)
-        db.commit()
+        db_session.add(lesson_b2)
+        db_session.commit()
         lesson_b2_id = lesson_b2.id
-        db.close()
 
         # 創建 Content（前端沒有傳 level）
-        response = client.post(
+        response = test_client.post(
             f"/api/teachers/lessons/{lesson_b2_id}/contents",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -346,7 +305,7 @@ class TestContentCRUD:
 
         # 讀取 Content 再次驗證
         content_id = data["id"]
-        get_response = client.get(
+        get_response = test_client.get(
             f"/api/teachers/contents/{content_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
         )
@@ -355,13 +314,13 @@ class TestContentCRUD:
         content_data = get_response.json()
         assert content_data["level"] == "B2"
 
-    def test_content_inherits_different_program_levels(self, auth_token):
+    def test_content_inherits_different_program_levels(
+        self, test_client: TestClient, db_session: Session, auth_token
+    ):
         """測試不同 Program level 的繼承（PreA, A1, C2）
 
         驗證所有可能的 ProgramLevel Enum 值都能正確轉換
         """
-        db = TestingSessionLocal()
-
         # 測試案例：(ProgramLevel Enum, 期望的字串值)
         test_cases = [
             (ProgramLevel.PRE_A, "preA"),
@@ -378,8 +337,8 @@ class TestContentCRUD:
                 classroom_id=1,
                 level=program_level,
             )
-            db.add(program)
-            db.commit()
+            db_session.add(program)
+            db_session.commit()
 
             # 創建 Lesson
             lesson = Lesson(
@@ -387,11 +346,11 @@ class TestContentCRUD:
                 program_id=program.id,
                 order_index=1,
             )
-            db.add(lesson)
-            db.commit()
+            db_session.add(lesson)
+            db_session.commit()
 
             # 創建 Content
-            response = client.post(
+            response = test_client.post(
                 f"/api/teachers/lessons/{lesson.id}/contents",
                 headers={"Authorization": f"Bearer {auth_token}"},
                 json={
@@ -408,10 +367,8 @@ class TestContentCRUD:
                 data["level"] == expected_string
             ), f"Program level {program_level} should convert to '{expected_string}', got '{data['level']}'"
 
-        db.close()
-
     def test_update_content_prefers_vocabulary_translation_over_definition(
-        self, auth_token
+        self, test_client: TestClient, auth_token
     ):
         """Issue #600: Preview 卡顯示的 translation 應該是使用者當前選擇語言的翻譯。
 
@@ -421,7 +378,7 @@ class TestContentCRUD:
           - definition = "你好"  (殘留的中文欄位)
         後端應存入 item.translation = "Hello"（vocabulary_translation 優先），
         而非中文的 definition。"""
-        create_response = client.post(
+        create_response = test_client.post(
             "/api/teachers/lessons/1/contents",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -443,7 +400,7 @@ class TestContentCRUD:
         content_id = create_response.json()["id"]
 
         # CREATE 路徑：translation 欄位應存英文（vocabulary_translation）
-        detail_response = client.get(
+        detail_response = test_client.get(
             f"/api/teachers/contents/{content_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
         )
@@ -453,7 +410,7 @@ class TestContentCRUD:
         assert created_items[0]["translation"] == "a friendly word of welcome"
 
         # UPDATE 路徑：切換語言到日文後，translation 欄位也要同步
-        update_response = client.put(
+        update_response = test_client.put(
             f"/api/teachers/contents/{content_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -470,7 +427,7 @@ class TestContentCRUD:
         )
         assert update_response.status_code == 200
 
-        detail_response_2 = client.get(
+        detail_response_2 = test_client.get(
             f"/api/teachers/contents/{content_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
         )
@@ -478,11 +435,11 @@ class TestContentCRUD:
         assert updated_items[0]["translation"] == "こんにちは"
 
     def test_update_content_falls_back_to_definition_when_no_vocab_translation(
-        self, auth_token
+        self, test_client: TestClient, auth_token
     ):
         """相容性：若前端未送 vocabulary_translation（舊 ReadingAssessmentPanel 流程），
         應沿用舊行為從 definition → translation fallback。"""
-        create_response = client.post(
+        create_response = test_client.post(
             "/api/teachers/lessons/1/contents",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -496,7 +453,7 @@ class TestContentCRUD:
         assert create_response.status_code == 200
         content_id = create_response.json()["id"]
 
-        detail_response = client.get(
+        detail_response = test_client.get(
             f"/api/teachers/contents/{content_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
         )
@@ -504,7 +461,7 @@ class TestContentCRUD:
         assert items[0]["translation"] == "你好"
 
         # UPDATE 路徑：同樣用舊格式（只送 definition，無 vocabulary_translation）
-        update_response = client.put(
+        update_response = test_client.put(
             f"/api/teachers/contents/{content_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -516,13 +473,9 @@ class TestContentCRUD:
         )
         assert update_response.status_code == 200
 
-        updated_detail = client.get(
+        updated_detail = test_client.get(
             f"/api/teachers/contents/{content_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
         )
         updated_items = updated_detail.json()["items"]
         assert updated_items[0]["translation"] == "謝謝"
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])

--- a/backend/tests/unit/test_lesson_crud_api.py
+++ b/backend/tests/unit/test_lesson_crud_api.py
@@ -1,98 +1,57 @@
 """
 Unit Tests for Lesson CRUD API Endpoints
 測試 Lesson 的 Create, Read, Update, Delete API 端點
+
+Issue #314: uses the shared conftest test_client/db_session fixtures instead of
+a module-level TestClient + app.dependency_overrides (which got wiped by the
+conftest fixture's override cleanup mid-suite).
 """
 
 import pytest
 from fastapi.testclient import TestClient
-from main import app
-from database import get_db
+from sqlalchemy.orm import Session
+
+from auth import create_access_token
 from models import Teacher, Program, Classroom
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from passlib.context import CryptContext
-
-# 密碼雜湊
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
-# 測試資料庫連接
-SQLALCHEMY_DATABASE_URL = "sqlite:///./test_lesson_crud.db"
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
-)
-TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-client = TestClient(app)
-
-
-def override_get_db():
-    """Override database dependency for testing"""
-    db = TestingSessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
-
-
-app.dependency_overrides[get_db] = override_get_db
-
-
-@pytest.fixture(scope="module", autouse=True)
-def setup_database():
-    """Setup test database before tests"""
-    from models import Base
-
-    Base.metadata.create_all(bind=engine)
-
-    # 創建測試老師
-    db = TestingSessionLocal()
-    teacher = Teacher(
-        email="test@teacher.com",
-        name="Test Teacher",
-        password_hash=pwd_context.hash("test123"),
-        email_verified=True,
-    )
-    db.add(teacher)
-
-    # 創建測試班級
-    classroom = Classroom(name="Test Classroom", teacher_id=1, grade="Grade 1")
-    db.add(classroom)
-
-    # 創建測試課程
-    program = Program(
-        name="Test Program",
-        description="Test Program Description",
-        teacher_id=1,
-        classroom_id=1,
-    )
-    db.add(program)
-
-    db.commit()
-    db.close()
-
-    yield
-
-    # Cleanup
-    Base.metadata.drop_all(bind=engine)
 
 
 @pytest.fixture
-def auth_token():
-    """Get authentication token for testing"""
-    response = client.post(
-        "/api/auth/teacher/login",
-        json={"email": "test@teacher.com", "password": "test123"},
+def auth_token(db_session: Session):
+    """Seed teacher + classroom + program (all id=1) and return a teacher token.
+
+    conftest cleans every table between tests, so the seeded rows get id=1.
+    """
+    teacher = Teacher(
+        email="test@teacher.com",
+        name="Test Teacher",
+        password_hash="x",
+        email_verified=True,
     )
-    assert response.status_code == 200
-    return response.json()["access_token"]
+    db_session.add(teacher)
+    db_session.commit()
+
+    classroom = Classroom(name="Test Classroom", teacher_id=teacher.id, grade="Grade 1")
+    db_session.add(classroom)
+    db_session.commit()
+
+    program = Program(
+        name="Test Program",
+        description="Test Program Description",
+        teacher_id=teacher.id,
+        classroom_id=classroom.id,
+    )
+    db_session.add(program)
+    db_session.commit()
+
+    return create_access_token({"sub": str(teacher.id), "type": "teacher"})
 
 
 class TestLessonCRUD:
     """測試 Lesson CRUD API"""
 
-    def test_create_lesson(self, auth_token):
+    def test_create_lesson(self, test_client: TestClient, auth_token):
         """測試創建 Lesson (CREATE)"""
-        response = client.post(
+        response = test_client.post(
             "/api/teachers/programs/1/lessons",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -111,10 +70,10 @@ class TestLessonCRUD:
         assert data["estimated_minutes"] == 30
         assert "id" in data
 
-    def test_read_lesson(self, auth_token):
+    def test_read_lesson(self, test_client: TestClient, auth_token):
         """測試讀取 Lesson (透過 Program) (READ)"""
         # 先創建一個 lesson
-        create_response = client.post(
+        create_response = test_client.post(
             "/api/teachers/programs/1/lessons",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -127,7 +86,7 @@ class TestLessonCRUD:
         lesson_id = create_response.json()["id"]
 
         # 透過 GET program 讀取 lesson
-        response = client.get(
+        response = test_client.get(
             "/api/teachers/programs/1",
             headers={"Authorization": f"Bearer {auth_token}"},
         )
@@ -147,10 +106,10 @@ class TestLessonCRUD:
         assert lesson is not None
         assert lesson["name"] == "Read Test Lesson"
 
-    def test_update_lesson(self, auth_token):
+    def test_update_lesson(self, test_client: TestClient, auth_token):
         """測試更新 Lesson (UPDATE)"""
         # 先創建一個 lesson
-        create_response = client.post(
+        create_response = test_client.post(
             "/api/teachers/programs/1/lessons",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -163,7 +122,7 @@ class TestLessonCRUD:
         lesson_id = create_response.json()["id"]
 
         # 更新 lesson
-        response = client.put(
+        response = test_client.put(
             f"/api/teachers/lessons/{lesson_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -181,10 +140,10 @@ class TestLessonCRUD:
         assert data["order_index"] == 2
         assert data["estimated_minutes"] == 60
 
-    def test_delete_lesson(self, auth_token):
+    def test_delete_lesson(self, test_client: TestClient, auth_token):
         """測試刪除 Lesson (DELETE) - 軟刪除"""
         # 先創建一個 lesson
-        create_response = client.post(
+        create_response = test_client.post(
             "/api/teachers/programs/1/lessons",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -197,7 +156,7 @@ class TestLessonCRUD:
         lesson_id = create_response.json()["id"]
 
         # 刪除 lesson
-        response = client.delete(
+        response = test_client.delete(
             f"/api/teachers/lessons/{lesson_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
         )
@@ -205,7 +164,7 @@ class TestLessonCRUD:
         assert response.status_code == 200
 
         # 驗證軟刪除：嘗試更新應該返回 404
-        update_response = client.put(
+        update_response = test_client.put(
             f"/api/teachers/lessons/{lesson_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -217,29 +176,29 @@ class TestLessonCRUD:
         )
         assert update_response.status_code == 404
 
-    def test_cannot_create_lesson_in_deleted_program(self, auth_token):
+    def test_cannot_create_lesson_in_deleted_program(
+        self, test_client: TestClient, db_session: Session, auth_token
+    ):
         """測試無法在已刪除的 Program 中創建 Lesson"""
         # 創建一個新 program
-        db = TestingSessionLocal()
         program = Program(
             name="To Delete Program",
             description="Will be deleted",
             teacher_id=1,
             classroom_id=1,
         )
-        db.add(program)
-        db.commit()
+        db_session.add(program)
+        db_session.commit()
         program_id = program.id
-        db.close()
 
         # 刪除 program
-        client.delete(
+        test_client.delete(
             f"/api/teachers/programs/{program_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
         )
 
         # 嘗試在已刪除的 program 中創建 lesson
-        response = client.post(
+        response = test_client.post(
             f"/api/teachers/programs/{program_id}/lessons",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -252,10 +211,10 @@ class TestLessonCRUD:
 
         assert response.status_code == 404
 
-    def test_unauthorized_access(self):
+    def test_unauthorized_access(self, test_client: TestClient):
         """測試未授權存取"""
         # 沒有 token
-        response = client.post(
+        response = test_client.post(
             "/api/teachers/programs/1/lessons",
             json={
                 "name": "Test",
@@ -267,7 +226,7 @@ class TestLessonCRUD:
         assert response.status_code == 401
 
         # 錯誤的 token
-        response = client.put(
+        response = test_client.put(
             "/api/teachers/lessons/1",
             headers={"Authorization": "Bearer invalid_token"},
             json={
@@ -278,7 +237,3 @@ class TestLessonCRUD:
             },
         )
         assert response.status_code == 401
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])

--- a/backend/tests/unit/test_program_crud_api.py
+++ b/backend/tests/unit/test_program_crud_api.py
@@ -1,89 +1,51 @@
 """
 Unit Tests for Program CRUD API Endpoints
 測試 Program 的 Create, Read, Update, Delete API 端點
+
+Issue #314: uses the shared conftest test_client/db_session fixtures instead of
+a module-level TestClient + app.dependency_overrides. The old pattern set the
+get_db override at import time; the conftest test_client fixture clears
+app.dependency_overrides between tests, which wiped this file's override mid
+run and made these tests hit the real DB in the full suite.
 """
 
 import pytest
 from fastapi.testclient import TestClient
-from main import app
-from database import get_db
+from sqlalchemy.orm import Session
+
+from auth import create_access_token
 from models import Teacher, Classroom
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from passlib.context import CryptContext
-
-# 密碼雜湊
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
-# 測試資料庫連接
-SQLALCHEMY_DATABASE_URL = "sqlite:///./test_program_crud.db"
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
-)
-TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-client = TestClient(app)
-
-
-def override_get_db():
-    """Override database dependency for testing"""
-    db = TestingSessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
-
-
-app.dependency_overrides[get_db] = override_get_db
-
-
-@pytest.fixture(scope="module", autouse=True)
-def setup_database():
-    """Setup test database before tests"""
-    from models import Base
-
-    Base.metadata.create_all(bind=engine)
-
-    # 創建測試老師
-    db = TestingSessionLocal()
-    teacher = Teacher(
-        email="test@teacher.com",
-        name="Test Teacher",
-        password_hash=pwd_context.hash("test123"),
-        email_verified=True,
-    )
-    db.add(teacher)
-
-    # 創建測試班級
-    classroom = Classroom(name="Test Classroom", teacher_id=1, grade="Grade 1")
-    db.add(classroom)
-
-    db.commit()
-    db.close()
-
-    yield
-
-    # Cleanup
-    Base.metadata.drop_all(bind=engine)
 
 
 @pytest.fixture
-def auth_token():
-    """Get authentication token for testing"""
-    response = client.post(
-        "/api/auth/teacher/login",
-        json={"email": "test@teacher.com", "password": "test123"},
+def auth_token(db_session: Session):
+    """Seed a teacher + classroom and return a teacher access token.
+
+    conftest cleans every table between tests, so the seeded rows get id=1
+    (the ids the request bodies below reference).
+    """
+    teacher = Teacher(
+        email="test@teacher.com",
+        name="Test Teacher",
+        password_hash="x",
+        email_verified=True,
     )
-    assert response.status_code == 200
-    return response.json()["access_token"]
+    db_session.add(teacher)
+    db_session.commit()
+
+    classroom = Classroom(name="Test Classroom", teacher_id=teacher.id, grade="Grade 1")
+    db_session.add(classroom)
+    db_session.commit()
+
+    return create_access_token({"sub": str(teacher.id), "type": "teacher"})
 
 
 class TestProgramCRUD:
     """測試 Program CRUD API"""
 
-    def test_create_program(self, auth_token):
+    def test_create_program(self, test_client: TestClient, auth_token):
         """測試創建 Program (CREATE)"""
-        response = client.post(
+        response = test_client.post(
             "/api/teachers/programs",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -99,13 +61,10 @@ class TestProgramCRUD:
         assert data["description"] == "Test Description"
         assert "id" in data
 
-        # 保存 program_id for後續測試
-        return data["id"]
-
-    def test_read_program(self, auth_token):
+    def test_read_program(self, test_client: TestClient, auth_token):
         """測試讀取 Program (READ)"""
         # 先創建一個 program
-        create_response = client.post(
+        create_response = test_client.post(
             "/api/teachers/programs",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -117,7 +76,7 @@ class TestProgramCRUD:
         program_id = create_response.json()["id"]
 
         # 讀取 program
-        response = client.get(
+        response = test_client.get(
             f"/api/teachers/programs/{program_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
         )
@@ -127,10 +86,10 @@ class TestProgramCRUD:
         assert data["id"] == program_id
         assert data["name"] == "Read Test Program"
 
-    def test_update_program(self, auth_token):
+    def test_update_program(self, test_client: TestClient, auth_token):
         """測試更新 Program (UPDATE)"""
         # 先創建一個 program
-        create_response = client.post(
+        create_response = test_client.post(
             "/api/teachers/programs",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -142,7 +101,7 @@ class TestProgramCRUD:
         program_id = create_response.json()["id"]
 
         # 更新 program
-        response = client.put(
+        response = test_client.put(
             f"/api/teachers/programs/{program_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -158,10 +117,10 @@ class TestProgramCRUD:
         assert data["description"] == "Updated Description"
         assert data["estimated_hours"] == 20
 
-    def test_update_program_level_and_tags(self, auth_token):
+    def test_update_program_level_and_tags(self, test_client: TestClient, auth_token):
         """測試更新 Program 的 level 和 tags"""
         # 先創建一個 program
-        create_response = client.post(
+        create_response = test_client.post(
             "/api/teachers/programs",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -173,7 +132,7 @@ class TestProgramCRUD:
         program_id = create_response.json()["id"]
 
         # 更新 level 和 tags
-        response = client.put(
+        response = test_client.put(
             f"/api/teachers/programs/{program_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -185,9 +144,6 @@ class TestProgramCRUD:
             },
         )
 
-        print(f"\n📊 Response status: {response.status_code}")
-        print(f"📊 Response body: {response.json()}")
-
         assert response.status_code == 200
         data = response.json()
         assert data["name"] == "Updated Program"
@@ -196,10 +152,10 @@ class TestProgramCRUD:
         assert data["estimated_hours"] == 35
         assert data["tags"] == ["英語", "基礎"]
 
-    def test_delete_program(self, auth_token):
+    def test_delete_program(self, test_client: TestClient, auth_token):
         """測試刪除 Program (DELETE)"""
         # 先創建一個 program
-        create_response = client.post(
+        create_response = test_client.post(
             "/api/teachers/programs",
             headers={"Authorization": f"Bearer {auth_token}"},
             json={
@@ -211,7 +167,7 @@ class TestProgramCRUD:
         program_id = create_response.json()["id"]
 
         # 刪除 program
-        response = client.delete(
+        response = test_client.delete(
             f"/api/teachers/programs/{program_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
         )
@@ -219,17 +175,17 @@ class TestProgramCRUD:
         assert response.status_code == 200
 
         # 驗證已刪除（應該 404）
-        get_response = client.get(
+        get_response = test_client.get(
             f"/api/teachers/programs/{program_id}",
             headers={"Authorization": f"Bearer {auth_token}"},
         )
         assert get_response.status_code == 404
 
-    def test_list_programs(self, auth_token):
+    def test_list_programs(self, test_client: TestClient, auth_token):
         """測試列出所有 Programs"""
         # 創建幾個 programs
         for i in range(3):
-            client.post(
+            test_client.post(
                 "/api/teachers/programs",
                 headers={"Authorization": f"Bearer {auth_token}"},
                 json={
@@ -240,8 +196,9 @@ class TestProgramCRUD:
             )
 
         # 列出所有 programs
-        response = client.get(
-            "/api/teachers/programs", headers={"Authorization": f"Bearer {auth_token}"}
+        response = test_client.get(
+            "/api/teachers/programs",
+            headers={"Authorization": f"Bearer {auth_token}"},
         )
 
         assert response.status_code == 200
@@ -249,18 +206,15 @@ class TestProgramCRUD:
         assert isinstance(data, list)
         assert len(data) >= 3
 
-    def test_unauthorized_access(self):
+    def test_unauthorized_access(self, test_client: TestClient):
         """測試未授權存取"""
         # 沒有 token
-        response = client.get("/api/teachers/programs")
+        response = test_client.get("/api/teachers/programs")
         assert response.status_code == 401
 
         # 錯誤的 token
-        response = client.get(
-            "/api/teachers/programs", headers={"Authorization": "Bearer invalid_token"}
+        response = test_client.get(
+            "/api/teachers/programs",
+            headers={"Authorization": "Bearer invalid_token"},
         )
         assert response.status_code == 401
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## 背景

#314 Part 1 收尾。這些檔在 import 時就建立 module-level `client = TestClient(app)` 並設 `app.dependency_overrides[get_db]`（用自己的 SQLite engine）。由於 `app.dependency_overrides` 是共享 singleton，而 conftest 的 `test_client` fixture 會在測試間 `clear()`，這些檔的 override 在整個 suite 跑時被清掉 → 打到真實 DB（OperationalError）。單獨跑會過、full suite 就爆。

## 變更（3 個檔改用 conftest `test_client` + `db_session`）
- `tests/unit/test_program_crud_api.py`
- `tests/unit/test_lesson_crud_api.py`
- `tests/unit/test_content_crud_api.py`

每個檔：
- 移除 module-level engine / TestingSessionLocal / client / override / 以及 module-scoped `setup_database` fixture
- 在 `auth_token` fixture 內用 `db_session` seed teacher/classroom/program/lesson（conftest 每個測試清表，故 seeded row 都是 id=1，對齊 request body 引用的 id）
- 測試中途的 `TestingSessionLocal()` 改用 `db_session`
- auth 改用 `create_access_token`，不再依賴 login endpoint

## 驗證
- ✅ 每個檔**單獨跑**通過
- ✅ 每個檔**接在 conftest-fixture 測試之後跑**也通過（就是原本會失敗的污染順序）——共 23 passed
- ✅ black / flake8 clean

## 本 PR **不含**（誠實列出）
- `test_content_update_with_practice_answers.py`：同樣 pattern，但其中一個測試有**獨立的真 bug**（content 更新時 practice_answers 沒被清除），單獨跑就 fail；轉 override 不會修好它，需另外調查。
- 另有 **~12 個 integration 測試檔**（`test_assignment_resubmit_status`、`test_grade_reports`、`test_quiz_batch_830` …）也是同一 module-level-override pattern。範圍比原本 issue 列的 4 個大很多，屬更大的後續清理，另開 PR。

Related to #314 (Part 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)