### PR TITLE
feat(#627): 教材卡片補上公開範圍設定（資源帳號）

### DIFF
--- a/frontend/src/components/ProgramVisibilitySelector.tsx
+++ b/frontend/src/components/ProgramVisibilitySelector.tsx
@@ -8,7 +8,7 @@ import {
 import { Globe, Lock, Building2, User } from "lucide-react";
 import { toast } from "sonner";
 
-type ProgramVisibility =
+export type ProgramVisibility =
   | "private"
   | "public"
   | "organization_only"

--- a/frontend/src/components/shared/ProgramFolderView.tsx
+++ b/frontend/src/components/shared/ProgramFolderView.tsx
@@ -39,6 +39,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
+  ProgramVisibilitySelector,
+  type ProgramVisibility,
+} from "@/components/ProgramVisibilitySelector";
+import {
   DndContext,
   closestCenter,
   PointerSensor,
@@ -176,6 +180,8 @@ function ProgramCard({
   onEdit,
   onDelete,
   onCopyTo,
+  showVisibility,
+  onVisibilityChange,
 }: {
   program: Program;
   isSelected: boolean;
@@ -183,6 +189,11 @@ function ProgramCard({
   onEdit: () => void;
   onDelete: () => void;
   onCopyTo?: () => void;
+  showVisibility?: boolean;
+  onVisibilityChange?: (
+    programId: number,
+    visibility: ProgramVisibility,
+  ) => Promise<void>;
 }) {
   const { t } = useTranslation();
   const lessons = program.lessons ?? [];
@@ -213,6 +224,18 @@ function ProgramCard({
             <p className="text-white text-xs leading-relaxed line-clamp-4 whitespace-pre-line">
               {program.description}
             </p>
+          </div>
+        )}
+
+        {/* Issue #627: 資源帳號可直接在卡片上設定公開範圍。放在描述遮罩之後，
+            才不會在 hover 時被蓋住 */}
+        {showVisibility && onVisibilityChange && (
+          <div className="absolute top-2 right-2">
+            <ProgramVisibilitySelector
+              programId={program.id}
+              currentVisibility={program.visibility ?? "private"}
+              onVisibilityChange={onVisibilityChange}
+            />
           </div>
         )}
       </div>
@@ -853,6 +876,12 @@ export interface ProgramFolderViewProps {
     fromIndex: number,
     toIndex: number,
   ) => void;
+  // Issue #627: 只有資源帳號（contact）能設定教材公開範圍
+  showVisibility?: boolean;
+  onVisibilityChange?: (
+    programId: number,
+    visibility: ProgramVisibility,
+  ) => Promise<void>;
 }
 
 export default function ProgramFolderView({
@@ -874,6 +903,8 @@ export default function ProgramFolderView({
   onReorderLessons,
   onReorderContents,
   onReorderProgramContents,
+  showVisibility,
+  onVisibilityChange,
 }: ProgramFolderViewProps) {
   const { t } = useTranslation();
   const [selectedProgramId, setSelectedProgramId] = useState<number | null>(
@@ -957,6 +988,8 @@ export default function ProgramFolderView({
                           ? () => onCopyProgramTo(program.id)
                           : undefined
                       }
+                      showVisibility={showVisibility}
+                      onVisibilityChange={onVisibilityChange}
                     />
                   </SortableItem>
                 ))}

--- a/frontend/src/components/shared/__tests__/ProgramFolderView.test.tsx
+++ b/frontend/src/components/shared/__tests__/ProgramFolderView.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ProgramFolderView from "../ProgramFolderView";
+import type { Program } from "@/types";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+    i18n: { language: "zh-TW" },
+  }),
+}));
+
+// jsdom 沒有 ResizeObserver，ProgramFolderView 用它算 grid 欄數
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// Radix dropdown 在 jsdom 需要這些 pointer API
+beforeEach(() => {
+  Element.prototype.hasPointerCapture = vi.fn(() => false);
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+const program = {
+  id: 1,
+  name: "Basic English",
+  description: "Foundation course",
+  level: "A1",
+  visibility: "private",
+  lessons: [{ id: 10, name: "Lesson A", contents: [] }],
+  contents: [],
+} as unknown as Program;
+
+function renderView(
+  overrides: Partial<React.ComponentProps<typeof ProgramFolderView>> = {},
+) {
+  return render(
+    <ProgramFolderView
+      programs={[program]}
+      onEditProgram={vi.fn()}
+      onDeleteProgram={vi.fn()}
+      onEditLesson={vi.fn()}
+      onDeleteLesson={vi.fn()}
+      onCreateLesson={vi.fn()}
+      onContentClick={vi.fn()}
+      onDeleteContent={vi.fn()}
+      onCopyContent={vi.fn()}
+      onCreateContent={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe("ProgramFolderView - 教材卡片公開設定 (Issue #627)", () => {
+  it("resource 帳號：卡片顯示目前的公開狀態徽章", () => {
+    renderView({ showVisibility: true, onVisibilityChange: vi.fn() });
+
+    expect(screen.getByRole("button", { name: "不公開" })).toBeInTheDocument();
+  });
+
+  it("resource 帳號：選擇「全公開」會帶 program id 與新的 visibility 呼叫 callback", async () => {
+    const user = userEvent.setup();
+    const onVisibilityChange = vi.fn().mockResolvedValue(undefined);
+    renderView({ showVisibility: true, onVisibilityChange });
+
+    await user.click(screen.getByRole("button", { name: "不公開" }));
+    await user.click(await screen.findByRole("menuitem", { name: /全公開/ }));
+
+    await waitFor(() =>
+      expect(onVisibilityChange).toHaveBeenCalledWith(1, "public"),
+    );
+  });
+
+  it("點徽章不會誤觸卡片、把教材展開", async () => {
+    const user = userEvent.setup();
+    renderView({ showVisibility: true, onVisibilityChange: vi.fn() });
+
+    await user.click(screen.getByRole("button", { name: "不公開" }));
+
+    // 卡片若被選中會展開 lessons 區，Lesson A 就會出現
+    expect(screen.queryByText("Lesson A")).not.toBeInTheDocument();
+  });
+
+  it("一般老師帳號（未傳 showVisibility）：卡片不顯示公開設定徽章", () => {
+    renderView();
+
+    expect(
+      screen.queryByRole("button", { name: "不公開" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
+++ b/frontend/src/pages/teacher/TeacherTemplatePrograms.tsx
@@ -814,6 +814,8 @@ function TeacherTemplateProgramsInner() {
         ) : (
           <ProgramFolderView
             programs={filteredPrograms}
+            showVisibility={isResourceAccount}
+            onVisibilityChange={handleVisibilityChange}
             onEditProgram={handleEditProgram}
             onDeleteProgram={handleDeleteProgram}
             onCopyProgramTo={


### PR DESCRIPTION
## 問題
Issue #627：Contact（資源）帳號在「我的教材」的教材卡片上，沒有設定教材公開範圍的按鈕。

「我的教材」預設是**資料夾檢視**，但 `ProgramVisibilitySelector` 只接在**樹狀檢視**的 config 上，`ProgramFolderView` 完全沒有 visibility 相關 props，導致資源帳號在卡片上看不到任何公開設定入口（要手動切到樹狀檢視才看得到）。

## 做法（純前端，無後端、無 migration）
- `ProgramFolderView` 新增**選填** props `showVisibility` / `onVisibilityChange`，往下傳到 `ProgramCard`。因為是選填的，另外兩個呼叫端（`OrgMaterialsPage`、`ResourceFolderView`）行為完全不變。
- 徽章浮動在**封面圖右上角**（`absolute top-2 right-2`），放在描述用的黑色 hover 遮罩**之後**，才不會在 hover 時被蓋住、點不到。
- `TeacherTemplatePrograms` 傳入 `showVisibility={isResourceAccount}` 與**既有的** `handleVisibilityChange`，樹狀／資料夾兩種檢視共用同一個 handler。
- `ProgramVisibilitySelector` 的 `ProgramVisibility` type 改為 export。

**後端不需異動**：`PATCH /api/resource-materials/{id}/visibility` 本來就只允許資源帳號（`teacher_id == resource_account.id`），且 `GET /api/teachers/programs` 已回傳 `visibility`。

## 測試
新增 `ProgramFolderView.test.tsx`（TDD，先紅後綠，4 個全過）：
- 資源帳號 → 卡片顯示目前公開狀態徽章
- 選「全公開」→ 以 `(programId, "public")` 呼叫 callback
- 點徽章不會誤觸卡片、展開教材
- 非資源帳號（未傳 prop）→ 不顯示徽章

`tsc --noEmit` 乾淨、`npm run build` 成功。ESLint 僅 1 個既有 warning（非本次改動）。同目錄 `ProgramTreeView.test.tsx` 的 5 個失敗經確認在乾淨 staging 上同樣失敗，屬既有問題。

Related to #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)