### PR TITLE
fix(#444): clipboard 複製失敗時提供 fallback + toast 回饋

### DIFF
--- a/frontend/src/components/teacher/StudentLoginQRShare.tsx
+++ b/frontend/src/components/teacher/StudentLoginQRShare.tsx
@@ -13,6 +13,7 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Check, Copy } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -41,6 +42,29 @@ interface ScopeOption {
 }
 
 const PERSONAL_VALUE = "personal";
+
+/**
+ * Legacy clipboard fallback for insecure contexts (HTTP) or browsers where
+ * navigator.clipboard is unavailable/blocked. Throws if the copy did not work.
+ */
+function legacyCopyToClipboard(text: string): void {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } finally {
+    document.body.removeChild(textarea);
+  }
+  if (!ok) {
+    throw new Error("execCommand('copy') returned false");
+  }
+}
 
 export default function StudentLoginQRShare({
   email,
@@ -103,12 +127,31 @@ export default function StudentLoginQRShare({
   );
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(url);
+    const markCopied = () => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+    };
+    try {
+      // Preferred path: async Clipboard API (secure contexts only).
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+      } else {
+        // Insecure context / unsupported: use the legacy fallback.
+        legacyCopyToClipboard(url);
+      }
+      markCopied();
     } catch (err) {
-      console.error("Failed to copy URL:", err);
+      // Clipboard API rejected (permission denied / insecure context).
+      // Try the legacy fallback before giving up.
+      try {
+        legacyCopyToClipboard(url);
+        markCopied();
+      } catch (fallbackErr) {
+        // Issue #444: surface the failure instead of swallowing it, so the
+        // teacher knows to copy the link manually.
+        console.error("Failed to copy URL:", err, fallbackErr);
+        toast.error(t("studentLoginQR.copyFailed"));
+      }
     }
   };
 

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1296,7 +1296,8 @@
     "viewLabel": "Select share view",
     "personal": "Personal",
     "orgPrefix": "Org: ",
-    "schoolPrefix": "School: "
+    "schoolPrefix": "School: ",
+    "copyFailed": "Copy failed. Please select and copy the link manually."
   },
   "studentLogin": {
     "header": {

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -1438,7 +1438,8 @@
     "viewLabel": "選擇分享視圖",
     "personal": "個人班級",
     "orgPrefix": "機構：",
-    "schoolPrefix": "學校："
+    "schoolPrefix": "學校：",
+    "copyFailed": "複製失敗，請手動選取連結複製"
   },
   "studentLogin": {
     "header": {


### PR DESCRIPTION
## 問題

`StudentLoginQRShare.handleCopy`（#444 提到的 handleCopyUrl，程式已搬到此元件）在 `navigator.clipboard.writeText` 失敗時只 `console.error`，**使用者無任何提示**。不安全環境（HTTP）或瀏覽器拒絕權限時，複製靜默失敗、連結也沒進剪貼簿。

## 變更（`components/teacher/StudentLoginQRShare.tsx`）

`handleCopy` 改為三段式：
1. 安全環境優先用 `navigator.clipboard.writeText`。
2. Clipboard API 不存在（不安全環境）或 reject 時，fallback 到 legacy `document.execCommand('copy')`（臨時 textarea）。
3. **兩條路都失敗**才 `toast.error(t("studentLoginQR.copyFailed"))`，讓老師知道要手動複製。

i18n：en、zh-TW 的 `studentLoginQR` 區塊新增 `copyFailed`（ja/ko 該區塊本就不存在，走 fallback，維持既有覆蓋範圍）。

## 驗證
- ✅ tsc / eslint / prettier / vite build 全通過

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)