### PR TITLE
fix(#679): 批改頁例句重組顯示例句而非單字（單字集）

### DIFF
--- a/backend/routers/assignments/grading.py
+++ b/backend/routers/assignments/grading.py
@@ -53,6 +53,7 @@ from services.analysis_quota import (
     reset_analysis_count_for_assignment,
     reset_analysis_count_for_assignments,
 )
+from services.preview_service import get_sentence_fields
 from .utils import (
     process_audio_with_whisper,
     calculate_text_similarity,
@@ -576,6 +577,17 @@ async def get_student_submission(
 
                     # 例句重組專用：補上 max_errors（來自 content_item）
                     if practice_mode == "rearrangement":
+                        # 與學生端出題一致：單字集（VOCABULARY_SET）要用
+                        # example_sentence 當題目，不是 item.text（單字本身）。
+                        # 唯一判定邏輯見 services.preview_service.get_sentence_fields。
+                        fields = get_sentence_fields(
+                            item, content.type, "rearrangement"
+                        )
+                        if fields is not None:
+                            q_text, q_translation, q_audio = fields
+                            submission["question_text"] = q_text
+                            submission["question_translation"] = q_translation
+                            submission["question_audio_url"] = q_audio
                         submission["max_errors"] = (
                             item.max_errors if hasattr(item, "max_errors") else None
                         )

--- a/backend/tests/integration/api/test_grading_rearrangement_vocab_sentence.py
+++ b/backend/tests/integration/api/test_grading_rearrangement_vocab_sentence.py
@@ -1,0 +1,180 @@
+"""Integration test — 單字集派成例句重組時，批改頁題目應顯示例句而非單字。
+
+Bug（#679 staging 回報）：學生端出題用 ``get_sentence_fields`` → 對單字集
+（VOCABULARY_SET）用 ``example_sentence`` 當重組句子，但批改頁
+``get_student_submission`` 無條件用 ``item.text``（單字本身），導致批改頁顯示
+單字而非學生實際重組的例句。
+
+用 in-memory SQLite + 直接呼叫 endpoint 函式（不經 auth / TestClient），可在
+本機無 Postgres 環境執行。
+"""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from database import Base
+from models import (
+    Assignment,
+    AssignmentContent,
+    Content,
+    ContentItem,
+    StudentItemProgress,
+)
+from routers.assignments import get_student_submission
+from tests.factories import TestDataFactory
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+WORD = "table"
+SENTENCE = "A table for two, please."
+SENTENCE_TRANSLATION = "兩位的桌子，麻煩了。"
+
+
+def _build_vocab_rearrangement_assignment(db):
+    """單字集內容 + 例句重組作業 + 學生作業 + 進度。回傳 (assignment_id, student_id, teacher)."""
+    teacher = TestDataFactory.create_teacher(db)
+    classroom = TestDataFactory.create_classroom(db, teacher)
+    student = TestDataFactory.create_student(db, classroom=classroom)
+    program = TestDataFactory.create_program(db, teacher)
+    lesson = TestDataFactory.create_lesson(db, program)
+
+    # 單字集：ContentItem.text 是單字，example_sentence 才是要重組的句子
+    content = Content(lesson_id=lesson.id, title="單字集", type="VOCABULARY_SET")
+    db.add(content)
+    db.commit()
+
+    item = ContentItem(
+        content_id=content.id,
+        text=WORD,
+        translation="桌子",
+        example_sentence=SENTENCE,
+        example_sentence_translation=SENTENCE_TRANSLATION,
+        word_count=5,
+        max_errors=3,
+        order_index=0,
+    )
+    db.add(item)
+    db.commit()
+
+    assignment = Assignment(
+        title="例句重組作業",
+        description="",
+        classroom_id=classroom.id,
+        teacher_id=teacher.id,
+        practice_mode="rearrangement",
+    )
+    db.add(assignment)
+    db.commit()
+
+    db.add(
+        AssignmentContent(
+            assignment_id=assignment.id, content_id=content.id, order_index=0
+        )
+    )
+    db.commit()
+
+    student_assignment = TestDataFactory.create_student_assignment(
+        db, student, assignment, classroom
+    )
+
+    db.add(
+        StudentItemProgress(
+            student_assignment_id=student_assignment.id,
+            content_item_id=item.id,
+            status="COMPLETED",
+            expected_score=100.0,
+            error_count=0,
+            rearrangement_data={"selections": [], "attempts": []},
+        )
+    )
+    db.commit()
+
+    return assignment.id, student.id, teacher
+
+
+class TestGradingRearrangementVocabSentence:
+    @pytest.mark.asyncio
+    async def test_question_text_is_example_sentence_not_word(self, db_session):
+        assignment_id, student_id, teacher = _build_vocab_rearrangement_assignment(
+            db_session
+        )
+
+        response = await get_student_submission(
+            assignment_id=assignment_id,
+            student_id=student_id,
+            current_teacher=teacher,
+            db=db_session,
+        )
+
+        submissions = response["submissions"]
+        assert len(submissions) == 1
+        sub = submissions[0]
+
+        # 核心：批改頁題目要顯示例句（學生重組的內容），不是單字本身
+        assert sub["question_text"] == SENTENCE
+        assert sub["question_text"] != WORD
+        # 翻譯也應對應例句翻譯
+        assert sub["question_translation"] == SENTENCE_TRANSLATION
+
+    @pytest.mark.asyncio
+    async def test_non_vocab_rearrangement_still_uses_item_text(self, db_session):
+        """回歸守衛：非單字集（EXAMPLE_SENTENCES）重組仍用 item.text，不受影響。"""
+        db = db_session
+        teacher = TestDataFactory.create_teacher(db)
+        classroom = TestDataFactory.create_classroom(db, teacher)
+        student = TestDataFactory.create_student(db, classroom=classroom)
+        program = TestDataFactory.create_program(db, teacher)
+        lesson = TestDataFactory.create_lesson(db, program)
+
+        # 例句類型：item.text 本身就是要重組的句子
+        content = Content(lesson_id=lesson.id, title="例句", type="EXAMPLE_SENTENCES")
+        db.add(content)
+        db.commit()
+        item = ContentItem(
+            content_id=content.id,
+            text=SENTENCE,
+            translation=SENTENCE_TRANSLATION,
+            word_count=5,
+            max_errors=3,
+            order_index=0,
+        )
+        db.add(item)
+        db.commit()
+
+        assignment = Assignment(
+            title="例句重組作業",
+            description="",
+            classroom_id=classroom.id,
+            teacher_id=teacher.id,
+            practice_mode="rearrangement",
+        )
+        db.add(assignment)
+        db.commit()
+        db.add(
+            AssignmentContent(
+                assignment_id=assignment.id, content_id=content.id, order_index=0
+            )
+        )
+        db.commit()
+        TestDataFactory.create_student_assignment(db, student, assignment, classroom)
+
+        response = await get_student_submission(
+            assignment_id=assignment.id,
+            student_id=student.id,
+            current_teacher=teacher,
+            db=db,
+        )
+        sub = response["submissions"][0]
+        assert sub["question_text"] == SENTENCE


### PR DESCRIPTION
## 問題（#679 staging 回報）

單字集（VOCABULARY_SET）派成**例句重組**時，學生個別批改頁的題目顯示的是**單字本身**，而不是學生實際重組的**例句**。

## 根本原因

- 學生端出題（`routers/students/assignments.py`）用 `get_sentence_fields(item, content.type, "rearrangement")` 決定重組句子 → 單字集回傳 `item.example_sentence`（例句）。
- 批改頁 `routers/assignments/grading.py::get_student_submission` 無條件用 `item.text`（單字本身），沒套用同一套判定邏輯 → 兩邊資料來源不一致。

`get_sentence_fields` 的 docstring 本身就定義「vocab set 在 reading/rearrangement 要用 example_sentence」，grading 是唯一漏掉的地方。此為**既有 bug**，非 #679 主 PR 引入，但正好在 #679 批改面板上被案主測出。

## 修正

在 grading `rearrangement` 分支同樣呼叫 `get_sentence_fields`（唯一判定邏輯）：
- 單字集 → `example_sentence` / `example_sentence_translation` / example sentence audio
- 非單字集（EXAMPLE_SENTENCES）→ 維持 `item.text`，**無回歸**

只動 rearrangement 分支，不碰 reading / speaking，避免擴散。

## 測試

新增 `tests/integration/api/test_grading_rearrangement_vocab_sentence.py`（in-memory SQLite + 直接呼叫 endpoint，本機無 Postgres 亦可跑）：
1. 單字集重組 → 批改頁 `question_text` == 例句（非單字）✅
2. 回歸守衛：非單字集重組 → 仍用 `item.text` ✅

本機驗證：2 passed、`black` / `flake8` clean。（周邊 4 個 SQLite 測試失敗經 stash 比對確認為 staging 既有、與本次無關。）

Related to #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)