### PR TITLE
feat(#862): 團購脫離機構 PR3 — 切讀新表 + 前置 re-sync + review #1/#2

### DIFF
--- a/backend/alembic/versions/20260723_1000_resync_group_buy_teams.py
+++ b/backend/alembic/versions/20260723_1000_resync_group_buy_teams.py
@@ -1,0 +1,125 @@
+"""Full re-sync of group_buy_teams / group_buy_members (issue #862 PR3)
+
+expand/contract 的 read-switch 前置：PR1 回填是「PR1 部署當下」的快照，PR2 起才
+對舊表寫入時同步鏡射新表。PR1 部署後、PR2 鏡射上線前那段時間內對舊表的變動
+（新開團、加團員、續約延長、退團）**只寫了舊表**，新表對這些會漏更新或漏建。
+
+本 migration 以「舊表當前狀態」對新表做一次全量 UPSERT，補平該間隙，讓 read-switch
+（cron / subscription-status / validate-team-emails 改讀新表）拿到最新資料。欄位推導
+與 PR1 回填、與 services.group_buy.sync_group_buy_team_from_org 一致。
+
+Idempotent：INSERT ... ON CONFLICT DO UPDATE，可安全重跑（重跑只把值刷新為當前舊表
+狀態）。遵守 CLAUDE.md Migration 鐵則（無 DROP/RENAME）。
+
+Revision ID: 20260723_1000
+Revises: 20260721_1000
+Create Date: 2026-07-23
+"""
+from typing import Union
+
+from alembic import op
+
+
+revision: str = "20260723_1000"
+down_revision: Union[str, None] = "20260721_1000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1) UPSERT teams：每個 group_buy org → 一列，衝突（同 source_organization_id）
+    #    時把欄位刷新為舊表當前值。seat_limit 以 plan.teacher_seats 保底，皆 NULL
+    #    才跳過（graceful，與 PR1 一致）。ON CONFLICT 目標為部分唯一索引，需帶述詞。
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        INSERT INTO group_buy_teams (
+            owner_teacher_id, plan_id, seat_limit,
+            subscription_start, subscription_end,
+            contact_email, contact_phone, is_active,
+            source_organization_id, created_at
+        )
+        SELECT
+            towner.teacher_id,
+            sch.plan_id,
+            COALESCE(o.teacher_limit, sch.teacher_seat_limit, sch.teacher_seats),
+            o.subscription_start_date,
+            o.subscription_end_date,
+            o.contact_email,
+            o.contact_phone,
+            o.is_active,
+            o.id,
+            now()
+        FROM organizations o
+        JOIN LATERAL (
+            SELECT s.plan_id, s.teacher_seat_limit, p.teacher_seats
+            FROM schools s
+            JOIN plans p ON p.id = s.plan_id
+            WHERE s.organization_id = o.id
+              AND s.is_active = TRUE
+              AND s.plan_id IS NOT NULL
+            ORDER BY s.created_at ASC
+            LIMIT 1
+        ) sch ON TRUE
+        JOIN LATERAL (
+            SELECT t_o.teacher_id
+            FROM teacher_organizations t_o
+            WHERE t_o.organization_id = o.id
+              AND t_o.role = 'org_owner'
+              AND t_o.is_active = TRUE
+            ORDER BY t_o.created_at ASC
+            LIMIT 1
+        ) towner ON TRUE
+        WHERE o.org_type = 'group_buy'
+          AND COALESCE(o.teacher_limit, sch.teacher_seat_limit, sch.teacher_seats)
+              IS NOT NULL
+        ON CONFLICT (source_organization_id) WHERE source_organization_id IS NOT NULL
+        DO UPDATE SET
+            owner_teacher_id = EXCLUDED.owner_teacher_id,
+            plan_id = EXCLUDED.plan_id,
+            seat_limit = EXCLUDED.seat_limit,
+            subscription_start = EXCLUDED.subscription_start,
+            subscription_end = EXCLUDED.subscription_end,
+            contact_email = EXCLUDED.contact_email,
+            contact_phone = EXCLUDED.contact_phone,
+            is_active = EXCLUDED.is_active,
+            updated_at = now();
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # 2) UPSERT members：team 來源 org 底下 active school 的 teacher_schools。
+    #    DISTINCT ON 保證每 (team, teacher) 一列（避免 ON CONFLICT 同列改兩次）。
+    #    衝突時刷新 is_owner/is_active/source_school_id 為當前舊表值。
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        INSERT INTO group_buy_members (
+            team_id, teacher_id, is_owner, is_active, source_school_id, created_at
+        )
+        SELECT DISTINCT ON (t.id, ts.teacher_id)
+            t.id,
+            ts.teacher_id,
+            (ts.teacher_id = t.owner_teacher_id),
+            ts.is_active,
+            ts.school_id,
+            now()
+        FROM group_buy_teams t
+        JOIN organizations o ON o.id = t.source_organization_id
+        JOIN schools s ON s.organization_id = o.id AND s.is_active = TRUE
+        JOIN teacher_schools ts ON ts.school_id = s.id
+        ORDER BY t.id, ts.teacher_id, ts.is_active DESC, ts.school_id
+        ON CONFLICT (team_id, teacher_id)
+        DO UPDATE SET
+            is_owner = EXCLUDED.is_owner,
+            is_active = EXCLUDED.is_active,
+            source_school_id = EXCLUDED.source_school_id,
+            updated_at = now();
+        """
+    )
+
+
+def downgrade() -> None:
+    # 純資料 re-sync，無結構變更；不提供破壞性 downgrade（依專案慣例）。
+    pass

--- a/backend/alembic/versions/20260723_1000_resync_group_buy_teams.py
+++ b/backend/alembic/versions/20260723_1000_resync_group_buy_teams.py
@@ -28,6 +28,20 @@ depends_on = None
 
 def upgrade() -> None:
     # ------------------------------------------------------------------
+    # 0) 自癒：補建 teams 的部分唯一索引。
+    #    PR1（20260721_1000）在 iterate 中把 ix_group_buy_teams_source_org（普通）
+    #    改成 uq_group_buy_teams_source_org（部分唯一）——但那是「改一支已被套用過
+    #    的 migration」。先前已套用該 revision 的環境不會重跑，於是缺 uq_ 索引，
+    #    下方 ON CONFLICT 會報 "no unique or exclusion constraint matching"。
+    #    這裡 IF NOT EXISTS 補上，讓所有環境一致（新環境 no-op）。
+    # ------------------------------------------------------------------
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_group_buy_teams_source_org "
+        "ON group_buy_teams (source_organization_id) "
+        "WHERE source_organization_id IS NOT NULL"
+    )
+
+    # ------------------------------------------------------------------
     # 1) UPSERT teams：每個 group_buy org → 一列，衝突（同 source_organization_id）
     #    時把欄位刷新為舊表當前值。seat_limit 以 plan.teacher_seats 保底，皆 NULL
     #    才跳過（graceful，與 PR1 一致）。ON CONFLICT 目標為部分唯一索引，需帶述詞。

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -35,7 +35,7 @@ from models import (
 )
 from models.credit_package import CreditPackage
 from routers.admin import get_current_admin
-from services.group_buy import create_group_buy_period, sync_group_buy_team_from_org
+from services.group_buy import create_group_buy_period, mirror_group_buy_dual_write
 
 router = APIRouter(prefix="/api/admin/subscription", tags=["admin-subscription"])
 logger = logging.getLogger(__name__)
@@ -314,23 +314,12 @@ async def _create_group_buy_admin_subscription(
         ]
     }
 
-    # issue #862 PR2 雙寫：admin 手動加團也把該 org 的名冊鏡射進新表，讓
-    # group_buy_members 保持新鮮（讀取仍走舊表到 PR3）。SAVEPOINT best-effort：
-    # 鏡射失敗只回滾鏡射本身，不影響已完成的加團寫入（鏡射 self-healing）。
+    # issue #862 雙寫：admin 手動加團也把該 org 的名冊 best-effort 鏡射進新表
+    # （共用 helper 內含 SAVEPOINT + logging；失敗只回滾鏡射本身，不影響加團寫入）。
     org = (
         db.query(Organization).filter(Organization.id == school.organization_id).first()
     )
-    if org is not None:
-        try:
-            with db.begin_nested():
-                sync_group_buy_team_from_org(org, db)
-        except Exception as sync_err:  # noqa: BLE001 - best-effort mirror
-            logger.error(
-                "group-buy dual-write mirror failed (non-fatal; mirror "
-                "unread until PR3) org=%s: %s",
-                org.id,
-                sync_err,
-            )
+    mirror_group_buy_dual_write(org, db, logger)
 
     db.commit()
     db.refresh(period)

--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -5,7 +5,6 @@ Admin Subscription Management API
 不依賴 teacher_subscription_transactions
 """
 
-import logging
 from collections import defaultdict
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session, aliased
@@ -38,7 +37,6 @@ from routers.admin import get_current_admin
 from services.group_buy import create_group_buy_period, mirror_group_buy_dual_write
 
 router = APIRouter(prefix="/api/admin/subscription", tags=["admin-subscription"])
-logger = logging.getLogger(__name__)
 
 
 # ============ Request/Response Models ============
@@ -319,7 +317,7 @@ async def _create_group_buy_admin_subscription(
     org = (
         db.query(Organization).filter(Organization.id == school.organization_id).first()
     )
-    mirror_group_buy_dual_write(org, db, logger)
+    mirror_group_buy_dual_write(org, db)
 
     db.commit()
     db.refresh(period)

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -28,6 +28,8 @@ from models import (
     TeacherSchool,
     School,
     Plan,
+    GroupBuyTeam,
+    GroupBuyMember,
 )
 from routers.teachers import get_current_teacher
 from services.tappay_service import TapPayService
@@ -38,7 +40,7 @@ from services.group_buy import (
     create_group_buy_org_and_school,
     create_group_buy_period,
     find_owned_group_buy_org,
-    sync_group_buy_team_from_org,
+    mirror_group_buy_dual_write,
     validate_group_buy_plan,
 )
 from config.plans import (
@@ -887,17 +889,16 @@ def _classify_team_emails(emails: list[str], db: Session) -> dict:
     teacher_ids_verified = [t.id for t in teachers if t.email_verified]
     in_team_ids: set[int] = set()
     if teacher_ids_verified:
+        # issue #862 read-switch：改讀新表 group_buy_members → group_buy_teams
+        # 判定「已在某團購團隊」，取代舊 TeacherSchool→School→Org(group_buy) join。
         in_team_ids = {
             row[0]
-            for row in db.query(TeacherSchool.teacher_id)
-            .join(School, School.id == TeacherSchool.school_id)
-            .join(Organization, Organization.id == School.organization_id)
+            for row in db.query(GroupBuyMember.teacher_id)
+            .join(GroupBuyTeam, GroupBuyTeam.id == GroupBuyMember.team_id)
             .filter(
-                TeacherSchool.teacher_id.in_(teacher_ids_verified),
-                TeacherSchool.is_active.is_(True),
-                School.is_active.is_(True),
-                Organization.org_type == "group_buy",
-                Organization.is_active.is_(True),
+                GroupBuyMember.teacher_id.in_(teacher_ids_verified),
+                GroupBuyMember.is_active.is_(True),
+                GroupBuyTeam.is_active.is_(True),
             )
             .all()
         }
@@ -1400,22 +1401,11 @@ async def open_group_buy(
                     )
                     members_bound += 1
 
-            # issue #862 PR2 雙寫：舊表（org/school/名冊/續約窗口）寫完後，於同一
-            # 交易鏡射進 group_buy_teams/members，讓新表保持新鮮（讀取仍走舊表到
-            # PR3）。用 SAVEPOINT 包起來 best-effort：鏡射屬「目前未被讀取」的鏡像表，
-            # 一旦失敗（例如並發撞 uq_group_buy_teams_source_org）只回滾鏡射本身，
-            # **不可**讓一筆已扣款且 org/school/名冊都正常的購買被 rollback→退款。
-            # 鏡射 self-healing，下次寫入或 PR3 前的全量 re-sync 會補上。
-            try:
-                with db.begin_nested():
-                    sync_group_buy_team_from_org(org, db)
-            except Exception as sync_err:  # noqa: BLE001 - best-effort mirror
-                logger.error(
-                    "group-buy dual-write mirror failed (non-fatal; mirror "
-                    "unread until PR3) org=%s: %s",
-                    org.id,
-                    sync_err,
-                )
+            # issue #862 雙寫：舊表（org/school/名冊/續約窗口）寫完後，於同一交易
+            # best-effort 鏡射進 group_buy_teams/members。鏡射失敗只回滾鏡射本身，
+            # **不可**讓一筆已扣款且 org/school/名冊都正常的購買被 rollback→退款
+            # （共用 helper 內含 SAVEPOINT + logging；drift 由每月 cron re-sync 補平）。
+            mirror_group_buy_dual_write(org, db, logger)
 
             success_txn = TeacherSubscriptionTransaction(
                 teacher_id=current_teacher.id,

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -1405,7 +1405,7 @@ async def open_group_buy(
             # best-effort 鏡射進 group_buy_teams/members。鏡射失敗只回滾鏡射本身，
             # **不可**讓一筆已扣款且 org/school/名冊都正常的購買被 rollback→退款
             # （共用 helper 內含 SAVEPOINT + logging；drift 由每月 cron re-sync 補平）。
-            mirror_group_buy_dual_write(org, db, logger)
+            mirror_group_buy_dual_write(org, db)
 
             success_txn = TeacherSubscriptionTransaction(
                 teacher_id=current_teacher.id,

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -18,6 +18,8 @@ from models import (
     Organization,
     School,
     TeacherSchool,
+    GroupBuyTeam,
+    GroupBuyMember,
 )
 from routers.teachers import get_current_teacher
 from services.tappay_service import TapPayService
@@ -984,42 +986,27 @@ async def get_subscription_status(
         # instead of two. For individual teachers this stays a single
         # zero-row query; for the (much rarer) group-buy case it's one
         # query for both bits of info.
+        # issue #862 read-switch：改讀新表 group_buy_members → group_buy_teams
+        # 判定團購身分（owner/member）與到期日覆寫，取代舊 Org/School/TeacherSchool
+        # /TeacherOrganization join。is_owner 直接來自成員列。
         gb_query = (
-            db.query(
-                Organization,
-                School,
-                TeacherOrganization.role,
-            )
-            .join(School, School.organization_id == Organization.id)
-            .join(TeacherSchool, TeacherSchool.school_id == School.id)
-            .outerjoin(
-                TeacherOrganization,
-                (TeacherOrganization.organization_id == Organization.id)
-                & (TeacherOrganization.teacher_id == current_teacher.id)
-                & (TeacherOrganization.is_active.is_(True))
-                & (TeacherOrganization.role == "org_owner"),
-            )
+            db.query(GroupBuyTeam, GroupBuyMember.is_owner)
+            .join(GroupBuyMember, GroupBuyMember.team_id == GroupBuyTeam.id)
             .filter(
-                TeacherSchool.teacher_id == current_teacher.id,
-                TeacherSchool.is_active.is_(True),
-                School.is_active.is_(True),
-                Organization.is_active.is_(True),
-                Organization.org_type == "group_buy",
+                GroupBuyMember.teacher_id == current_teacher.id,
+                GroupBuyMember.is_active.is_(True),
+                GroupBuyTeam.is_active.is_(True),
             )
-            .order_by(Organization.subscription_end_date.desc().nullslast())
+            .order_by(GroupBuyTeam.subscription_end.desc().nullslast())
             .first()
         )
         plan_type = "individual"
         gb_end_date_override = None
         gb_auto_renew_override = None
         if gb_query is not None:
-            gb_org, _gb_school, gb_owner_role = gb_query
-            plan_type = (
-                "group_buy_owner"
-                if gb_owner_role == "org_owner"
-                else "group_buy_member"
-            )
-            gb_end_date_override = gb_org.subscription_end_date
+            gb_team, gb_is_owner = gb_query
+            plan_type = "group_buy_owner" if gb_is_owner else "group_buy_member"
+            gb_end_date_override = gb_team.subscription_end
             # Group-buy plans don't have per-teacher auto-renew — points
             # come from the team leader's annual fee.
             gb_auto_renew_override = False

--- a/backend/services/group_buy.py
+++ b/backend/services/group_buy.py
@@ -536,7 +536,7 @@ def sync_group_buy_team_from_org(org: Organization, db: Session) -> GroupBuyTeam
     return team
 
 
-def mirror_group_buy_dual_write(org, db, logger) -> None:
+def mirror_group_buy_dual_write(org: Organization | None, db: Session) -> None:
     """Best-effort dual-write of a group-buy org into the new tables (issue #862).
 
     Wraps ``sync_group_buy_team_from_org`` in a SAVEPOINT so a mirror failure
@@ -562,21 +562,21 @@ def mirror_group_buy_dual_write(org, db, logger) -> None:
         )
 
 
-def resync_all_group_buy_teams(db) -> int:
-    """Re-run the mirror for every active group-buy Organization (issue #862).
+def resync_all_group_buy_teams(db: Session) -> int:
+    """Re-run the mirror for every group-buy Organization (issue #862).
 
     Heals drift left by any best-effort mirror write that failed after the
     read-switch. Idempotent (``sync_group_buy_team_from_org`` upserts). Returns
     the number of orgs synced. Does NOT commit — caller owns the transaction.
+
+    Does NOT filter on ``Organization.is_active``: a group-buy org can be
+    deactivated / soft-deleted via the generic org endpoints (PUT/DELETE
+    /organizations/{id}) which don't call the mirror, so an inactive org is
+    exactly the drift case we must heal — ``sync_group_buy_team_from_org`` sets
+    ``team.is_active = org.is_active`` regardless, flipping the stale team to
+    inactive so the read-switched status/roster queries stop surfacing it.
     """
-    orgs = (
-        db.query(Organization)
-        .filter(
-            Organization.org_type == "group_buy",
-            Organization.is_active.is_(True),
-        )
-        .all()
-    )
+    orgs = db.query(Organization).filter(Organization.org_type == "group_buy").all()
     synced = 0
     for org in orgs:
         # Per-org SAVEPOINT so one bad org can't abort the whole heal / the

--- a/backend/services/group_buy.py
+++ b/backend/services/group_buy.py
@@ -7,6 +7,7 @@ All amount/quota computations are server-side from the Plan row — never
 trust the frontend.
 """
 
+import logging
 from datetime import datetime, timedelta, timezone
 from typing import Tuple
 from zoneinfo import ZoneInfo
@@ -26,6 +27,9 @@ from models import (
     TeacherOrganization,
     TeacherSchool,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 # Each monthly grant gives this many points to every teacher bound to an
@@ -344,21 +348,26 @@ def grant_monthly_for_group_buy(today: datetime, db: Session) -> dict:
     )
     month_start = today_local.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
 
+    # issue #862 read-switch：發點眼前先全量 re-sync，補平任何 best-effort 鏡射
+    # 失敗留下的漂移，確保下方以新表計算資格時是最新狀態（在 advisory lock 內、
+    # commit 前執行，heal 與發點同一交易原子提交）。
+    resync_all_group_buy_teams(db)
+
+    # 資格改讀新表 group_buy_members → group_buy_teams（取代舊 TeacherSchool→
+    # School→Org join）。條件對齊舊語意：成員 active、team active 且訂閱未過期、
+    # 方案 active 且為團購方案、老師 active。
     rows = (
         db.query(Teacher, Plan)
-        .join(TeacherSchool, TeacherSchool.teacher_id == Teacher.id)
-        .join(School, School.id == TeacherSchool.school_id)
-        .join(Plan, Plan.id == School.plan_id)
-        .join(Organization, Organization.id == School.organization_id)
+        .join(GroupBuyMember, GroupBuyMember.teacher_id == Teacher.id)
+        .join(GroupBuyTeam, GroupBuyTeam.id == GroupBuyMember.team_id)
+        .join(Plan, Plan.id == GroupBuyTeam.plan_id)
         .filter(
-            TeacherSchool.is_active.is_(True),
-            School.is_active.is_(True),
+            GroupBuyMember.is_active.is_(True),
+            GroupBuyTeam.is_active.is_(True),
+            GroupBuyTeam.subscription_end >= today_local,
             Teacher.is_active.is_(True),
             Plan.is_active.is_(True),
             Plan.teacher_seats.isnot(None),
-            Organization.org_type == "group_buy",
-            Organization.is_active.is_(True),
-            Organization.subscription_end_date >= today_local,
         )
         .all()
     )
@@ -525,3 +534,59 @@ def sync_group_buy_team_from_org(org: Organization, db: Session) -> GroupBuyTeam
     db.flush()
 
     return team
+
+
+def mirror_group_buy_dual_write(org, db, logger) -> None:
+    """Best-effort dual-write of a group-buy org into the new tables (issue #862).
+
+    Wraps ``sync_group_buy_team_from_org`` in a SAVEPOINT so a mirror failure
+    rolls back ONLY the mirror rows — never the caller's real write / charge —
+    then absorbs + logs the error. Shared by every write call site so the
+    SAVEPOINT + logging behaviour lives in one place (review PR #968 #2).
+
+    After the PR3 read-switch the mirror is load-bearing, so a swallowed failure
+    means a briefly stale new-table row; ``resync_all_group_buy_teams`` (run at
+    the monthly cron start) heals that drift, and the ERROR log flags it for ops.
+    """
+    if org is None:
+        return
+    try:
+        with db.begin_nested():
+            sync_group_buy_team_from_org(org, db)
+    except Exception as sync_err:  # noqa: BLE001 - best-effort mirror
+        logger.error(
+            "group-buy dual-write mirror failed (non-fatal; healed by monthly "
+            "re-sync) org=%s: %s",
+            getattr(org, "id", "?"),
+            sync_err,
+        )
+
+
+def resync_all_group_buy_teams(db) -> int:
+    """Re-run the mirror for every active group-buy Organization (issue #862).
+
+    Heals drift left by any best-effort mirror write that failed after the
+    read-switch. Idempotent (``sync_group_buy_team_from_org`` upserts). Returns
+    the number of orgs synced. Does NOT commit — caller owns the transaction.
+    """
+    orgs = (
+        db.query(Organization)
+        .filter(
+            Organization.org_type == "group_buy",
+            Organization.is_active.is_(True),
+        )
+        .all()
+    )
+    synced = 0
+    for org in orgs:
+        # Per-org SAVEPOINT so one bad org can't abort the whole heal / the
+        # monthly grant transaction it runs inside.
+        try:
+            with db.begin_nested():
+                if sync_group_buy_team_from_org(org, db) is not None:
+                    synced += 1
+        except Exception as sync_err:  # noqa: BLE001 - best-effort heal
+            logger.error(
+                "group-buy re-sync heal failed for org=%s: %s", org.id, sync_err
+            )
+    return synced

--- a/backend/tests/test_admin_subscriptions_group_buy_branch.py
+++ b/backend/tests/test_admin_subscriptions_group_buy_branch.py
@@ -262,6 +262,58 @@ def test_admin_joins_teacher_to_existing_team(
     assert member.is_active is True
 
 
+def test_admin_join_survives_mirror_failure(
+    test_client,
+    admin,
+    owner,
+    target,
+    opened_team,
+    gb_plan_30,
+    shared_test_session,
+    monkeypatch,
+):
+    """issue #862：鏡射失敗**不可**回滾已完成的 admin 加團寫入。強迫 sync 拋錯，
+    斷言端點仍成功、TeacherSchool + period 仍寫入。"""
+    import services.group_buy as gb
+
+    def _boom(org, db):
+        raise RuntimeError("mirror boom")
+
+    monkeypatch.setattr(gb, "sync_group_buy_team_from_org", _boom)
+
+    r = _post_create(
+        test_client,
+        admin,
+        {
+            "teacher_email": target.email,
+            "plan_name": gb_plan_30.name,
+            "group_owner_email": owner.email,
+            "reason": "comp",
+        },
+    )
+    assert r.status_code == 200, r.json()  # 加團仍成功
+    org, school = opened_team
+    shared_test_session.expire_all()
+    assert (
+        shared_test_session.query(TeacherSchool)
+        .filter(
+            TeacherSchool.teacher_id == target.id,
+            TeacherSchool.school_id == school.id,
+            TeacherSchool.is_active.is_(True),
+        )
+        .one()
+    )
+    assert (
+        shared_test_session.query(SubscriptionPeriod)
+        .filter(
+            SubscriptionPeriod.teacher_id == target.id,
+            SubscriptionPeriod.payment_method == "group_buy",
+        )
+        .count()
+        >= 1
+    )
+
+
 # ---------- post-join guards ----------
 
 

--- a/backend/tests/test_group_buy_dual_write.py
+++ b/backend/tests/test_group_buy_dual_write.py
@@ -23,7 +23,10 @@ from models import (
     TeacherOrganization,
     TeacherSchool,
 )
-from services.group_buy import sync_group_buy_team_from_org
+from services.group_buy import (
+    resync_all_group_buy_teams,
+    sync_group_buy_team_from_org,
+)
 
 
 def _teacher(db, email):
@@ -198,6 +201,29 @@ def test_sync_reflects_member_leave(shared_test_session):
         .is_active
         is False
     )
+
+
+def test_resync_heals_deactivated_org(shared_test_session):
+    """B（PR3 review）：團購 org 經一般 org 端點停用（不經鏡射）後，heal 必須把
+    stale 的 team.is_active 從 True 翻成 False，否則切讀後成員無限期顯示團購身分。
+    resync 不可過濾 is_active，否則永遠掃不到這個 org。"""
+    db = shared_test_session
+    owner = _teacher(db, "o_heal@d.com")
+    plan = _plan(db)
+    org, _ = _group_buy_org(db, owner, plan)
+    team = sync_group_buy_team_from_org(org, db)
+    db.commit()
+    assert team.is_active is True
+
+    # 一般 org 端點停用（不經鏡射）→ 新表 stale
+    org.is_active = False
+    db.commit()
+
+    synced = resync_all_group_buy_teams(db)
+    db.commit()
+    assert synced >= 1
+    db.refresh(team)
+    assert team.is_active is False
 
 
 def test_sync_skips_non_group_buy(shared_test_session):

--- a/backend/tests/test_group_buy_open_endpoint.py
+++ b/backend/tests/test_group_buy_open_endpoint.py
@@ -222,6 +222,57 @@ def test_happy_path_creates_org_school_binding_period(
     assert owner_member.is_active is True
 
 
+def test_open_survives_mirror_failure(
+    test_client, auth_header, teacher, gb_plan, shared_test_session, monkeypatch
+):
+    """issue #862：雙寫鏡射失敗**不可**讓一筆已扣款的開團被 rollback→退款。
+    強迫 sync 拋錯，斷言端點仍成功、org/school/period 仍寫入、team 未建（鏡射回滾）。"""
+    import services.group_buy as gb
+
+    def _boom(org, db):
+        raise RuntimeError("mirror boom")
+
+    monkeypatch.setattr(gb, "sync_group_buy_team_from_org", _boom)
+
+    mock_tappay = Mock()
+    mock_tappay.process_payment.return_value = {
+        "status": 0,
+        "rec_trade_id": "REC-BOOM",
+        "card_secret": {},
+    }
+    with patch("routers.credit_packages.ENABLE_PAYMENT", True), patch(
+        "routers.credit_packages.TapPayService", return_value=mock_tappay
+    ):
+        r = test_client.post(
+            "/api/credit-packages/group-buy-open",
+            json={"prime": "prime-x", "plan_name": gb_plan.name},
+            headers=auth_header,
+        )
+
+    assert r.status_code == 200, r.json()  # 已扣款購買未被鏡射失敗連累
+    body = r.json()
+    shared_test_session.expire_all()
+    # 真實寫入仍 commit
+    assert (
+        shared_test_session.query(Organization)
+        .filter(Organization.id == body["organization_id"])
+        .one()
+    )
+    assert (
+        shared_test_session.query(SubscriptionPeriod)
+        .filter(SubscriptionPeriod.teacher_id == teacher.id)
+        .count()
+        >= 1
+    )
+    # 鏡射（SAVEPOINT）已回滾 → 無 team 列
+    assert (
+        shared_test_session.query(GroupBuyTeam)
+        .filter(GroupBuyTeam.source_organization_id == body["organization_id"])
+        .count()
+        == 0
+    )
+
+
 def test_repeat_open_adds_school_to_existing_org(
     test_client, auth_header, teacher, gb_plan, shared_test_session
 ):

--- a/backend/tests/test_subscription_status_group_buy.py
+++ b/backend/tests/test_subscription_status_group_buy.py
@@ -21,6 +21,7 @@ from models import (
     TeacherOrganization,
     TeacherSchool,
 )
+from services.group_buy import sync_group_buy_team_from_org
 
 
 def _bearer(teacher_id):
@@ -125,6 +126,10 @@ def _make_group_buy_team(
                 status="active",
             )
         )
+    # issue #862 read-switch：status 端點改讀新表，故 fixture 也把舊表狀態鏡射
+    # 進 group_buy_teams/members（等同 production 雙寫）。
+    shared_test_session.flush()
+    sync_group_buy_team_from_org(org, shared_test_session)
     shared_test_session.commit()
     return org, school
 

--- a/backend/tests/test_validate_team_emails_endpoint.py
+++ b/backend/tests/test_validate_team_emails_endpoint.py
@@ -9,6 +9,8 @@ import pytest
 
 from auth import create_access_token, get_password_hash
 from models import (
+    GroupBuyMember,
+    GroupBuyTeam,
     Organization,
     Plan,
     School,
@@ -118,6 +120,20 @@ def teacher_in_group_buy_team(shared_test_session):
             roles=["teacher"],
             is_active=True,
         )
+    )
+    # issue #862 read-switch：in_group_buy_team 改讀新表，故直接建 team + member
+    # 列（此 fixture 無 owner，直接建以表達「t 已在某團購團隊」）。
+    team = GroupBuyTeam(
+        owner_teacher_id=t.id,
+        plan_id=plan.id,
+        seat_limit=plan.teacher_seats,
+        is_active=True,
+        source_organization_id=org.id,
+    )
+    shared_test_session.add(team)
+    shared_test_session.flush()
+    shared_test_session.add(
+        GroupBuyMember(team_id=team.id, teacher_id=t.id, is_owner=False, is_active=True)
     )
     shared_test_session.commit()
     return t


### PR DESCRIPTION
## 方案 B 後端重構 — PR3 / N（expand/contract 的 contract：讀取切到新表）

Related to #862（接續已 merge 的 PR1 #966、PR2 #968）

### 內容

**1. 切讀（改讀 `group_buy_teams`/`group_buy_members`，取代舊 Org/School/TeacherSchool join）**
- `cron grant_monthly_for_group_buy`：發點資格改讀新表，保留 dedup + advisory lock
- `/subscription/status` plan_type（owner/member）改讀新表
- `_classify_team_emails`（validate-team-emails）`in_group_buy_team` 改讀新表

**2. 前置 re-sync（補平 PR1 回填後、PR2 鏡射上線前只寫舊表的間隙）**
- migration `20260723_1000`：全量 UPSERT teams+members（`ON CONFLICT DO UPDATE`，冪等）
- cron 發點前跑 `resync_all_group_buy_teams` heal → 錢的路徑永遠最新

**3. review #1/#2（PR #968 延到本 PR）**
- #2 抽共用 helper `mirror_group_buy_dual_write`（SAVEPOINT+log），兩 call-site 改用
- #1 失敗路徑測試：open/admin 端點鏡射拋錯時仍 commit 真實寫入（不退款/不回滾加團）

### 設計決定（reconcile）
切讀後鏡射變 load-bearing。採 **best-effort 鏡射（不害付款）+ 每月 cron 全量 re-sync heal（錢的路徑自癒）**。代價：`status`/`validate` 顯示/驗證路徑若鏡射曾失敗，最壞到下次月結才自癒（非錢，可接受）。

### 驗證
- 本機 **41 passed**（既有 cron 測試經 resync bridge 仍綠＝切讀行為等價）、lint clean、單一 alembic head、2530 collect 無破壞。
- 端點測試（status/validate/open/admin，含失敗路徑）由 CI Test Backend 驗證。

### Reviewer 重點
1. 切讀三處的新表查詢條件是否對齊舊語意（active/expired/owner 判定）。
2. re-sync migration 的 UPSERT（ON CONFLICT 部分唯一索引帶述詞、DISTINCT ON 防同列改兩次）。
3. cron heal 的交易邊界（advisory lock 內、per-org SAVEPOINT、與發點同一交易 commit）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)