### PR TITLE
feat(#891): magic_paste_usage 每月配額表（PR 1 資料層）

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -291,6 +291,7 @@ jobs:
               'assignments', 'assignment_content', 'assignment_contents', 'student_assignments',
               'student_content_progress', 'student_item_progress',
               'subscription_periods', 'point_usage_logs', 'credit_packages', 'plans',
+              'magic_paste_usage',
               'teacher_subscription_transaction', 'teacher_subscription_transactions', 'invoice_status_history',
               'user_word_progress', 'practice_sessions', 'practice_answers',
               'organizations', 'schools', 'teacher_organizations', 'teacher_schools', 'classroom_schools', 'student_schools',

--- a/backend/alembic/versions/20260710_1000_add_magic_paste_usage.py
+++ b/backend/alembic/versions/20260710_1000_add_magic_paste_usage.py
@@ -1,0 +1,72 @@
+"""Add magic_paste_usage table (issue #891)
+
+「教材內容魔術貼上」每位老師每月免費額度計數表。每位老師每個自然月一列，
+year_month 以 'YYYY-MM' 字串表示，跨月自然重置；唯一約束
+(teacher_id, year_month) 供後續 UPSERT 累加使用。
+
+Idempotent：CREATE TABLE / CONSTRAINT / INDEX 皆 IF NOT EXISTS 或先檢查後建立，
+可安全重複執行（遵守 CLAUDE.md Migration 鐵則）。
+
+本表為 JWT-auth 業務表，不使用 Supabase RLS（已加入 deploy-backend.yml 排除清單）。
+
+Revision ID: 20260710_1000
+Revises: 20260706_1000
+Create Date: 2026-07-10
+"""
+from typing import Union
+
+from alembic import op
+
+
+revision: str = "20260710_1000"
+down_revision: Union[str, None] = "20260706_1000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1) 建表（冪等）
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS magic_paste_usage (
+            id SERIAL PRIMARY KEY,
+            teacher_id INTEGER NOT NULL
+                REFERENCES teachers (id) ON DELETE CASCADE,
+            year_month VARCHAR(7) NOT NULL,
+            count INTEGER NOT NULL DEFAULT 0,
+            created_at TIMESTAMPTZ DEFAULT now(),
+            updated_at TIMESTAMPTZ
+        )
+        """
+    )
+
+    # 2) 唯一約束（先檢查後建立，pg_constraint 依 table OID 鎖定）
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint c
+                JOIN pg_class cls ON c.conrelid = cls.oid
+                WHERE c.conname = 'uq_magic_paste_usage_teacher_month'
+                  AND cls.relname = 'magic_paste_usage'
+            ) THEN
+                ALTER TABLE magic_paste_usage
+                ADD CONSTRAINT uq_magic_paste_usage_teacher_month
+                UNIQUE (teacher_id, year_month);
+            END IF;
+        END $$;
+        """
+    )
+
+    # 3) 查詢索引（冪等）
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_magic_paste_usage_teacher_month
+        ON magic_paste_usage (teacher_id, year_month)
+        """
+    )
+
+
+def downgrade() -> None:
+    # 破壞性操作對其他環境不安全，依專案慣例不在 downgrade 刪表。
+    pass

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -35,6 +35,9 @@ from .subscription import (
 from .credit_package import CreditPackage
 from .credit_package_definition import CreditPackageDefinition
 
+# Magic Paste 每月配額計數（issue #891）
+from .magic_paste_usage import MagicPasteUsage
+
 # Plan models (admin-editable price/quota overrides)
 from .plan import Plan
 
@@ -126,6 +129,7 @@ __all__ = [
     # Credit packages
     "CreditPackage",
     "CreditPackageDefinition",
+    "MagicPasteUsage",
     # Plans
     "Plan",
     # Promo codes / referrals

--- a/backend/models/magic_paste_usage.py
+++ b/backend/models/magic_paste_usage.py
@@ -1,0 +1,53 @@
+"""
+Magic Paste 每月配額計數 model（issue #891）。
+
+「教材內容魔術貼上」每位老師每月有免費額度（預設 5 張），超額改扣點數。
+本表只負責記錄「某老師在某個年月用了幾次」，每個自然月一列，跨月自然重置。
+
+year_month 以 'YYYY-MM' 字串表示（例：'2026-07'），
+唯一約束 (teacher_id, year_month) 確保同月只有一列，供 UPSERT 累加。
+"""
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    ForeignKey,
+    UniqueConstraint,
+    Index,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from database import Base
+
+
+class MagicPasteUsage(Base):
+    """魔術貼上每月使用計數（每位老師每個自然月一列）。"""
+
+    __tablename__ = "magic_paste_usage"
+    __table_args__ = (
+        UniqueConstraint(
+            "teacher_id", "year_month", name="uq_magic_paste_usage_teacher_month"
+        ),
+        Index("ix_magic_paste_usage_teacher_month", "teacher_id", "year_month"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    teacher_id = Column(
+        Integer, ForeignKey("teachers.id", ondelete="CASCADE"), nullable=False
+    )
+    # 'YYYY-MM'，代表計數所屬的自然月
+    year_month = Column(String(7), nullable=False)
+    count = Column(Integer, nullable=False, default=0, server_default="0")
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    teacher = relationship("Teacher")
+
+    def __repr__(self):
+        return (
+            f"<MagicPasteUsage teacher={self.teacher_id} "
+            f"month={self.year_month} count={self.count}>"
+        )

--- a/backend/tests/test_magic_paste_usage_model.py
+++ b/backend/tests/test_magic_paste_usage_model.py
@@ -1,0 +1,87 @@
+"""
+PR 1 (issue #891) — 魔術貼上「每月配額計數」資料層測試。
+
+只證明 magic_paste_usage 這張表的 schema、預設值與唯一約束。
+擷取 / 配額扣點 / API 行為留待後續 PR。
+"""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from models import Teacher, MagicPasteUsage
+
+
+def _make_teacher(db, email):
+    teacher = Teacher(name="T", email=email, password_hash="x")
+    db.add(teacher)
+    db.commit()
+    db.refresh(teacher)
+    return teacher
+
+
+def test_defaults(test_db_session):
+    """新建列 count 預設為 0。"""
+    teacher = _make_teacher(test_db_session, "mp-defaults@test.com")
+    row = MagicPasteUsage(teacher_id=teacher.id, year_month="2026-07")
+    test_db_session.add(row)
+    test_db_session.commit()
+    test_db_session.refresh(row)
+
+    assert row.count == 0
+    assert row.id is not None
+    assert row.year_month == "2026-07"
+
+
+def test_unique_teacher_year_month(test_db_session):
+    """同一老師同一個月只能有一列（UNIQUE 約束）。"""
+    teacher = _make_teacher(test_db_session, "mp-unique@test.com")
+    test_db_session.add(
+        MagicPasteUsage(teacher_id=teacher.id, year_month="2026-07", count=3)
+    )
+    test_db_session.commit()
+
+    test_db_session.add(
+        MagicPasteUsage(teacher_id=teacher.id, year_month="2026-07", count=1)
+    )
+    with pytest.raises(IntegrityError):
+        test_db_session.commit()
+    test_db_session.rollback()
+
+
+def test_same_teacher_different_months_allowed(test_db_session):
+    """同一老師不同月份可各有一列。"""
+    teacher = _make_teacher(test_db_session, "mp-months@test.com")
+    test_db_session.add_all(
+        [
+            MagicPasteUsage(teacher_id=teacher.id, year_month="2026-07", count=5),
+            MagicPasteUsage(teacher_id=teacher.id, year_month="2026-08", count=0),
+        ]
+    )
+    test_db_session.commit()
+
+    rows = (
+        test_db_session.query(MagicPasteUsage)
+        .filter(MagicPasteUsage.teacher_id == teacher.id)
+        .all()
+    )
+    assert len(rows) == 2
+
+
+def test_different_teachers_same_month_allowed(test_db_session):
+    """不同老師同月份互不衝突。"""
+    t1 = _make_teacher(test_db_session, "mp-t1@test.com")
+    t2 = _make_teacher(test_db_session, "mp-t2@test.com")
+    test_db_session.add_all(
+        [
+            MagicPasteUsage(teacher_id=t1.id, year_month="2026-07"),
+            MagicPasteUsage(teacher_id=t2.id, year_month="2026-07"),
+        ]
+    )
+    test_db_session.commit()
+
+    rows = (
+        test_db_session.query(MagicPasteUsage)
+        .filter(MagicPasteUsage.year_month == "2026-07")
+        .all()
+    )
+    assert len(rows) == 2


### PR DESCRIPTION
## 目的

「教材內容魔術貼上」功能（#891）的 **PR 1 / 純資料層**。刻意拆小、先行 merge，讓 alembic head 儘早落地，避免綁在大 feature PR 裡拖延而與其他 issue 的 migration 產生雙 head 衝突。

## 內容

- **新表 `magic_paste_usage`**：每位老師每個自然月一列，記錄魔術貼上使用次數。
  - `teacher_id` FK（ON DELETE CASCADE）、`year_month` VARCHAR(7) `'YYYY-MM'`、`count` INT 預設 0、timestamps
  - `UNIQUE(teacher_id, year_month)` — 供後續 UPSERT 累加
  - 跨月自然重置（免月度 cron）
- **冪等 migration** `20260710_1000`：`CREATE TABLE / CONSTRAINT / INDEX` 皆 `IF NOT EXISTS` 或先檢查後建立，遵守 CLAUDE.md Migration 鐵則
- **RLS**：JWT-auth 業務表，已加入 `deploy-backend.yml` RLS 排除清單
- **model 註冊**：`models/__init__.py`（import + `__all__`）
- 純資料層，**不接任何路由，不改現有行為**

## 驗證

- ✅ 4 個資料層測試通過（預設值、唯一約束、跨月、跨老師）
- ✅ 真實 Postgres 15 跑完整 `alembic upgrade head`；upgrade() SQL **重跑第二次不報錯**（冪等）
- ✅ schema 確認：PK / FK CASCADE / UNIQUE 皆正確
- ✅ flake8 + black clean
- ✅ `import main` 成功

## 後續

PR 2（feature）將接上：AI 擷取 service（依 `USE_VERTEX_AI` 切換 Vertex/OpenAI vision）、每月配額 + 超額扣點、`POST /api/programs/magic-paste` 端點、前端共用 `MagicPasteDialog`（老師個人 + 組織教材兩處）。

Related to #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)