### PR TITLE
fix(#679): 強制重來封存該輪選字歷程（前端回傳 selections）

### DIFF
--- a/backend/routers/students/assignments.py
+++ b/backend/routers/students/assignments.py
@@ -3401,14 +3401,30 @@ async def retry_rearrangement(
     if not progress:
         raise HTTPException(status_code=404, detail="Progress not found")
 
-    # 封存當次選字歷程到 attempts[]（強制重來），再開新一輪
-    # 資料來源為後端逐字累積的 rearrangement_data，前端不需回傳
+    # 封存「剛結束（強制重來 / 超時）那一輪」到 attempts[]，再開新一輪。
+    # 逐字挑選在前端本地驗證、不經 answer endpoint，故選字歷程以前端回傳為權威；
+    # 沒帶時（舊前端）退回後端累積值，只是通常為空 → 不新增空白列。
+    round_selections = (
+        [s.model_dump() for s in request.selections]
+        if request.selections is not None
+        else (progress.rearrangement_data or {}).get("selections")
+    )
+    ended_reason = "timeout" if request.timeout else "force_retry"
     attempts = archive_current_attempt(
         progress.rearrangement_data,
-        error_count=progress.error_count or 0,
-        expected_score=progress.expected_score or 0,
-        ended_reason="force_retry",
+        error_count=(
+            request.error_count
+            if request.error_count is not None
+            else (progress.error_count or 0)
+        ),
+        expected_score=(
+            request.expected_score
+            if request.expected_score is not None
+            else (progress.expected_score or 0)
+        ),
+        ended_reason=ended_reason,
         ended_at=datetime.now(timezone.utc).isoformat(),
+        selections=round_selections,
     )
 
     # 重置進度

--- a/backend/routers/students/validators.py
+++ b/backend/routers/students/validators.py
@@ -141,12 +141,6 @@ class RearrangementAnswerResponse(BaseModel):
     completed: bool  # 是否完成此題
 
 
-class RearrangementRetryRequest(BaseModel):
-    """重新挑戰請求"""
-
-    content_item_id: int
-
-
 class RearrangementSelectionRecord(BaseModel):
     """單次選字記錄"""
 
@@ -155,6 +149,21 @@ class RearrangementSelectionRecord(BaseModel):
     correct: str  # 正確的字
     is_correct: bool  # 是否正確
     timestamp: str  # ISO 8601 時間戳
+
+
+class RearrangementRetryRequest(BaseModel):
+    """重新挑戰請求
+
+    #679: 逐字挑選在前端本地驗證、不經 rearrangement-answer endpoint，
+    故「剛結束（強制重來 / 超時）那一輪」的選字歷程由前端在 retry 時一併回傳，
+    後端才能封存進 attempts[]。舊前端不帶這些欄位時降級為只記 retry_count。
+    """
+
+    content_item_id: int
+    selections: Optional[List["RearrangementSelectionRecord"]] = None  # 該輪選字歷程
+    error_count: Optional[int] = None  # 該輪錯誤次數
+    expected_score: Optional[float] = None  # 該輪分數
+    timeout: bool = False  # 該輪是否因超時結束（否則視為強制重來）
 
 
 class RearrangementCompleteRequest(BaseModel):

--- a/backend/tests/integration/api/test_rearrangement_retry_archives_round.py
+++ b/backend/tests/integration/api/test_rearrangement_retry_archives_round.py
@@ -1,0 +1,211 @@
+"""Integration test — retry 封存「剛結束那一輪」的選字歷程到 attempts[]（#679）。
+
+Bug（staging 回報）：學生強制重來時，前端只送 content_item_id，該輪選字歷程
+（在前端本地驗證、不經 answer endpoint）沒送給後端 → retry endpoint 無可封存，
+只增加 retry_count。批改頁因此看不到重試/錯誤的歷程。
+
+修正：retry 帶 selections/error_count/expected_score/timeout，後端封存為
+force_retry（或 timeout）attempt。
+
+用 in-memory SQLite + 直接呼叫 endpoint 函式，本機無 Postgres 亦可跑。
+"""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from database import Base
+from models import (
+    Assignment,
+    AssignmentContent,
+    Content,
+    ContentItem,
+    StudentItemProgress,
+)
+from routers.students.assignments import retry_rearrangement
+from routers.students.validators import (
+    RearrangementRetryRequest,
+    RearrangementSelectionRecord,
+)
+from tests.factories import TestDataFactory
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _setup(db):
+    teacher = TestDataFactory.create_teacher(db)
+    classroom = TestDataFactory.create_classroom(db, teacher)
+    student = TestDataFactory.create_student(db, classroom=classroom)
+    program = TestDataFactory.create_program(db, teacher)
+    lesson = TestDataFactory.create_lesson(db, program)
+
+    content = Content(lesson_id=lesson.id, title="例句", type="EXAMPLE_SENTENCES")
+    db.add(content)
+    db.commit()
+    item = ContentItem(
+        content_id=content.id, text="A B C D", word_count=4, max_errors=3, order_index=0
+    )
+    db.add(item)
+    db.commit()
+
+    assignment = Assignment(
+        title="重組作業",
+        description="",
+        classroom_id=classroom.id,
+        teacher_id=teacher.id,
+        practice_mode="rearrangement",
+    )
+    db.add(assignment)
+    db.commit()
+    db.add(
+        AssignmentContent(
+            assignment_id=assignment.id, content_id=content.id, order_index=0
+        )
+    )
+    db.commit()
+    sa = TestDataFactory.create_student_assignment(db, student, assignment, classroom)
+
+    progress = StudentItemProgress(
+        student_assignment_id=sa.id,
+        content_item_id=item.id,
+        status="IN_PROGRESS",
+        error_count=3,
+        expected_score=25.0,
+        retry_count=0,
+        rearrangement_data={"selections": [], "attempts": []},
+    )
+    db.add(progress)
+    db.commit()
+    return student, sa, item, progress
+
+
+def _round_selections(n_wrong):
+    """一輪選字：先錯 n_wrong 次（達上限）。"""
+    sels = []
+    for i in range(n_wrong):
+        sels.append(
+            RearrangementSelectionRecord(
+                position=0,
+                selected="X",
+                correct="A",
+                is_correct=False,
+                timestamp="2026-07-10T05:00:0%d+00:00" % i,
+            )
+        )
+    return sels
+
+
+class TestRetryArchivesRound:
+    @pytest.mark.asyncio
+    async def test_force_retry_archives_round_selections(self, db_session):
+        db = db_session
+        student, sa, item, progress = _setup(db)
+
+        req = RearrangementRetryRequest(
+            content_item_id=item.id,
+            selections=_round_selections(3),
+            error_count=3,
+            expected_score=25.0,
+            timeout=False,
+        )
+        await retry_rearrangement(
+            student_assignment_id=sa.id,
+            request=req,
+            current_student={"sub": str(student.id)},
+            db=db,
+        )
+
+        db.refresh(progress)
+        rd = progress.rearrangement_data
+        assert progress.retry_count == 1
+        assert len(rd["attempts"]) == 1
+        att = rd["attempts"][0]
+        assert att["ended_reason"] == "force_retry"
+        assert att["error_count"] == 3
+        assert len(att["selections"]) == 3
+        # 開新一輪：selections 清空
+        assert rd["selections"] == []
+
+    @pytest.mark.asyncio
+    async def test_multiple_retries_accumulate(self, db_session):
+        db = db_session
+        student, sa, item, progress = _setup(db)
+
+        for round_no in range(3):
+            req = RearrangementRetryRequest(
+                content_item_id=item.id,
+                selections=_round_selections(3),
+                error_count=3,
+                expected_score=0.0,
+                timeout=False,
+            )
+            await retry_rearrangement(
+                student_assignment_id=sa.id,
+                request=req,
+                current_student={"sub": str(student.id)},
+                db=db,
+            )
+
+        db.refresh(progress)
+        rd = progress.rearrangement_data
+        assert progress.retry_count == 3
+        assert len(rd["attempts"]) == 3
+        assert all(a["ended_reason"] == "force_retry" for a in rd["attempts"])
+
+    @pytest.mark.asyncio
+    async def test_empty_selections_does_not_add_blank_attempt(self, db_session):
+        """完成後再重試：該輪已由 complete 封存，前端送空 selections → 不重複封存。"""
+        db = db_session
+        student, sa, item, progress = _setup(db)
+
+        req = RearrangementRetryRequest(
+            content_item_id=item.id,
+            selections=[],  # 完成的那一輪不重送
+            error_count=0,
+            expected_score=100.0,
+            timeout=False,
+        )
+        await retry_rearrangement(
+            student_assignment_id=sa.id,
+            request=req,
+            current_student={"sub": str(student.id)},
+            db=db,
+        )
+
+        db.refresh(progress)
+        rd = progress.rearrangement_data
+        assert progress.retry_count == 1  # 仍記錄重試次數
+        assert rd["attempts"] == []  # 但不新增空白 attempt
+
+    @pytest.mark.asyncio
+    async def test_timeout_round_archived_with_timeout_reason(self, db_session):
+        db = db_session
+        student, sa, item, progress = _setup(db)
+
+        req = RearrangementRetryRequest(
+            content_item_id=item.id,
+            selections=_round_selections(2),
+            error_count=2,
+            expected_score=50.0,
+            timeout=True,
+        )
+        await retry_rearrangement(
+            student_assignment_id=sa.id,
+            request=req,
+            current_student={"sub": str(student.id)},
+            db=db,
+        )
+
+        db.refresh(progress)
+        att = progress.rearrangement_data["attempts"][0]
+        assert att["ended_reason"] == "timeout"

--- a/frontend/src/components/activities/RearrangementActivity.tsx
+++ b/frontend/src/components/activities/RearrangementActivity.tsx
@@ -73,6 +73,9 @@ export interface RearrangementQuestionState {
   timeRemaining: number;
   hasSeenAnswer: boolean; // 是否已看過答案（用於計算重試後滿分）
   maxScore: number; // 該題滿分（初始 100，看過答案後變 60）
+  // #679: 這一輪的 challengeFailed 是否由「超時」造成（否則為錯誤達上限）。
+  // 用於 retry 封存時標記 ended_reason = timeout / force_retry。
+  endedByTimeout?: boolean;
 }
 
 // 內部使用的別名
@@ -493,6 +496,7 @@ const RearrangementActivity: React.FC<RearrangementActivityProps> = ({
             expectedScore: actualScore,
             hasSeenAnswer: true,
             maxScore: 60,
+            endedByTimeout: true, // #679: 這輪因超時結束
           });
         }
         return newStates;
@@ -678,6 +682,8 @@ const RearrangementActivity: React.FC<RearrangementActivityProps> = ({
       : [];
     const endedRoundErrorCount = prevRoundState?.errorCount ?? 0;
     const endedRoundScore = prevRoundState?.expectedScore ?? 0;
+    // 這輪是超時還是錯誤達上限 → 決定後端 ended_reason
+    const endedRoundWasTimeout = !!prevRoundState?.endedByTimeout;
 
     // 🚀 重置狀態（本地操作，不需要 API）
     // 保留 hasSeenAnswer 和 maxScore（一旦看過答案就永不重置）
@@ -694,6 +700,7 @@ const RearrangementActivity: React.FC<RearrangementActivityProps> = ({
         timeRemaining: currentQuestion.time_limit,
         hasSeenAnswer: prevState?.hasSeenAnswer || false, // 保留
         maxScore: prevState?.maxScore || 100, // 保留
+        endedByTimeout: false, // 新一輪重置
       });
       return newStates;
     });
@@ -715,7 +722,7 @@ const RearrangementActivity: React.FC<RearrangementActivityProps> = ({
             selections: endedRoundSelections,
             error_count: endedRoundErrorCount,
             expected_score: endedRoundScore,
-            timeout: false,
+            timeout: endedRoundWasTimeout,
           },
         );
       } catch (error) {

--- a/frontend/src/components/activities/RearrangementActivity.tsx
+++ b/frontend/src/components/activities/RearrangementActivity.tsx
@@ -666,6 +666,19 @@ const RearrangementActivity: React.FC<RearrangementActivityProps> = ({
     const currentQuestion = questions[currentQuestionIndex];
     setResultModalOpen(false); // 關閉結果 Modal
 
+    // #679: 封存「剛結束那一輪」到 attempts[]。逐字挑選只存在前端本機
+    // （不經 answer endpoint），故需在清空前把該輪 selections 送給後端。
+    // 只有「強制重來」（未完成）需要送 → 完成的那一輪已由 rearrangement-complete
+    // 封存，這裡送空避免重複封存。
+    const prevRoundState = questionStates.get(currentQuestion.content_item_id);
+    const wasForceFailed =
+      !!prevRoundState?.challengeFailed && !prevRoundState?.completed;
+    const endedRoundSelections = wasForceFailed
+      ? [...(selectionsRef.current.get(currentQuestion.content_item_id) || [])]
+      : [];
+    const endedRoundErrorCount = prevRoundState?.errorCount ?? 0;
+    const endedRoundScore = prevRoundState?.expectedScore ?? 0;
+
     // 🚀 重置狀態（本地操作，不需要 API）
     // 保留 hasSeenAnswer 和 maxScore（一旦看過答案就永不重置）
     setQuestionStates((prev) => {
@@ -699,6 +712,10 @@ const RearrangementActivity: React.FC<RearrangementActivityProps> = ({
           `/api/students/assignments/${studentAssignmentId}/rearrangement-retry`,
           {
             content_item_id: currentQuestion.content_item_id,
+            selections: endedRoundSelections,
+            error_count: endedRoundErrorCount,
+            expected_score: endedRoundScore,
+            timeout: false,
           },
         );
       } catch (error) {


### PR DESCRIPTION
## 問題（staging DB 實查證實）

學生個別批改頁的「選字歷程」只顯示 **1 列**，前面重試/錯誤的歷程消失。

實查 assignment 247 / student 3：item 7990 `retry_count=3` 但 `attempts` 只有 **1 筆**（completed）——3 次強制重來的歷程完全沒被存下來。

## 根本原因

例句重組的逐字挑選是**前端本機驗證**（`handleWordSelect`），**不呼叫 `rearrangement-answer` endpoint** → 後端一輪進行中的 `rearrangement_data.selections` 一直是空的。

- **完成 / 超時**：前端 `rearrangement-complete` 有帶該輪 selections → 有封存 ✅
- **強制重來**：前端 `handleRetry` 只送 `content_item_id`，且送出前先清空 `selectionsRef` → 該輪歷程直接丟失，只增加 `retry_count` ❌

（這正是先前 PR 為求簡化略過「retry 帶 selections」的後果，本 PR 回到 issue #679 的原設計。）

## 修正

- `RearrangementRetryRequest` 加 `selections / error_count / expected_score / timeout`
- retry endpoint 用前端回傳的該輪 selections 封存為 `force_retry`（或 `timeout`）attempt；**空 selections 不新增空白列**（完成的那一輪已由 complete 封存，避免重複）
- 前端 `handleRetry` 在清空前，把「強制重來那一輪」的 selections + error_count + expected_score 送給後端；完成的那一輪送空（不重複封存）

## 測試

新增 `tests/integration/api/test_rearrangement_retry_archives_round.py`（in-memory SQLite + 直呼 endpoint，本機無 Postgres 可跑）：
1. force_retry 封存該輪 selections ✅
2. 多次重試累積成多筆 attempts ✅
3. 空 selections 不新增空白 attempt（不重複封存）✅
4. timeout 標記 `ended_reason=timeout` ✅

本機驗證：後端 12 passed、black/flake8 clean；前端 typecheck / build / prettier 皆過。

Related to #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)