### PR TITLE
fix(#936): index.html 設 no-cache，避免部署後卡舊 bundle

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -32,9 +32,14 @@ server {
         add_header X-XSS-Protection "1; mode=block" always;
     }
 
-    # Cache static assets (content-hashed → safe to cache forever)
+    # Cache static assets (content-hashed → safe to cache forever).
+    # Re-declare security headers: add_header does NOT inherit into a location
+    # that has its own add_header (same gotcha as the index.html block above).
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
     }
 }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -20,7 +20,19 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
-    # Cache static assets
+    # index.html must never be cached (Issue #936): it points to hashed asset
+    # chunks, so a stale index makes users load an old bundle after deploy.
+    # try_files / index fallbacks internal-redirect here, so this exact-match
+    # location covers "/" and all SPA routes. add_header does NOT inherit into a
+    # location that has its own add_header, so re-declare the security headers.
+    location = /index.html {
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+    }
+
+    # Cache static assets (content-hashed → safe to cache forever)
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -36,10 +36,15 @@ server {
         add_header X-XSS-Protection "1; mode=block" always;
     }
 
-    # Cache static assets (content-hashed → safe to cache forever)
+    # Cache static assets (content-hashed → safe to cache forever).
+    # Re-declare security headers: add_header does NOT inherit into a location
+    # that has its own add_header (same gotcha as the index.html block above).
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
     }
 
     # Gzip compression

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -24,6 +24,24 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
+    # index.html must never be cached (Issue #936): it points to hashed asset
+    # chunks, so a stale index makes users load an old bundle after deploy.
+    # try_files / index fallbacks internal-redirect here, so this exact-match
+    # location covers "/" and all SPA routes. add_header does NOT inherit into a
+    # location that has its own add_header, so re-declare the security headers.
+    location = /index.html {
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+    }
+
+    # Cache static assets (content-hashed → safe to cache forever)
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
     # Gzip compression
     gzip on;
     gzip_vary on;

--- a/frontend/nginx.staging.conf
+++ b/frontend/nginx.staging.conf
@@ -35,10 +35,15 @@ server {
         add_header X-XSS-Protection "1; mode=block" always;
     }
 
-    # Cache static assets (content-hashed → safe to cache forever)
+    # Cache static assets (content-hashed → safe to cache forever).
+    # Re-declare security headers: add_header does NOT inherit into a location
+    # that has its own add_header (same gotcha as the index.html block above).
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
     }
 
     # Gzip compression

--- a/frontend/nginx.staging.conf
+++ b/frontend/nginx.staging.conf
@@ -24,6 +24,23 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
+    # index.html must never be cached (Issue #936): it points to hashed asset
+    # chunks, so a stale index makes users load an old bundle after deploy.
+    # NOTE: this file is currently NOT used by any Dockerfile (Dockerfile.staging
+    # copies nginx.conf); kept consistent to avoid misleading future edits.
+    location = /index.html {
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+    }
+
+    # Cache static assets (content-hashed → safe to cache forever)
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
     # Gzip compression
     gzip on;
     gzip_vary on;


### PR DESCRIPTION
## 問題 (Fixes #936)

前端 nginx 對 hashed assets 有 `immutable` 快取，但 **`index.html` 沒設任何 `Cache-Control`**。瀏覽器啟發式快取 `index.html` → 指向舊的 hashed chunk → 使用者部署後仍載入**舊 bundle**，需手動 `Ctrl+Shift+R`。這已實際害 **#847** 的測試者誤判「修正沒生效」（強制重整後即正常）。

## 修改

| 檔案 | 用途 | 變更 |
|---|---|---|
| `frontend/nginx.conf` | **staging** 實際使用（`Dockerfile.staging` COPY 此檔）| 加 `location = /index.html` → `no-cache, must-revalidate` + 重新宣告 security headers |
| `frontend/nginx.conf.template` | **prod** 使用 | 同上 + **補上目前缺的** hashed assets `immutable` 區塊 |
| `frontend/nginx.staging.conf` | 目前未被任何 Dockerfile 使用 | 一致性加同樣區塊 + 加註說明 |

### 關鍵設計
- nginx `add_header` **不會**從 server 層繼承到「有自己 `add_header`」的 location，所以在 `location = /index.html` 內**重新宣告** X-Frame-Options 等 security headers，避免 index.html 掉 header。
- SPA fallback（`try_files … /index.html`）與 `/` 的 index 都是 internal redirect，會**重新匹配** exact-match `location = /index.html`，故 `/`、`/index.html`、所有前端路由都涵蓋。
- hashed assets（含 content hash）維持 `immutable` — 安全，且才是快取真正該做的地方。

## 驗證（本機 docker nginx + curl，已實測）
```
GET /                       → Cache-Control: no-cache, must-revalidate  ✅ + X-Frame/X-Content/X-XSS 完整
GET /index.html             → Cache-Control: no-cache, must-revalidate  ✅
GET /teacher/org-materials  → Cache-Control: no-cache, must-revalidate  ✅（SPA route）
GET /assets/app-*.js        → Cache-Control: public, immutable          ✅
```
- `nginx -t` 三份設定語法皆通過（prod template 經 envsubst 後驗證）

## 驗收標準
- [x] index.html 回 `no-cache`（本機實測）
- [x] hashed assets 回 `immutable`（本機實測）
- [x] index.html security headers 未因 add_header 繼承問題掉失
- [ ] 部署後 `curl -I` staging 首頁確認 header（CI/部署後驗）

> 註：VM 版設定（`nginx.conf.vm.template`、`deployment/vm/nginx.conf`）本 PR 不動，Cloud Run 未使用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)