### PR TITLE
fix(#959): Vertex region asia-east1 → asia-northeast1（asia-east1 無 Gemini 2.5）

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -387,7 +387,7 @@ jobs:
         esac
         ENV_VARS="$ENV_VARS,USE_VERTEX_AI=${_USE_VERTEX_AI}"
         ENV_VARS="$ENV_VARS,VERTEX_AI_PROJECT_ID=$PROJECT_ID"
-        ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=asia-east1"
+        ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=asia-northeast1"
         ENV_VARS="$ENV_VARS,SMTP_HOST=${{ secrets.SMTP_HOST }}"
         ENV_VARS="$ENV_VARS,SMTP_PORT=${{ secrets.SMTP_PORT }}"
         ENV_VARS="$ENV_VARS,SMTP_USER=${{ secrets.SMTP_USER }}"

--- a/.github/workflows/deploy-per-issue.yml
+++ b/.github/workflows/deploy-per-issue.yml
@@ -120,7 +120,7 @@ jobs:
           ENV_VARS="$ENV_VARS,OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}"
           ENV_VARS="$ENV_VARS,USE_VERTEX_AI=${{ vars.USE_VERTEX_AI_PREVIEW || 'false' }}"
           ENV_VARS="$ENV_VARS,VERTEX_AI_PROJECT_ID=${PROJECT_ID}"
-          ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=asia-east1"
+          ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=asia-northeast1"
           ENV_VARS="$ENV_VARS,SMTP_HOST=${{ secrets.SMTP_HOST }}"
           ENV_VARS="$ENV_VARS,SMTP_PORT=${{ secrets.SMTP_PORT }}"
           ENV_VARS="$ENV_VARS,SMTP_USER=${{ secrets.SMTP_USER }}"

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -101,9 +101,11 @@ class Settings:
     VERTEX_AI_PROJECT_ID: Optional[str] = os.getenv(
         "VERTEX_AI_PROJECT_ID", "duotopia-472708"
     )
-    # 預設 asia-east1（台灣）：收斂學生學習資料出境範圍，與 GCS/Cloud Run 同區
-    # （Issue #959）。gemini-2.5-flash/pro 於 asia-east1 支援。
-    VERTEX_AI_LOCATION: str = os.getenv("VERTEX_AI_LOCATION", "asia-east1")
+    # 預設 asia-northeast1（東京）：收斂學生學習資料出境範圍至亞洲（Issue #959）。
+    # asia-east1（台灣）經實測無 Gemini 2.5 模型（404），asia-northeast1 是唯一
+    # 同時提供 gemini-2.5-flash 與 gemini-2.5-pro 的亞洲 region，且與 Azure
+    # Speech（japaneast）同在日本東京，合規（非中港澳）。
+    VERTEX_AI_LOCATION: str = os.getenv("VERTEX_AI_LOCATION", "asia-northeast1")
 
     # TapPay Configuration
     TAPPAY_ENV: Literal["sandbox", "production"] = os.getenv("TAPPAY_ENV", "sandbox")

--- a/backend/tests/unit/test_vertex_ai_service.py
+++ b/backend/tests/unit/test_vertex_ai_service.py
@@ -308,12 +308,14 @@ class TestGetVertexAIService:
 class TestVertexLocationDefault:
     """Issue #959: Vertex AI 資料出境收斂迴歸測試
 
-    未設定 VERTEX_AI_LOCATION 時，預設應為 asia-east1（台灣），
-    收斂學生學習資料出境範圍。config.py 於 import 時會 load_dotenv 讀本機
-    .env，故 patch dotenv.load_dotenv 成 no-op 以單獨驗證程式碼預設值。
+    未設定 VERTEX_AI_LOCATION 時，預設應為 asia-northeast1（東京）。
+    asia-east1（台灣）實測無 Gemini 2.5 模型，asia-northeast1 是唯一同時
+    提供 gemini-2.5-flash 與 gemini-2.5-pro 的亞洲 region。config.py 於
+    import 時會 load_dotenv 讀本機 .env，故 patch dotenv.load_dotenv 成
+    no-op 以單獨驗證程式碼預設值。
     """
 
-    def test_default_location_is_asia_east1(self):
+    def test_default_location_is_asia_northeast1(self):
         import importlib
         import os
         from unittest.mock import patch
@@ -328,7 +330,8 @@ class TestVertexLocationDefault:
 
             importlib.reload(core.config)
             try:
-                assert core.config.settings.VERTEX_AI_LOCATION == "asia-east1"
+                assert core.config.settings.VERTEX_AI_LOCATION == "asia-northeast1"
+                assert core.config.settings.VERTEX_AI_LOCATION != "asia-east1"
             finally:
                 importlib.reload(core.config)
 


### PR DESCRIPTION
## 修正：Vertex region asia-east1 → asia-northeast1

PR #962 把 Vertex 遷到 `asia-east1`（台灣），但 **staging 實測 AI 全數失敗**：

```
404 Publisher model .../locations/asia-east1/.../gemini-2.5-flash
was not found or your project does not have access to it.
```

## 根因：asia-east1 沒有 Gemini 2.5 模型

以真實 Vertex generateContent API 實測各亞洲 region：

| region | gemini-2.5-flash | gemini-2.5-pro |
|---|---|---|
| asia-east1（台灣） | ❌ 404 | ❌ 404 |
| **asia-northeast1（東京）** | ✅ 200 | ✅ 200 |
| asia-southeast1（新加坡） | ✅ 200 | ❌ 404 |
| us-central1（對照） | ✅ 200 | ✅ 200 |

程式用 flash + pro 兩個模型，**asia-northeast1（東京）是唯一雙模型齊全的亞洲 region**。

## 變更

`asia-east1` → `asia-northeast1`（東京）於：
- `backend/core/config.py`（預設值 + 說明）
- `.github/workflows/deploy-backend.yml`
- `.github/workflows/deploy-per-issue.yml`
- `tests/unit/test_vertex_ai_service.py`（迴歸測試斷言）

合規：東京在日本、非中港澳，與 Azure Speech（japaneast）同城，資料出境仍收斂在亞洲。

## 影響範圍
- Prod **未受影響**：#959 僅上 staging，prod 仍 us-central1 正常運作。
- 本 PR 合併到 staging 後，staging 部署會切到 asia-northeast1，需重測 AI 功能。

## 驗證
- [x] 真實 API 實測 asia-northeast1 flash+pro 皆 200
- [x] test_vertex_ai_service.py 24 passed
- [x] flake8 / black / YAML valid
- [ ] staging 部署後重測 AI（例句生成 / 翻譯 / 學習分析）

Related to #959
🤖 Generated with [Claude Code](https://claude.com/claude-code)
