### PR TITLE
hotfix(#917): 建作業複製 Content 帶上 program_id 避免頂層內容回 500

### DIFF
--- a/backend/routers/assignments/crud.py
+++ b/backend/routers/assignments/crud.py
@@ -387,6 +387,11 @@ async def create_assignment(
         # 複製 Content
         content_copy = Content(
             lesson_id=original_content.lesson_id,
+            # Issue #587 / #917: carry program_id so program-direct content
+            # (lesson_id=NULL) doesn't violate the ck_contents_lesson_or_program
+            # CHECK constraint. Without this the copy has lesson_id=NULL AND
+            # program_id=NULL → 500 (surfaced in the browser as a CORS error).
+            program_id=original_content.program_id,
             type=original_content.type,
             title=original_content.title,
             order_index=original_content.order_index,

--- a/backend/tests/integration/api/test_assignment_content_copy_mechanism.py
+++ b/backend/tests/integration/api/test_assignment_content_copy_mechanism.py
@@ -289,6 +289,88 @@ class TestAssignmentContentCopy:
 
         db.close()
 
+    def test_create_assignment_copies_program_id_for_program_direct_content(
+        self, test_data
+    ):
+        """Issue #917: 直接掛在 program 底下的頂層內容（lesson_id=NULL, program_id 有值）
+        建作業時，Content 副本必須帶上 program_id。
+
+        若漏帶 program_id，副本 lesson_id 與 program_id 皆為 NULL，違反 Postgres
+        CHECK 約束 ck_contents_lesson_or_program，正式站回 500（前端誤報為 CORS）。
+        SQLite 不強制該 CHECK，因此改以「副本是否帶上 program_id」的行為斷言把關。
+        """
+        db = TestingSessionLocal()
+
+        # 建立「頂層 program 內容」：lesson_id=None、program_id 指向 program
+        program_direct = Content(
+            id=2,
+            lesson_id=None,
+            program_id=1,
+            title="頂層單字集",
+            type=ContentType.EXAMPLE_SENTENCES,
+            order_index=1,
+            is_active=True,
+            is_assignment_copy=False,
+        )
+        db.add(program_direct)
+        db.commit()
+
+        db.add(
+            ContentItem(
+                id=2,
+                content_id=2,
+                order_index=1,
+                text="apple",
+                translation="蘋果",
+                audio_url="https://example.com/audio2.mp3",
+            )
+        )
+        db.commit()
+        db.close()
+
+        token = get_auth_token()
+        headers = {"Authorization": f"Bearer {token}"}
+
+        response = client.post(
+            "/api/teachers/assignments/create",
+            headers=headers,
+            json={
+                "title": "頂層內容作業",
+                "description": "測試描述",
+                "classroom_id": 1,
+                "content_ids": [2],
+                "student_ids": [1],
+                "due_date": (datetime.now(timezone.utc).isoformat()),
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        assignment_id = response.json()["assignment_id"]
+
+        db = TestingSessionLocal()
+        assignment_contents = (
+            db.query(AssignmentContent)
+            .filter(AssignmentContent.assignment_id == assignment_id)
+            .all()
+        )
+        content_ids = [ac.content_id for ac in assignment_contents]
+        copy_content = (
+            db.query(Content)
+            .filter(
+                Content.id.in_(content_ids),
+                Content.is_assignment_copy.is_(True),
+            )
+            .first()
+        )
+
+        assert copy_content is not None
+        assert copy_content.source_content_id == 2
+        # 核心斷言：副本帶上 program_id、lesson_id 維持 None
+        assert copy_content.program_id == 1
+        assert copy_content.lesson_id is None
+
+        db.close()
+
     def test_template_modification_does_not_affect_assignment(self, test_data):
         """測試：修改模板不會影響已派發的作業"""
         token = get_auth_token()


### PR DESCRIPTION
## 問題
正式站老師用「直接掛在 program 底下的頂層單字集」建作業時失敗，前端 console 一連串 CORS 錯誤，實際上是後端回 **HTTP 500**（500 回應沒帶 CORS header，瀏覽器誤報為 CORS）。

## 根因
`create_assignment` 複製 Content 副本時只帶 `lesson_id`，漏帶 `program_id`。當來源是頂層 program 內容（`lesson_id=NULL`, `program_id` 有值，#587 功能）時，副本兩者皆 NULL → 違反 Postgres CHECK 約束 `ck_contents_lesson_or_program` → 500。同邏輯在 `instant_practice.py` 已於 #587 修過，主流程被漏掉。

## 修正
- `crud.py`：Content 副本補上 `program_id=original_content.program_id`
- 新增測試：program-direct content 建作業，斷言副本帶上 `program_id`、`lesson_id=None`（SQLite 不強制該 CHECK，故以行為斷言把關）

## 診斷來源
Production Cloud Run log `duotopia-production-backend`，2026-07-07 04:45:58 UTC，trace `950d0a468f7d717bce2a65a92d86563c`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Hotfix → main（正式站）**。與 staging PR 使用同一 commit，採一般 merge（非 squash）確保 main/staging 共用相同 commit。

Fixes #917