### PR TITLE
feat(#860): add show_example_sentence column to assignments (migration only)

### DIFF
--- a/backend/alembic/versions/20260716_1000_add_show_example_sentence_to_assignments.py
+++ b/backend/alembic/versions/20260716_1000_add_show_example_sentence_to_assignments.py
@@ -1,0 +1,38 @@
+"""add_show_example_sentence_to_assignments
+
+Revision ID: 20260716_1000
+Revises: 20260710_1000
+Create Date: 2026-07-16 10:00:00.000000
+
+Issue #860: 單字選擇小考／艾賓浩斯新增「顯示例句（答案挖空）」派發條件。
+題目改為顯示該單字的例句、單字本身挖空，作答維持四選一（不需打字）。
+與既有的 show_word / play_audio 為互斥的「題目呈現方式」；預設 FALSE
+以保留現有作業行為（顯示單字 / 播放音檔）。
+
+本 PR 僅新增欄位；串接 API 與前端渲染於後續 PR 進行。
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260716_1000"
+down_revision: Union[str, None] = "20260710_1000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE assignments
+        ADD COLUMN IF NOT EXISTS show_example_sentence BOOLEAN DEFAULT FALSE
+        """
+    )
+
+
+def downgrade() -> None:
+    # Additive-only migration policy: do not drop columns on downgrade.
+    pass


### PR DESCRIPTION
## 目的

Issue #860：單字選擇小考／艾賓浩斯要新增「顯示例句（答案挖空）」派發條件。派發設定在 `assignments` 表是一個個獨立欄位（非 JSON blob），因此新增這個開關需要一支 migration。

依討論，**先把 migration 拆成第一個 PR**，確認進 staging、DB 套用無誤後，再進行 API 與前端串接。

## 變更內容

- 新增 `backend/alembic/versions/20260716_1000_add_show_example_sentence_to_assignments.py`
  - `ALTER TABLE assignments ADD COLUMN IF NOT EXISTS show_example_sentence BOOLEAN DEFAULT FALSE`
  - 冪等、additive-only（downgrade 不 drop 欄位）
  - `down_revision = 20260710_1000`，history 線性、單一 head

## 本 PR **不包含**

- SQLAlchemy model 欄位、pydantic schema、CRUD、學生端渲染、前端 registry / dialog / 預覽 — 皆留待後續 PR
- 已確認 repo 無 model↔migration autogenerate 一致性檢查，故只加 migration 不會使 CI 紅燈

## 影響

預設 `FALSE`，對所有現有作業零影響。

Related to #860