### PR TITLE
fix(#655): analysis_service 支援 word_reading，不再 500

### DIFF
--- a/backend/services/analysis_service.py
+++ b/backend/services/analysis_service.py
@@ -345,8 +345,13 @@ def _build_prompt(collected_data: Dict[str, Any]) -> str:
 - 超時的題目代表難度較高
 - 請用繁體中文回答"""
 
-    elif mode == "reading":
-        return f"""你是一位英語教學分析專家。請根據以下「例句朗讀」作業的學生表現數據，產生一份結構化的分析報告。
+    elif mode in ("reading", "word_reading"):
+        # Issue #655: word_reading shares the reading prompt; only the
+        # human-facing label/unit differ. JSON structure stays identical so the
+        # frontend renders both report types the same way.
+        label = "單字朗讀" if mode == "word_reading" else "例句朗讀"
+        unit = "單字" if mode == "word_reading" else "句子"
+        return f"""你是一位英語教學分析專家。請根據以下「{label}」作業的學生表現數據，產生一份結構化的分析報告。
 
 作業名稱：{title}
 學生人數：{len(students)}
@@ -367,7 +372,7 @@ def _build_prompt(collected_data: Dict[str, Any]) -> str:
   }},
   "difficult_sentences": [
     {{
-      "sentence": "表現最差的句子",
+      "sentence": "表現最差的{unit}",
       "avg_score": 數字,
       "common_issues": ["常見問題"]
     }}
@@ -481,8 +486,12 @@ async def generate_analysis_report(
             collected_data = _collect_rearrangement_data(
                 db, assignment, student_assignments
             )
-        elif practice_mode == "reading":
+        elif practice_mode in ("reading", "word_reading"):
+            # Issue #655: word_reading (單字朗讀) is the same speech-assessment
+            # data model as reading (例句朗讀), so it reuses the reading
+            # collector. Preserve the real mode so the prompt labels it 單字朗讀.
             collected_data = _collect_reading_data(db, assignment, student_assignments)
+            collected_data["practice_mode"] = practice_mode
         elif practice_mode == "word_selection":
             collected_data = _collect_word_selection_data(
                 db, assignment, student_assignments

--- a/backend/tests/unit/test_analysis_word_reading_655.py
+++ b/backend/tests/unit/test_analysis_word_reading_655.py
@@ -1,0 +1,96 @@
+"""Issue #655: analysis_service.generate_analysis_report must handle the
+word_reading (單字朗讀) practice mode. It previously fell through to
+``raise ValueError("Unsupported practice mode: word_reading")`` (HTTP 500).
+"""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from services.analysis_service import _build_prompt, generate_analysis_report
+from models import (
+    Teacher,
+    Classroom,
+    Assignment,
+    Student,
+    StudentAssignment,
+    AssignmentStatus,
+)
+
+
+def _reading_like_collected(mode: str) -> dict:
+    return {
+        "practice_mode": mode,
+        "assignment_title": "T",
+        "total_sentences": 1,
+        "students": [
+            {
+                "name": "A",
+                "student_number": "1",
+                "overall_score": 90,
+                "status": "GRADED",
+                "items": [],
+            }
+        ],
+    }
+
+
+class TestWordReadingPrompt:
+    def test_word_reading_prompt_builds(self):
+        prompt = _build_prompt(_reading_like_collected("word_reading"))
+        assert "單字朗讀" in prompt
+
+    def test_reading_prompt_still_builds(self):
+        prompt = _build_prompt(_reading_like_collected("reading"))
+        assert "例句朗讀" in prompt
+
+
+class _FakeVertex:
+    async def generate_json(self, **kwargs):
+        return {"overall_summary": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_generate_analysis_report_word_reading_completes(
+    db_session: Session, monkeypatch
+):
+    """word_reading assignment reaches the LLM and completes (no 500)."""
+    teacher = Teacher(email="wr_t@test.com", name="T", password_hash="x")
+    db_session.add(teacher)
+    db_session.commit()
+
+    classroom = Classroom(name="C", teacher_id=teacher.id)
+    db_session.add(classroom)
+    db_session.commit()
+
+    assignment = Assignment(
+        title="WR",
+        classroom_id=classroom.id,
+        teacher_id=teacher.id,
+        practice_mode="word_reading",
+        is_archived=False,
+    )
+    db_session.add(assignment)
+    db_session.commit()
+
+    student = Student(email="wr_s@test.com", name="S")
+    db_session.add(student)
+    db_session.commit()
+
+    db_session.add(
+        StudentAssignment(
+            assignment_id=assignment.id,
+            student_id=student.id,
+            classroom_id=classroom.id,
+            title="WR",
+            status=AssignmentStatus.GRADED,
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "services.vertex_ai.get_vertex_ai_service", lambda: _FakeVertex()
+    )
+
+    report = await generate_analysis_report(db_session, assignment, teacher.id)
+    assert report.status == "completed"
+    assert report.practice_mode == "word_reading"


### PR DESCRIPTION
## 問題
對 `word_reading`（單字朗讀）作業呼叫 `POST /assignments/{id}/generate-analysis` 時，`generate_analysis_report` 的 collector 分支與 `_build_prompt` 都會落到 `else` 拋 `ValueError: Unsupported practice mode: word_reading` → **HTTP 500**。

## 修法
`word_reading` 與 `reading`（例句朗讀）是**同一套語音評測資料模型**（逐 item 的 accuracy/fluency/pronunciation/completeness + transcription），所以：
- collector 重用 `_collect_reading_data`，並保留真實 mode。
- `_build_prompt` 的 reading 分支改為同時處理 `reading`/`word_reading`，label 依模式顯示「單字朗讀」/「例句朗讀」、單位「單字」/「句子」，**JSON 報告結構完全不變**（前端渲染方式一致）。

## 測試（`tests/unit/test_analysis_word_reading_655.py`）
- `_build_prompt` 對 word_reading（含「單字朗讀」）與 reading 都能產生 prompt
- `generate_analysis_report` 對 word_reading 作業（mock LLM）**status=completed，不再拋錯**

3 passed；black/flake8 clean。

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)