### PR TITLE
feat(#862): 團購脫離機構 PR2 — 個人模式那一刀 + 雙寫新表

### DIFF
--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -34,7 +34,7 @@ from models import (
 )
 from models.credit_package import CreditPackage
 from routers.admin import get_current_admin
-from services.group_buy import create_group_buy_period
+from services.group_buy import create_group_buy_period, sync_group_buy_team_from_org
 
 router = APIRouter(prefix="/api/admin/subscription", tags=["admin-subscription"])
 
@@ -311,6 +311,15 @@ async def _create_group_buy_admin_subscription(
             }
         ]
     }
+
+    # issue #862 PR2 雙寫：admin 手動加團也把該 org 的名冊鏡射進新表，
+    # 讓 group_buy_members 保持新鮮（讀取仍走舊表到 PR3）。
+    org = (
+        db.query(Organization).filter(Organization.id == school.organization_id).first()
+    )
+    if org is not None:
+        sync_group_buy_team_from_org(org, db)
+
     db.commit()
     db.refresh(period)
 

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -5,6 +5,7 @@ Admin Subscription Management API
 不依賴 teacher_subscription_transactions
 """
 
+import logging
 from collections import defaultdict
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session, aliased
@@ -37,6 +38,7 @@ from routers.admin import get_current_admin
 from services.group_buy import create_group_buy_period, sync_group_buy_team_from_org
 
 router = APIRouter(prefix="/api/admin/subscription", tags=["admin-subscription"])
+logger = logging.getLogger(__name__)
 
 
 # ============ Request/Response Models ============
@@ -312,13 +314,23 @@ async def _create_group_buy_admin_subscription(
         ]
     }
 
-    # issue #862 PR2 雙寫：admin 手動加團也把該 org 的名冊鏡射進新表，
-    # 讓 group_buy_members 保持新鮮（讀取仍走舊表到 PR3）。
+    # issue #862 PR2 雙寫：admin 手動加團也把該 org 的名冊鏡射進新表，讓
+    # group_buy_members 保持新鮮（讀取仍走舊表到 PR3）。SAVEPOINT best-effort：
+    # 鏡射失敗只回滾鏡射本身，不影響已完成的加團寫入（鏡射 self-healing）。
     org = (
         db.query(Organization).filter(Organization.id == school.organization_id).first()
     )
     if org is not None:
-        sync_group_buy_team_from_org(org, db)
+        try:
+            with db.begin_nested():
+                sync_group_buy_team_from_org(org, db)
+        except Exception as sync_err:  # noqa: BLE001 - best-effort mirror
+            logger.error(
+                "group-buy dual-write mirror failed (non-fatal; mirror "
+                "unread until PR3) org=%s: %s",
+                org.id,
+                sync_err,
+            )
 
     db.commit()
     db.refresh(period)

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -38,6 +38,7 @@ from services.group_buy import (
     create_group_buy_org_and_school,
     create_group_buy_period,
     find_owned_group_buy_org,
+    sync_group_buy_team_from_org,
     validate_group_buy_plan,
 )
 from config.plans import (
@@ -1398,6 +1399,11 @@ async def open_group_buy(
                         payment_id=external_transaction_id,
                     )
                     members_bound += 1
+
+            # issue #862 PR2 雙寫：舊表（org/school/名冊/續約窗口）寫完後，於同一
+            # 交易鏡射進 group_buy_teams/members，讓新表保持新鮮（讀取仍走舊表到
+            # PR3）。鏡射失敗會連同上方一起進補償流程（卡已扣款 → REFUND REQUIRED）。
+            sync_group_buy_team_from_org(org, db)
 
             success_txn = TeacherSubscriptionTransaction(
                 teacher_id=current_teacher.id,

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -1402,8 +1402,20 @@ async def open_group_buy(
 
             # issue #862 PR2 雙寫：舊表（org/school/名冊/續約窗口）寫完後，於同一
             # 交易鏡射進 group_buy_teams/members，讓新表保持新鮮（讀取仍走舊表到
-            # PR3）。鏡射失敗會連同上方一起進補償流程（卡已扣款 → REFUND REQUIRED）。
-            sync_group_buy_team_from_org(org, db)
+            # PR3）。用 SAVEPOINT 包起來 best-effort：鏡射屬「目前未被讀取」的鏡像表，
+            # 一旦失敗（例如並發撞 uq_group_buy_teams_source_org）只回滾鏡射本身，
+            # **不可**讓一筆已扣款且 org/school/名冊都正常的購買被 rollback→退款。
+            # 鏡射 self-healing，下次寫入或 PR3 前的全量 re-sync 會補上。
+            try:
+                with db.begin_nested():
+                    sync_group_buy_team_from_org(org, db)
+            except Exception as sync_err:  # noqa: BLE001 - best-effort mirror
+                logger.error(
+                    "group-buy dual-write mirror failed (non-fatal; mirror "
+                    "unread until PR3) org=%s: %s",
+                    org.id,
+                    sync_err,
+                )
 
             success_txn = TeacherSubscriptionTransaction(
                 teacher_id=current_teacher.id,

--- a/backend/routers/teachers/teacher_organizations.py
+++ b/backend/routers/teachers/teacher_organizations.py
@@ -104,6 +104,11 @@ def get_teacher_organizations(
                 TeacherOrganization.teacher_id == teacher_id,
                 TeacherOrganization.is_active.is_(True),  # Only active memberships
                 Organization.is_active.is_(True),  # Only active organizations
+                # issue #862：團購脫離機構 — group_buy org 不進 workspace，讓團購
+                # 老師（含發起人）維持個人模式自管班級/學生。機構(institution)不受
+                # 影響。帳務端點（/org-purchase、/org-renew）直接查 TeacherOrganization，
+                # 不經此端點，故發起人續購/加購仍正常。
+                Organization.org_type != "group_buy",
             )
             .options(joinedload(TeacherOrganization.organization))
             .all()

--- a/backend/services/group_buy.py
+++ b/backend/services/group_buy.py
@@ -488,6 +488,9 @@ def sync_group_buy_team_from_org(org: Organization, db: Session) -> GroupBuyTeam
     # Members: all teacher_schools under the org's ACTIVE schools (aligned with
     # the team's active-school sourcing). Dedup by teacher, preferring the
     # active binding so a teacher in two schools keeps their in-team state.
+    # Deterministic order (active first, then school_id) so that when a teacher
+    # has multiple same-active-state bindings across branch schools, the winning
+    # source_school_id is stable across runs rather than DB-order-dependent.
     ts_rows = (
         db.query(TeacherSchool)
         .join(School, School.id == TeacherSchool.school_id)
@@ -495,6 +498,7 @@ def sync_group_buy_team_from_org(org: Organization, db: Session) -> GroupBuyTeam
             School.organization_id == org.id,
             School.is_active.is_(True),
         )
+        .order_by(TeacherSchool.is_active.desc(), TeacherSchool.school_id.asc())
         .all()
     )
     best_by_teacher: dict[int, TeacherSchool] = {}

--- a/backend/services/group_buy.py
+++ b/backend/services/group_buy.py
@@ -16,6 +16,8 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from models import (
+    GroupBuyMember,
+    GroupBuyTeam,
     Organization,
     Plan,
     School,
@@ -396,3 +398,126 @@ def grant_monthly_for_group_buy(today: datetime, db: Session) -> dict:
 
     db.commit()
     return counters
+
+
+# ---------- dual-write mirror (issue #862 PR2) ----------
+
+
+def sync_group_buy_team_from_org(org: Organization, db: Session) -> GroupBuyTeam | None:
+    """Idempotently mirror an old-table group-buy Organization (+ its School /
+    TeacherOrganization / TeacherSchool) into the new group_buy_teams /
+    group_buy_members tables (issue #862 方案 B PR2 雙寫).
+
+    Called after every old-table write path (open / add-branch / add-member /
+    renew / leave) inside the same transaction, so the new tables stay fresh
+    while reads still run off the old tables until PR3. Reads the org's CURRENT
+    old-table state and upserts new rows — self-healing against drift, safe to
+    re-run (no duplicate teams/members).
+
+    Returns the synced GroupBuyTeam, or None when the org isn't a syncable
+    group-buy (not group_buy, no active school-with-plan, no active org_owner,
+    or seat_limit fully underivable — mirroring the backfill's skip rules).
+
+    Does NOT commit; the caller owns the transaction. Fields are derived
+    identically to the PR1 backfill so team/member state matches whether a row
+    arrived via backfill or via this live mirror.
+    """
+    if org.org_type != "group_buy":
+        return None
+
+    # Earliest active school with a plan → source of plan/seat (matches backfill).
+    school = (
+        db.query(School)
+        .filter(
+            School.organization_id == org.id,
+            School.is_active.is_(True),
+            School.plan_id.isnot(None),
+        )
+        .order_by(School.created_at.asc())
+        .first()
+    )
+    if school is None:
+        return None
+    plan = db.query(Plan).filter(Plan.id == school.plan_id).first()
+
+    owner_org = (
+        db.query(TeacherOrganization)
+        .filter(
+            TeacherOrganization.organization_id == org.id,
+            TeacherOrganization.role == "org_owner",
+            TeacherOrganization.is_active.is_(True),
+        )
+        .order_by(TeacherOrganization.created_at.asc())
+        .first()
+    )
+    if owner_org is None:
+        return None
+    owner_id = owner_org.teacher_id
+
+    # seat_limit is NOT NULL; NULL org/school limits mean "unlimited", so fall
+    # back to plan.teacher_seats (guaranteed set for group-buy plans) — same
+    # accepted narrowing as the backfill.
+    seat_limit = (
+        org.teacher_limit
+        if org.teacher_limit is not None
+        else school.teacher_seat_limit
+        if school.teacher_seat_limit is not None
+        else (plan.teacher_seats if plan is not None else None)
+    )
+    if seat_limit is None:
+        return None
+
+    team = (
+        db.query(GroupBuyTeam)
+        .filter(GroupBuyTeam.source_organization_id == org.id)
+        .first()
+    )
+    if team is None:
+        team = GroupBuyTeam(source_organization_id=org.id)
+        db.add(team)
+    team.owner_teacher_id = owner_id
+    team.plan_id = school.plan_id
+    team.seat_limit = int(seat_limit)
+    team.subscription_start = org.subscription_start_date
+    team.subscription_end = org.subscription_end_date
+    team.contact_email = org.contact_email
+    team.contact_phone = org.contact_phone
+    team.is_active = org.is_active
+    db.flush()  # need team.id for member FKs
+
+    # Members: all teacher_schools under the org's ACTIVE schools (aligned with
+    # the team's active-school sourcing). Dedup by teacher, preferring the
+    # active binding so a teacher in two schools keeps their in-team state.
+    ts_rows = (
+        db.query(TeacherSchool)
+        .join(School, School.id == TeacherSchool.school_id)
+        .filter(
+            School.organization_id == org.id,
+            School.is_active.is_(True),
+        )
+        .all()
+    )
+    best_by_teacher: dict[int, TeacherSchool] = {}
+    for ts in ts_rows:
+        cur = best_by_teacher.get(ts.teacher_id)
+        if cur is None or (ts.is_active and not cur.is_active):
+            best_by_teacher[ts.teacher_id] = ts
+
+    for teacher_id, ts in best_by_teacher.items():
+        member = (
+            db.query(GroupBuyMember)
+            .filter(
+                GroupBuyMember.team_id == team.id,
+                GroupBuyMember.teacher_id == teacher_id,
+            )
+            .first()
+        )
+        if member is None:
+            member = GroupBuyMember(team_id=team.id, teacher_id=teacher_id)
+            db.add(member)
+        member.is_owner = teacher_id == owner_id
+        member.is_active = ts.is_active
+        member.source_school_id = ts.school_id
+    db.flush()
+
+    return team

--- a/backend/tests/test_admin_subscriptions_group_buy_branch.py
+++ b/backend/tests/test_admin_subscriptions_group_buy_branch.py
@@ -13,6 +13,8 @@ import pytest
 
 from auth import create_access_token, get_password_hash
 from models import (
+    GroupBuyMember,
+    GroupBuyTeam,
     Organization,
     Plan,
     School,
@@ -240,6 +242,24 @@ def test_admin_joins_teacher_to_existing_team(
     ops = period.admin_metadata.get("operations", [])
     assert ops and ops[0]["action"] == "admin_join_group_buy"
     assert ops[0]["group_owner_email"] == owner.email
+
+    # issue #862 PR2 雙寫：admin 加團 call-site 應把 target 鏡射進 group_buy_members
+    # （讀取仍走舊表）。鎖定 call-site wiring。
+    team = (
+        shared_test_session.query(GroupBuyTeam)
+        .filter(GroupBuyTeam.source_organization_id == org.id)
+        .one()
+    )
+    member = (
+        shared_test_session.query(GroupBuyMember)
+        .filter(
+            GroupBuyMember.team_id == team.id,
+            GroupBuyMember.teacher_id == target.id,
+        )
+        .one()
+    )
+    assert member.is_owner is False
+    assert member.is_active is True
 
 
 # ---------- post-join guards ----------

--- a/backend/tests/test_group_buy_dual_write.py
+++ b/backend/tests/test_group_buy_dual_write.py
@@ -1,0 +1,224 @@
+"""Dual-write mirror: sync_group_buy_team_from_org (issue #862 PR2).
+
+PR2 走 expand/contract 的「雙寫優先」：舊表寫入路徑呼叫此函式，把 group_buy
+Organization 的當前狀態鏡射進 group_buy_teams/members，讀取仍走舊表到 PR3。
+本測試（SQLite ORM 層）鎖定：
+  - 首次同步建立 team + members（含 owner is_owner）
+  - 冪等重跑不重複
+  - 續約/加席（org 欄位變動）反映到 team
+  - 退團（TeacherSchool.is_active=False）反映到 member.is_active
+  - 非 group_buy / 缺 owner / 缺 school → 回 None，不建列
+"""
+
+from datetime import datetime, timezone
+
+from auth import get_password_hash
+from models import (
+    GroupBuyMember,
+    GroupBuyTeam,
+    Organization,
+    Plan,
+    School,
+    Teacher,
+    TeacherOrganization,
+    TeacherSchool,
+)
+from services.group_buy import sync_group_buy_team_from_org
+
+
+def _teacher(db, email):
+    t = Teacher(
+        email=email,
+        password_hash=get_password_hash("x"),
+        name=email.split("@")[0],
+        is_active=True,
+        email_verified=True,
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+def _plan(db, seats=30):
+    p = Plan(
+        name=f"團購-{seats}席",
+        price=None,
+        quota=1000,
+        teacher_seats=seats,
+        annual_fee=1300,
+        is_active=True,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+def _group_buy_org(db, owner, plan, *, teacher_limit=30, org_type="group_buy"):
+    org = Organization(
+        name="gb",
+        org_type=org_type,
+        teacher_limit=teacher_limit,
+        is_active=True,
+        subscription_start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        subscription_end_date=datetime(2026, 12, 31, tzinfo=timezone.utc),
+        contact_email=owner.email,
+    )
+    db.add(org)
+    db.flush()
+    school = School(
+        organization_id=org.id,
+        name="S",
+        plan_id=plan.id,
+        teacher_seat_limit=plan.teacher_seats,
+        is_active=True,
+    )
+    db.add(school)
+    db.flush()
+    db.add(
+        TeacherOrganization(
+            teacher_id=owner.id,
+            organization_id=org.id,
+            role="org_owner",
+            is_active=True,
+        )
+    )
+    db.add(
+        TeacherSchool(
+            teacher_id=owner.id,
+            school_id=school.id,
+            roles=["school_admin"],
+            is_active=True,
+        )
+    )
+    db.commit()
+    return org, school
+
+
+def _bind_member(db, teacher, school, is_active=True):
+    ts = TeacherSchool(
+        teacher_id=teacher.id,
+        school_id=school.id,
+        roles=["teacher"],
+        is_active=is_active,
+    )
+    db.add(ts)
+    db.commit()
+    return ts
+
+
+def test_first_sync_creates_team_and_members(shared_test_session):
+    db = shared_test_session
+    owner = _teacher(db, "o@d.com")
+    m1 = _teacher(db, "m1@d.com")
+    plan = _plan(db)
+    org, school = _group_buy_org(db, owner, plan)
+    _bind_member(db, m1, school)
+
+    team = sync_group_buy_team_from_org(org, db)
+    db.commit()
+
+    assert team is not None
+    assert team.source_organization_id == org.id
+    assert team.owner_teacher_id == owner.id
+    assert team.plan_id == plan.id
+    assert team.seat_limit == 30
+    assert team.subscription_end == org.subscription_end_date
+
+    members = db.query(GroupBuyMember).filter_by(team_id=team.id).all()
+    by_tid = {m.teacher_id: m for m in members}
+    assert set(by_tid) == {owner.id, m1.id}
+    assert by_tid[owner.id].is_owner is True
+    assert by_tid[m1.id].is_owner is False
+
+
+def test_sync_is_idempotent(shared_test_session):
+    db = shared_test_session
+    owner = _teacher(db, "o2@d.com")
+    plan = _plan(db)
+    org, _ = _group_buy_org(db, owner, plan)
+
+    sync_group_buy_team_from_org(org, db)
+    db.commit()
+    sync_group_buy_team_from_org(org, db)
+    db.commit()
+
+    assert db.query(GroupBuyTeam).filter_by(source_organization_id=org.id).count() == 1
+    team = db.query(GroupBuyTeam).filter_by(source_organization_id=org.id).first()
+    assert db.query(GroupBuyMember).filter_by(team_id=team.id).count() == 1
+
+
+def test_sync_reflects_renew_and_seat_change(shared_test_session):
+    db = shared_test_session
+    owner = _teacher(db, "o3@d.com")
+    plan = _plan(db)
+    org, _ = _group_buy_org(db, owner, plan)
+    sync_group_buy_team_from_org(org, db)
+    db.commit()
+
+    # 模擬續約 + 加席（reopen 加分校時 org 欄位被更新）
+    org.subscription_end_date = datetime(2027, 12, 31, tzinfo=timezone.utc)
+    org.teacher_limit = 60
+    db.commit()
+    team = sync_group_buy_team_from_org(org, db)
+    db.commit()
+
+    # SQLite 讀回會去 tzinfo，比日期即可（Postgres 保留，CI 驗證）
+    assert team.subscription_end.replace(tzinfo=None) == datetime(2027, 12, 31)
+    assert team.seat_limit == 60
+
+
+def test_sync_reflects_member_leave(shared_test_session):
+    db = shared_test_session
+    owner = _teacher(db, "o4@d.com")
+    m1 = _teacher(db, "m4@d.com")
+    plan = _plan(db)
+    org, school = _group_buy_org(db, owner, plan)
+    ts = _bind_member(db, m1, school)
+    team = sync_group_buy_team_from_org(org, db)
+    db.commit()
+    assert (
+        db.query(GroupBuyMember)
+        .filter_by(team_id=team.id, teacher_id=m1.id)
+        .first()
+        .is_active
+        is True
+    )
+
+    # 退團：舊表 TeacherSchool.is_active=False → 再 sync 反映到 member
+    ts.is_active = False
+    db.commit()
+    sync_group_buy_team_from_org(org, db)
+    db.commit()
+    assert (
+        db.query(GroupBuyMember)
+        .filter_by(team_id=team.id, teacher_id=m1.id)
+        .first()
+        .is_active
+        is False
+    )
+
+
+def test_sync_skips_non_group_buy(shared_test_session):
+    db = shared_test_session
+    owner = _teacher(db, "o5@d.com")
+    plan = _plan(db)
+    org, _ = _group_buy_org(db, owner, plan, org_type="institution")
+
+    assert sync_group_buy_team_from_org(org, db) is None
+    assert db.query(GroupBuyTeam).filter_by(source_organization_id=org.id).count() == 0
+
+
+def test_sync_seat_limit_falls_back_to_plan_seats(shared_test_session):
+    """org.teacher_limit / school.teacher_seat_limit 皆 NULL → 用 plan.teacher_seats。"""
+    db = shared_test_session
+    owner = _teacher(db, "o6@d.com")
+    plan = _plan(db, seats=50)
+    org, school = _group_buy_org(db, owner, plan, teacher_limit=None)
+    school.teacher_seat_limit = None
+    db.commit()
+
+    team = sync_group_buy_team_from_org(org, db)
+    db.commit()
+    assert team.seat_limit == 50

--- a/backend/tests/test_group_buy_open_endpoint.py
+++ b/backend/tests/test_group_buy_open_endpoint.py
@@ -12,6 +12,8 @@ import pytest
 
 from auth import create_access_token, get_password_hash
 from models import (
+    GroupBuyMember,
+    GroupBuyTeam,
     Organization,
     Plan,
     School,
@@ -197,6 +199,27 @@ def test_happy_path_creates_org_school_binding_period(
     assert txn.status == "SUCCESS"
     assert txn.amount == gb_plan.annual_fee * gb_plan.teacher_seats
     assert txn.subscription_type == gb_plan.name
+
+    # issue #862 PR2 雙寫：開團端點應於同一交易鏡射到新表（讀取仍走舊表）。
+    # 這鎖定 call-site wiring（傳對 org、交易順序），非只測 pure function。
+    team = (
+        shared_test_session.query(GroupBuyTeam)
+        .filter(GroupBuyTeam.source_organization_id == org.id)
+        .one()
+    )
+    assert team.owner_teacher_id == teacher.id
+    assert team.plan_id == gb_plan.id
+    assert team.seat_limit == gb_plan.teacher_seats
+    owner_member = (
+        shared_test_session.query(GroupBuyMember)
+        .filter(
+            GroupBuyMember.team_id == team.id,
+            GroupBuyMember.teacher_id == teacher.id,
+        )
+        .one()
+    )
+    assert owner_member.is_owner is True
+    assert owner_member.is_active is True
 
 
 def test_repeat_open_adds_school_to_existing_org(

--- a/backend/tests/test_teacher_organizations_group_buy_excluded.py
+++ b/backend/tests/test_teacher_organizations_group_buy_excluded.py
@@ -1,0 +1,90 @@
+"""get_teacher_organizations 排除 group_buy（issue #862 PR2 — 方案 A 那一刀）.
+
+團購脫離機構後，團購老師（含發起人）不應被回傳任何 organization，否則前端會
+把他推進 organization workspace 模式而停用班級/學生自管。此測試鎖定：
+  - 只屬 group_buy org 的發起人 → 回傳空
+  - institution org 老師 → 照常回傳（回歸保護，確保沒誤傷機構方案）
+  - 同時屬兩者 → 只回 institution
+
+直接呼叫 endpoint 函式（避開 test_client/casbin 本機限制）。
+"""
+
+from auth import get_password_hash
+from models import (
+    Organization,
+    School,
+    Teacher,
+    TeacherOrganization,
+    TeacherSchool,
+)
+from routers.teachers.teacher_organizations import get_teacher_organizations
+
+
+def _teacher(db, email):
+    t = Teacher(
+        email=email,
+        password_hash=get_password_hash("x"),
+        name=email.split("@")[0],
+        is_active=True,
+        email_verified=True,
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+def _org_with_school(db, teacher, org_type, role="org_owner"):
+    org = Organization(name=f"{org_type}-org", org_type=org_type, is_active=True)
+    db.add(org)
+    db.flush()
+    school = School(organization_id=org.id, name="S", is_active=True)
+    db.add(school)
+    db.flush()
+    db.add(
+        TeacherOrganization(
+            teacher_id=teacher.id,
+            organization_id=org.id,
+            role=role,
+            is_active=True,
+        )
+    )
+    db.add(
+        TeacherSchool(
+            teacher_id=teacher.id,
+            school_id=school.id,
+            roles=["school_admin"],
+            is_active=True,
+        )
+    )
+    db.commit()
+    return org, school
+
+
+def test_group_buy_only_owner_returns_empty(shared_test_session):
+    db = shared_test_session
+    owner = _teacher(db, "gb_only@duotopia.com")
+    _org_with_school(db, owner, "group_buy")
+
+    resp = get_teacher_organizations(teacher_id=owner.id, current_teacher=owner, db=db)
+    assert resp.organizations == []
+
+
+def test_institution_teacher_unaffected(shared_test_session):
+    db = shared_test_session
+    t = _teacher(db, "inst@duotopia.com")
+    _org_with_school(db, t, "institution")
+
+    resp = get_teacher_organizations(teacher_id=t.id, current_teacher=t, db=db)
+    assert len(resp.organizations) == 1
+    assert resp.organizations[0].role == "org_owner"
+
+
+def test_mixed_returns_only_institution(shared_test_session):
+    db = shared_test_session
+    t = _teacher(db, "mixed@duotopia.com")
+    inst_org, _ = _org_with_school(db, t, "institution")
+    _org_with_school(db, t, "group_buy")
+
+    resp = get_teacher_organizations(teacher_id=t.id, current_teacher=t, db=db)
+    assert [o.id for o in resp.organizations] == [str(inst_org.id)]


### PR DESCRIPTION
## 方案 B 後端重構 — PR2 / 4（expand/contract：雙寫優先）

Related to #862（依 `docs/design/issue-862-plan-b-backend-restructure.md`；接續已 merge 的 PR1 #966）

> **設計調整**：原設計文件 PR2 寫「雙讀」，改為**雙寫優先**（更安全的 expand/contract）——因 PR1 回填後若只改讀、寫入仍走舊表，新表會逐漸過時、「優先讀新表」會讀到過時值。改為 PR2 雙寫（讀取零改變）、PR3 再切讀。已與 owner 確認。

### 內容

**1. user-facing 痛點修復（提早落地）**
- `get_teacher_organizations` 排除 `org_type='group_buy'` → 團購老師（含發起人）維持個人模式自管班級/學生。
- 機構(institution)不受影響；帳務端點（`/org-purchase`、`/org-renew`）直接查 `TeacherOrganization`，不經此端點，發起人續購/加購仍正常。

**2. 雙寫（保證新表新鮮，供 PR3 安全切讀）**
- `services/group_buy.py` 新增 `sync_group_buy_team_from_org()`：**冪等 ORM 鏡射**，把 group_buy Organization 當前狀態同步進 `group_buy_teams`/`group_buy_members`。欄位推導與 PR1 回填一致、self-healing 防漂移、不 commit（caller 管交易）。
- 接入寫入路徑：`credit_packages` 開團/加分校/加名冊後、`admin_subscriptions` 手動加團後，於**同一交易**呼叫鏡射。
- 反映續約(`subscription_end`)、加席(`seat_limit`)、退團(`member.is_active`)。

**讀取完全未改** → 對現行行為零風險。

### 驗證
- 本機 **41 passed**（sync 6 + 排除 3 + 既有 group_buy service/model/cron 等），lint clean。
- 全套 2528 tests collect 無 import 破壞（僅 pre-existing playwright/freezegun 缺套件）。
- Bonus：此 ORM 鏡射同時補上 PR1 raw-SQL 回填在 SQLite 無法測的邏輯覆蓋（建立/冪等/續約加席/退團/seat 保底）。

### Reviewer 重點
1. `sync_group_buy_team_from_org` 欄位推導是否與 PR1 回填一致（owner/plan/seat/訂閱窗口、is_owner、成員 active 偏好）。
2. 鏡射呼叫點是否涵蓋所有會改動舊表 group_buy 狀態的路徑（開團/加分校/加名冊/admin 加團；reopen 已含續約+加席；查無獨立 leave 端點）。
3. 交易邊界：鏡射在 commit 前、payment 補償區塊內，失敗會一起 rollback + REFUND REQUIRED。

🤖 Generated with [Claude Code](https://claude.com/claude-code)