### PR TITLE
fix(#884): live quiz 模式 whitelist（item 1）+ /quiz/status 單次查詢（item 3）

### DIFF
--- a/backend/routers/assignments/crud.py
+++ b/backend/routers/assignments/crud.py
@@ -39,6 +39,7 @@ from .validators import (
     UpdateAssignmentRequest,
     StudentResponse,
     ContentResponse,
+    LIVE_QUIZ_MODES,
 )
 from .dependencies import get_current_teacher
 from services.preview_service import _VOCABULARY_CONTENT_TYPES
@@ -361,10 +362,11 @@ async def create_assignment(
         answer_mode=sanitized_answer_mode,
         time_limit_per_question=request.time_limit_per_question,
         quiz_time_limit_seconds=request.quiz_time_limit_seconds,
-        # Issue #835: live 模式僅對小考有效；非小考一律 False
+        # Issue #835 / #884 item 1: live 模式僅對「有學生端 gate 的小考」有效
+        # （whitelist），其餘 practice_mode（含 speaking_quiz）一律 False。
         is_live_quiz=bool(
             getattr(request, "is_live_quiz", False)
-            and (request.practice_mode or "").endswith("_quiz")
+            and (request.practice_mode or "") in LIVE_QUIZ_MODES
         ),
         shuffle_questions=request.shuffle_questions or False,
         show_answer=request.show_answer or False,
@@ -985,9 +987,11 @@ async def patch_assignment(
         if field in provided:
             setattr(assignment, field, getattr(request, field))
 
-    # Issue #835: live 模式僅對小考有效（practice_mode 在 PATCH 不可變）
-    if "is_live_quiz" in provided and not (assignment.practice_mode or "").endswith(
-        "_quiz"
+    # Issue #835 / #884 item 1: live 模式僅對 whitelist 的小考有效
+    # （practice_mode 在 PATCH 不可變）
+    if (
+        "is_live_quiz" in provided
+        and (assignment.practice_mode or "") not in LIVE_QUIZ_MODES
     ):
         assignment.is_live_quiz = False
 

--- a/backend/routers/assignments/detail.py
+++ b/backend/routers/assignments/detail.py
@@ -27,6 +27,7 @@ from models import (
 )
 from .dependencies import get_current_teacher
 from .utils import compute_speaking_total_score
+from .validators import LIVE_QUIZ_MODES
 
 # Single source of truth for speaking-scored modes (Azure pronunciation assessment,
 # score_category=speaking). Imported — not re-declared — so a new speaking mode added
@@ -611,8 +612,11 @@ def _get_owned_live_quiz_or_404(
         raise HTTPException(
             status_code=404, detail="Assignment not found or you don't have permission"
         )
+    # Issue #884 item 1: restrict live-quiz teacher ops to the whitelisted modes
+    # (word_selection/spelling/cloze_quiz) that have student-side gates, so a
+    # speaking_quiz can't be driven as a live quiz.
     practice_mode = assignment.practice_mode or ""
-    if not practice_mode.endswith("_quiz") or not getattr(
+    if practice_mode not in LIVE_QUIZ_MODES or not getattr(
         assignment, "is_live_quiz", False
     ):
         raise HTTPException(

--- a/backend/routers/assignments/validators.py
+++ b/backend/routers/assignments/validators.py
@@ -8,6 +8,14 @@ from pydantic import BaseModel, Field, model_validator, field_validator
 
 from utils.practice_mode import validate_practice_mode
 
+# Issue #884 item 1: the only practice modes that have student-side live-gate
+# endpoints (_guard_live_gate on start/answer). is_live_quiz is restricted to
+# these on create/patch so e.g. speaking_quiz can't be marked live without a
+# gate protecting students.
+LIVE_QUIZ_MODES = frozenset(
+    {"word_selection_quiz", "word_spelling_quiz", "word_cloze_quiz"}
+)
+
 # Issue #828: 整卷限時上限守衛（10 小時），擋掉負數/超大值；
 # 不用精確 allow-list 以免日後 UI 新增選項就壞掉
 _MAX_QUIZ_TIME_LIMIT_SECONDS = 36000

--- a/backend/routers/students/quiz_assignments.py
+++ b/backend/routers/students/quiz_assignments.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from database import get_db
 from models import (
@@ -397,13 +397,26 @@ async def get_quiz_live_status(
     ``assignment_id`` 為 StudentAssignment.id（與其餘 quiz 端點一致）。
     """
     student_id = int(current_student.get("sub"))
-    sa = _get_student_assignment_or_404(db, assignment_id, student_id)
-    # 注意：path 的 assignment_id 是 StudentAssignment.id；真正的 Assignment 要靠 sa.assignment_id 反查。
-    assignment = (
-        db.query(Assignment).filter(Assignment.id == sa.assignment_id).first()
-        if sa.assignment_id
-        else None
+    # Issue #884 item 3: this endpoint is polled every 3–15s per student, so
+    # load StudentAssignment + its Assignment in ONE round-trip via joinedload
+    # instead of two separate queries.
+    # 注意：path 的 assignment_id 是 StudentAssignment.id；Assignment 由關聯載入。
+    sa = (
+        db.query(StudentAssignment)
+        .options(joinedload(StudentAssignment.assignment))
+        .filter(
+            StudentAssignment.id == assignment_id,
+            StudentAssignment.student_id == student_id,
+            StudentAssignment.is_active.is_(True),
+        )
+        .first()
     )
+    if not sa:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Assignment not found or not assigned to you",
+        )
+    assignment = sa.assignment
     if assignment is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Assignment not found"

--- a/backend/tests/integration/api/test_live_quiz_whitelist_status_884.py
+++ b/backend/tests/integration/api/test_live_quiz_whitelist_status_884.py
@@ -1,0 +1,104 @@
+"""Issue #884: item 1 (live-quiz mode whitelist) + item 3 (/quiz/status query).
+
+Item 1: is_live_quiz is restricted to modes that have a student-side gate
+(word_selection/spelling/cloze_quiz); speaking_quiz must not be drivable as a
+live quiz.
+Item 3: GET /quiz/status still returns the correct gate fields after being
+optimized to a single joinedload query.
+"""
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from auth import create_access_token
+from routers.assignments.detail import _get_owned_live_quiz_or_404
+from routers.assignments.validators import LIVE_QUIZ_MODES
+from models import (
+    Teacher,
+    Classroom,
+    Assignment,
+    Student,
+    StudentAssignment,
+    AssignmentStatus,
+)
+
+
+def _live_assignment(db_session, teacher, mode):
+    classroom = Classroom(name="C", teacher_id=teacher.id)
+    db_session.add(classroom)
+    db_session.commit()
+    a = Assignment(
+        title="A",
+        classroom_id=classroom.id,
+        teacher_id=teacher.id,
+        practice_mode=mode,
+        is_live_quiz=True,
+        is_active=True,
+    )
+    db_session.add(a)
+    db_session.commit()
+    return a
+
+
+class TestLiveQuizWhitelist:
+    def test_whitelist_excludes_speaking_quiz(self):
+        assert "speaking_quiz" not in LIVE_QUIZ_MODES
+        assert {
+            "word_selection_quiz",
+            "word_spelling_quiz",
+            "word_cloze_quiz",
+        } <= set(LIVE_QUIZ_MODES)
+
+    def test_gate_rejects_speaking_live_quiz(self, db_session: Session):
+        teacher = Teacher(email="sp_t@test.com", name="T", password_hash="x")
+        db_session.add(teacher)
+        db_session.commit()
+        a = _live_assignment(db_session, teacher, "speaking_quiz")
+
+        with pytest.raises(HTTPException) as exc:
+            _get_owned_live_quiz_or_404(a.id, db_session, teacher)
+        assert exc.value.status_code == 400
+
+    def test_gate_allows_word_selection_live_quiz(self, db_session: Session):
+        teacher = Teacher(email="ws_t@test.com", name="T", password_hash="x")
+        db_session.add(teacher)
+        db_session.commit()
+        a = _live_assignment(db_session, teacher, "word_selection_quiz")
+
+        result = _get_owned_live_quiz_or_404(a.id, db_session, teacher)
+        assert result.id == a.id
+
+
+class TestQuizStatusEndpoint:
+    def test_status_returns_gate_fields(
+        self, test_client: TestClient, db_session: Session
+    ):
+        teacher = Teacher(email="qt@test.com", name="T", password_hash="x")
+        student = Student(email="qs@test.com", name="S")
+        db_session.add_all([teacher, student])
+        db_session.commit()
+        parent = _live_assignment(db_session, teacher, "word_selection_quiz")
+        sa = StudentAssignment(
+            assignment_id=parent.id,
+            student_id=student.id,
+            classroom_id=parent.classroom_id,
+            title="LQ",
+            status=AssignmentStatus.NOT_STARTED,
+        )
+        db_session.add(sa)
+        db_session.commit()
+
+        token = create_access_token({"sub": str(student.id), "type": "student"})
+        resp = test_client.get(
+            f"/api/students/assignments/{sa.id}/quiz/status",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        # assignment_id is the teacher-side Assignment.id (not the StudentAssignment.id)
+        assert body["assignment_id"] == parent.id
+        assert body["is_live_quiz"] is True
+        assert body["opened_at"] is None
+        assert body["closed_at"] is None


### PR DESCRIPTION
處理 #884 的 item 1 + item 3。

## Item 1：speaking_quiz live-gate gap
`is_live_quiz` 原本用 `practice_mode.endswith("_quiz")` 判定，導致 `speaking_quiz` 也能被標成 live——但它**沒有學生端 gate 端點**，學生不受保護。

改為明確 whitelist `LIVE_QUIZ_MODES = {word_selection_quiz, word_spelling_quiz, word_cloze_quiz}`（有 `_guard_live_gate` 的三種），套用於：
- `create_assignment` / PATCH（`crud.py`）：非 whitelist 模式一律 `is_live_quiz=False`
- `_get_owned_live_quiz_or_404`（`detail.py`）：老師端 live quiz 操作拒絕非 whitelist 模式

→ speaking_quiz（或未來任何無 gate 的 `*_quiz`）都無法被當 live quiz 驅動。

## Item 3：/quiz/status 查詢減量
`get_quiz_live_status` 每 3–15s 被每位在考學生輪詢，原本做 2 次查詢（StudentAssignment 再查 Assignment）。改用 `joinedload(StudentAssignment.assignment)` **一次往返**取回。

## 測試（`test_live_quiz_whitelist_status_884.py`）
- whitelist 不含 speaking_quiz
- gate 拒絕 speaking live quiz、允許 word_selection live quiz
- `/quiz/status` 重構後仍回正確 gate 欄位
- 既有 `test_quiz_assignments_828` / `test_quiz_revision_830`（10）全過，無 regression

black/flake8 clean。

## 關於 #884 其餘項
**Closes #884**（item 1、3）。item 2（gate loading 防閃）+ item 4（live quiz 端點整合測試）已移到 **#912**；item 5（收卷逐生 commit）是**刻意的容錯隔離權衡**，維持現狀。

🤖 Generated with [Claude Code](https://claude.com/claude-code)