### PR TITLE
fix(#862): PR4a — sync 修 school 層停用漏 heal(#2) + 清 payment 死 import(#1)

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -14,10 +14,6 @@ from models import (
     TransactionType,
     SubscriptionPeriod,
     PointUsageLog,
-    TeacherOrganization,
-    Organization,
-    School,
-    TeacherSchool,
     GroupBuyTeam,
     GroupBuyMember,
 )

--- a/backend/services/group_buy.py
+++ b/backend/services/group_buy.py
@@ -434,6 +434,25 @@ def sync_group_buy_team_from_org(org: Organization, db: Session) -> GroupBuyTeam
     if org.org_type != "group_buy":
         return None
 
+    def _orphan_none() -> None:
+        """issue #862 #2 — the org is (or became) un-syncable: no active
+        school-with-plan / no active org_owner / seat underivable. If a team row
+        already exists for this org, flip it inactive so the read-switched
+        status/roster/grant paths stop surfacing it. This is the ONLY heal for
+        SCHOOL-level deactivation (schools.py delete/update_school flips
+        School.is_active without touching the org or the mirror), which would
+        otherwise leave group_buy_teams.is_active stuck True and keep granting.
+        """
+        existing = (
+            db.query(GroupBuyTeam)
+            .filter(GroupBuyTeam.source_organization_id == org.id)
+            .first()
+        )
+        if existing is not None and existing.is_active:
+            existing.is_active = False
+            db.flush()
+        return None
+
     # Earliest active school with a plan → source of plan/seat (matches backfill).
     school = (
         db.query(School)
@@ -446,7 +465,7 @@ def sync_group_buy_team_from_org(org: Organization, db: Session) -> GroupBuyTeam
         .first()
     )
     if school is None:
-        return None
+        return _orphan_none()
     plan = db.query(Plan).filter(Plan.id == school.plan_id).first()
 
     owner_org = (
@@ -460,7 +479,7 @@ def sync_group_buy_team_from_org(org: Organization, db: Session) -> GroupBuyTeam
         .first()
     )
     if owner_org is None:
-        return None
+        return _orphan_none()
     owner_id = owner_org.teacher_id
 
     # seat_limit is NOT NULL; NULL org/school limits mean "unlimited", so fall
@@ -474,7 +493,7 @@ def sync_group_buy_team_from_org(org: Organization, db: Session) -> GroupBuyTeam
         else (plan.teacher_seats if plan is not None else None)
     )
     if seat_limit is None:
-        return None
+        return _orphan_none()
 
     team = (
         db.query(GroupBuyTeam)

--- a/backend/tests/test_group_buy_dual_write.py
+++ b/backend/tests/test_group_buy_dual_write.py
@@ -152,6 +152,28 @@ def test_sync_is_idempotent(shared_test_session):
     assert db.query(GroupBuyMember).filter_by(team_id=team.id).count() == 1
 
 
+def test_sync_deactivates_team_when_only_school_deactivated(shared_test_session):
+    """#2（PR4）：org 仍 active、但其唯一 school 被停用（schools.py delete/update，
+    不經鏡射）→ sync 找不到 active school 會 return None，此時必須把既有 team 翻
+    inactive，否則切讀後 cron 持續發點、membership 持續說「已在團」。"""
+    db = shared_test_session
+    owner = _teacher(db, "o_school@d.com")
+    plan = _plan(db)
+    org, school = _group_buy_org(db, owner, plan)
+    team = sync_group_buy_team_from_org(org, db)
+    db.commit()
+    assert team.is_active is True
+
+    # 只停用 school（org 不動）→ sync 應 return None 且把 team 翻 inactive
+    school.is_active = False
+    db.commit()
+    result = sync_group_buy_team_from_org(org, db)
+    db.commit()
+    assert result is None
+    db.refresh(team)
+    assert team.is_active is False
+
+
 def test_sync_reflects_renew_and_seat_change(shared_test_session):
     db = shared_test_session
     owner = _teacher(db, "o3@d.com")


### PR DESCRIPTION
## 方案 B — PR4a（純防護，零改變現有流程行為）

Related to #862（PR1 #966 / PR2 #968 / PR3 #970 已 merge。§4.8 暫停+延展主體在後續 PR4b）

> **線上風險**：prod 目前 **0 個團購 org**、`group_buy_teams/members` 表 prod 尚未存在（整個 #862 目前僅在 staging），故本 PR 對現有線上使用者實際影響為 **0**。純防護修正。

### #2（money-path）— sync 修 school 層停用漏 heal
`sync_group_buy_team_from_org` 原本在「org 無 active school-with-plan / 無 active org_owner / seat 無法推導」時直接 `return None`，**但不處理已存在的 team 列**。而 `schools.py` 的 `delete_school`/`update_school` 會翻 `School.is_active`（不動 org、不經鏡射）。單校團購把那唯一一校停用後，`group_buy_teams.is_active` 會**卡在 True** → 切讀後 cron 持續發點、membership 持續說「已在團」。

修法：這三個 early-return 改走 `_orphan_none()` — 若已有 team 列先 `is_active=False` 再 return。這是 school 層停用唯一的 heal（每月 cron `resync_all_group_buy_teams` 會呼叫到）。+ 測試 `test_sync_deactivates_team_when_only_school_deactivated`。

### #1（低）— 清 payment.py 死 import
切讀後 `TeacherOrganization/Organization/School/TeacherSchool` 只剩註解/docstring 在用，程式碼零引用，清掉。

### 驗證
本機 43 passed、lint clean、payment.py 移除後 import OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)