### PR TITLE
docs(#862): 團購脫離機構改屬個人模式 — 設計文件（A/B 方案，定案 B）

### DIFF
--- a/docs/design/issue-862-groupbuy-decouple-comparison.md
+++ b/docs/design/issue-862-groupbuy-decouple-comparison.md
@@ -1,0 +1,121 @@
+# Issue #862 — 團購脫離機構、改屬個人模式：兩案比較
+
+> 目標：團購老師（發起人 + 團員）在 App 內一律以「個人模式」運作，自行管理班級/學生；
+> **完全不得影響正常機構（institution）方案的行為**。
+> 已確認產品決策：workspace 切換器對團購老師隱藏（全個人模式）；發起人僅為「付款人」，
+> 對其他團員的班級/學生無管理權。
+
+## 背景：現況耦合點
+
+| 面向 | 現況 | 檔案 |
+|------|------|------|
+| 方案判別 | `Organization.org_type ∈ {institution, group_buy}`（已存在的唯一判別欄位） | [organization.py:57](../../backend/models/organization.py#L57) |
+| 團購建立 | 開團 = 建 `Organization(group_buy)` + `School` + 發起人 `TeacherOrganization(org_owner)` + `TeacherSchool(school_admin)` | [group_buy.py:97](../../backend/services/group_buy.py#L97) |
+| 團員綁定 | 只綁 `TeacherSchool(roles=["teacher"])`，**無** `TeacherOrganization` | [credit_packages.py:1385](../../backend/routers/credit_packages.py#L1385) |
+| 進 org 模式 | 前端 `WorkspaceContext` 打 `GET /teachers/{id}/organizations`，回傳非空即出現 org 切換器 | [WorkspaceContext.tsx:129](../../frontend/src/contexts/WorkspaceContext.tsx#L129) |
+| 停用自管 | `TeacherClassrooms` 在 `mode==='organization' \|\| selectedSchool!==null` 時停用新增/編輯/刪除鈕 | [TeacherClassrooms.tsx:885](../../frontend/src/pages/teacher/TeacherClassrooms.tsx#L885) |
+| 發起人帳務 | 續購/加購走 org-owner 把關的 `/org-purchase`、`/org-renew`（直接查 DB 的 `TeacherOrganization.role`） | [credit_packages.py](../../backend/routers/credit_packages.py) |
+| 每月點數 | cron 以 `TeacherSchool→School→Plan→Organization(group_buy)` join 發點 | [group_buy.py:305](../../backend/services/group_buy.py#L305) |
+| 訂閱狀態 | `/subscription/status` 由 `org_type=='group_buy'` 推導 `plan_type ∈ {group_buy_owner, group_buy_member}` | [payment.py:964](../../backend/routers/payment.py#L964) |
+
+**關鍵**：只有**發起人**因 `TeacherOrganization(org_owner)` 被推進 org 模式；團員本來就是空 organizations → 已是個人模式。
+
+---
+
+## 方案 A — 只切 UI/Workspace（外科手術式）
+
+**核心思路**：後端帳務/名冊/點數/座位限制的 `Organization`/`School` 機制**原封不動**；
+只讓團購老師在 App 內「看不到、進不去」org 模式，恢復個人自管路徑。
+
+### 變更清單
+
+1. **後端 `get_teacher_organizations`** — 加 `Organization.org_type != 'group_buy'` 過濾，讓團購 org 不再進 workspace。
+   發起人的 `organizations` 因此變空 → 前端回到 personal，新增/編輯鈕解除停用。
+   - 機構老師：`org_type=='institution'` 不受影響，行為完全一致。
+   - 帳務不受影響：`/org-purchase`、`/org-renew` 直接查 DB 的 `TeacherOrganization`，不經此端點。
+2. **前端**：無需大改。organizations 變空後 org 切換器自然消失。
+   （可選加固：`TeacherClassrooms`/layout 不再依賴 group_buy org。）
+3. **驗證**：發起人與團員都能在個人模式新增班級/學生；機構老師 org 後台不變；
+   發起人續購/加購仍可用；每月點數 cron 照常。
+4. **測試**：
+   - `test_teacher_organizations_excludes_group_buy`（新）：發起人只有 group_buy org → 回傳空。
+   - 機構老師 org 仍回傳（回歸）。
+   - 既有 `test_group_buy_*`、帳務、cron 測試全綠。
+
+### 影響檔案（約 1 後端端點 + 測試；前端多為驗證）
+- `backend/routers/teachers/teacher_organizations.py`（+ 過濾）
+- `backend/tests/test_teacher_organizations*.py`（新測試）
+- 前端 `TeacherClassrooms.tsx` / `WorkspaceContext.tsx`（視驗證結果微調）
+
+### 優缺點
+- ✅ 風險極低、零觸及機構方案、無資料遷移、可 1 個 PR 完成。
+- ✅ 帳務/名冊/cron 全部沿用既有已測試路徑。
+- ⚠️ 概念上團購「底層仍是一個 Organization/School」，只是對老師隱形；
+  admin 後台仍會看到 group_buy org（現況本就如此，且 admin 需要它做帳務）。
+- ⚠️ 未來若要讓團購座位/名冊語意完全脫離機構表，仍是技術債。
+
+### 工作量：**S**（小，1–2 檔 + 測試）
+
+---
+
+## 方案 B — 後端全面重構（團購自成一格）
+
+**核心思路**：團購不再借用 `Organization`/`School`。新增專屬模型，把「開團、座位、名冊、
+帳務窗口、每月點數」全部搬離機構表，機構表只服務真正的機構方案。
+
+### 變更清單
+
+1. **新資料模型**（idempotent migration，只新增不刪除）
+   - `group_buy_teams`：`id, owner_teacher_id, plan_id, seat_limit, subscription_start/end, contact_email/phone, is_active`。
+   - `group_buy_members`：`team_id, teacher_id, is_active`（取代團員的 `TeacherSchool`）。
+   - 發起人記於 `owner_teacher_id`（取代 `TeacherOrganization(org_owner)` + `TeacherSchool(school_admin)`）。
+2. **開團流程** `group_buy.py`：`create_group_buy_org_and_school` → `create_group_buy_team`；
+   重複開團 `add_group_buy_school_to_org` → `add_seats_to_team`（或多 team）。
+3. **帳務**：新增團購專屬 `/group-buy-purchase`、`/group-buy-renew`，把 org-owner 把關換成
+   `group_buy_teams.owner_teacher_id == current_teacher`；不再共用 `/org-purchase`、`/org-renew`。
+4. **每月點數 cron** `grant_monthly_for_group_buy`：改 join `group_buy_members→group_buy_teams→Plan`。
+5. **訂閱狀態** `/subscription/status`：`plan_type` 改由 `group_buy_teams/members` 推導，不再看 `org_type`。
+6. **Admin**：`AdminOrganizations`、`admin_subscriptions` 的 group_buy 分支、`/validate-team-emails`
+   （`in_group_buy_team` 判定）、`credit_packages` 名冊/加購全部改讀新表。
+7. **資料遷移**：把既有 group_buy `Organization/School/TeacherSchool/TeacherOrganization/SubscriptionPeriod`
+   回填進 `group_buy_teams/members`（保留舊列，雙讀過渡；依 migration 鐵則不 drop）。
+8. **前端**：`GroupBuyOpenPage`、`TeacherSubscription`（group_buy_owner/member 分支）、
+   `PricingPage`、`admin/*`、`api.ts` 全部改對新端點/欄位。
+9. **測試**：整組 `test_group_buy_*` 重寫；新增 team/member CRUD、帳務、cron、遷移回填、
+   admin 分支測試；機構回歸測試。
+
+### 影響檔案（約 15+ 後端 + 8+ 前端 + 遷移）
+group_buy.py、credit_packages.py、payment.py、admin_subscriptions.py、cron.py、
+models/（新增）、多支 alembic、`test_group_buy_*` 全套；
+前端 GroupBuyOpenPage、TeacherSubscription、PricingPage、admin/AdminOrganizations、
+AdminSubscriptionDashboard、types/admin.ts、lib/api.ts。
+
+### 優缺點
+- ✅ 語意乾淨：團購與機構完全解耦，機構表不再混入 group_buy 列。
+- ✅ 移除「借用 org_owner 端點」的技術債。
+- ⚠️ 風險高：觸及帳務、cron、admin、遷移；任何回填錯誤會影響營收/發點。
+- ⚠️ 需資料遷移 + 雙讀過渡，建議拆 3–4 個 PR 分階段上線並各自驗證。
+- ⚠️ 機構方案雖非直接目標，但共用檔案多（credit_packages、payment、admin），回歸面積大。
+
+### 工作量：**L**（大，多 PR、含資料遷移與雙讀過渡）
+
+---
+
+## 併排總結
+
+| 面向 | 方案 A（UI 切割） | 方案 B（後端重構） |
+|------|------------------|-------------------|
+| 達成「團購=個人模式、自管班級/學生」 | ✅ | ✅ |
+| 隱藏 workspace 切換器 | ✅ | ✅ |
+| 發起人僅付款人 | ✅（沿用現況帳務） | ✅（專屬帳務端點） |
+| 觸及機構方案風險 | 幾乎為零 | 中（共用檔案多） |
+| 資料遷移 | 無 | 有（回填 + 雙讀） |
+| 帳務/cron 重寫 | 無 | 有 |
+| admin 後台看得到 group_buy org | 是（不變） | 否（改新表） |
+| 技術債清償 | 否（org/school 仍為底層） | 是 |
+| PR 數 / 工作量 | 1 PR / **S** | 3–4 PR / **L** |
+| 回歸測試面積 | 小 | 大 |
+
+**建議**：先出 **方案 A** 解決使用者痛點（發起人被鎖在 org 模式無法自管），
+把 **方案 B** 列為後續技術債重構（另開 issue，分階段）。方案 A 的過濾若採
+「`org_type` 判別」寫法，本身也是方案 B 的乾淨墊腳石，不會白做。

--- a/docs/design/issue-862-plan-a-ui-decouple.md
+++ b/docs/design/issue-862-plan-a-ui-decouple.md
@@ -1,0 +1,120 @@
+# Issue #862 — 方案 A：只切 UI/Workspace（外科手術式）
+
+> **一句話**：後端帳務／名冊／點數／座位限制的 `Organization`／`School` 機制**原封不動**；
+> 只讓團購老師在 App 內「看不到、也進不去」機構（organization）模式，恢復個人自管路徑。
+
+---
+
+## 1. 需求與產品決策
+
+| 項目 | 決策 |
+|------|------|
+| 團購老師的模式 | 一律「個人模式」，自行管理班級／學生 |
+| Workspace 切換器 | 對團購老師**隱藏**（不出現 org/school 切換） |
+| 發起人（開團人）角色 | 僅「付款人」：買席次、邀名冊、付款／續約；**無**對他人班級/學生的管理權 |
+| 不可影響 | 正常機構（`org_type='institution'`）方案行為必須完全一致 |
+
+## 2. 現況與問題根因
+
+- 方案判別欄位已存在：`Organization.org_type ∈ {institution, group_buy}`
+  （[organization.py:57](../../backend/models/organization.py#L57)）。
+- 開團時（[group_buy.py:97](../../backend/services/group_buy.py#L97)）建立：
+  `Organization(group_buy)` + `School` + 發起人 `TeacherOrganization(org_owner)` + `TeacherSchool(school_admin)`。
+- 團員只綁 `TeacherSchool(roles=["teacher"])`，**無** `TeacherOrganization`
+  （[credit_packages.py:1385](../../backend/routers/credit_packages.py#L1385)）。
+- 前端 `WorkspaceContext` 打 `GET /teachers/{id}/organizations`
+  （[WorkspaceContext.tsx:129](../../frontend/src/contexts/WorkspaceContext.tsx#L129)）；
+  回傳非空即出現 org 切換器，並可 `selectSchool` 進 organization 模式。
+- `TeacherClassrooms` 在 `mode==='organization' || selectedSchool!==null` 時
+  **停用**新增/編輯/刪除班級鈕（[TeacherClassrooms.tsx:885](../../frontend/src/pages/teacher/TeacherClassrooms.tsx#L885)）。
+
+**根因**：`get_teacher_organizations` 端點
+（[teacher_organizations.py:100](../../backend/routers/teachers/teacher_organizations.py#L100)）
+join `TeacherOrganization` 且**不分 `org_type`**。於是持有 `org_owner` 的**發起人**被回傳一個
+group_buy org → 前端進入 organization 模式 → 自管鈕被停用。
+（團員無 `TeacherOrganization`，本來就回傳空 → 已是個人模式；本案讓兩者行為一致並鎖死。）
+
+## 3. 設計
+
+**唯一切點**：在 `get_teacher_organizations` 加入 `Organization.org_type != 'group_buy'` 過濾。
+
+- 發起人的 `organizations` 因此變空 → 前端回到 `personal` → 自管鈕解除停用。
+- 機構老師（`org_type='institution'`）不受影響，回傳與行為完全一致。
+- **帳務不受影響**：`/org-purchase`、`/org-renew` 是後端端點，直接查 DB 的
+  `TeacherOrganization.role=='org_owner'`，**不經** `get_teacher_organizations`。
+  發起人續約/加購照常。
+- **每月點數 cron 不受影響**：`grant_monthly_for_group_buy`
+  （[group_buy.py:305](../../backend/services/group_buy.py#L305)）用
+  `TeacherSchool→School→Plan→Organization(group_buy)` 直接查 DB，與此端點無關。
+- **`/subscription/status` 不受影響**：`plan_type` 仍由 `org_type` 推導
+  （[payment.py:964](../../backend/routers/payment.py#L964)），團購付款/名冊頁照常運作。
+
+> 寫法建議：以 **`org_type` 判別**（非名稱）過濾，與現有 `_guard_group_buy`、cron 一致，
+> 且日後若走方案 B，這個 `org_type`-based 判別可直接沿用，不白做。
+
+### 3.1 後端變更
+
+`backend/routers/teachers/teacher_organizations.py` — 在既有 query 加條件：
+
+```python
+.join(Organization, TeacherOrganization.organization_id == Organization.id)
+.filter(
+    TeacherOrganization.teacher_id == teacher_id,
+    TeacherOrganization.is_active.is_(True),
+    Organization.is_active.is_(True),
+    Organization.org_type != "group_buy",   # ← 新增：團購 org 不進 workspace
+)
+```
+
+> `org_type` 目前 NOT NULL 且 default `'institution'`，故 `!= 'group_buy'` 安全涵蓋所有機構列。
+
+### 3.2 前端變更
+
+- 理論上**零改動**：`organizations` 變空後，org 切換器與 organization 模式自然消失，
+  `TeacherClassrooms` 回到個人自管。
+- 加固（視驗證結果，可選）：
+  - `WorkspaceContext` / layout 若有任何以 `TeacherSchool` 存在就顯示 school 工作區的分支，確認團購 school 不觸發。
+  - `TeacherClassrooms.tsx` 的 1Campus 同步 gate `hasOrganization = organizations.length>0` 對團購老師會變 false（正確：團購非機構，不該有 1Campus 同步）。
+
+## 4. 測試計畫（TDD）
+
+| 測試 | 期望 |
+|------|------|
+| `test_get_teacher_organizations_excludes_group_buy`（新） | 只屬 group_buy org 的發起人 → 回傳 `organizations: []` |
+| `test_get_teacher_organizations_returns_institution`（回歸） | 機構老師 → 照常回傳其 org/school |
+| `test_group_buy_open_*`（既有） | 開團、名冊、座位限制全綠 |
+| `test_org_purchase / org_renew`（回歸） | 發起人續約/加購仍可用（不依賴此端點） |
+| `test_monthly_renewal_group_buy_phase`（既有） | 每月點數照發 |
+| 前端 e2e（手動或 Playwright） | 團購發起人 + 團員都能新增班級/學生；機構老師 org 後台不變 |
+
+## 5. 影響檔案
+
+| 檔案 | 變更 |
+|------|------|
+| `backend/routers/teachers/teacher_organizations.py` | +1 filter 條件 |
+| `backend/tests/test_teacher_organizations*.py` | 新增 2 個測試 |
+| `frontend/src/pages/teacher/TeacherClassrooms.tsx`（視需要） | 驗證/微調 |
+| `frontend/src/contexts/WorkspaceContext.tsx`（視需要） | 驗證/微調 |
+
+## 6. 風險與緩解
+
+| 風險 | 等級 | 緩解 |
+|------|------|------|
+| 誤過濾到機構 org | 低 | 以 `org_type` 精準判別；回歸測試覆蓋 institution |
+| 發起人帳務失效 | 低 | 帳務走獨立端點查 DB，不經此端點；加回歸測試 |
+| 前端仍有殘留 org 入口 | 低 | e2e 驗證發起人與團員兩種帳號 |
+
+## 7. 上線
+
+- 單一 PR → staging 驗證 → 正式。
+- 無資料遷移、無破壞性變更。
+
+## 8. 取捨結論
+
+- ✅ 風險極低、零觸及機構方案、無資料遷移、1 個 PR。
+- ✅ 帳務/名冊/cron 全走既有已測試路徑。
+- ⚠️ 概念上團購「底層仍是一個 Organization/School」，僅對老師隱形；admin 後台仍看得到
+  group_buy org（現況本就如此，admin 需要它做帳務）。
+- ⚠️ 若日後要讓座位/名冊語意完全脫離機構表，仍是技術債 → 見**方案 B**。
+
+**工作量：S（小）**

--- a/docs/design/issue-862-plan-b-backend-restructure.md
+++ b/docs/design/issue-862-plan-b-backend-restructure.md
@@ -1,0 +1,216 @@
+# Issue #862 — 方案 B：後端全面重構（團購自成一格）
+
+> **一句話**：團購不再借用 `Organization`／`School`。新增團購專屬模型，把「開團、座位、
+> 名冊、帳務窗口、每月點數」全部搬離機構表，機構表只服務真正的機構方案。
+
+---
+
+## 1. 需求與產品決策
+
+同方案 A：團購老師一律個人模式、自管班級/學生、切換器隱藏、發起人僅付款人、不得影響機構方案。
+差異在於本案**從資料層徹底解耦**，清償「借用 org_owner 端點」的技術債。
+
+## 2. 目標狀態
+
+- 團購與機構在資料層完全獨立：機構表（`organizations`/`schools`/`teacher_organizations`/`teacher_schools`）
+  不再出現任何 `group_buy` 列。
+- 團購以專屬 `group_buy_teams` / `group_buy_members` 表達；發起人是 team 的 `owner_teacher_id`。
+- 團購老師天生就是個人模式（沒有任何 org/school 綁定 → 不可能進 org 模式）。
+
+## 3. 新資料模型（idempotent migration，只新增不刪除）
+
+```
+group_buy_teams
+  id                    PK
+  owner_teacher_id      FK teachers            -- 發起人（取代 TeacherOrganization org_owner + TeacherSchool school_admin）
+  plan_id               FK plans               -- 團購方案（teacher_seats/annual_fee/topup_discount）
+  seat_limit            int                    -- 席次上限（取代 School.teacher_seat_limit / Org.teacher_limit）
+  subscription_start    timestamptz
+  subscription_end      timestamptz            -- 年度窗口（取代 Org.subscription_*）
+  contact_email         varchar                -- 發起人聯絡資訊
+  contact_phone         varchar
+  is_active             bool default true
+  created_at / updated_at
+
+group_buy_members
+  id                    PK
+  team_id               FK group_buy_teams
+  teacher_id            FK teachers            -- 取代團員的 TeacherSchool(roles=["teacher"])
+  is_active             bool default true
+  UNIQUE(team_id, teacher_id)
+```
+
+> 重複開團：依現況語意（新增分校 = 加席次）改為 `add_seats_to_team`（同 team 疊加 `seat_limit`
+> 並延展 `subscription_end`），或另建 team；建議沿用「同發起人聚合到同一 team」以對齊現有行為。
+
+## 4. 變更清單（依層）
+
+### 4.1 開團 / 名冊 `backend/services/group_buy.py`
+- `create_group_buy_org_and_school` → `create_group_buy_team`（建 team + owner 記於 `owner_teacher_id`）。
+- `add_group_buy_school_to_org` → `add_seats_to_team`。
+- `find_owned_group_buy_org` → `find_owned_group_buy_team`。
+- 團員綁定（`credit_packages.py:1385` 的 `TeacherSchool`）→ 建 `group_buy_members`。
+
+### 4.2 帳務 `backend/routers/credit_packages.py`
+- 新增團購專屬 `/group-buy-purchase`、`/group-buy-renew`；
+  把關由 `TeacherOrganization.role=='org_owner'` 換成 `group_buy_teams.owner_teacher_id == current_teacher`。
+- **不再共用** `/org-purchase`、`/org-renew`（機構專用，回歸機構語意乾淨）。
+- `/validate-team-emails` 的 `in_group_buy_team` 判定改讀 `group_buy_members`。
+
+### 4.3 每月點數 cron `backend/services/group_buy.py:305`
+- `grant_monthly_for_group_buy` 改 join `group_buy_members → group_buy_teams → Plan`
+  （條件：team `is_active` 且 `subscription_end >= today`）。
+- Idempotency / advisory-lock / dedup 邏輯沿用。
+
+### 4.4 訂閱狀態 `backend/routers/payment.py:964`
+- `plan_type ∈ {individual, group_buy_owner, group_buy_member}` 改由
+  `group_buy_teams`（owner）/ `group_buy_members`（member）推導，不再看 `org_type`。
+
+### 4.5 Admin
+- `admin_subscriptions.py` group_buy 分支（手動加入）改寫至新表。
+- `frontend/src/pages/admin/AdminOrganizations.tsx`：group_buy 不再是 org → 需要獨立「團購管理」視圖或從 org 列表移除。
+- `AdminSubscriptionDashboard.tsx`、`types/admin.ts`（`org_type` 相關）對應調整。
+
+### 4.6 前端
+- `GroupBuyOpenPage.tsx`、`TeacherSubscription.tsx`（`group_buy_owner/member` 分支）、
+  `PricingPage.tsx`、`GroupBuyPlanCards.tsx`、`lib/api.ts` 改對新端點/欄位。
+
+### 4.7 資料遷移（關鍵、最高風險）
+- 回填：既有 group_buy `Organization/School` → `group_buy_teams`；
+  `TeacherSchool(teacher)` → `group_buy_members`；`TeacherOrganization(org_owner)` → `owner_teacher_id`；
+  既有 `SubscriptionPeriod(payment_method='group_buy')` 保持不動（仍掛在 teacher 上）。
+- **雙讀過渡**：新舊路徑並行一段時間，cron/帳務先讀新表、缺漏 fallback 舊表；驗證無誤後再收斂。
+- 依 migration 鐵則：**只新增、不 drop/rename**；舊 group_buy org/school 列保留（標記或閒置）。
+
+## 4.8 既有個人訂閱者加入團購：暫停 + 延展（殘值保留）
+
+> **產品決策（已定案）**：團購為期一年。若成員入團前已有有效個人訂閱，入團時**暫停**個人訂閱、
+> 期間改吃團購每月 1000 點；退團或團購結束時**恢復個人訂閱的殘值**（凍結當下的剩餘時間＋未用點數
+> 原封接續），殘值走完後 `auto_renew` 再自然接手續扣。**不給全新月配額。**
+
+### 現況機制（設計前提）
+- 個人訂閱 = 一筆 `SubscriptionPeriod`；`current_period` 只取 `status='active'` 且 `start_date` 最新一筆，
+  quota 只算 current_period + credit_packages（多筆 active period 不相加）。
+- **致命前提**：暫停期間只要 auto_renew cron 建了一筆 `status='active'` 個人 period（`start_date=now`），
+  會立刻蓋掉團購並重複收費 → 暫停**必須同時關掉** `subscription_auto_renew`。
+
+### 資料模型增修
+- `SubscriptionPeriod.status` 新增 `'paused'`：暫停中的個人 period 不再是 current，
+  也**不會**被 cron Phase 1 標 expired（Phase 1 只掃 `status='active'`）。
+- `group_buy_members` 增欄位：
+  - `paused_period_id` FK `subscription_periods`（被暫停的個人 period；NULL = 入團時無個人訂閱）
+  - `paused_remaining_seconds` int（凍結的剩餘時間，精確到秒，避免時區誤差）
+  - `individual_auto_renew_suspended` bool（入團時是否為它關掉 auto_renew，決定退團要不要恢復）
+  - `paused_at` timestamptz
+
+### 入團演算法
+```
+join(teacher, team):
+    ind = teacher.current_period            # active 個人 period
+    if ind and ind.end_date > now:
+        member.paused_remaining_seconds = int((ind.end_date - now).total_seconds())  # 凍結殘值(時間)
+        member.paused_period_id = ind.id
+        member.paused_at = now
+        ind.status = 'paused'               # 退出 current 選取；quota_used 原封不動 = 殘值(點數)
+        if teacher.subscription_auto_renew:
+            teacher.subscription_auto_renew = False
+            member.individual_auto_renew_suspended = True
+    # 之後成員照常吃團購每月 1000 monthly grant（4.3）
+```
+> `end_date <= now`（個人訂閱已過期）→ 不暫停，當純團購成員處理。
+
+### 恢復演算法（退團 / 團購結束共用）
+`resume trigger` = 會籍失效那一刻：**提早退團** → 退團日；**團購年度結束/發起人不續約** → 團購 `subscription_end`。
+```
+resume(member):
+    resume_at = now
+    p = member.paused_period_id -> SubscriptionPeriod
+    if p:
+        # 把凍結的殘值（時間＋未用點數）原封接到 resume 之後
+        p.start_date = resume_at
+        p.end_date   = resume_at + timedelta(seconds=member.paused_remaining_seconds)
+        p.status     = 'active'             # quota_used 保持不變 → 點數殘值延續
+        if member.individual_auto_renew_suspended:
+            teacher.subscription_auto_renew = True   # 殘值走完後由既有月扣 cron 自然接手
+```
+> 在 **resume 當下**（`start_date=now`）才改動 period，不在入團時預建未來 period，
+> 避免「未來 start_date 的 period 被誤選為 current」。恢復是「原 period 平移殘值」而非新建，
+> 故時間與點數殘值皆保留。
+
+### 恢復觸發點（實作面）
+1. **成員主動退團 / 被移出名冊** → 立即 `resume(member)`。
+2. **團購結束**：cron（月結或每日）掃 `group_buy_teams.subscription_end < now && is_active`，
+   對其所有 `group_buy_members` 執行 `resume`，並停發次月團購點。
+3. **對帳兜底 cron**：掃「有 `paused_period_id` 但會籍已失效卻仍 paused」的成員，補跑 resume（防 P2）。
+
+### 邊界與定案
+| 情境 | 處理 |
+|------|------|
+| 入團時無個人訂閱 | 純團購成員，`paused_period_id=NULL`，退團無恢復動作 |
+| 個人訂閱已過期才入團 | 不暫停 |
+| auto_renew 月扣型 | 殘值通常僅約當月剩餘＋未用點數；恢復後走完即 auto_renew 續扣 |
+| manual 預付多月型 | 殘值可能數月；恢復後完整延續，走完才續扣（若當初有 auto_renew）|
+| 提早退團 | 立即從退團日恢復殘值（不等年度走完）|
+| 恢復時卡已失效 | 殘值先照跑；殘值走完 auto_renew 首扣失敗 → 走既有 auto_renew 失敗流程（見 P5）|
+
+## 5. 測試計畫
+- 新：team/member CRUD、`create_group_buy_team`、`add_seats_to_team`、
+  `/group-buy-purchase`、`/group-buy-renew`、cron（新 join）、`/subscription/status`（新推導）、
+  遷移回填正確性、雙讀 fallback。
+- 重寫：整組既有 `test_group_buy_*`。
+- 回歸：機構方案（org/school、`/org-purchase`、`/org-renew`、admin org）完全不變。
+
+## 6. 影響檔案（約 15+ 後端 + 8+ 前端 + 多支遷移）
+
+**後端**：`models/`（新增 2 模型）、`services/group_buy.py`、`routers/credit_packages.py`、
+`routers/payment.py`、`routers/admin_subscriptions.py`、`routers/cron.py`、
+`routers/teachers/teacher_organizations.py`、多支 `alembic/versions/*`、
+`tests/test_group_buy_*` 全套 + 新測試。
+**前端**：`GroupBuyOpenPage.tsx`、`TeacherSubscription.tsx`、`PricingPage.tsx`、
+`GroupBuyPlanCards.tsx`、`admin/AdminOrganizations.tsx`、`admin/AdminSubscriptionDashboard.tsx`、
+`types/admin.ts`、`lib/api.ts`。
+
+## 7. 分階段上線（建議 3–4 PR）
+1. **PR1**：新增 `group_buy_teams/members` 模型 + 遷移回填（不改讀寫路徑，純建表 + backfill）。
+2. **PR2**：開團/名冊/cron/subscription-status 改雙讀新表（fallback 舊表）。
+3. **PR3**：帳務改專屬端點；前端切新端點；admin 團購視圖。
+4. **PR4**：收斂雙讀、清理舊路徑（保留舊資料列，不 drop）。
+
+每個 PR 各自 staging 驗證；帳務/發點屬營收關鍵，需重點回歸。
+
+## 8. 風險與緩解
+
+### 8.1 重構整體風險
+| 風險 | 等級 | 緩解 |
+|------|------|------|
+| 遷移回填錯誤影響營收/發點 | 高 | 雙讀過渡 + 回填對帳測試 + 只新增不刪除，可回滾讀取來源 |
+| 共用檔案（credit_packages/payment/admin）回歸面積大 | 中 | 機構回歸測試套件 + 分階段 PR |
+| 帳務端點切換期間邊界（跨月續約） | 中 | fallback 舊表 + 明確切換日 |
+| `subscription_status` 語意變動 | 中 | 同步調整 status property + `/subscription/status` + e2e |
+| admin 團購視圖缺口（group_buy 不再是 org） | 中 | 遷移前先做好獨立「團購管理」視圖 |
+
+### 8.2 暫停+延展（4.8）專屬風險
+| # | 風險 | 情境 | 等級 | 緩解 |
+|---|------|------|:--:|------|
+| P1 | **auto_renew 沒擋成** | 暫停期間 cron 仍月扣並建 active period → 蓋掉團購 + 重複收費 | 高 | 入團強制關 `subscription_auto_renew`；cron 加防呆：跳過有 active 團購會籍的老師 |
+| P2 | **resume 沒被觸發** | 退團/團購結束事件漏跑 → 個人訂閱永停 paused，吞掉已付權益 | 高 | 事件即時 resume + 對帳兜底 cron（掃會籍失效但仍 paused 者）|
+| P3 | **凍結時間算錯** | 時區/naive datetime（SQLite vs PG）→ `paused_remaining_seconds` 偏差 | 中 | 一律 tz-aware UTC 計算；沿用 `_as_utc` 模式；單元測試覆蓋跨時區 |
+| P4 | **既有資料** | prod 已同時有個人訂閱＋團購的老師，遷移時需偵測並套暫停狀態 | 中 | 遷移回填階段掃描並套用 `join` 邏輯；對帳報表 |
+| P5 | **恢復月扣的卡失效** | 暫停一年後卡過期，殘值走完 auto_renew 首扣失敗 | 中 | 走既有 auto_renew 失敗流程（關 auto_renew + 通知）；不阻斷殘值使用 |
+| P6 | **`paused` status 汙染既有查詢** | 別處假設 status 只有 active/expired/cancelled | 中 | 全域搜尋 status 使用點；paused 明確排除於 current/expired 掃描 |
+
+> P1、P2 為最致命兩點（一個重複收費、一個吞掉已付權益），實作必須有對帳 cron 兜底。
+
+## 9. 取捨結論
+- ✅ 語意乾淨：團購與機構在資料層完全解耦；機構表不再混入 group_buy。
+- ✅ 移除「借用 org_owner 端點」技術債。
+- ⚠️ 風險高、需資料遷移 + 雙讀、多 PR、回歸面積大。
+
+**工作量：L（大）**
+
+---
+
+> 併排比較與最終建議見
+> [`issue-862-groupbuy-decouple-comparison.md`](./issue-862-groupbuy-decouple-comparison.md)。
+> 目前建議：先做**方案 A** 解痛點，**方案 B** 另開技術債 issue 分階段執行；方案 A 的
+> `org_type`-based 過濾為方案 B 的乾淨墊腳石。


### PR DESCRIPTION
## 目的
純設計文件 PR，供團隊 review issue #862 的實作方向。**不含任何實作 code。**

Refs #862（刻意不寫 Fixes，merge 後 issue 仍保留供實作追蹤）

## 定案
走 **方案 B — 後端重構（團購自成一格）**：新增 `group_buy_teams`/`group_buy_members`，把開團、座位、名冊、帳務、每月點數搬離機構表，機構表只服務 institution 方案。

## 文件
| 檔案 | 內容 |
|------|------|
| `docs/design/issue-862-plan-b-backend-restructure.md` | **定案方案**。含 §4.8「既有個人訂閱者入團的暫停+延展（殘值保留）」演算法、§8.2 專屬風險 P1–P6 |
| `docs/design/issue-862-plan-a-ui-decouple.md` | 方案 A（只切 UI/Workspace，未採用），留作參考與未來墊腳石 |
| `docs/design/issue-862-groupbuy-decouple-comparison.md` | A/B 併排比較 |

## 關鍵決策紀錄
- 團購老師一律「個人模式」自管班級/學生；workspace 切換器隱藏；發起人僅付款人。
- **既有個人訂閱者入團 → 暫停 + 延展（殘值保留）**：入團凍結剩餘時間＋未用點數、關 auto_renew；退團/團購結束時原封接續殘值，走完再由 auto_renew 續扣。
- 最致命風險：P1 重複收費（auto_renew 沒擋成）、P2 吞已付權益（resume 沒觸發）→ 需對帳兜底 cron。

## Review 重點
1. 方案 B 的資料模型（`group_buy_teams`/`group_buy_members`）與遷移雙讀策略是否合理。
2. §4.8 暫停+延展演算法的邊界（提早退團、卡失效、既有雙訂閱者遷移）。
3. 分階段 3–4 PR 的切法。

> merge 後我會把這些檔案路徑補進 issue #862 description，方便後續用 worktree / subagent 依 docs 實作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)