### PR TITLE
🚀 Prod 升版：Vertex AI 遷東京(asia-northeast1) + GA/Pixel 分支污染修正 (#959)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -387,7 +387,7 @@ jobs:
         esac
         ENV_VARS="$ENV_VARS,USE_VERTEX_AI=${_USE_VERTEX_AI}"
         ENV_VARS="$ENV_VARS,VERTEX_AI_PROJECT_ID=$PROJECT_ID"
-        ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=asia-east1"
+        ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=asia-northeast1"
         ENV_VARS="$ENV_VARS,SMTP_HOST=${{ secrets.SMTP_HOST }}"
         ENV_VARS="$ENV_VARS,SMTP_PORT=${{ secrets.SMTP_PORT }}"
         ENV_VARS="$ENV_VARS,SMTP_USER=${{ secrets.SMTP_USER }}"

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -387,7 +387,7 @@ jobs:
         esac
         ENV_VARS="$ENV_VARS,USE_VERTEX_AI=${_USE_VERTEX_AI}"
         ENV_VARS="$ENV_VARS,VERTEX_AI_PROJECT_ID=$PROJECT_ID"
-        ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=us-central1"
+        ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=asia-east1"
         ENV_VARS="$ENV_VARS,SMTP_HOST=${{ secrets.SMTP_HOST }}"
         ENV_VARS="$ENV_VARS,SMTP_PORT=${{ secrets.SMTP_PORT }}"
         ENV_VARS="$ENV_VARS,SMTP_USER=${{ secrets.SMTP_USER }}"

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -235,6 +235,18 @@ jobs:
         TAPPAY_PRODUCTION_APP_ID="${{ secrets.TAPPAY_PRODUCTION_APP_ID }}"
         TAPPAY_PRODUCTION_APP_KEY="${{ secrets.TAPPAY_PRODUCTION_APP_KEY }}"
 
+        # Analytics/Pixel: only inject real IDs on production (main). staging/develop
+        # get empty values so their traffic never pollutes production analytics and
+        # no Meta Pixel loads in non-prod. index.html guards treat empty as disabled.
+        # (Issue #959)
+        if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+          GA_MEASUREMENT_ID="${{ secrets.VITE_GA_MEASUREMENT_ID }}"
+          META_PIXEL_ID="${{ secrets.VITE_META_PIXEL_ID }}"
+        else
+          GA_MEASUREMENT_ID=""
+          META_PIXEL_ID=""
+        fi
+
         docker build -f $DOCKERFILE \
           --build-arg VITE_API_URL=${{ steps.backend_url.outputs.BACKEND_URL }} \
           --build-arg VITE_ENVIRONMENT=${{ steps.env_vars.outputs.ENV_NAME }} \
@@ -242,8 +254,8 @@ jobs:
           --build-arg VITE_TAPPAY_SERVER_TYPE=$TAPPAY_SERVER_TYPE \
           --build-arg VITE_TAPPAY_PRODUCTION_APP_ID=$TAPPAY_PRODUCTION_APP_ID \
           --build-arg VITE_TAPPAY_PRODUCTION_APP_KEY=$TAPPAY_PRODUCTION_APP_KEY \
-          --build-arg VITE_GA_MEASUREMENT_ID=${{ secrets.VITE_GA_MEASUREMENT_ID }} \
-          --build-arg VITE_META_PIXEL_ID=${{ secrets.VITE_META_PIXEL_ID }} \
+          --build-arg VITE_GA_MEASUREMENT_ID=$GA_MEASUREMENT_ID \
+          --build-arg VITE_META_PIXEL_ID=$META_PIXEL_ID \
           --build-arg VITE_SUPABASE_URL=${{ steps.supabase.outputs.URL }} \
           --build-arg VITE_SUPABASE_ANON_KEY=${{ steps.supabase.outputs.ANON_KEY }} \
           -t $REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/${{ steps.env_vars.outputs.FRONTEND_SERVICE }}:$GITHUB_SHA .

--- a/.github/workflows/deploy-per-issue.yml
+++ b/.github/workflows/deploy-per-issue.yml
@@ -120,7 +120,7 @@ jobs:
           ENV_VARS="$ENV_VARS,OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}"
           ENV_VARS="$ENV_VARS,USE_VERTEX_AI=${{ vars.USE_VERTEX_AI_PREVIEW || 'false' }}"
           ENV_VARS="$ENV_VARS,VERTEX_AI_PROJECT_ID=${PROJECT_ID}"
-          ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=asia-east1"
+          ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=asia-northeast1"
           ENV_VARS="$ENV_VARS,SMTP_HOST=${{ secrets.SMTP_HOST }}"
           ENV_VARS="$ENV_VARS,SMTP_PORT=${{ secrets.SMTP_PORT }}"
           ENV_VARS="$ENV_VARS,SMTP_USER=${{ secrets.SMTP_USER }}"

--- a/.github/workflows/deploy-per-issue.yml
+++ b/.github/workflows/deploy-per-issue.yml
@@ -120,7 +120,7 @@ jobs:
           ENV_VARS="$ENV_VARS,OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}"
           ENV_VARS="$ENV_VARS,USE_VERTEX_AI=${{ vars.USE_VERTEX_AI_PREVIEW || 'false' }}"
           ENV_VARS="$ENV_VARS,VERTEX_AI_PROJECT_ID=${PROJECT_ID}"
-          ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=us-central1"
+          ENV_VARS="$ENV_VARS,VERTEX_AI_LOCATION=asia-east1"
           ENV_VARS="$ENV_VARS,SMTP_HOST=${{ secrets.SMTP_HOST }}"
           ENV_VARS="$ENV_VARS,SMTP_PORT=${{ secrets.SMTP_PORT }}"
           ENV_VARS="$ENV_VARS,SMTP_USER=${{ secrets.SMTP_USER }}"
@@ -267,6 +267,9 @@ jobs:
           gcloud auth configure-docker ${REGION}-docker.pkg.dev
 
           echo "🔍 DEBUG: Building frontend image"
+          # Per-issue previews are always non-prod test traffic — GA/Meta Pixel IDs
+          # are passed empty (disabled via index.html guard) to avoid polluting
+          # production analytics. (Issue #959)
           docker build \
             -f Dockerfile.staging \
             --build-arg VITE_API_URL="${BACKEND_URL}" \
@@ -274,8 +277,8 @@ jobs:
             --build-arg VITE_TAPPAY_SERVER_TYPE=production \
             --build-arg VITE_TAPPAY_PRODUCTION_APP_ID="${{ secrets.TAPPAY_PRODUCTION_APP_ID }}" \
             --build-arg VITE_TAPPAY_PRODUCTION_APP_KEY="${{ secrets.TAPPAY_PRODUCTION_APP_KEY }}" \
-            --build-arg VITE_GA_MEASUREMENT_ID="${{ secrets.VITE_GA_MEASUREMENT_ID }}" \
-            --build-arg VITE_META_PIXEL_ID="${{ secrets.VITE_META_PIXEL_ID }}" \
+            --build-arg VITE_GA_MEASUREMENT_ID="" \
+            --build-arg VITE_META_PIXEL_ID="" \
             --build-arg VITE_SUPABASE_URL="${{ secrets.STAGING_SUPABASE_URL }}" \
             --build-arg VITE_SUPABASE_ANON_KEY="${{ secrets.STAGING_SUPABASE_ANON_KEY }}" \
             -t "${IMAGE}" \

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -101,7 +101,9 @@ class Settings:
     VERTEX_AI_PROJECT_ID: Optional[str] = os.getenv(
         "VERTEX_AI_PROJECT_ID", "duotopia-472708"
     )
-    VERTEX_AI_LOCATION: str = os.getenv("VERTEX_AI_LOCATION", "us-central1")
+    # 預設 asia-east1（台灣）：收斂學生學習資料出境範圍，與 GCS/Cloud Run 同區
+    # （Issue #959）。gemini-2.5-flash/pro 於 asia-east1 支援。
+    VERTEX_AI_LOCATION: str = os.getenv("VERTEX_AI_LOCATION", "asia-east1")
 
     # TapPay Configuration
     TAPPAY_ENV: Literal["sandbox", "production"] = os.getenv("TAPPAY_ENV", "sandbox")

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -101,9 +101,11 @@ class Settings:
     VERTEX_AI_PROJECT_ID: Optional[str] = os.getenv(
         "VERTEX_AI_PROJECT_ID", "duotopia-472708"
     )
-    # 預設 asia-east1（台灣）：收斂學生學習資料出境範圍，與 GCS/Cloud Run 同區
-    # （Issue #959）。gemini-2.5-flash/pro 於 asia-east1 支援。
-    VERTEX_AI_LOCATION: str = os.getenv("VERTEX_AI_LOCATION", "asia-east1")
+    # 預設 asia-northeast1（東京）：收斂學生學習資料出境範圍至亞洲（Issue #959）。
+    # asia-east1（台灣）經實測無 Gemini 2.5 模型（404），asia-northeast1 是唯一
+    # 同時提供 gemini-2.5-flash 與 gemini-2.5-pro 的亞洲 region，且與 Azure
+    # Speech（japaneast）同在日本東京，合規（非中港澳）。
+    VERTEX_AI_LOCATION: str = os.getenv("VERTEX_AI_LOCATION", "asia-northeast1")
 
     # TapPay Configuration
     TAPPAY_ENV: Literal["sandbox", "production"] = os.getenv("TAPPAY_ENV", "sandbox")

--- a/backend/services/vertex_ai.py
+++ b/backend/services/vertex_ai.py
@@ -19,6 +19,8 @@ import asyncio
 import time
 from typing import Optional, Literal
 
+from core.config import settings
+
 logger = logging.getLogger(__name__)
 
 # Model name constants
@@ -34,7 +36,8 @@ class VertexAIService:
 
     def __init__(self):
         self.project_id = os.getenv("VERTEX_AI_PROJECT_ID", "duotopia-472708")
-        self.location = os.getenv("VERTEX_AI_LOCATION", "asia-northeast1")
+        # 單一設定來源，避免與 config.py 預設值不一致（Issue #959）
+        self.location = settings.VERTEX_AI_LOCATION
         self._initialized = False
         # Cached models without system_instruction (for reuse)
         self._flash_model = None

--- a/backend/tests/unit/test_vertex_ai_service.py
+++ b/backend/tests/unit/test_vertex_ai_service.py
@@ -19,18 +19,22 @@ class TestVertexAIServiceInit:
     """Test VertexAIService initialization"""
 
     def test_default_config(self):
+        from core.config import settings
+
         service = VertexAIService()
         assert service.project_id == "duotopia-472708"
-        assert service.location == "us-central1"
+        # location 收斂為單一來源 settings.VERTEX_AI_LOCATION（Issue #959），
+        # 不 pin 特定字面值以免隨環境變數變動而脆弱
+        assert service.location == settings.VERTEX_AI_LOCATION
         assert service._initialized is False
         assert service._flash_model is None
         assert service._pro_model is None
 
-    @patch.dict(
-        "os.environ",
-        {"VERTEX_AI_PROJECT_ID": "test-proj", "VERTEX_AI_LOCATION": "us-west1"},
-    )
-    def test_custom_config(self):
+    @patch.dict("os.environ", {"VERTEX_AI_PROJECT_ID": "test-proj"})
+    @patch("services.vertex_ai.settings")
+    def test_custom_config(self, mock_settings):
+        # location 來自 settings，改以 patch settings 驗證覆寫（Issue #959）
+        mock_settings.VERTEX_AI_LOCATION = "us-west1"
         service = VertexAIService()
         assert service.project_id == "test-proj"
         assert service.location == "us-west1"
@@ -299,3 +303,47 @@ class TestGetVertexAIService:
         svc2 = get_vertex_ai_service()
         assert svc1 is svc2
         module._vertex_ai_service = None  # cleanup
+
+
+class TestVertexLocationDefault:
+    """Issue #959: Vertex AI 資料出境收斂迴歸測試
+
+    未設定 VERTEX_AI_LOCATION 時，預設應為 asia-east1（台灣），
+    收斂學生學習資料出境範圍。config.py 於 import 時會 load_dotenv 讀本機
+    .env，故 patch dotenv.load_dotenv 成 no-op 以單獨驗證程式碼預設值。
+    """
+
+    def test_default_location_is_asia_east1(self):
+        import importlib
+        import os
+        from unittest.mock import patch
+
+        env_without_loc = {
+            k: v for k, v in os.environ.items() if k != "VERTEX_AI_LOCATION"
+        }
+        with patch.dict(os.environ, env_without_loc, clear=True), patch(
+            "dotenv.load_dotenv"
+        ):
+            import core.config
+
+            importlib.reload(core.config)
+            try:
+                assert core.config.settings.VERTEX_AI_LOCATION == "asia-east1"
+            finally:
+                importlib.reload(core.config)
+
+    def test_env_location_overrides_default(self):
+        import importlib
+        import os
+        from unittest.mock import patch
+
+        with patch.dict(os.environ, {"VERTEX_AI_LOCATION": "us-central1"}), patch(
+            "dotenv.load_dotenv"
+        ):
+            import core.config
+
+            importlib.reload(core.config)
+            try:
+                assert core.config.settings.VERTEX_AI_LOCATION == "us-central1"
+            finally:
+                importlib.reload(core.config)

--- a/backend/tests/unit/test_vertex_ai_service.py
+++ b/backend/tests/unit/test_vertex_ai_service.py
@@ -308,12 +308,14 @@ class TestGetVertexAIService:
 class TestVertexLocationDefault:
     """Issue #959: Vertex AI 資料出境收斂迴歸測試
 
-    未設定 VERTEX_AI_LOCATION 時，預設應為 asia-east1（台灣），
-    收斂學生學習資料出境範圍。config.py 於 import 時會 load_dotenv 讀本機
-    .env，故 patch dotenv.load_dotenv 成 no-op 以單獨驗證程式碼預設值。
+    未設定 VERTEX_AI_LOCATION 時，預設應為 asia-northeast1（東京）。
+    asia-east1（台灣）實測無 Gemini 2.5 模型，asia-northeast1 是唯一同時
+    提供 gemini-2.5-flash 與 gemini-2.5-pro 的亞洲 region。config.py 於
+    import 時會 load_dotenv 讀本機 .env，故 patch dotenv.load_dotenv 成
+    no-op 以單獨驗證程式碼預設值。
     """
 
-    def test_default_location_is_asia_east1(self):
+    def test_default_location_is_asia_northeast1(self):
         import importlib
         import os
         from unittest.mock import patch
@@ -328,7 +330,8 @@ class TestVertexLocationDefault:
 
             importlib.reload(core.config)
             try:
-                assert core.config.settings.VERTEX_AI_LOCATION == "asia-east1"
+                assert core.config.settings.VERTEX_AI_LOCATION == "asia-northeast1"
+                assert core.config.settings.VERTEX_AI_LOCATION != "asia-east1"
             finally:
                 importlib.reload(core.config)
 


### PR DESCRIPTION
## Staging → Production 升版（Issue #959）

將 staging 已驗證的 #959 變更部署到 production。帶 2 個 commit（皆 #959）：
1. #962 — Vertex AI 遷移 + GA/Pixel 分支污染修正
2. #963 — Vertex region 修正 asia-east1 → **asia-northeast1（東京）**（asia-east1 無 Gemini 2.5）

淨結果：`VERTEX_AI_LOCATION=asia-northeast1`。

### 內容
**Part A — Vertex AI 遷 asia-northeast1（東京）**：學生學習資料（翻譯/題目/分析）從美國 us-central1 改在日本東京處理，收斂資料出境。asia-northeast1 是唯一同時提供 gemini-2.5-flash + pro 的亞洲 region。

**Part B — GA4/Meta Pixel 分支污染修正**：僅 main（prod）注入真 GA/Pixel ID，staging/develop/per-issue 傳空值。**prod 追蹤行為不變**。

### Staging 驗證（已通過）
- ✅ AI 例句生成 / 翻譯 / 學習分析 UI 實測正常
- ✅ 後端 log：`Vertex AI generate_json DONE | region=asia-northeast1`，無 404
- ✅ staging index.html gaId/pixelId 為空（Part B 生效）
- ✅ 真實 Vertex API：asia-northeast1 flash+pro 皆 200

### Prod 部署後驗證計畫
- [ ] prod env `VERTEX_AI_LOCATION=asia-northeast1`
- [ ] prod AI 功能正常（翻譯/題目/分析），log 無 404
- [ ] prod index.html **仍含**真 GA/Pixel ID（prod 行為不變）
- [ ] 連線清單第 7 項確認為日本東京

### 影響
- Vertex：us-central1 → asia-northeast1（prod 首次切換，靠上述驗證把關）
- GA/Pixel prod：無變化

Related to #959
🤖 Generated with [Claude Code](https://claude.com/claude-code)
