### PR TITLE
fix(#847): 機構教材新增教材直屬內容 + 教材卡內容數 + logo CORS

### DIFF
--- a/backend/routers/organization_programs.py
+++ b/backend/routers/organization_programs.py
@@ -88,7 +88,9 @@ class ContentResponse(BaseModel):
     """Response model for content"""
 
     id: int
-    lesson_id: int
+    # Issue #587/#847: program-direct content has lesson_id NULL + program_id set
+    lesson_id: Optional[int] = None
+    program_id: Optional[int] = None
     type: str
     title: str
     order_index: int
@@ -133,6 +135,8 @@ class ProgramResponse(BaseModel):
     visibility: Optional[str] = "private"
     source_metadata: Optional[dict]
     lessons: List[LessonResponse] = []
+    # Issue #587/#847: contents that live directly under the program (no lesson)
+    contents: List[ContentResponse] = []
 
     @model_validator(mode="before")
     @classmethod
@@ -155,6 +159,32 @@ class ProgramResponse(BaseModel):
 
 
 # ============ Helper Functions ============
+
+
+def _build_content_response(content: Content) -> ContentResponse:
+    """Serialize a Content (lesson-attached or program-direct) with its items."""
+    content_data = ContentResponse.model_validate(content)
+    content_data.items = [
+        ContentItemResponse.model_validate(item)
+        for item in sorted(content.content_items, key=lambda x: x.order_index)
+    ]
+    return content_data
+
+
+def _build_program_direct_contents(program: Program) -> List[ContentResponse]:
+    """
+    Issue #587/#847: Build response for contents that live directly under the
+    program (lesson_id IS NULL). Program.contents is a viewonly relationship
+    already filtered to lesson_id IS NULL.
+    """
+    contents = []
+    for content in sorted(program.contents, key=lambda x: x.order_index):
+        if hasattr(content, "is_active") and not content.is_active:
+            continue
+        if getattr(content, "is_assignment_copy", False):
+            continue
+        contents.append(_build_content_response(content))
+    return contents
 
 
 def get_organization_programs(
@@ -282,7 +312,9 @@ async def list_organization_materials(
         .options(
             joinedload(Program.lessons)
             .joinedload(Lesson.contents)
-            .joinedload(Content.content_items)
+            .joinedload(Content.content_items),
+            # Issue #587/#847: eager-load program-direct contents (lesson_id NULL)
+            joinedload(Program.contents).joinedload(Content.content_items),
         )
         .filter(
             Program.is_template.is_(True),
@@ -313,19 +345,12 @@ async def list_organization_materials(
                     continue
                 if getattr(content, "is_assignment_copy", False):
                     continue
-                content_data = ContentResponse.model_validate(content)
-
-                # Build items
-                content_data.items = [
-                    ContentItemResponse.model_validate(item)
-                    for item in sorted(
-                        content.content_items, key=lambda x: x.order_index
-                    )
-                ]
-
-                lesson_data.contents.append(content_data)
+                lesson_data.contents.append(_build_content_response(content))
 
             program_data.lessons.append(lesson_data)
+
+        # Issue #587/#847: program-direct contents (no lesson)
+        program_data.contents = _build_program_direct_contents(program)
 
         result.append(program_data)
 
@@ -358,7 +383,9 @@ async def get_organization_material_details(
         .options(
             joinedload(Program.lessons)
             .joinedload(Lesson.contents)
-            .joinedload(Content.content_items)
+            .joinedload(Content.content_items),
+            # Issue #587/#847: eager-load program-direct contents (lesson_id NULL)
+            joinedload(Program.contents).joinedload(Content.content_items),
         )
         .filter(Program.id == program_id)
         .first()
@@ -392,14 +419,12 @@ async def get_organization_material_details(
                 continue
             if getattr(content, "is_assignment_copy", False):
                 continue
-            content_data = ContentResponse.model_validate(content)
-            content_data.items = [
-                ContentItemResponse.model_validate(item)
-                for item in sorted(content.content_items, key=lambda x: x.order_index)
-            ]
-            lesson_data.contents.append(content_data)
+            lesson_data.contents.append(_build_content_response(content))
 
         program_data.lessons.append(lesson_data)
+
+    # Issue #587/#847: program-direct contents (no lesson)
+    program_data.contents = _build_program_direct_contents(program)
 
     return program_data
 

--- a/backend/routers/organization_programs.py
+++ b/backend/routers/organization_programs.py
@@ -13,7 +13,7 @@ Endpoints:
 """
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session, joinedload, selectinload
 from pydantic import BaseModel, Field, computed_field, field_serializer, model_validator
 from typing import List, Optional
 import uuid
@@ -313,8 +313,10 @@ async def list_organization_materials(
             joinedload(Program.lessons)
             .joinedload(Lesson.contents)
             .joinedload(Content.content_items),
-            # Issue #587/#847: eager-load program-direct contents (lesson_id NULL)
-            joinedload(Program.contents).joinedload(Content.content_items),
+            # Issue #587/#847: eager-load program-direct contents (lesson_id NULL).
+            # Use selectinload (separate query) to avoid a cartesian-product row
+            # explosion with the joinedload on the Program.lessons collection.
+            selectinload(Program.contents).selectinload(Content.content_items),
         )
         .filter(
             Program.is_template.is_(True),
@@ -384,8 +386,10 @@ async def get_organization_material_details(
             joinedload(Program.lessons)
             .joinedload(Lesson.contents)
             .joinedload(Content.content_items),
-            # Issue #587/#847: eager-load program-direct contents (lesson_id NULL)
-            joinedload(Program.contents).joinedload(Content.content_items),
+            # Issue #587/#847: eager-load program-direct contents (lesson_id NULL).
+            # Use selectinload (separate query) to avoid a cartesian-product row
+            # explosion with the joinedload on the Program.lessons collection.
+            selectinload(Program.contents).selectinload(Content.content_items),
         )
         .filter(Program.id == program_id)
         .first()

--- a/backend/routers/teachers.py
+++ b/backend/routers/teachers.py
@@ -667,6 +667,9 @@ async def get_teacher_programs(
             selectinload(Program.lessons)
             .selectinload(Lesson.contents)
             .selectinload(Content.content_items),
+            # Issue #587/#847: eager-load program-direct contents (lesson_id NULL)
+            # so the material card count includes them
+            selectinload(Program.contents).selectinload(Content.content_items),
         )
     )
 
@@ -799,6 +802,41 @@ async def get_teacher_programs(
                     }
                 )
 
+        # Issue #587/#847: program-direct contents (no lesson). Program.contents
+        # is a viewonly relationship filtered to lesson_id IS NULL.
+        program_contents_data = []
+        for content in sorted(program.contents, key=lambda x: x.order_index):
+            if not content.is_active or content.is_assignment_copy:
+                continue
+            items_data = []
+            if content.content_items:
+                for item in sorted(content.content_items, key=lambda x: x.order_index):
+                    items_data.append(
+                        {
+                            "id": item.id,
+                            "text": item.text,
+                            "translation": item.translation,
+                            "audio_url": item.audio_url,
+                            "example_sentence": item.example_sentence,
+                            "example_sentence_translation": item.example_sentence_translation,
+                            "order_index": item.order_index,
+                        }
+                    )
+            program_contents_data.append(
+                {
+                    "id": content.id,
+                    "title": content.title,
+                    "type": content.type,
+                    "lesson_id": None,
+                    "program_id": program.id,
+                    "items": items_data,
+                    "items_count": len(items_data),
+                    "order_index": content.order_index,
+                    "level": content.level,
+                    "tags": content.tags or [],
+                }
+            )
+
         result.append(
             {
                 "id": program.id,
@@ -822,6 +860,8 @@ async def get_teacher_programs(
                 "tags": program.tags or [],
                 "visibility": program.visibility,
                 "lessons": lessons_data,
+                # Issue #587/#847: contents directly under the program (no lesson)
+                "contents": program_contents_data,
             }
         )
 

--- a/backend/tests/test_organization_programs.py
+++ b/backend/tests/test_organization_programs.py
@@ -468,6 +468,93 @@ class TestGetMaterialDetails:
 
 
 # ============================================================================
+# Test Cases: Program-Direct Contents (Issue #587/#847)
+# ============================================================================
+
+
+class TestProgramDirectContents:
+    """
+    Issue #847: contents living directly under a program (lesson_id IS NULL)
+    must be returned by both the list and detail endpoints, otherwise the
+    org-materials UI cannot show them and the card count is wrong.
+    """
+
+    def _add_program_direct_content(
+        self, test_db: Session, program: Program, title: str = "Program Content"
+    ) -> Content:
+        content = Content(
+            lesson_id=None,
+            program_id=program.id,
+            type=ContentType.READING_ASSESSMENT,
+            title=title,
+            order_index=0,
+            is_active=True,
+        )
+        test_db.add(content)
+        test_db.flush()
+        test_db.add(
+            ContentItem(
+                content_id=content.id,
+                text="direct item",
+                translation="直屬項目",
+                order_index=0,
+            )
+        )
+        test_db.commit()
+        test_db.refresh(content)
+        return content
+
+    def test_detail_includes_program_direct_contents(
+        self,
+        test_client: TestClient,
+        test_db: Session,
+        test_org: Organization,
+        test_org_with_materials: list,
+        owner_headers: dict,
+    ):
+        """Detail endpoint returns program-level contents with items."""
+        material = test_org_with_materials[0]
+        content = self._add_program_direct_content(test_db, material)
+
+        response = test_client.get(
+            f"/api/organizations/{test_org.id}/programs/{material.id}",
+            headers=owner_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "contents" in data
+        ids = [c["id"] for c in data["contents"]]
+        assert content.id in ids
+        direct = next(c for c in data["contents"] if c["id"] == content.id)
+        assert direct["lesson_id"] is None
+        assert direct["program_id"] == material.id
+        assert direct["items_count"] == 1
+
+    def test_list_includes_program_direct_contents(
+        self,
+        test_client: TestClient,
+        test_db: Session,
+        test_org: Organization,
+        test_org_with_materials: list,
+        owner_headers: dict,
+    ):
+        """List endpoint returns program-level contents for each material."""
+        material = test_org_with_materials[0]
+        content = self._add_program_direct_content(test_db, material)
+
+        response = test_client.get(
+            f"/api/organizations/{test_org.id}/programs",
+            headers=owner_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        target = next(p for p in data if p["id"] == material.id)
+        assert content.id in [c["id"] for c in target["contents"]]
+
+
+# ============================================================================
 # Test Cases: Create Material (POST)
 # ============================================================================
 

--- a/frontend/src/components/shared/ProgramFolderView.tsx
+++ b/frontend/src/components/shared/ProgramFolderView.tsx
@@ -186,10 +186,12 @@ function ProgramCard({
 }) {
   const { t } = useTranslation();
   const lessons = program.lessons ?? [];
-  const contentCount = lessons.reduce(
-    (sum, l) => sum + (l.contents?.length ?? 0),
-    0,
-  );
+  // Issue #847: include program-direct contents (lesson_id IS NULL, Issue #587)
+  // in the card count — previously only lesson.contents were summed, so the
+  // badge stayed stale after adding content directly under the program.
+  const contentCount =
+    lessons.reduce((sum, l) => sum + (l.contents?.length ?? 0), 0) +
+    (program.contents?.length ?? 0);
 
   return (
     <div

--- a/frontend/src/pages/teacher/OrgMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/OrgMaterialsPage.tsx
@@ -744,11 +744,19 @@ export default function OrgMaterialsPage() {
                 });
                 setShowInstantPractice(true);
               }}
-              onAssignContent={(content, lessonId) => {
-                const program = programs.find((p) =>
-                  p.lessons?.some((l) => l.id === lessonId),
-                );
-                const lesson = program?.lessons?.find((l) => l.id === lessonId);
+              onAssignContent={(content, lessonId, programId) => {
+                // Issue #847: program-direct content (lessonId === 0) is looked
+                // up by programId, not by lesson.
+                const program =
+                  lessonId === 0
+                    ? programs.find((p) => p.id === programId)
+                    : programs.find((p) =>
+                        p.lessons?.some((l) => l.id === lessonId),
+                      );
+                const lesson =
+                  lessonId === 0
+                    ? undefined
+                    : program?.lessons?.find((l) => l.id === lessonId);
                 const cartItem: CartItem = {
                   contentId: content.id,
                   programName: program?.name || "",

--- a/frontend/src/pages/teacher/OrgMaterialsPage.tsx
+++ b/frontend/src/pages/teacher/OrgMaterialsPage.tsx
@@ -66,11 +66,16 @@ export default function OrgMaterialsPage() {
     programName: string;
     lessonName: string;
     lessonId: number;
+    // Issue #587/#847: set when creating program-direct content (lesson_id NULL)
+    programId?: number;
   } | null>(null);
 
   // Reading assessment modal
   const [showReadingEditor, setShowReadingEditor] = useState(false);
   const [editorLessonId, setEditorLessonId] = useState<number | null>(null);
+  // Issue #847: programId is set (and editorLessonId is null) when creating/
+  // editing program-direct content
+  const [editorProgramId, setEditorProgramId] = useState<number | null>(null);
   const [editorContentId, setEditorContentId] = useState<number | null>(null);
   const [selectedContent, setSelectedContent] = useState<Content | null>(null);
 
@@ -83,6 +88,10 @@ export default function OrgMaterialsPage() {
     return () => setSidebarDisabled(false);
   }, [showReadingEditor, showVocabularySetEditor, setSidebarDisabled]);
   const [vocabularySetLessonId, setVocabularySetLessonId] = useState<
+    number | null
+  >(null);
+  // Issue #847: programId for program-direct vocabulary set creation/editing
+  const [vocabularySetProgramId, setVocabularySetProgramId] = useState<
     number | null
   >(null);
   const [vocabularySetContentId, setVocabularySetContentId] = useState<
@@ -254,8 +263,22 @@ export default function OrgMaterialsPage() {
   // Content handlers
   const handleCreateContent = (programId: number, lessonId: number) => {
     const program = programs.find((p) => p.id === programId);
-    const lesson = program?.lessons?.find((l) => l.id === lessonId);
-    if (lesson && program) {
+    if (!program) return;
+
+    // Issue #847: lessonId === 0 means create program-direct content (no lesson)
+    if (lessonId === 0) {
+      setContentLessonInfo({
+        programName: program.name,
+        lessonName: "",
+        lessonId: 0,
+        programId: program.id,
+      });
+      setShowContentTypeDialog(true);
+      return;
+    }
+
+    const lesson = program.lessons?.find((l) => l.id === lessonId);
+    if (lesson) {
       setContentLessonInfo({
         programName: program.name,
         lessonName: lesson.name,
@@ -269,11 +292,16 @@ export default function OrgMaterialsPage() {
     content: Content & {
       lessonName?: string;
       programName?: string;
-      lesson_id?: number;
+      lesson_id?: number | null;
+      program_id?: number | null;
     },
   ) => {
     // 統一轉成小寫比對
     const contentType = content.type?.toLowerCase();
+
+    // Issue #847: program-direct content has lesson_id = null; carry program_id
+    // so the editor render gate (which requires lessonId OR programId) passes.
+    const isProgramDirect = !content.lesson_id && !!content.program_id;
 
     // EXAMPLE_SENTENCES uses the same ReadingAssessmentPanel as READING_ASSESSMENT
     if (
@@ -282,6 +310,7 @@ export default function OrgMaterialsPage() {
     ) {
       setSelectedContent(content);
       setEditorLessonId(content.lesson_id || null);
+      setEditorProgramId(isProgramDirect ? content.program_id! : null);
       setEditorContentId(content.id);
       setShowReadingEditor(true);
     } else if (
@@ -290,6 +319,7 @@ export default function OrgMaterialsPage() {
     ) {
       // 編輯單字集內容
       setVocabularySetLessonId(content.lesson_id || null);
+      setVocabularySetProgramId(isProgramDirect ? content.program_id! : null);
       setVocabularySetContentId(content.id);
       setShowVocabularySetEditor(true);
     }
@@ -314,6 +344,13 @@ export default function OrgMaterialsPage() {
       await apiClient.deleteContent(contentId);
       const updatedPrograms = programs.map((program) => ({
         ...program,
+        // Issue #847: ProgramFolderView passes lessonId=0 for program-direct
+        // content; filter program.contents so the deleted card disappears
+        // without a page refresh.
+        contents:
+          lessonId === 0
+            ? program.contents?.filter((c) => c.id !== contentId)
+            : program.contents,
         lessons: program.lessons?.map((lesson) => {
           if (lesson.id === lessonId) {
             return {
@@ -735,92 +772,113 @@ export default function OrgMaterialsPage() {
         </div>
 
         {/* Reading Assessment Modal (新增模式) */}
-        {showReadingEditor && editorLessonId && editorContentId === null && (
-          <>
-            <div
-              className="editor-panel fixed top-0 right-0 h-screen bg-white shadow-2xl border-l border-gray-200 z-50 flex flex-col animate-in slide-in-from-right duration-300"
-              style={{ left: `${sidebarWidth}px` }}
-            >
-              <div className="flex justify-between items-center px-6 py-4 border-b border-gray-200">
-                <h2 className="text-lg font-semibold">
-                  {t("teacherTemplatePrograms.dialogs.addReadingTitle")}
-                </h2>
-                <div className="flex items-center gap-2">
-                  <RefSaveButton panelRef={readingPanelRef} />
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    disabled={editorBusy}
-                    onClick={() => {
-                      if (editorBusy) return;
-                      if (
-                        !window.confirm(
-                          t("contentEditor.labels.unsavedChangesConfirm"),
+        {showReadingEditor &&
+          (editorLessonId || editorProgramId) &&
+          editorContentId === null && (
+            <>
+              <div
+                className="editor-panel fixed top-0 right-0 h-screen bg-white shadow-2xl border-l border-gray-200 z-50 flex flex-col animate-in slide-in-from-right duration-300"
+                style={{ left: `${sidebarWidth}px` }}
+              >
+                <div className="flex justify-between items-center px-6 py-4 border-b border-gray-200">
+                  <h2 className="text-lg font-semibold">
+                    {t("teacherTemplatePrograms.dialogs.addReadingTitle")}
+                  </h2>
+                  <div className="flex items-center gap-2">
+                    <RefSaveButton panelRef={readingPanelRef} />
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      disabled={editorBusy}
+                      onClick={() => {
+                        if (editorBusy) return;
+                        if (
+                          !window.confirm(
+                            t("contentEditor.labels.unsavedChangesConfirm"),
+                          )
                         )
-                      )
-                        return;
+                          return;
+                        setShowReadingEditor(false);
+                        setEditorLessonId(null);
+                        setEditorProgramId(null);
+                        setEditorContentId(null);
+                        setSelectedContent(null);
+                      }}
+                    >
+                      <X className="h-5 w-5" />
+                    </Button>
+                  </div>
+                </div>
+                <div className="flex-1 overflow-auto p-6 min-h-0 flex flex-col">
+                  <ReadingAssessmentPanel
+                    ref={readingPanelRef}
+                    lessonId={editorLessonId || undefined}
+                    programId={editorProgramId || undefined}
+                    isCreating={true}
+                    onSave={async (
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      newContent?: any,
+                    ) => {
+                      // 如果有返回新內容，直接更新前端狀態，不重整頁面
+                      if (newContent && editorLessonId) {
+                        setPrograms(
+                          programs.map((program) => ({
+                            ...program,
+                            lessons: program.lessons?.map((lesson) => {
+                              if (lesson.id === editorLessonId) {
+                                return {
+                                  ...lesson,
+                                  contents: [
+                                    ...(lesson.contents || []),
+                                    newContent,
+                                  ],
+                                };
+                              }
+                              return lesson;
+                            }),
+                          })),
+                        );
+                      } else if (newContent && editorProgramId) {
+                        // Issue #847: program-direct content — append to program.contents
+                        setPrograms(
+                          programs.map((program) =>
+                            program.id === editorProgramId
+                              ? {
+                                  ...program,
+                                  contents: [
+                                    ...(program.contents || []),
+                                    newContent,
+                                  ],
+                                }
+                              : program,
+                          ),
+                        );
+                      }
                       setShowReadingEditor(false);
                       setEditorLessonId(null);
+                      setEditorProgramId(null);
+                      setEditorContentId(null);
+                      setSelectedContent(null);
+                      toast.success(
+                        t("teacherTemplatePrograms.messages.contentSaved"),
+                      );
+                    }}
+                    onCancel={() => {
+                      setShowReadingEditor(false);
+                      setEditorLessonId(null);
+                      setEditorProgramId(null);
                       setEditorContentId(null);
                       setSelectedContent(null);
                     }}
-                  >
-                    <X className="h-5 w-5" />
-                  </Button>
+                  />
                 </div>
               </div>
-              <div className="flex-1 overflow-auto p-6 min-h-0 flex flex-col">
-                <ReadingAssessmentPanel
-                  ref={readingPanelRef}
-                  lessonId={editorLessonId}
-                  isCreating={true}
-                  onSave={async (
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    newContent?: any,
-                  ) => {
-                    // 如果有返回新內容，直接更新前端狀態，不重整頁面
-                    if (newContent && editorLessonId) {
-                      setPrograms(
-                        programs.map((program) => ({
-                          ...program,
-                          lessons: program.lessons?.map((lesson) => {
-                            if (lesson.id === editorLessonId) {
-                              return {
-                                ...lesson,
-                                contents: [
-                                  ...(lesson.contents || []),
-                                  newContent,
-                                ],
-                              };
-                            }
-                            return lesson;
-                          }),
-                        })),
-                      );
-                    }
-                    setShowReadingEditor(false);
-                    setEditorLessonId(null);
-                    setEditorContentId(null);
-                    setSelectedContent(null);
-                    toast.success(
-                      t("teacherTemplatePrograms.messages.contentSaved"),
-                    );
-                  }}
-                  onCancel={() => {
-                    setShowReadingEditor(false);
-                    setEditorLessonId(null);
-                    setEditorContentId(null);
-                    setSelectedContent(null);
-                  }}
-                />
-              </div>
-            </div>
-          </>
-        )}
+            </>
+          )}
 
         {/* Reading Assessment Panel (編輯模式 - 側邊欄) */}
         {showReadingEditor &&
-          editorLessonId &&
+          (editorLessonId || editorProgramId) &&
           editorContentId !== null &&
           selectedContent && (
             <>
@@ -850,6 +908,7 @@ export default function OrgMaterialsPage() {
                           return;
                         setShowReadingEditor(false);
                         setEditorLessonId(null);
+                        setEditorProgramId(null);
                         setEditorContentId(null);
                         setSelectedContent(null);
                       }}
@@ -876,7 +935,8 @@ export default function OrgMaterialsPage() {
                 <div className="p-6">
                   <ReadingAssessmentPanel
                     ref={readingPanelRef}
-                    lessonId={editorLessonId}
+                    lessonId={editorLessonId || undefined}
+                    programId={editorProgramId || undefined}
                     contentId={editorContentId}
                     content={{
                       id: selectedContent.id,
@@ -893,6 +953,12 @@ export default function OrgMaterialsPage() {
                         setPrograms((prevPrograms) =>
                           prevPrograms.map((program) => ({
                             ...program,
+                            // Issue #847: also update program-direct contents
+                            contents: program.contents?.map((content) =>
+                              content.id === editorContentId
+                                ? { ...content, ...updatedContent }
+                                : content,
+                            ),
                             lessons: program.lessons?.map((lesson) => ({
                               ...lesson,
                               contents: lesson.contents?.map((content) =>
@@ -906,6 +972,7 @@ export default function OrgMaterialsPage() {
                       }
                       setShowReadingEditor(false);
                       setEditorLessonId(null);
+                      setEditorProgramId(null);
                       setEditorContentId(null);
                       setSelectedContent(null);
                       toast.success(
@@ -915,6 +982,7 @@ export default function OrgMaterialsPage() {
                     onCancel={() => {
                       setShowReadingEditor(false);
                       setEditorLessonId(null);
+                      setEditorProgramId(null);
                       setEditorContentId(null);
                       setSelectedContent(null);
                     }}
@@ -926,7 +994,7 @@ export default function OrgMaterialsPage() {
 
         {/* Sentence Making Editor (新增模式 - 側滑) */}
         {showVocabularySetEditor &&
-          vocabularySetLessonId &&
+          (vocabularySetLessonId || vocabularySetProgramId) &&
           !vocabularySetContentId && (
             <>
               <div
@@ -953,6 +1021,7 @@ export default function OrgMaterialsPage() {
                           return;
                         setShowVocabularySetEditor(false);
                         setVocabularySetLessonId(null);
+                        setVocabularySetProgramId(null);
                         setVocabularySetContentId(null);
                       }}
                     >
@@ -967,7 +1036,8 @@ export default function OrgMaterialsPage() {
                     editingContent={{
                       id: vocabularySetContentId || undefined,
                     }}
-                    lessonId={vocabularySetLessonId}
+                    lessonId={vocabularySetLessonId || undefined}
+                    programId={vocabularySetProgramId || undefined}
                     onUpdateContent={() => {}}
                     onSave={async (
                       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -992,15 +1062,32 @@ export default function OrgMaterialsPage() {
                             }),
                           })),
                         );
+                      } else if (newContent && vocabularySetProgramId) {
+                        // Issue #847: program-direct content — append to program.contents
+                        setPrograms((prevPrograms) =>
+                          prevPrograms.map((program) =>
+                            program.id === vocabularySetProgramId
+                              ? {
+                                  ...program,
+                                  contents: [
+                                    ...(program.contents || []),
+                                    newContent,
+                                  ],
+                                }
+                              : program,
+                          ),
+                        );
                       }
                       setShowVocabularySetEditor(false);
                       setVocabularySetLessonId(null);
+                      setVocabularySetProgramId(null);
                       setVocabularySetContentId(null);
                       toast.success("內容已成功儲存");
                     }}
                     onCancel={() => {
                       setShowVocabularySetEditor(false);
                       setVocabularySetLessonId(null);
+                      setVocabularySetProgramId(null);
                       setVocabularySetContentId(null);
                     }}
                     isCreating={!vocabularySetContentId}
@@ -1012,7 +1099,7 @@ export default function OrgMaterialsPage() {
 
         {/* Sentence Making Editor (編輯模式 - 側邊欄) */}
         {showVocabularySetEditor &&
-          vocabularySetLessonId &&
+          (vocabularySetLessonId || vocabularySetProgramId) &&
           vocabularySetContentId && (
             <>
               {/* Backdrop */}
@@ -1041,6 +1128,7 @@ export default function OrgMaterialsPage() {
                           return;
                         setShowVocabularySetEditor(false);
                         setVocabularySetLessonId(null);
+                        setVocabularySetProgramId(null);
                         setVocabularySetContentId(null);
                       }}
                       className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
@@ -1056,7 +1144,8 @@ export default function OrgMaterialsPage() {
                     ref={vocabPanelRef}
                     content={{ id: vocabularySetContentId }}
                     editingContent={{ id: vocabularySetContentId }}
-                    lessonId={vocabularySetLessonId}
+                    lessonId={vocabularySetLessonId || undefined}
+                    programId={vocabularySetProgramId || undefined}
                     onUpdateContent={() => {}}
                     onSave={async (
                       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1067,6 +1156,12 @@ export default function OrgMaterialsPage() {
                         setPrograms((prevPrograms) =>
                           prevPrograms.map((program) => ({
                             ...program,
+                            // Issue #847: also update program-direct contents
+                            contents: program.contents?.map((content) =>
+                              content.id === vocabularySetContentId
+                                ? { ...content, ...updatedContent }
+                                : content,
+                            ),
                             lessons: program.lessons?.map((lesson) => ({
                               ...lesson,
                               contents: lesson.contents?.map((content) =>
@@ -1080,12 +1175,14 @@ export default function OrgMaterialsPage() {
                       }
                       setShowVocabularySetEditor(false);
                       setVocabularySetLessonId(null);
+                      setVocabularySetProgramId(null);
                       setVocabularySetContentId(null);
                       toast.success("內容已成功儲存");
                     }}
                     onCancel={() => {
                       setShowVocabularySetEditor(false);
                       setVocabularySetLessonId(null);
+                      setVocabularySetProgramId(null);
                       setVocabularySetContentId(null);
                     }}
                     isCreating={false}
@@ -1134,6 +1231,11 @@ export default function OrgMaterialsPage() {
               setShowContentTypeDialog(false);
               setContentLessonInfo(null);
 
+              // Issue #847: lessonId === 0 + programId set means program-direct
+              // content — thread programId so the editor render gate passes.
+              const isProgramDirect =
+                selection.lessonId === 0 && !!selection.programId;
+
               // Handle different content types
               // EXAMPLE_SENTENCES uses the same ReadingAssessmentPanel as READING_ASSESSMENT
               if (
@@ -1142,7 +1244,10 @@ export default function OrgMaterialsPage() {
                 selection.type === "EXAMPLE_SENTENCES"
               ) {
                 // Open modal for new content
-                setEditorLessonId(selection.lessonId);
+                setEditorLessonId(isProgramDirect ? null : selection.lessonId);
+                setEditorProgramId(
+                  isProgramDirect ? selection.programId! : null,
+                );
                 setEditorContentId(null); // null = new content
                 setSelectedContent(null); // No existing content
                 setShowReadingEditor(true);
@@ -1153,7 +1258,12 @@ export default function OrgMaterialsPage() {
                 selection.type === "VOCABULARY_SET"
               ) {
                 // For sentence_making/vocabulary_set, use popup for new content creation
-                setVocabularySetLessonId(selection.lessonId);
+                setVocabularySetLessonId(
+                  isProgramDirect ? null : selection.lessonId,
+                );
+                setVocabularySetProgramId(
+                  isProgramDirect ? selection.programId! : null,
+                );
                 setVocabularySetContentId(null); // null for new content
                 setShowVocabularySetEditor(true);
               } else {

--- a/infrastructure/gcs-cors-social-media-videos.json
+++ b/infrastructure/gcs-cors-social-media-videos.json
@@ -1,0 +1,8 @@
+[
+  {
+    "origin": ["*"],
+    "method": ["GET", "HEAD"],
+    "responseHeader": ["Content-Type"],
+    "maxAgeSeconds": 3600
+  }
+]


### PR DESCRIPTION
## 問題 (Fixes #847)

機構教材頁 `/teacher/org-materials` 有兩個 bug：

1. **機構教材無法新增「教材內容」（教材直屬內容）** — `OrgMaterialsPage.tsx` 是「我的教材」頁的舊複製，從沒拿到 Issue #587（`lesson_id` NULL 的 program-direct content）的修正。sentinel `lessonId=0` 為 falsy，導致 `handleCreateContent`、編輯器 render 閘門、`onSave` 全部落入 falsy 陷阱，點「新增教材內容」無反應。
2. **教材卡上內容數量未計入教材直屬內容**（「我的教材」與「機構教材」共用 `ProgramFolderView`，兩頁通病）。
3. **後端 GET programs 端點未回傳 program 直屬 contents** — 即使前端能新增，reload 後也會消失、數量也不對（org 與 teacher 兩個端點都缺）。

另附使用者回報的 logo CORS 錯誤修正。

## 修改

### Frontend
- `ProgramFolderView.tsx`：教材卡 `contentCount` 加計 `program.contents`
- `OrgMaterialsPage.tsx`：移植 #587 全套流程 — `editorProgramId` / `vocabularySetProgramId` state、`lessonId === 0` 分支、render 閘門改 `(lessonId || programId)`、面板傳 `programId`、`onSave` / `handleDeleteContent` 更新 `program.contents`、`handleContentClick` 帶 `program_id`

### Backend
- `organization_programs.py`：`ContentResponse.lesson_id` 改 `Optional` + 加 `program_id`；`ProgramResponse` 加 `contents`；list / detail 端點 eager-load `Program.contents` 並回傳（新增 `_build_content_response` 共用 helper）
- `teachers.py` `get_teacher_programs`：回傳 program 直屬 contents（修正「我的教材」數量通病）

### CORS
- `infrastructure/gcs-cors-social-media-videos.json`：logo bucket CORS 設定（GET/HEAD、origin `*`）。已用 `gsutil cors set` 套用至 `gs://duotopia-social-media-videos`，preflight 驗證回傳 `access-control-allow-origin: *`

### Tests
- `test_organization_programs.py` `TestProgramDirectContents`：驗證 list / detail 端點回傳教材直屬內容（`lesson_id` NULL、`program_id` set、`items_count`）

## 驗證
- ✅ frontend `tsc --noEmit`、`eslint`（僅一個既有 warning）、`vite build`
- ✅ backend `black`、`flake8`、`py_compile`
- ⚠️ 端點測試（casbin/test_client）本機無法執行，交由 CI 驗證
- ✅ GCS bucket CORS 已套用並用 curl preflight 驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)