### PR TITLE
fix(#679): 例句重組的錯誤歷程 — 封存每次選字到 attempts[] (Fixes #679)

### DIFF
--- a/backend/routers/students/assignments.py
+++ b/backend/routers/students/assignments.py
@@ -29,6 +29,7 @@ from models import (
 from services.preview_service import get_sentence_fields, _VOCABULARY_CONTENT_TYPES
 from services.quota_service import QuotaService
 from utils.cloze import extract_cloze_for_item
+from utils.rearrangement_history import archive_current_attempt
 from .dependencies import get_current_student
 from .quiz_assignments import score_and_finalize_quiz
 from .validators import (
@@ -3316,7 +3317,10 @@ async def submit_rearrangement_answer(
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
     )
-    progress.rearrangement_data = {"selections": selections}
+    # 合併寫回，保留既有 attempts / retries（不可整包覆蓋，否則會清掉封存的歷程）
+    data = dict(progress.rearrangement_data or {})
+    data["selections"] = selections
+    progress.rearrangement_data = data
 
     # 檢查是否達到錯誤上限
     challenge_failed = progress.error_count >= max_errors
@@ -3397,13 +3401,27 @@ async def retry_rearrangement(
     if not progress:
         raise HTTPException(status_code=404, detail="Progress not found")
 
+    # 封存當次選字歷程到 attempts[]（強制重來），再開新一輪
+    # 資料來源為後端逐字累積的 rearrangement_data，前端不需回傳
+    attempts = archive_current_attempt(
+        progress.rearrangement_data,
+        error_count=progress.error_count or 0,
+        expected_score=progress.expected_score or 0,
+        ended_reason="force_retry",
+        ended_at=datetime.now(timezone.utc).isoformat(),
+    )
+
     # 重置進度
     progress.error_count = 0
     progress.correct_word_count = 0
     progress.expected_score = 100.0
     progress.retry_count = (progress.retry_count or 0) + 1
     progress.status = "IN_PROGRESS"
-    progress.rearrangement_data = {"selections": [], "retries": progress.retry_count}
+    progress.rearrangement_data = {
+        "attempts": attempts,
+        "selections": [],
+        "retries": progress.retry_count,
+    }
 
     db.commit()
 
@@ -3447,15 +3465,28 @@ async def complete_rearrangement(
         .first()
     )
 
-    # 組裝 rearrangement_data（包含完整答題歷程）
-    rearrangement_data = {}
-    if request.selections:
-        rearrangement_data["selections"] = [s.model_dump() for s in request.selections]
-    rearrangement_data["completed_at"] = datetime.now(timezone.utc).isoformat()
-    rearrangement_data["timeout"] = request.timeout
+    now_iso = datetime.now(timezone.utc).isoformat()
+    ended_reason = "timeout" if request.timeout else "completed"
+    request_selections = (
+        [s.model_dump() for s in request.selections] if request.selections else None
+    )
 
     if not progress:
         # 防禦性：建立新記錄（正常情況下應該已存在）
+        attempt_selections = request_selections or []
+        rearrangement_data = {
+            "attempts": archive_current_attempt(
+                None,
+                error_count=request.error_count or 0,
+                expected_score=request.expected_score or 0,
+                ended_reason=ended_reason,
+                ended_at=now_iso,
+                selections=attempt_selections,
+            ),
+            "selections": attempt_selections,
+            "completed_at": now_iso,
+            "timeout": request.timeout,
+        }
         progress = StudentItemProgress(
             student_assignment_id=student_assignment_id,
             content_item_id=request.content_item_id,
@@ -3477,9 +3508,21 @@ async def complete_rearrangement(
         if request.error_count is not None:
             progress.error_count = request.error_count
 
-        # 合併答題歷程（保留既有 retries 等資訊）
-        existing_data = progress.rearrangement_data or {}
-        existing_data.update(rearrangement_data)
+        # 封存當次選字歷程到 attempts[]（完成 / 超時），保留既有 attempts / retries
+        # selections 以後端逐字累積為準，前端 request.selections 為 fallback
+        existing_data = dict(progress.rearrangement_data or {})
+        attempt_selections = existing_data.get("selections") or request_selections or []
+        existing_data["attempts"] = archive_current_attempt(
+            existing_data,
+            error_count=progress.error_count or 0,
+            expected_score=progress.expected_score or 0,
+            ended_reason=ended_reason,
+            ended_at=now_iso,
+            selections=attempt_selections,
+        )
+        existing_data["selections"] = attempt_selections
+        existing_data["completed_at"] = now_iso
+        existing_data["timeout"] = request.timeout
         progress.rearrangement_data = existing_data
 
     db.commit()

--- a/backend/tests/unit/test_rearrangement_history.py
+++ b/backend/tests/unit/test_rearrangement_history.py
@@ -1,0 +1,125 @@
+"""單元測試：例句重組作答歷程封存（#679）。
+
+純函式，不需 DB，可在本機直接跑。
+"""
+
+from utils.rearrangement_history import archive_current_attempt
+
+
+SEL_A = [
+    {"position": 0, "selected": "A", "correct": "A", "is_correct": True},
+    {"position": 1, "selected": "for", "correct": "table", "is_correct": False},
+]
+SEL_B = [
+    {"position": 0, "selected": "two,", "correct": "A", "is_correct": False},
+]
+
+
+class TestArchiveCurrentAttempt:
+    def test_archives_from_data_selections_by_default(self):
+        data = {"selections": SEL_A, "retries": 1}
+        attempts = archive_current_attempt(
+            data,
+            error_count=1,
+            expected_score=80,
+            ended_reason="force_retry",
+            ended_at="2026-04-24T15:28:00+00:00",
+        )
+        assert len(attempts) == 1
+        assert attempts[0]["selections"] == SEL_A
+        assert attempts[0]["error_count"] == 1
+        assert attempts[0]["expected_score"] == 80.0
+        assert attempts[0]["ended_reason"] == "force_retry"
+        assert attempts[0]["ended_at"] == "2026-04-24T15:28:00+00:00"
+
+    def test_preserves_existing_attempts(self):
+        prior = {
+            "selections": SEL_A,
+            "error_count": 1,
+            "expected_score": 80.0,
+            "ended_reason": "force_retry",
+            "ended_at": "2026-04-24T15:28:00+00:00",
+        }
+        data = {"attempts": [prior], "selections": SEL_B, "retries": 2}
+        attempts = archive_current_attempt(
+            data,
+            error_count=1,
+            expected_score=90,
+            ended_reason="completed",
+            ended_at="2026-04-24T15:32:00+00:00",
+        )
+        assert len(attempts) == 2
+        assert attempts[0] == prior  # 舊的原封不動
+        assert attempts[1]["selections"] == SEL_B
+        assert attempts[1]["ended_reason"] == "completed"
+
+    def test_does_not_mutate_input_attempts(self):
+        original_attempts = [{"selections": SEL_A, "ended_reason": "timeout"}]
+        data = {"attempts": original_attempts, "selections": SEL_B}
+        archive_current_attempt(
+            data,
+            error_count=0,
+            expected_score=100,
+            ended_reason="completed",
+            ended_at="2026-04-24T15:32:00+00:00",
+        )
+        # 原 list 不應被就地修改
+        assert len(original_attempts) == 1
+
+    def test_skips_when_no_selections(self):
+        data = {"attempts": [], "selections": []}
+        attempts = archive_current_attempt(
+            data,
+            error_count=0,
+            expected_score=100,
+            ended_reason="completed",
+            ended_at="2026-04-24T15:32:00+00:00",
+        )
+        assert attempts == []
+
+    def test_skips_when_selections_missing(self):
+        data = {"retries": 3}
+        attempts = archive_current_attempt(
+            data,
+            error_count=0,
+            expected_score=100,
+            ended_reason="completed",
+            ended_at="2026-04-24T15:32:00+00:00",
+        )
+        assert attempts == []
+
+    def test_none_data_returns_empty(self):
+        attempts = archive_current_attempt(
+            None,
+            error_count=0,
+            expected_score=100,
+            ended_reason="completed",
+            ended_at="2026-04-24T15:32:00+00:00",
+            selections=SEL_A,
+        )
+        assert len(attempts) == 1
+        assert attempts[0]["selections"] == SEL_A
+
+    def test_explicit_selections_override_data(self):
+        data = {"selections": SEL_A}
+        attempts = archive_current_attempt(
+            data,
+            error_count=1,
+            expected_score=50,
+            ended_reason="timeout",
+            ended_at="2026-04-24T15:42:00+00:00",
+            selections=SEL_B,
+        )
+        assert attempts[0]["selections"] == SEL_B
+
+    def test_expected_score_coerced_to_float(self):
+        data = {"selections": SEL_A}
+        attempts = archive_current_attempt(
+            data,
+            error_count=2,
+            expected_score=None,
+            ended_reason="force_retry",
+            ended_at="2026-04-24T15:20:00+00:00",
+        )
+        assert attempts[0]["expected_score"] == 0.0
+        assert isinstance(attempts[0]["expected_score"], float)

--- a/backend/utils/rearrangement_history.py
+++ b/backend/utils/rearrangement_history.py
@@ -1,0 +1,53 @@
+"""例句重組（rearrangement）作答歷程封存工具。
+
+批改頁要看到學生每次嘗試的完整選字歷程（#679）。核心不變量：
+**永不遺失先前的 attempts，只有在當次真的有選字時才封存。**
+
+歷史 bug：`rearrangement-retry` 直接把 `rearrangement_data` 覆寫成
+`{"selections": []}`，學生一按「重新挑戰」前一輪歷程就消失。這裡把封存邏輯
+抽成純函式，讓 endpoint 呼叫、並可在無 DB 環境下單元測試。
+"""
+
+from typing import Any, Dict, List, Optional
+
+
+def archive_current_attempt(
+    data: Optional[Dict[str, Any]],
+    *,
+    error_count: int,
+    expected_score: float,
+    ended_reason: str,
+    ended_at: str,
+    selections: Optional[List[Dict[str, Any]]] = None,
+) -> List[Dict[str, Any]]:
+    """回傳 attempts[] 清單，並把「當次」封存進去。
+
+    Args:
+        data: 現有的 ``rearrangement_data``（可為 None）。既有的 ``attempts``
+            一定會被保留。
+        error_count: 當次錯誤次數。
+        expected_score: 當次分數（會轉成 float）。
+        ended_reason: ``"completed"`` / ``"timeout"`` / ``"force_retry"``。
+        ended_at: 結束時間（ISO 8601 字串）。
+        selections: 當次選字歷程；未提供時退回 ``data["selections"]``。
+
+    Returns:
+        新的 attempts list（既有 + 當次）。若當次沒有任何選字（None 或空），
+        則原樣回傳既有 attempts，不新增空白列。
+    """
+    data = data or {}
+    attempts: List[Dict[str, Any]] = list(data.get("attempts", []))
+
+    sel = selections if selections is not None else data.get("selections")
+    if sel:
+        attempts.append(
+            {
+                "selections": sel,
+                "error_count": error_count or 0,
+                "expected_score": float(expected_score or 0),
+                "ended_reason": ended_reason,
+                "ended_at": ended_at,
+            }
+        )
+
+    return attempts

--- a/frontend/src/components/grading/SentenceRearrangementPanel.tsx
+++ b/frontend/src/components/grading/SentenceRearrangementPanel.tsx
@@ -11,9 +11,11 @@
  *   - 其他（尚未作答 / 無分數）                                → 灰色 placeholder
  * 完全不讀 itemFeedbacks、不 onClick、不 autosave。
  *
- * 展開區「選字歷程」label 永遠顯示，但內容依分數分流：
- *   - expected_score >= 60 → 用綠色 chip 呈現完整正確答案（雛型，等 #679 補完整 attempts[] 再接真實資料）
- *   - 其他（沒分數 / < 60） → 顯示「更詳細的作答紀錄 Coming Soon」灰色佔位文字
+ * 展開區「選字歷程」顯示 rearrangement_data.attempts[]（#679）：
+ *   - 每次 attempt 一列：結束時間 · 狀態 pill（完成 / 超時 / 強制重來）· 選字 chips
+ *   - chip 綠底=選對、紅底+✗=選錯（顯示學生實際選的字）
+ *   - 最多顯示最近 3 次；chips 需 flex-wrap（長句一列最多 ~16 chip）
+ *   - 舊資料只有 selections（無 attempts）→ 優雅降級成單一「完成」attempt
  *
  * 詳見 docs/design/grading-page-architecture.md
  */
@@ -29,12 +31,12 @@ import {
   AlertCircle,
   Clock,
   RotateCcw,
-  Target,
 } from "lucide-react";
 import type {
   StudentSubmission,
   ItemFeedback,
   SubmissionItem,
+  RearrangementAttempt,
 } from "@/pages/teacher/GradingPage";
 
 interface SentenceRearrangementPanelProps {
@@ -59,8 +61,18 @@ function formatCompletedAt(timestamp?: string | null): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-function splitAnswerWords(sentence: string): string[] {
-  return sentence.trim().split(/\s+/).filter(Boolean);
+const MAX_VISIBLE_ATTEMPTS = 3;
+
+function attemptBadgeClass(reason?: string): string {
+  switch (reason) {
+    case "timeout":
+      return "bg-amber-100 text-amber-700";
+    case "force_retry":
+      return "bg-red-100 text-red-700";
+    case "completed":
+    default:
+      return "bg-green-100 text-green-700";
+  }
 }
 
 export function SentenceRearrangementPanel({
@@ -84,47 +96,133 @@ export function SentenceRearrangementPanel({
     }
   }
 
-  const renderSelectionHistory = (item: SubmissionItem) => {
-    // 分流：>= 60 才顯示綠色 chips 雛型；其餘（沒分數 / < 60）顯示 Coming Soon 佔位。
-    // 與 isPassed 判斷（expected_score >= 60）統一，避免 60 分剛好的學生 ✓ 但無歷程。
-    const expectedScore = item.expected_score;
-    const showChips = expectedScore != null && expectedScore >= 60;
+  const badgeLabel = (reason?: string): string => {
+    switch (reason) {
+      case "timeout":
+        return t("gradingPage.rearrangement.badges.timeout");
+      case "force_retry":
+        return t("gradingPage.rearrangement.badges.forceRetry");
+      case "completed":
+      default:
+        return t("gradingPage.rearrangement.badges.completed");
+    }
+  };
 
-    if (!showChips) {
+  const renderSelectionHistory = (item: SubmissionItem) => {
+    const rd = item.rearrangement_data;
+    let attempts: RearrangementAttempt[] = rd?.attempts ?? [];
+
+    // 優雅降級：舊資料只有 selections（無 attempts）→ 當成單一「完成 / 超時」attempt
+    if (
+      attempts.length === 0 &&
+      rd?.selections &&
+      rd.selections.length > 0
+    ) {
+      attempts = [
+        {
+          selections: rd.selections,
+          error_count: item.error_count,
+          expected_score: item.expected_score ?? undefined,
+          ended_reason: rd.timeout ? "timeout" : "completed",
+          ended_at: rd.completed_at ?? item.completed_at ?? undefined,
+        },
+      ];
+    }
+
+    if (attempts.length === 0) {
       return (
         <div className="text-xs text-gray-400 italic">
-          {t("gradingPage.rearrangement.labels.detailedHistoryComingSoon")}
+          {t("gradingPage.rearrangement.labels.noHistory")}
         </div>
       );
     }
 
-    // ⚠️ 示意圖：目前後端還沒提供每次作答（含 retry / timeout）的完整逐字歷程，
-    // 這裡先拿正確答案切成 chips 當 placeholder，讓老師知道未來會看到什麼樣的 UI。
-    // 等 #679 後端補完 attempts[] 資料後再接真實資料。
-    // Layout 參照 docs/design/pencil-new.pen 案例 1（一次答對）：
-    //   時間 · 「完成」綠 pill · 單字 chips 一字排開
-    const formattedTime = formatCompletedAt(item.completed_at);
-    const words = splitAnswerWords(item.question_text);
+    const totalAttempts = attempts.length;
+    const visibleAttempts = attempts.slice(-MAX_VISIBLE_ATTEMPTS);
+    const totalErrors = attempts.reduce(
+      (sum, a) => sum + (a.error_count ?? 0),
+      0,
+    );
+    const score = item.expected_score;
 
     return (
-      <div className="flex flex-wrap items-center gap-2.5">
-        {formattedTime && (
-          <span className="text-xs font-semibold text-gray-700 font-mono">
-            {formattedTime}
-          </span>
-        )}
-        <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-green-100 text-green-700 text-[10px] font-semibold">
-          {t("gradingPage.rearrangement.badges.completed")}
-        </span>
-        <div className="flex flex-wrap gap-1.5">
-          {words.map((word, idx) => (
-            <span
-              key={idx}
-              className="inline-flex items-center px-2.5 py-1 rounded-md border border-green-200 bg-green-50 text-green-700 text-xs font-semibold"
-            >
-              {word}
+      <div className="space-y-3">
+        {/* Summary：分數 · N 次嘗試 · 共 M 次錯誤（· 僅顯示最近 3 次）*/}
+        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-gray-600">
+          {score != null && (
+            <span className="font-semibold text-blue-600">
+              {t("gradingPage.rearrangement.labels.scorePoints", {
+                score: Number(score).toFixed(0),
+              })}
             </span>
-          ))}
+          )}
+          {score != null && <span className="text-gray-300">·</span>}
+          <span>
+            {t("gradingPage.rearrangement.labels.attemptCount", {
+              count: totalAttempts,
+            })}
+          </span>
+          <span className="text-gray-300">·</span>
+          <span>
+            {t("gradingPage.rearrangement.labels.totalErrors", {
+              count: totalErrors,
+            })}
+          </span>
+          {totalAttempts > MAX_VISIBLE_ATTEMPTS && (
+            <>
+              <span className="text-gray-300">·</span>
+              <span className="text-gray-400">
+                {t("gradingPage.rearrangement.labels.showingRecent", {
+                  count: MAX_VISIBLE_ATTEMPTS,
+                })}
+              </span>
+            </>
+          )}
+        </div>
+
+        {/* 每次 attempt 一列 */}
+        <div className="space-y-2">
+          {visibleAttempts.map((attempt, idx) => {
+            const formattedTime = formatCompletedAt(attempt.ended_at);
+            const selections = attempt.selections ?? [];
+            return (
+              <div
+                key={idx}
+                className="flex flex-wrap items-center gap-2.5"
+              >
+                {formattedTime && (
+                  <span className="text-xs font-semibold text-gray-700 font-mono whitespace-nowrap">
+                    {formattedTime}
+                  </span>
+                )}
+                <span
+                  className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold whitespace-nowrap ${attemptBadgeClass(
+                    attempt.ended_reason,
+                  )}`}
+                >
+                  {badgeLabel(attempt.ended_reason)}
+                </span>
+                <div className="flex flex-wrap gap-1.5">
+                  {selections.map((sel, i) => {
+                    const isWrong = sel.is_correct === false;
+                    return (
+                      <span
+                        key={i}
+                        className={`inline-flex items-center px-2.5 py-1 rounded-md border text-xs font-semibold ${
+                          isWrong
+                            ? "border-red-200 bg-red-50 text-red-700"
+                            : "border-green-200 bg-green-50 text-green-700"
+                        }`}
+                      >
+                        {sel.selected}
+                        {isWrong && <span className="ml-0.5">✗</span>}
+                      </span>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
         </div>
       </div>
     );
@@ -187,7 +285,6 @@ export function SentenceRearrangementPanel({
 
                 const errorCount = item.error_count ?? 0;
                 const maxErrors = item.max_errors ?? null;
-                const correctWords = item.correct_word_count ?? 0;
                 const retryCount = item.retry_count ?? 0;
                 const expectedScore = item.expected_score;
                 const timedOut = item.timeout_ended === true;
@@ -274,18 +371,6 @@ export function SentenceRearrangementPanel({
                               <span className="font-semibold">
                                 {errorCount}
                                 {maxErrors != null ? ` / ${maxErrors}` : ""}
-                              </span>
-                            </span>
-                          </div>
-                          <div className="flex items-center gap-1">
-                            <Target className="h-3 w-3 text-gray-400" />
-                            <span className="text-gray-600">
-                              {t(
-                                "gradingPage.rearrangement.labels.correctWords",
-                              )}
-                              :{" "}
-                              <span className="font-semibold">
-                                {correctWords}
                               </span>
                             </span>
                           </div>

--- a/frontend/src/components/grading/SentenceRearrangementPanel.tsx
+++ b/frontend/src/components/grading/SentenceRearrangementPanel.tsx
@@ -113,11 +113,7 @@ export function SentenceRearrangementPanel({
     let attempts: RearrangementAttempt[] = rd?.attempts ?? [];
 
     // 優雅降級：舊資料只有 selections（無 attempts）→ 當成單一「完成 / 超時」attempt
-    if (
-      attempts.length === 0 &&
-      rd?.selections &&
-      rd.selections.length > 0
-    ) {
+    if (attempts.length === 0 && rd?.selections && rd.selections.length > 0) {
       attempts = [
         {
           selections: rd.selections,
@@ -186,10 +182,7 @@ export function SentenceRearrangementPanel({
             const formattedTime = formatCompletedAt(attempt.ended_at);
             const selections = attempt.selections ?? [];
             return (
-              <div
-                key={idx}
-                className="flex flex-wrap items-center gap-2.5"
-              >
+              <div key={idx} className="flex flex-wrap items-center gap-2.5">
                 {formattedTime && (
                   <span className="text-xs font-semibold text-gray-700 font-mono whitespace-nowrap">
                     {formattedTime}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -3089,12 +3089,19 @@
         "selected": "Selected",
         "expected": "Expected",
         "completedAt": "Completed at",
-        "detailedHistoryComingSoon": "Detailed answer history Coming Soon"
+        "detailedHistoryComingSoon": "Detailed answer history Coming Soon",
+        "scorePoints": "{{score}} pts",
+        "attemptCount": "{{count}} attempts",
+        "totalErrors": "{{count}} errors total",
+        "showingRecent": "Showing last {{count}}",
+        "noHistory": "No answer history"
       },
       "badges": {
         "completed": "Completed",
         "incomplete": "Below passing",
-        "notAnswered": "Not answered"
+        "notAnswered": "Not answered",
+        "timeout": "Timed out",
+        "forceRetry": "Forced retry"
       }
     }
   },

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -3081,7 +3081,6 @@
     "rearrangement": {
       "labels": {
         "errors": "Errors",
-        "correctWords": "Correct Words",
         "retryCount": "Retries",
         "expectedScore": "Score",
         "timedOut": "Timed Out",
@@ -3089,7 +3088,6 @@
         "selected": "Selected",
         "expected": "Expected",
         "completedAt": "Completed at",
-        "detailedHistoryComingSoon": "Detailed answer history Coming Soon",
         "scorePoints": "{{score}} pts",
         "attemptCount": "{{count}} attempts",
         "totalErrors": "{{count}} errors total",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -3224,7 +3224,6 @@
     "rearrangement": {
       "labels": {
         "errors": "錯誤",
-        "correctWords": "正確選字",
         "retryCount": "重試",
         "expectedScore": "分數",
         "timedOut": "超時結束",
@@ -3232,7 +3231,6 @@
         "selected": "選擇",
         "expected": "應選",
         "completedAt": "完成時間",
-        "detailedHistoryComingSoon": "更詳細的作答紀錄 Coming Soon",
         "scorePoints": "{{score}} 分",
         "attemptCount": "{{count}} 次嘗試",
         "totalErrors": "共 {{count}} 次錯誤",

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -3232,12 +3232,19 @@
         "selected": "選擇",
         "expected": "應選",
         "completedAt": "完成時間",
-        "detailedHistoryComingSoon": "更詳細的作答紀錄 Coming Soon"
+        "detailedHistoryComingSoon": "更詳細的作答紀錄 Coming Soon",
+        "scorePoints": "{{score}} 分",
+        "attemptCount": "{{count}} 次嘗試",
+        "totalErrors": "共 {{count}} 次錯誤",
+        "showingRecent": "僅顯示最近 {{count}} 次",
+        "noHistory": "無作答紀錄"
       },
       "badges": {
         "completed": "完成",
         "incomplete": "未達標",
-        "notAnswered": "尚未作答"
+        "notAnswered": "尚未作答",
+        "timeout": "超時",
+        "forceRetry": "強制重來"
       }
     }
   },

--- a/frontend/src/pages/teacher/GradingPage.tsx
+++ b/frontend/src/pages/teacher/GradingPage.tsx
@@ -70,7 +70,18 @@ export interface RearrangementSelection {
   timestamp?: string;
 }
 
+export type RearrangementEndedReason = "completed" | "timeout" | "force_retry";
+
+export interface RearrangementAttempt {
+  selections?: RearrangementSelection[];
+  error_count?: number;
+  expected_score?: number;
+  ended_reason?: RearrangementEndedReason;
+  ended_at?: string; // ISO 8601
+}
+
 export interface RearrangementData {
+  attempts?: RearrangementAttempt[];
   selections?: RearrangementSelection[];
   retries?: number;
   completed_at?: string;


### PR DESCRIPTION
## 問題

批改頁（#630）已有「選字歷程」區塊，但 `rearrangement_data.selections` 幾乎永遠是空的。根因：`rearrangement-retry` 直接把資料覆寫成 `{"selections": []}`，學生一按「重新挑戰」前一輪歷程就被清空（#539 只補了 complete/timeout，漏了 retry）。

## 改動

### 後端 (`backend/routers/students/assignments.py`)
- **answer endpoint**：逐字寫入改成合併，保留既有 `attempts` / `retries`（修掉次要覆寫 bug）
- **retry endpoint**：重置前先把當次封存進 `attempts[]`（`ended_reason="force_retry"`）
- **complete endpoint**：完成 / 超時 push 進 `attempts[]`（`completed` / `timeout`），防禦性新建分支同步處理
- 封存不變量抽成純函式 `utils/rearrangement_history.py`（永不遺失先前 attempts、只在有選字時封存），三處共用
- `grading.py` 無需改：已回傳整包 `rearrangement_data`，`attempts` 自動帶到前端

### 前端
- `GradingPage.tsx`：新增 `RearrangementAttempt` 型別 + `RearrangementData.attempts`
- `SentenceRearrangementPanel.tsx`：真實多段 attempts 渲染（最近 3 次；時間戳不 wrap · 狀態 pill 🟢完成/🟡超時/🔴強制重來 · chips `flex-wrap`、綠=對、紅+✗=錯顯示學生實選字）；舊資料優雅降級；依 owner 回饋**移除「正確字數」列**
- i18n（en / zh-TW）新增 `timeout` / `forceRetry` pill 與 summary 文案

### 決策
- 依 owner 留言移除「正確字數」統計列
- 未動 `RearrangementRetryRequest` schema / 前端 retry payload，改用後端已累積的 server-side 資料（單一資料來源）

## 測試
- 後端：`py_compile` / `black` / `flake8` ✅；新單元測試 **8/8 pass**（`test_rearrangement_history.py`，純函式無需 DB）
- 前端：`typecheck` ✅ / `build` ✅ / lint 改動檔案零新增警告
- 端點整線行為交由 CI 驗證（本機無 Postgres）

## 已知限制
- 已按過 retry 的舊紀錄 DB 已被清空、救不回；只能從部署後新產生的紀錄開始累積

Fixes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)