### PR TITLE
feat(#761): Sync 1Campus 前對有機構帳號的老師顯示防呆提醒

### DIFF
--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -3386,7 +3386,12 @@
       "errorsSuffix": "error(s) — see logs",
       "notLinked": "Your account is not linked to 1Campus. Log in via 1Campus first.",
       "rateLimited": "Sync was triggered recently — please wait a minute and try again.",
-      "failed": "Failed to start 1Campus sync. Please try again."
+      "failed": "Failed to start 1Campus sync. Please try again.",
+      "confirm": {
+        "title": "Sync into your personal account?",
+        "message": "AI point usage for classes under your personal account will be deducted from your personal points. If the students belong to an organization, please import the class within the organization instead.",
+        "confirmButton": "Sync anyway"
+      }
     }
   },
   "teacherStudents": {

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -3385,7 +3385,12 @@
       "errorsSuffix": "個錯誤——請查看伺服器記錄",
       "notLinked": "您的帳號尚未綁定 1Campus，請先以 1Campus 方式登入",
       "rateLimited": "剛剛已觸發過同步，請稍候片刻再試",
-      "failed": "1Campus 同步失敗，請稍後再試"
+      "failed": "1Campus 同步失敗，請稍後再試",
+      "confirm": {
+        "title": "確定要同步到個人帳號嗎？",
+        "message": "個人帳號下，班級使用 AI 點數將從老師個人點數扣除；如果學生屬於機構，請於機構內匯入班級。",
+        "confirmButton": "仍要同步"
+      }
     }
   },
   "teacherStudents": {

--- a/frontend/src/pages/teacher/TeacherClassrooms.tsx
+++ b/frontend/src/pages/teacher/TeacherClassrooms.tsx
@@ -68,7 +68,8 @@ type SortDirection = "asc" | "desc";
 
 export default function TeacherClassrooms() {
   const { t } = useTranslation();
-  const { selectedSchool, selectedOrganization, mode } = useWorkspace();
+  const { selectedSchool, selectedOrganization, mode, organizations } =
+    useWorkspace();
   const [classrooms, setClassrooms] = useState<ClassroomDetail[]>([]);
   const [loading, setLoading] = useState(true);
   const [editingClassroom, setEditingClassroom] =
@@ -103,6 +104,28 @@ export default function TeacherClassrooms() {
 
   // 1Campus class sync (#635)
   const [syncingOneCampus, setSyncingOneCampus] = useState(false);
+  // Foolproof confirmation before syncing into a personal account when the
+  // teacher also belongs to an organization (#761). Personal-account syncs
+  // deduct AI points from the teacher's personal balance, which is usually
+  // not what an org teacher intends for org-owned students.
+  const [showSyncConfirm, setShowSyncConfirm] = useState(false);
+  const hasOrganization = organizations.length > 0;
+
+  // Gate the Sync button: org teachers see a warning dialog first; personal-
+  // only teachers sync immediately (unchanged behavior).
+  const handleSyncOneCampusClick = () => {
+    if (syncingOneCampus) return;
+    if (hasOrganization) {
+      setShowSyncConfirm(true);
+    } else {
+      handleSyncOneCampusClasses();
+    }
+  };
+
+  const handleConfirmSyncOneCampus = () => {
+    setShowSyncConfirm(false);
+    handleSyncOneCampusClasses();
+  };
 
   const handleSyncOneCampusClasses = async () => {
     if (syncingOneCampus) return;
@@ -473,7 +496,7 @@ export default function TeacherClassrooms() {
             </span>
           </Button>
           <Button
-            onClick={handleSyncOneCampusClasses}
+            onClick={handleSyncOneCampusClick}
             variant="outline"
             size="sm"
             className="flex-1 sm:flex-none"
@@ -1057,6 +1080,48 @@ export default function TeacherClassrooms() {
       </Dialog>
 
       {/* Delete Confirmation Dialog */}
+      {/* 1Campus Sync Confirmation Dialog (#761) */}
+      <Dialog open={showSyncConfirm} onOpenChange={setShowSyncConfirm}>
+        <DialogContent
+          className="bg-white"
+          style={{ backgroundColor: "white" }}
+        >
+          <DialogHeader>
+            <DialogTitle className="flex items-center space-x-2">
+              <AlertTriangle className="h-5 w-5 text-amber-500" />
+              <span>
+                {t("teacherClassrooms.oneCampusSync.confirm.title", {
+                  defaultValue: "Sync into your personal account?",
+                })}
+              </span>
+            </DialogTitle>
+            <DialogDescription>
+              {t("teacherClassrooms.oneCampusSync.confirm.message", {
+                defaultValue:
+                  "AI point usage for classes under your personal account will be deducted from your personal points. If the students belong to an organization, please import the class within the organization instead.",
+              })}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="flex flex-col sm:flex-row gap-2 sm:gap-0">
+            <Button
+              variant="outline"
+              onClick={() => setShowSyncConfirm(false)}
+              className="w-full sm:w-auto"
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button
+              onClick={handleConfirmSyncOneCampus}
+              className="w-full sm:w-auto"
+            >
+              {t("teacherClassrooms.oneCampusSync.confirm.confirmButton", {
+                defaultValue: "Sync anyway",
+              })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <Dialog
         open={!!deleteConfirmId}
         onOpenChange={(open) => !open && setDeleteConfirmId(null)}

--- a/frontend/src/pages/teacher/__tests__/TeacherClassrooms.test.tsx
+++ b/frontend/src/pages/teacher/__tests__/TeacherClassrooms.test.tsx
@@ -78,6 +78,14 @@ vi.mock("react-i18next", () => ({
         "teacherClassrooms.dialogs.createDescription": "Create a new classroom",
         "teacherClassrooms.placeholders.classroomName": "e.g., Grade 5",
         "teacherClassrooms.placeholders.description": "Description",
+        "teacherClassrooms.oneCampusSync.buttonIdle": "Sync 1Campus",
+        "teacherClassrooms.oneCampusSync.buttonSyncing": "Syncing...",
+        "teacherClassrooms.oneCampusSync.tooltip": "Sync 1Campus tooltip",
+        "teacherClassrooms.oneCampusSync.confirm.title":
+          "Sync into your personal account?",
+        "teacherClassrooms.oneCampusSync.confirm.message":
+          "Points will be deducted from your personal balance.",
+        "teacherClassrooms.oneCampusSync.confirm.confirmButton": "Sync anyway",
         "common.loading": "Loading...",
         "common.edit": "Edit",
         "common.delete": "Delete",
@@ -112,13 +120,19 @@ vi.mock("@/components/AssignmentDialog", () => ({
 
 // Mock API
 const mockGetTeacherClassrooms = vi.fn();
+const mockSyncOneCampusClasses = vi.fn();
 vi.mock("@/lib/api", () => ({
   apiClient: {
     getTeacherClassrooms: (...args: unknown[]) =>
       mockGetTeacherClassrooms(...args),
+    syncOneCampusClasses: (...args: unknown[]) =>
+      mockSyncOneCampusClasses(...args),
     createClassroom: vi.fn(),
     updateClassroom: vi.fn(),
     deleteClassroom: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    status?: number;
   },
 }));
 
@@ -170,9 +184,14 @@ describe("TeacherClassrooms", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetTeacherClassrooms.mockResolvedValue(mockClassrooms);
+    mockSyncOneCampusClasses.mockResolvedValue({
+      synced: false,
+      schools: [],
+    });
     mockWorkspace.mode = "personal";
     mockWorkspace.selectedSchool = null;
     mockWorkspace.selectedOrganization = null;
+    mockWorkspace.organizations = [];
   });
 
   describe("Rendering", () => {
@@ -489,6 +508,99 @@ describe("TeacherClassrooms", () => {
         (btn) => !btn.hasAttribute("disabled"),
       );
       expect(enabledDispatch).toBeDefined();
+    });
+  });
+
+  describe("1Campus Sync Foolproof (#761)", () => {
+    it("syncs immediately without a dialog when the teacher has no organization", async () => {
+      const user = userEvent.setup();
+      mockWorkspace.organizations = [];
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getAllByText("Alpha Class").length).toBeGreaterThan(0);
+      });
+
+      const syncButton = screen.getByTitle("Sync 1Campus tooltip");
+      await user.click(syncButton);
+
+      await waitFor(() => {
+        expect(mockSyncOneCampusClasses).toHaveBeenCalledTimes(1);
+      });
+      // No confirmation dialog for personal-only teachers.
+      expect(
+        screen.queryByText("Sync into your personal account?"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows a confirmation dialog (and does not sync yet) when the teacher belongs to an organization", async () => {
+      const user = userEvent.setup();
+      mockWorkspace.organizations = [{ id: "org-1", name: "Test Org" }];
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getAllByText("Alpha Class").length).toBeGreaterThan(0);
+      });
+
+      const syncButton = screen.getByTitle("Sync 1Campus tooltip");
+      await user.click(syncButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Sync into your personal account?"),
+        ).toBeInTheDocument();
+      });
+      // Sync must not fire until the teacher confirms.
+      expect(mockSyncOneCampusClasses).not.toHaveBeenCalled();
+    });
+
+    it("runs the sync after the teacher confirms in the dialog", async () => {
+      const user = userEvent.setup();
+      mockWorkspace.organizations = [{ id: "org-1", name: "Test Org" }];
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getAllByText("Alpha Class").length).toBeGreaterThan(0);
+      });
+
+      await user.click(screen.getByTitle("Sync 1Campus tooltip"));
+      await waitFor(() => {
+        expect(
+          screen.getByText("Sync into your personal account?"),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: "Sync anyway" }));
+
+      await waitFor(() => {
+        expect(mockSyncOneCampusClasses).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("does not sync when the teacher cancels the dialog", async () => {
+      const user = userEvent.setup();
+      mockWorkspace.organizations = [{ id: "org-1", name: "Test Org" }];
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getAllByText("Alpha Class").length).toBeGreaterThan(0);
+      });
+
+      await user.click(screen.getByTitle("Sync 1Campus tooltip"));
+      await waitFor(() => {
+        expect(
+          screen.getByText("Sync into your personal account?"),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("Sync into your personal account?"),
+        ).not.toBeInTheDocument();
+      });
+      expect(mockSyncOneCampusClasses).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## 摘要
Fixes #761

老師若同時擁有機構帳號，按「同步 1Campus」時會先跳出防呆確認對話框，提醒：**個人帳號下班級使用的 AI 點數會從老師個人點數扣除；若學生屬於機構，請於機構內匯入班級。** 僅有個人帳號的老師維持原本「直接同步」的行為。

## 變更內容
- **TeacherClassrooms.tsx**：依 `useWorkspace().organizations` 判斷是否有機構帳號並分流
  - 無機構帳號 → 直接同步（行為不變）
  - 有機構帳號 → 先跳出確認對話框，按「仍要同步」才執行、「取消」不動作
- 新增確認對話框（沿用既有 Dialog 元件與樣式）
- i18n：`teacherClassrooms.oneCampusSync.confirm.*`（zh-TW / en；ja/ko 自動 fallback 英文）
- 新增 4 個測試涵蓋有/無機構、確認、取消情境

## 測試計畫
- [x] 老師無機構 → 按同步直接觸發（不出現對話框）
- [x] 老師有機構 → 按同步跳出提醒對話框
- [x] 確認 → 執行同步；取消 → 不執行
- [x] `npm run typecheck` / eslint / `npm run build` 通過
- [x] 單元測試 17/17 通過（含 4 個新測試）

🤖 Generated with [Claude Code](https://claude.com/claude-code)