### PR TITLE
fix(#959): Vertex AI 遷 asia-east1 + GA/Pixel 分支污染修正

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -387,7 +387,7 @@ jobs:
         esac
         ENV_VARS="$ENV_VARS,USE_VERTEX_AI=${_USE_VERTEX_AI}"
         ENV_VARS="$ENV_VARS,VERTEX_AI_PROJECT_ID=$PROJECT_ID"
-        ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=us-central1"
+        ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=asia-east1"
         ENV_VARS="$ENV_VARS,SMTP_HOST=${{ secrets.SMTP_HOST }}"
         ENV_VARS="$ENV_VARS,SMTP_PORT=${{ secrets.SMTP_PORT }}"
         ENV_VARS="$ENV_VARS,SMTP_USER=${{ secrets.SMTP_USER }}"

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -235,6 +235,18 @@ jobs:
         TAPPAY_PRODUCTION_APP_ID="${{ secrets.TAPPAY_PRODUCTION_APP_ID }}"
         TAPPAY_PRODUCTION_APP_KEY="${{ secrets.TAPPAY_PRODUCTION_APP_KEY }}"
 
+        # Analytics/Pixel: only inject real IDs on production (main). staging/develop
+        # get empty values so their traffic never pollutes production analytics and
+        # no Meta Pixel loads in non-prod. index.html guards treat empty as disabled.
+        # (Issue #959)
+        if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+          GA_MEASUREMENT_ID="${{ secrets.VITE_GA_MEASUREMENT_ID }}"
+          META_PIXEL_ID="${{ secrets.VITE_META_PIXEL_ID }}"
+        else
+          GA_MEASUREMENT_ID=""
+          META_PIXEL_ID=""
+        fi
+
         docker build -f $DOCKERFILE \
           --build-arg VITE_API_URL=${{ steps.backend_url.outputs.BACKEND_URL }} \
           --build-arg VITE_ENVIRONMENT=${{ steps.env_vars.outputs.ENV_NAME }} \
@@ -242,8 +254,8 @@ jobs:
           --build-arg VITE_TAPPAY_SERVER_TYPE=$TAPPAY_SERVER_TYPE \
           --build-arg VITE_TAPPAY_PRODUCTION_APP_ID=$TAPPAY_PRODUCTION_APP_ID \
           --build-arg VITE_TAPPAY_PRODUCTION_APP_KEY=$TAPPAY_PRODUCTION_APP_KEY \
-          --build-arg VITE_GA_MEASUREMENT_ID=${{ secrets.VITE_GA_MEASUREMENT_ID }} \
-          --build-arg VITE_META_PIXEL_ID=${{ secrets.VITE_META_PIXEL_ID }} \
+          --build-arg VITE_GA_MEASUREMENT_ID=$GA_MEASUREMENT_ID \
+          --build-arg VITE_META_PIXEL_ID=$META_PIXEL_ID \
           --build-arg VITE_SUPABASE_URL=${{ steps.supabase.outputs.URL }} \
           --build-arg VITE_SUPABASE_ANON_KEY=${{ steps.supabase.outputs.ANON_KEY }} \
           -t $REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/${{ steps.env_vars.outputs.FRONTEND_SERVICE }}:$GITHUB_SHA .

--- a/.github/workflows/deploy-per-issue.yml
+++ b/.github/workflows/deploy-per-issue.yml
@@ -120,7 +120,7 @@ jobs:
           ENV_VARS="$ENV_VARS,OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}"
           ENV_VARS="$ENV_VARS,USE_VERTEX_AI=${{ vars.USE_VERTEX_AI_PREVIEW || 'false' }}"
           ENV_VARS="$ENV_VARS,VERTEX_AI_PROJECT_ID=${PROJECT_ID}"
-          ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=us-central1"
+          ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=asia-east1"
           ENV_VARS="$ENV_VARS,SMTP_HOST=${{ secrets.SMTP_HOST }}"
           ENV_VARS="$ENV_VARS,SMTP_PORT=${{ secrets.SMTP_PORT }}"
           ENV_VARS="$ENV_VARS,SMTP_USER=${{ secrets.SMTP_USER }}"

--- a/.github/workflows/deploy-per-issue.yml
+++ b/.github/workflows/deploy-per-issue.yml
@@ -267,6 +267,9 @@ jobs:
           gcloud auth configure-docker ${REGION}-docker.pkg.dev
 
           echo "🔍 DEBUG: Building frontend image"
+          # Per-issue previews are always non-prod test traffic — GA/Meta Pixel IDs
+          # are passed empty (disabled via index.html guard) to avoid polluting
+          # production analytics. (Issue #959)
           docker build \
             -f Dockerfile.staging \
             --build-arg VITE_API_URL="${BACKEND_URL}" \
@@ -274,8 +277,8 @@ jobs:
             --build-arg VITE_TAPPAY_SERVER_TYPE=production \
             --build-arg VITE_TAPPAY_PRODUCTION_APP_ID="${{ secrets.TAPPAY_PRODUCTION_APP_ID }}" \
             --build-arg VITE_TAPPAY_PRODUCTION_APP_KEY="${{ secrets.TAPPAY_PRODUCTION_APP_KEY }}" \
-            --build-arg VITE_GA_MEASUREMENT_ID="${{ secrets.VITE_GA_MEASUREMENT_ID }}" \
-            --build-arg VITE_META_PIXEL_ID="${{ secrets.VITE_META_PIXEL_ID }}" \
+            --build-arg VITE_GA_MEASUREMENT_ID="" \
+            --build-arg VITE_META_PIXEL_ID="" \
             --build-arg VITE_SUPABASE_URL="${{ secrets.STAGING_SUPABASE_URL }}" \
             --build-arg VITE_SUPABASE_ANON_KEY="${{ secrets.STAGING_SUPABASE_ANON_KEY }}" \
             -t "${IMAGE}" \

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -101,7 +101,9 @@ class Settings:
     VERTEX_AI_PROJECT_ID: Optional[str] = os.getenv(
         "VERTEX_AI_PROJECT_ID", "duotopia-472708"
     )
-    VERTEX_AI_LOCATION: str = os.getenv("VERTEX_AI_LOCATION", "us-central1")
+    # 預設 asia-east1（台灣）：收斂學生學習資料出境範圍，與 GCS/Cloud Run 同區
+    # （Issue #959）。gemini-2.5-flash/pro 於 asia-east1 支援。
+    VERTEX_AI_LOCATION: str = os.getenv("VERTEX_AI_LOCATION", "asia-east1")
 
     # TapPay Configuration
     TAPPAY_ENV: Literal["sandbox", "production"] = os.getenv("TAPPAY_ENV", "sandbox")

--- a/backend/services/vertex_ai.py
+++ b/backend/services/vertex_ai.py
@@ -19,6 +19,8 @@ import asyncio
 import time
 from typing import Optional, Literal
 
+from core.config import settings
+
 logger = logging.getLogger(__name__)
 
 # Model name constants
@@ -34,7 +36,8 @@ class VertexAIService:
 
     def __init__(self):
         self.project_id = os.getenv("VERTEX_AI_PROJECT_ID", "duotopia-472708")
-        self.location = os.getenv("VERTEX_AI_LOCATION", "asia-northeast1")
+        # 單一設定來源，避免與 config.py 預設值不一致（Issue #959）
+        self.location = settings.VERTEX_AI_LOCATION
         self._initialized = False
         # Cached models without system_instruction (for reuse)
         self._flash_model = None

--- a/backend/tests/unit/test_vertex_ai_service.py
+++ b/backend/tests/unit/test_vertex_ai_service.py
@@ -19,18 +19,22 @@ class TestVertexAIServiceInit:
     """Test VertexAIService initialization"""
 
     def test_default_config(self):
+        from core.config import settings
+
         service = VertexAIService()
         assert service.project_id == "duotopia-472708"
-        assert service.location == "us-central1"
+        # location 收斂為單一來源 settings.VERTEX_AI_LOCATION（Issue #959），
+        # 不 pin 特定字面值以免隨環境變數變動而脆弱
+        assert service.location == settings.VERTEX_AI_LOCATION
         assert service._initialized is False
         assert service._flash_model is None
         assert service._pro_model is None
 
-    @patch.dict(
-        "os.environ",
-        {"VERTEX_AI_PROJECT_ID": "test-proj", "VERTEX_AI_LOCATION": "us-west1"},
-    )
-    def test_custom_config(self):
+    @patch.dict("os.environ", {"VERTEX_AI_PROJECT_ID": "test-proj"})
+    @patch("services.vertex_ai.settings")
+    def test_custom_config(self, mock_settings):
+        # location 來自 settings，改以 patch settings 驗證覆寫（Issue #959）
+        mock_settings.VERTEX_AI_LOCATION = "us-west1"
         service = VertexAIService()
         assert service.project_id == "test-proj"
         assert service.location == "us-west1"
@@ -299,3 +303,47 @@ class TestGetVertexAIService:
         svc2 = get_vertex_ai_service()
         assert svc1 is svc2
         module._vertex_ai_service = None  # cleanup
+
+
+class TestVertexLocationDefault:
+    """Issue #959: Vertex AI 資料出境收斂迴歸測試
+
+    未設定 VERTEX_AI_LOCATION 時，預設應為 asia-east1（台灣），
+    收斂學生學習資料出境範圍。config.py 於 import 時會 load_dotenv 讀本機
+    .env，故 patch dotenv.load_dotenv 成 no-op 以單獨驗證程式碼預設值。
+    """
+
+    def test_default_location_is_asia_east1(self):
+        import importlib
+        import os
+        from unittest.mock import patch
+
+        env_without_loc = {
+            k: v for k, v in os.environ.items() if k != "VERTEX_AI_LOCATION"
+        }
+        with patch.dict(os.environ, env_without_loc, clear=True), patch(
+            "dotenv.load_dotenv"
+        ):
+            import core.config
+
+            importlib.reload(core.config)
+            try:
+                assert core.config.settings.VERTEX_AI_LOCATION == "asia-east1"
+            finally:
+                importlib.reload(core.config)
+
+    def test_env_location_overrides_default(self):
+        import importlib
+        import os
+        from unittest.mock import patch
+
+        with patch.dict(os.environ, {"VERTEX_AI_LOCATION": "us-central1"}), patch(
+            "dotenv.load_dotenv"
+        ):
+            import core.config
+
+            importlib.reload(core.config)
+            try:
+                assert core.config.settings.VERTEX_AI_LOCATION == "us-central1"
+            finally:
+                importlib.reload(core.config)


### PR DESCRIPTION
## 背景

教育部校園徵求案「資料出境與第三方追蹤合規盤點」(Issue #959) 的處理。
依決策：**1Campus 維持現狀本次不動**；GA/Pixel 都保留只修污染；Vertex AI 遷 asia-east1。

## Part A — Vertex AI 遷 asia-east1（收斂資料出境）

學生學習資料（翻譯、題目生成、學習分析）原送美國 us-central1 處理，改在台灣 asia-east1，與 GCS/Cloud Run 同區。

- [`deploy-backend.yml`](.github/workflows/deploy-backend.yml)：`VERTEX_AI_LOCATION` us-central1 → asia-east1（literal，全環境生效，不需改 secret）
- [`config.py`](backend/core/config.py) 預設 us-central1 → asia-east1
- [`vertex_ai.py`](backend/services/vertex_ai.py) 收斂為 `settings.VERTEX_AI_LOCATION`，**消除與 config.py 不一致的第二個預設值**（原 `asia-northeast1`，#958 同類問題）
- 更新/新增測試：預設 location 為 asia-east1、env 覆寫、custom config 改 patch settings
- `gemini-2.5-flash` / `gemini-2.5-pro` 於 asia-east1 支援

## Part B — GA4 / Meta Pixel 分支污染修正（都保留，僅修污染）

原本 [`deploy-frontend.yml`](.github/workflows/deploy-frontend.yml) 對所有分支注入同一組 GA/Pixel ID，導致 staging/develop 測試流量污染正式分析、非 prod 也載入 Meta Pixel。

- 僅 `main` 注入真 GA/Pixel ID；staging/develop 傳空字串
- 靠 `index.html` 既有 guard（空值 = 不啟用）自動關閉
- **prod 行為完全不變**

## ⚠️ Vertex region 風險 — 必須先在 staging 驗證

換 region 需模型在 asia-east1 可用 + 專案該區已啟用 API/配額。合併到 staging 後**務必實測 AI 功能正常**才可升 prod：
- [ ] 翻譯功能正常
- [ ] 題目生成正常
- [ ] 學習分析報告正常

若 asia-east1 跑不動 → 回退 us-central1（改回三處 + 保留 GA/Pixel 修正）。

## 驗證結果（本機）

- [x] 後端測試：test_vertex_ai_service.py 24 passed（含新迴歸測試）
- [x] flake8 / black clean
- [x] 兩個 workflow YAML 有效
- [x] `VertexAIService().location` == asia-east1（讀新預設）

## Staging 部署後驗證（AI 功能 + GA/Pixel）
- [ ] staging AI 功能（翻譯/題目/分析）正常
- [ ] `gcloud run services describe duotopia-staging-backend` 確認 VERTEX_AI_LOCATION=asia-east1
- [ ] curl staging 前端 index.html 確認**不含** GA/Pixel ID

## 不在本 PR
- 1Campus API 主機（依決策維持 devapi.1campus.net）

Related to #959
🤖 Generated with [Claude Code](https://claude.com/claude-code)
