### PR TITLE
fix(#730): Identity.one_campus_student_id UNIQUE + 併發 upsert 衝突復原

### DIFF
--- a/backend/alembic/versions/20260706_1000_add_identity_one_campus_student_id_unique.py
+++ b/backend/alembic/versions/20260706_1000_add_identity_one_campus_student_id_unique.py
@@ -1,0 +1,39 @@
+"""Add UNIQUE index on identities.one_campus_student_id
+
+Revision ID: 20260706_1000
+Revises: 20260626_1000
+Create Date: 2026-07-06 10:00:00.000000
+
+Issue #730: one_campus_class_sync_service._upsert_student did a
+query-then-insert on Identity by one_campus_student_id with no lock or unique
+constraint. Two concurrent syncs (e.g. a teacher's manual sync overlapping the
+OAuth-login background sync) could both read "identity is None" and both insert
+a row with the same one_campus_student_id, silently splitting a student's
+history.
+
+Enforce uniqueness at the DB level with a partial unique index (mirrors
+ix_identities_one_campus_uuid). Idempotent — safe to re-run across
+develop/staging/prod.
+
+Related: #730, #722
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260706_1000"
+down_revision = "20260626_1000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ux_identities_one_campus_student_id "
+        "ON identities (one_campus_student_id) "
+        "WHERE one_campus_student_id IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -49,7 +49,9 @@ class Identity(Base):
 
     # 1Campus SSO 欄位
     one_campus_uuid = Column(String(100), nullable=True, unique=True, index=True)
-    one_campus_student_id = Column(String(100), nullable=True, index=True)
+    # Issue #730: unique so concurrent 1Campus syncs can't create duplicate
+    # identities for the same student (DB-enforced via partial unique index).
+    one_campus_student_id = Column(String(100), nullable=True, unique=True, index=True)
     one_campus_account = Column(String(255), nullable=True)
     national_id_hash = Column(String(64), nullable=True, index=True)
 

--- a/backend/services/one_campus_class_sync_service.py
+++ b/backend/services/one_campus_class_sync_service.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import List, Optional
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from models.classroom import Classroom, ClassroomStudent
@@ -310,25 +311,43 @@ def _upsert_student(db: Session, stu: dict) -> tuple[Student, bool, bool]:
     )
 
     if identity is None:
-        identity = Identity(
-            one_campus_student_id=one_campus_student_id,
-            email_verified=False,
-            is_active=True,
-        )
-        db.add(identity)
-        db.flush()
-
-        student = Student(
-            name=student_name or one_campus_student_id,
-            student_number=student_number,
-            password_hash=None,
-            identity_id=identity.id,
-            is_primary_account=True,
-            is_active=True,
-        )
-        db.add(student)
-        db.flush()
-        return student, True, False
+        try:
+            # Issue #730: isolate the INSERT in a SAVEPOINT so a unique-constraint
+            # conflict (a concurrent sync inserted the same one_campus_student_id
+            # first) rolls back only this insert, not the whole batch transaction.
+            with db.begin_nested():
+                identity = Identity(
+                    one_campus_student_id=one_campus_student_id,
+                    email_verified=False,
+                    is_active=True,
+                )
+                db.add(identity)
+                db.flush()
+        except IntegrityError:
+            # The concurrent sync won the race. Re-read the existing row (ignore
+            # is_active so a previously soft-deleted identity is reused and
+            # reactivated) and fall through to the existing-identity update path.
+            identity = (
+                db.query(Identity)
+                .filter(Identity.one_campus_student_id == one_campus_student_id)
+                .first()
+            )
+            if identity is None:
+                raise
+            if not identity.is_active:
+                identity.is_active = True
+        else:
+            student = Student(
+                name=student_name or one_campus_student_id,
+                student_number=student_number,
+                password_hash=None,
+                identity_id=identity.id,
+                is_primary_account=True,
+                is_active=True,
+            )
+            db.add(student)
+            db.flush()
+            return student, True, False
 
     linked_students = (
         db.query(Student)

--- a/backend/tests/integration/test_one_campus_identity_unique_730.py
+++ b/backend/tests/integration/test_one_campus_identity_unique_730.py
@@ -1,0 +1,88 @@
+"""Issue #730: Identity.one_campus_student_id must be unique so two concurrent
+1Campus syncs (manual + login) can't insert duplicate identities for the same
+student; _upsert_student recovers from the unique-constraint conflict by
+re-reading (and reactivating) the existing row.
+"""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from models.user import Identity
+from services.one_campus_class_sync_service import _upsert_student
+
+
+def _stu(sid: str, name: str = "Amy", number: str = "7") -> dict:
+    return {"studentID": sid, "studentName": name, "studentNumber": number}
+
+
+class TestIdentityOneCampusStudentIdUnique:
+    def test_duplicate_id_rejected_at_db(self, db_session: Session):
+        db_session.add(
+            Identity(one_campus_student_id="X1", is_active=True, email_verified=False)
+        )
+        db_session.commit()
+        db_session.add(
+            Identity(one_campus_student_id="X1", is_active=True, email_verified=False)
+        )
+        with pytest.raises(IntegrityError):
+            db_session.flush()
+        db_session.rollback()
+
+    def test_null_id_allows_multiple(self, db_session: Session):
+        # The unique index is partial (WHERE one_campus_student_id IS NOT NULL),
+        # so students without a 1Campus id are unaffected.
+        db_session.add(
+            Identity(one_campus_student_id=None, is_active=True, email_verified=False)
+        )
+        db_session.add(
+            Identity(one_campus_student_id=None, is_active=True, email_verified=False)
+        )
+        db_session.flush()  # must not raise
+        db_session.rollback()
+
+    def test_upsert_is_idempotent(self, db_session: Session):
+        s1, created1, _ = _upsert_student(db_session, _stu("2001", "Bob"))
+        db_session.commit()
+        s2, created2, _ = _upsert_student(db_session, _stu("2001", "Bob"))
+        db_session.commit()
+
+        assert created1 is True
+        assert created2 is False
+        assert s1.id == s2.id
+        idents = (
+            db_session.query(Identity)
+            .filter(Identity.one_campus_student_id == "2001")
+            .all()
+        )
+        assert len(idents) == 1
+
+    def test_upsert_recovers_from_conflict_without_duplicate(self, db_session: Session):
+        # First sync creates an active identity + student.
+        _upsert_student(db_session, _stu("3001", "Cindy"))
+        db_session.commit()
+
+        # Soft-delete the identity so the next upsert's is_active lookup MISSES
+        # and takes the INSERT path -> the new active insert collides with the
+        # existing (now inactive) row on the unique index. This deterministically
+        # exercises the same IntegrityError -> re-read -> reuse path a concurrent
+        # sync would hit.
+        ident = (
+            db_session.query(Identity)
+            .filter(Identity.one_campus_student_id == "3001")
+            .one()
+        )
+        ident.is_active = False
+        db_session.commit()
+
+        student, created, _ = _upsert_student(db_session, _stu("3001", "Cindy"))
+        db_session.commit()
+
+        idents = (
+            db_session.query(Identity)
+            .filter(Identity.one_campus_student_id == "3001")
+            .all()
+        )
+        assert len(idents) == 1  # no duplicate identity
+        assert idents[0].is_active is True  # reused + reactivated
+        assert created is False


### PR DESCRIPTION
## 問題
`one_campus_class_sync_service._upsert_student` 用 query-then-insert（`Identity.one_campus_student_id` 只有 index、無 unique、無鎖）。兩個併發 sync（老師手動 sync 撞上 OAuth 登入的背景 sync）可能都讀到 `identity is None`、都 insert 同一個 one_campus_student_id → **重複 Identity，靜默拆散學生歷史**。（存在已久，自 #721/#635。）

## 修法
1. **Migration `20260706_1000`**：idempotent 的 partial UNIQUE index `ux_identities_one_campus_student_id ... WHERE one_campus_student_id IS NOT NULL`（比照 `ix_identities_one_campus_uuid`，安全可重跑）。
2. **`models/user.py`**：`one_campus_student_id` 標 `unique=True`。
3. **`_upsert_student`**：INSERT 包在 **SAVEPOINT（`db.begin_nested`）**——因為呼叫端是**整批一次 commit**，若用 `db.rollback()` 會把整批清掉；savepoint 只回滾這一筆 insert。衝突時 catch `IntegrityError` → 重讀既有列（不帶 is_active filter，讓被 soft-delete 的 identity 也能重用並 reactivate）→ 走既有 identity 更新路徑。

## 測試（`tests/integration/test_one_campus_identity_unique_730.py`）
- DB 層拒絕重複 one_campus_student_id
- NULL 仍可多筆（partial index）
- `_upsert_student` 冪等（重複 sync 只有一個 identity）
- **衝突復原**：deterministically 用 soft-delete 觸發 insert→衝突→重讀→重用，結果無重複 identity
- 既有 `test_one_campus_class_sync.py`（8）全過，無 regression

black / flake8 clean。

Closes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)