### PR TITLE
fix(#958): Azure Speech 遷離香港機房（japaneast）＋ 移除 soundhelix 外連

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,8 @@ OPENAI_API_KEY=sk-proj-xxxxx
 
 # ===== AZURE SPEECH API =====
 AZURE_SPEECH_KEY=your-azure-speech-key
-AZURE_SPEECH_REGION=eastasia
-AZURE_SPEECH_ENDPOINT=https://eastasia.api.cognitive.microsoft.com/
+AZURE_SPEECH_REGION=japaneast
+AZURE_SPEECH_ENDPOINT=https://japaneast.api.cognitive.microsoft.com/
 
 # ===== ENCRYPTION =====
 ENCRYPTION_KEY=generate-with-python-script

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -35,7 +35,7 @@ OPENAI_API_KEY=[production-api-key]
 
 # ===== AZURE SPEECH SERVICE =====
 AZURE_SPEECH_KEY=[production-azure-key]
-AZURE_SPEECH_REGION=eastasia
+AZURE_SPEECH_REGION=japaneast
 
 # ===== DEMO MODE CONFIGURATION =====
 # Allowed origins for demo speech token requests (comma-separated)

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -29,7 +29,7 @@ OPENAI_API_KEY=[your-api-key]
 
 # ===== AZURE SPEECH SERVICE =====
 AZURE_SPEECH_KEY=[your-azure-key]
-AZURE_SPEECH_REGION=eastasia
+AZURE_SPEECH_REGION=japaneast
 
 # ===== DEMO MODE CONFIGURATION =====
 # Allowed origins for demo speech token requests (comma-separated)

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -82,7 +82,10 @@ class Settings:
 
     # Azure Speech Services (optional)
     AZURE_SPEECH_KEY: Optional[str] = os.getenv("AZURE_SPEECH_KEY")
-    AZURE_SPEECH_REGION: Optional[str] = os.getenv("AZURE_SPEECH_REGION", "eastasia")
+    # 預設 japaneast（東京）：教育部校園徵求案規定不得連線至中國大陸含港澳，
+    # Azure eastasia 實體位於香港，故預設值改為合規的 japaneast，
+    # 避免漏設環境變數時靜默 fallback 到香港（Issue #958）
+    AZURE_SPEECH_REGION: Optional[str] = os.getenv("AZURE_SPEECH_REGION", "japaneast")
     AZURE_SPEECH_ENDPOINT: Optional[str] = os.getenv("AZURE_SPEECH_ENDPOINT")
 
     # Resource Account (資源教材包來源帳號)

--- a/backend/routers/azure_speech_token.py
+++ b/backend/routers/azure_speech_token.py
@@ -59,7 +59,7 @@ async def get_speech_token(
     Returns:
         {
             "token": "<authorization-token>",
-            "region": "eastasia",
+            "region": "japaneast",
             "expires_in": 600
         }
     """

--- a/backend/routers/demo.py
+++ b/backend/routers/demo.py
@@ -241,7 +241,7 @@ async def get_demo_speech_token(request: Request):
     Returns:
         {
             "token": "<azure-speech-token>",
-            "region": "eastasia",
+            "region": "japaneast",
             "expires_in": 300,
             "demo_mode": true,
             "remaining_today": <remaining quota>

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -3,7 +3,7 @@
 用於提供學生錄音檔案和其他靜態資源
 """
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, HTTPException
 
 router = APIRouter(prefix="/api/files", tags=["files"])
 
@@ -17,37 +17,3 @@ async def get_recording(filename: str):
         status_code=404,
         detail=f"Recording file not found: {filename}. Files should be accessed directly from GCS.",
     )
-
-
-@router.get("/audio/{content_id}/{item_index}")
-async def get_content_audio(content_id: int, item_index: int):
-    """獲取內容音檔（題目參考音檔）"""
-    # 這裡應該從資料庫或儲存系統中獲取實際的音檔路徑
-    # 現在返回範例音檔用於測試
-
-    # 範例：返回不同的測試音檔
-    sample_urls = [
-        "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3",
-        "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3",
-        "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3",
-    ]
-
-    # 使用 item_index 選擇不同的範例音檔
-    sample_url = sample_urls[item_index % len(sample_urls)]
-
-    # 在實際應用中，這裡應該返回實際的音檔檔案
-    # return FileResponse(path=audio_file_path)
-
-    # 暫時返回重定向到範例音檔
-    return Response(status_code=307, headers={"Location": sample_url})
-
-
-@router.get("/test-audio")
-async def get_test_audio():
-    """提供測試用音檔"""
-    # 返回線上範例音檔
-    return {
-        "message": "Test audio endpoint",
-        "alternative": "Using online sample audio files for testing",
-        "sample_url": "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3",
-    }

--- a/backend/routers/speech_assessment.py
+++ b/backend/routers/speech_assessment.py
@@ -20,6 +20,7 @@ from database import get_db
 from auth import get_current_user
 from performance_monitoring import trace_function, start_span, PerformanceSnapshot
 from core.thread_pool import get_speech_thread_pool, get_audio_thread_pool
+from core.config import settings
 from models import (
     Student,
     StudentContentProgress,
@@ -304,7 +305,8 @@ def assess_pronunciation(audio_data: bytes, reference_text: str) -> Dict[str, An
 
     # 取得 Azure 設定
     speech_key = os.getenv("AZURE_SPEECH_KEY")
-    speech_region = os.getenv("AZURE_SPEECH_REGION", "eastasia")
+    # 單一設定來源，避免寫死 fallback region（Issue #958）
+    speech_region = settings.AZURE_SPEECH_REGION
 
     logger.debug(f"Azure Speech Key configured: {bool(speech_key)}")
     logger.debug(f"Azure Speech Region: {speech_region}")

--- a/backend/services/azure_speech_token.py
+++ b/backend/services/azure_speech_token.py
@@ -12,6 +12,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Optional, Dict
 from utils.http_client import get_http_client
+from core.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,8 @@ class AzureSpeechTokenService:
 
     def __init__(self):
         self.subscription_key = os.getenv("AZURE_SPEECH_KEY")
-        self.region = os.getenv("AZURE_SPEECH_REGION", "eastasia")
+        # 單一設定來源，避免各處寫死 fallback region（Issue #958）
+        self.region = settings.AZURE_SPEECH_REGION
         self._cached_token: Optional[str] = None
         self._token_expires_at: Optional[datetime] = None
 
@@ -36,7 +38,7 @@ class AzureSpeechTokenService:
         Returns:
             {
                 "token": "<authorization-token>",
-                "region": "eastasia",
+                "region": "japaneast",
                 "expires_in": 600
             }
 

--- a/backend/services/tts.py
+++ b/backend/services/tts.py
@@ -11,6 +11,7 @@ from typing import Optional, Dict  # noqa: F401
 from google.cloud import storage
 from datetime import datetime  # noqa: F401
 import azure.cognitiveservices.speech as speechsdk
+from core.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,8 @@ class TTSService:
 
         # Azure Speech 設定
         self.azure_speech_key = os.getenv("AZURE_SPEECH_KEY")
-        self.azure_speech_region = os.getenv("AZURE_SPEECH_REGION", "eastasia")
+        # 單一設定來源，避免寫死 fallback region（Issue #958）
+        self.azure_speech_region = settings.AZURE_SPEECH_REGION
 
         if not self.azure_speech_key:
             # 不立即拋出錯誤，允許延遲檢查（用於開發環境）

--- a/backend/tests/unit/test_azure_speech_token_api.py
+++ b/backend/tests/unit/test_azure_speech_token_api.py
@@ -22,7 +22,7 @@ class TestAzureSpeechTokenAPI:
         """Test 2: 登录教师成功获取 token"""
         mock_get_token.return_value = {
             "token": "fake-token-12345",
-            "region": "eastasia",
+            "region": "japaneast",
             "expires_in": 600,
         }
 
@@ -33,7 +33,7 @@ class TestAzureSpeechTokenAPI:
         assert response.status_code == 200
         data = response.json()
         assert data["token"] == "fake-token-12345"
-        assert data["region"] == "eastasia"
+        assert data["region"] == "japaneast"
         assert data["expires_in"] == 600
 
     @patch("services.azure_speech_token.AzureSpeechTokenService.get_token")
@@ -43,7 +43,7 @@ class TestAzureSpeechTokenAPI:
         """Test 3: 登录学生成功获取 token"""
         mock_get_token.return_value = {
             "token": "student-token-67890",
-            "region": "eastasia",
+            "region": "japaneast",
             "expires_in": 600,
         }
 
@@ -54,7 +54,7 @@ class TestAzureSpeechTokenAPI:
         assert response.status_code == 200
         data = response.json()
         assert data["token"] == "student-token-67890"
-        assert data["region"] == "eastasia"
+        assert data["region"] == "japaneast"
 
     @patch("services.azure_speech_token.AzureSpeechTokenService.get_token")
     def test_token_service_called_once(
@@ -63,7 +63,7 @@ class TestAzureSpeechTokenAPI:
         """Test 4: 验证服务层被正确调用"""
         mock_get_token.return_value = {
             "token": "test-token",
-            "region": "eastasia",
+            "region": "japaneast",
             "expires_in": 600,
         }
 
@@ -125,7 +125,9 @@ class TestAzureSpeechTokenService:
             result = await service.get_token()
 
             assert result["token"] == "new-azure-token-12345"
-            assert result["region"] == "eastasia"
+            # region 來自 settings（env 驅動），回應應與 service 設定一致，
+            # 不 pin 特定字面值以免隨環境變數變動而脆弱（Issue #958）
+            assert result["region"] == service.region
             assert result["expires_in"] == 600
 
             # 验证调用了 Azure issueToken endpoint
@@ -315,7 +317,7 @@ class TestTokenRateLimiting:
         """Test 13: Rate limiting 阻止过多请求 (10次/分钟)"""
         mock_get_token.return_value = {
             "token": "test-token",
-            "region": "eastasia",
+            "region": "japaneast",
             "expires_in": 600,
         }
 
@@ -334,3 +336,58 @@ class TestTokenRateLimiting:
 
         assert success_count == 10
         assert rate_limited_count == 1
+
+
+class TestAzureSpeechRegionCompliance:
+    """
+    Issue #958: 合規性迴歸測試
+
+    教育部校園徵求案規定產品不得連線至中國大陸（含港、澳）IP。
+    Azure Speech 的 `eastasia` region 實體位於香港，故：
+    1. 未設定環境變數時，預設 region 必須是合規的 `japaneast`（東京），不得為 `eastasia`
+    2. 程式碼中不得有任何寫死 `eastasia` 的 fallback
+    """
+
+    def test_default_region_is_compliant_japaneast(self):
+        """未設定 AZURE_SPEECH_REGION 時，程式碼預設應為 japaneast 而非香港 eastasia
+
+        config.py 於 import 時會 load_dotenv() 讀取本機 .env，為了單獨驗證
+        「程式碼寫死的 fallback」，此處把 load_dotenv patch 成 no-op，
+        並清除環境變數，讓 os.getenv 回傳 code default。
+        """
+        import importlib
+        import os
+        from unittest.mock import patch
+
+        env_without_region = {
+            k: v for k, v in os.environ.items() if k != "AZURE_SPEECH_REGION"
+        }
+        with patch.dict(os.environ, env_without_region, clear=True), patch(
+            "dotenv.load_dotenv"
+        ):
+            import core.config
+
+            importlib.reload(core.config)
+            try:
+                assert core.config.settings.AZURE_SPEECH_REGION == "japaneast"
+                assert core.config.settings.AZURE_SPEECH_REGION != "eastasia"
+            finally:
+                # 還原 singleton，避免污染其他測試
+                importlib.reload(core.config)
+
+    def test_env_region_overrides_default(self):
+        """明確設定 AZURE_SPEECH_REGION 時應覆寫預設值"""
+        import importlib
+        import os
+        from unittest.mock import patch
+
+        with patch.dict(os.environ, {"AZURE_SPEECH_REGION": "southeastasia"}), patch(
+            "dotenv.load_dotenv"
+        ):
+            import core.config
+
+            importlib.reload(core.config)
+            try:
+                assert core.config.settings.AZURE_SPEECH_REGION == "southeastasia"
+            finally:
+                importlib.reload(core.config)

--- a/backend/tests/unit/test_files_router.py
+++ b/backend/tests/unit/test_files_router.py
@@ -1,0 +1,27 @@
+"""
+Tests for files router (Issue #958)
+
+驗證已移除的 soundhelix 佔位端點不再存在，避免正式環境把使用者
+307 導向第三方音檔網站（教育部徵求案對外連線清單合規需求）。
+"""
+
+
+class TestSoundhelixEndpointsRemoved:
+    """Issue #958: soundhelix 佔位端點已移除"""
+
+    def test_content_audio_endpoint_removed(self, test_client):
+        """GET /api/files/audio/{content_id}/{item_index} 應已移除（404）"""
+        response = test_client.get("/api/files/audio/1/0")
+        assert response.status_code == 404
+        # 不得再重定向到第三方 soundhelix
+        assert "soundhelix" not in response.headers.get("location", "").lower()
+
+    def test_test_audio_endpoint_removed(self, test_client):
+        """GET /api/files/test-audio 應已移除（404）"""
+        response = test_client.get("/api/files/test-audio")
+        assert response.status_code == 404
+
+    def test_recordings_endpoint_still_returns_404(self, test_client):
+        """既有 /api/files/recordings/{filename} 行為維持不變（404）"""
+        response = test_client.get("/api/files/recordings/nonexistent.webm")
+        assert response.status_code == 404

--- a/frontend/src/services/__tests__/azureSpeechService.test.ts
+++ b/frontend/src/services/__tests__/azureSpeechService.test.ts
@@ -72,7 +72,7 @@ describe("AzureSpeechService", () => {
       const mockTokenResponse = {
         data: {
           token: "test-token-abc123",
-          region: "eastasia",
+          region: "japaneast",
           expires_in: 600,
         },
       };
@@ -89,14 +89,14 @@ describe("AzureSpeechService", () => {
         }),
       );
       expect(result.token).toBe("test-token-abc123");
-      expect(result.region).toBe("eastasia");
+      expect(result.region).toBe("japaneast");
     });
 
     it("should cache token and reuse within expiration time", async () => {
       const mockTokenResponse = {
         data: {
           token: "cached-token",
-          region: "eastasia",
+          region: "japaneast",
           expires_in: 600,
         },
       };
@@ -118,10 +118,10 @@ describe("AzureSpeechService", () => {
 
     it("should refresh token after expiration", async () => {
       const mockToken1 = {
-        data: { token: "token-1", region: "eastasia", expires_in: 1 }, // 1 second
+        data: { token: "token-1", region: "japaneast", expires_in: 1 }, // 1 second
       };
       const mockToken2 = {
-        data: { token: "token-2", region: "eastasia", expires_in: 600 },
+        data: { token: "token-2", region: "japaneast", expires_in: 600 },
       };
 
       vi.mocked(axios.post)
@@ -143,7 +143,7 @@ describe("AzureSpeechService", () => {
 
     it("should cache with a 120s safety buffer (Issue #136)", async () => {
       vi.mocked(axios.post).mockResolvedValueOnce({
-        data: { token: "buffer-token", region: "eastasia", expires_in: 600 },
+        data: { token: "buffer-token", region: "japaneast", expires_in: 600 },
       });
 
       const before = Date.now();
@@ -163,12 +163,12 @@ describe("AzureSpeechService", () => {
       // 后端 cache 命中时可能回传很小的剩余秒数（如 100s）
       vi.mocked(axios.post)
         .mockResolvedValueOnce({
-          data: { token: "small-token", region: "eastasia", expires_in: 100 },
+          data: { token: "small-token", region: "japaneast", expires_in: 100 },
         })
         .mockResolvedValueOnce({
           data: {
             token: "refetched-token",
-            region: "eastasia",
+            region: "japaneast",
             expires_in: 600,
           },
         });

--- a/frontend/src/services/__tests__/demoSpeechService.test.ts
+++ b/frontend/src/services/__tests__/demoSpeechService.test.ts
@@ -85,7 +85,7 @@ describe("DemoSpeechService", () => {
         ok: true,
         json: async () => ({
           token: "test-token",
-          region: "eastasia",
+          region: "japaneast",
           expires_in: 300,
           demo_mode: true,
           remaining_today: 59,
@@ -94,7 +94,7 @@ describe("DemoSpeechService", () => {
 
       const result = await service.getToken();
       expect(result.token).toBe("test-token");
-      expect(result.region).toBe("eastasia");
+      expect(result.region).toBe("japaneast");
       expect(result.remaining_today).toBe(59);
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
@@ -105,7 +105,7 @@ describe("DemoSpeechService", () => {
         ok: true,
         json: async () => ({
           token: "cached-token",
-          region: "eastasia",
+          region: "japaneast",
           expires_in: 300,
           demo_mode: true,
           remaining_today: 58,
@@ -127,7 +127,7 @@ describe("DemoSpeechService", () => {
           ok: true,
           json: async () => ({
             token: "first-token",
-            region: "eastasia",
+            region: "japaneast",
             expires_in: 300,
             demo_mode: true,
             remaining_today: 59,
@@ -137,7 +137,7 @@ describe("DemoSpeechService", () => {
           ok: true,
           json: async () => ({
             token: "fresh-token",
-            region: "eastasia",
+            region: "japaneast",
             expires_in: 300,
             demo_mode: true,
             remaining_today: 58,
@@ -218,7 +218,7 @@ describe("DemoSpeechService", () => {
           ok: true,
           json: async () => ({
             token: "token-1",
-            region: "eastasia",
+            region: "japaneast",
             expires_in: 300,
             demo_mode: true,
             remaining_today: 59,
@@ -228,7 +228,7 @@ describe("DemoSpeechService", () => {
           ok: true,
           json: async () => ({
             token: "token-2",
-            region: "eastasia",
+            region: "japaneast",
             expires_in: 300,
             demo_mode: true,
             remaining_today: 58,
@@ -257,7 +257,7 @@ describe("DemoSpeechService", () => {
         ok: true,
         json: async () => ({
           token: "test",
-          region: "eastasia",
+          region: "japaneast",
           expires_in: 300,
           demo_mode: true,
           remaining_today: 42,


### PR DESCRIPTION
## 背景

填寫「教育部 115 年校園數位內容與教學軟體產品公開徵求 — 產品對外連線清單」時，盤點正式環境發現兩項合規阻擋問題（Issue #958）。

作業須知規定：
> 選購名單產品使用過程中不得有連線至中國大陸（含港、澳）IP 等網路行為，且不得跨該等境內傳輸相關資料。

## 問題

1. **Azure Speech 使用 `eastasia`（香港機房）** — 學生錄音經 `wss://eastasia.stt.speech.microsoft.com` 直送微軟香港，屬跨港傳輸個資，不符資格。且 4 處程式碼把 `eastasia` 寫死成 fallback，漏設環境變數就靜默跑回香港。
2. **`files.py` 兩個佔位端點會 307 導向 `www.soundhelix.com`**（第三方音檔網站），已部署在正式環境且未列於連線清單。

## 變更內容

### Azure region 遷移（→ japaneast 東京）
- [`core/config.py`](backend/core/config.py) 預設值 `eastasia` → `japaneast`，讓漏設環境變數時 fallback 到合規區域
- 4 處讀取點收斂為單一來源 `settings.AZURE_SPEECH_REGION`：
  - `services/azure_speech_token.py`、`services/tts.py`、`routers/speech_assessment.py`
- docstring、`.env.example` / `.env.staging.example` / `.env.production.example`、前後端測試斷言同步更新

### 移除 soundhelix 外連
- 刪除 `routers/files.py` 的 `get_content_audio`、`get_test_audio` 兩個死碼端點（前後端 grep 確認無呼叫者），清除未用的 `Response` import
- 保留 `/api/files/recordings/{filename}`（行為不變）

### 新增測試
- `TestAzureSpeechRegionCompliance`：未設環境變數時預設 region 必為 `japaneast`（不得 `eastasia`）、env 覆寫生效
- `test_files_router.py`：soundhelix 兩端點回 404、recordings 行為不變
- 順手修 `test_token_first_call_fetches_from_azure` 的字面值脆弱性（改 `== service.region`）

## ⚠️ 部署相依：GitHub Secrets（已更新）

本 PR 為程式碼變更，需搭配以下 repo-level secrets 才會實際生效（**已更新完成**）：

| Secret | 新值 |
|---|---|
| `AZURE_SPEECH_KEY` | 新 japaneast 資源 Key 1 |
| `AZURE_SPEECH_REGION` | `japaneast` |
| `AZURE_SPEECH_ENDPOINT` | `https://japaneast.api.cognitive.microsoft.com/` |

> 先合併程式碼是安全的：secret 只在部署時讀取，且新的 key+region 自洽，任何環境重新部署都會落在可運作的 japaneast 設定。

## 驗證計畫

- [x] 後端測試：19 passed, 1 skipped（既有 rate-limit）
- [x] flake8 / black clean
- [x] `grep -ri eastasia`（行為碼）/ `grep -ri soundhelix` 無殘留
- [x] 模組 import OK，soundhelix 路由確認移除
- [ ] Staging 部署後：發音評分正常（登入 + demo 兩條路徑）
- [ ] Staging token 端點回傳 region=`japaneast`
- [ ] 升 prod 後再測一次

## 本機測試限制
前端測試因本機 node 版本 + 無 node_modules 未跑，但前端僅改 2 個 `__tests__` mock 值、無 source 變動，交由 CI 驗證。

Related to #958
🤖 Generated with [Claude Code](https://claude.com/claude-code)
