### PR TITLE
test(#443): 補 RpsTool 測試覆蓋

### DIFF
--- a/frontend/src/components/teachingTools/__tests__/DigitalTeachingToolbar.test.tsx
+++ b/frontend/src/components/teachingTools/__tests__/DigitalTeachingToolbar.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import DigitalTeachingToolbar from "../DigitalTeachingToolbar";
 
@@ -138,6 +144,95 @@ describe("DigitalTeachingToolbar", () => {
       await user.click(closeButton);
 
       expect(screen.queryByLabelText("Close dice")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("RPS Tool", () => {
+    it("should open RPS when clicked", () => {
+      render(<DigitalTeachingToolbar />);
+      fireEvent.click(screen.getByLabelText("Rock Paper Scissors"));
+
+      expect(screen.getByLabelText("Spin")).toBeInTheDocument();
+      expect(screen.getByLabelText("Close RPS")).toBeInTheDocument();
+    });
+
+    it("should disable Spin while spinning and re-enable after it settles", () => {
+      vi.useFakeTimers();
+      try {
+        render(<DigitalTeachingToolbar />);
+        fireEvent.click(screen.getByLabelText("Rock Paper Scissors"));
+
+        const spinButton = screen.getByLabelText("Spin");
+        expect(spinButton).not.toBeDisabled();
+
+        fireEvent.click(spinButton);
+        expect(spinButton).toBeDisabled(); // isSpinning = true
+
+        // Spin animation settles after 1900ms
+        act(() => {
+          vi.advanceTimersByTime(1900);
+        });
+        expect(spinButton).not.toBeDisabled();
+
+        // Flush the two 50ms reel-reset timers
+        act(() => {
+          vi.advanceTimersByTime(100);
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should ignore a second spin while one is in progress", () => {
+      vi.useFakeTimers();
+      const randomSpy = vi.spyOn(Math, "random");
+      try {
+        render(<DigitalTeachingToolbar />);
+        fireEvent.click(screen.getByLabelText("Rock Paper Scissors"));
+
+        const spinButton = screen.getByLabelText("Spin");
+        fireEvent.click(spinButton); // first spin runs
+        const callsAfterFirstSpin = randomSpy.mock.calls.length;
+
+        // Button is disabled + spin() guards on isSpinning → no second spin
+        fireEvent.click(spinButton);
+        expect(randomSpy.mock.calls.length).toBe(callsAfterFirstSpin);
+
+        act(() => {
+          vi.advanceTimersByTime(2000);
+        });
+      } finally {
+        randomSpy.mockRestore();
+        vi.useRealTimers();
+      }
+    });
+
+    it("should close RPS when close button clicked", () => {
+      render(<DigitalTeachingToolbar />);
+      fireEvent.click(screen.getByLabelText("Rock Paper Scissors"));
+
+      fireEvent.click(screen.getByLabelText("Close RPS"));
+
+      expect(screen.queryByLabelText("Spin")).not.toBeInTheDocument();
+    });
+
+    it("should clear pending spin timers on unmount", () => {
+      vi.useFakeTimers();
+      const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+      try {
+        const { unmount } = render(<DigitalTeachingToolbar />);
+        fireEvent.click(screen.getByLabelText("Rock Paper Scissors"));
+        fireEvent.click(screen.getByLabelText("Spin")); // schedules spinTimerRef
+
+        clearTimeoutSpy.mockClear();
+        unmount();
+
+        // RpsTool's unmount cleanup clears its pending spin/reset timers.
+        expect(clearTimeoutSpy).toHaveBeenCalled();
+      } finally {
+        clearTimeoutSpy.mockRestore();
+        vi.useRealTimers();
+      }
     });
   });
 


### PR DESCRIPTION
## 背景

RpsTool 先前 0 測試覆蓋（Timer/Dice 有測，RPS 沒有）。這是 **#442 大重構前的回歸網**（先釘住現有行為再拆檔）。

## 新增測試（`__tests__/DigitalTeachingToolbar.test.tsx` 的 "RPS Tool" 區塊）

依 issue 列的情境：
- 開啟 RPS（Spin + Close RPS 出現）
- **spin 進行中 Spin 鈕 disabled**，1900ms 後 settle 才 re-enable
- **spin 進行中禁止重複觸發**（第二次點擊不會再呼叫 Math.random — disabled 鈕 + `isSpinning` guard 雙重保護）
- 關閉 RPS
- **unmount 時清除 pending 的 spin/reset timers**（spinTimerRef/resetTimerLRef/resetTimerRRef）

用 `fireEvent` + fake timers 精準驅動 spin 生命週期。

## 驗證
- ✅ 5 個 RPS 測試本地全過（`5 passed`）
- ✅ tsc / eslint / prettier 通過

## 說明
此檔另有 **pre-existing 的本地 failure**：既有 Timer/Dice 測試用 `userEvent`，在此 jsdom/user-event 版本下會撞 "pointer-events: none"。**與本次無關**（乾淨 baseline 也一樣 fail），且 **CI 會過**（見 #906 的 Test Frontend）。我的新測試用 `fireEvent`，本地 + CI 都過。既有測試的本地修正不在本 PR 範圍。

Related to #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)