### PR TITLE
ci: 將 institution invoice 兩表加入 RLS 排除清單

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -295,6 +295,8 @@ jobs:
               'user_word_progress', 'practice_sessions', 'practice_answers',
               'organizations', 'schools', 'teacher_organizations', 'teacher_schools', 'classroom_schools', 'student_schools',
               'organization_points_log',
+              -- 機構請款（#838，JWT auth 業務表，比照 invoice_status_history）
+              'institution_invoices', 'institution_invoice_emails',
               'program_copy_logs',
               'demo_config',
               'identities',


### PR DESCRIPTION
## 問題

staging 的 **Deploy Backend → 🔒 Verify RLS Configuration** 失敗（[run](https://github.com/myduotopia/duotopia/actions/runs/28769951776/job/85301821257)）：

\`\`\`
❌ ERROR: The following tables do not have RLS enabled:
   - institution_invoice_emails
   - institution_invoices
\`\`\`

這兩張表由 #838 機構請款的 migration \`20260626_1000_add_institution_invoice_tables.py\` 建立（model 在 \`backend/models/institution_invoice.py\`），漏了加進 RLS gate 的排除清單。

## 為什麼是「排除」而非「啟用 RLS」

該 gate 的註解已說明：Duotopia 系統用 **JWT auth（非 Supabase Auth）**，\`auth.uid()\` 永遠是 NULL，對業務表啟用 RLS 沒有意義。因此**所有業務表**都在 \`NOT IN (...)\` 白名單裡（例如 \`invoice_status_history\` 已在清單中）。institution invoice 兩表屬同類，理應一併排除。

## 變更
- \`deploy-backend.yml\` 的 RLS 白名單新增 \`institution_invoices\`、\`institution_invoice_emails\`（附註解，比照 invoice_status_history）。

已確認這是全 repo 唯一一份該白名單，且這兩張是唯二的 institution_* 表（不會有下一張漏網）。YAML 驗證通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)