### PR TITLE
feat(#862): PR4b — §4.8 個人訂閱者入團「暫停+延展（殘值保留）」

### DIFF
--- a/backend/routers/admin_subscriptions.py
+++ b/backend/routers/admin_subscriptions.py
@@ -34,7 +34,11 @@ from models import (
 )
 from models.credit_package import CreditPackage
 from routers.admin import get_current_admin
-from services.group_buy import create_group_buy_period, mirror_group_buy_dual_write
+from services.group_buy import (
+    create_group_buy_period,
+    mirror_group_buy_dual_write,
+    pause_joining_teachers_for_org,
+)
 
 router = APIRouter(prefix="/api/admin/subscription", tags=["admin-subscription"])
 
@@ -318,6 +322,10 @@ async def _create_group_buy_admin_subscription(
         db.query(Organization).filter(Organization.id == school.organization_id).first()
     )
     mirror_group_buy_dual_write(org, db)
+    # issue #862 §4.8：admin 加團也要暫停該老師的既有個人訂閱（凍結殘值 + 關
+    # auto_renew）。mirror 先建好 member 列後再暫停；無個人訂閱者為 no-op。
+    if org is not None:
+        pause_joining_teachers_for_org(org, [teacher], db, now=now)
 
     db.commit()
     db.refresh(period)

--- a/backend/routers/credit_packages.py
+++ b/backend/routers/credit_packages.py
@@ -41,6 +41,7 @@ from services.group_buy import (
     create_group_buy_period,
     find_owned_group_buy_org,
     mirror_group_buy_dual_write,
+    pause_joining_teachers_for_org,
     validate_group_buy_plan,
 )
 from config.plans import (
@@ -1356,6 +1357,7 @@ async def open_group_buy(
             # leader-fill window from roster to pay is hours; a member
             # could have joined another team in between). All-or-nothing.
             members_bound = 0
+            joined_member_objs = []
             if normalized_member_emails:
                 # Batch the defensive in-tx re-check too — at the 50-seat
                 # ceiling the per-email helper was 49 × 2 = 98 queries
@@ -1399,6 +1401,7 @@ async def open_group_buy(
                         start=now,
                         payment_id=external_transaction_id,
                     )
+                    joined_member_objs.append(member)
                     members_bound += 1
 
             # issue #862 雙寫：舊表（org/school/名冊/續約窗口）寫完後，於同一交易
@@ -1406,6 +1409,14 @@ async def open_group_buy(
             # **不可**讓一筆已扣款且 org/school/名冊都正常的購買被 rollback→退款
             # （共用 helper 內含 SAVEPOINT + logging；drift 由每月 cron re-sync 補平）。
             mirror_group_buy_dual_write(org, db)
+
+            # issue #862 §4.8：入團 → 暫停各人（發起人 + 團員）的既有個人訂閱並凍結
+            # 殘值、關 auto_renew（防 P1 重複收費）。在主交易內（非 SAVEPOINT）：pause
+            # 是 P1 防線，失敗應連同退款補償一起處理而非靜默吞掉；cron Phase 2 guard
+            # 為執行期雙保險。無個人訂閱者為 no-op。mirror 需先建好 member 列。
+            pause_joining_teachers_for_org(
+                org, [current_teacher] + joined_member_objs, db, now=now
+            )
 
             success_txn = TeacherSubscriptionTransaction(
                 teacher_id=current_teacher.id,

--- a/backend/routers/cron.py
+++ b/backend/routers/cron.py
@@ -143,9 +143,12 @@ async def monthly_renewal_cron(
         f"Found {len(teachers_with_auto_renew)} teachers with auto_renew enabled"
     )
 
-    # issue #862 §4.8 P1 雙保險：跳過「active 團購成員」的個人 auto_renew 扣款。
+    # issue #862 §4.8 P1 雙保險：跳過「仍在享有團購」成員的個人 auto_renew 扣款。
     # 團購成員點數來自團隊年費、個人訂閱入團時已 paused；這裡在扣款前再攔一次，
     # 即使某次 pause 漏關 auto_renew，也不會對團購成員重複收費（防 P1）。
+    # 必須同時檢查 subscription_end >= now，與「發點資格」「resume sweep」對齊
+    # 「還在享有團購」的定義——否則團隊年度到期後（沒續約），成員已被 resume、
+    # auto_renew 轉回 True，卻仍被此 skip-list 命中而永遠不扣款、靜默失去訂閱。
     active_gb_member_ids = {
         row[0]
         for row in db.query(GroupBuyMember.teacher_id)
@@ -153,6 +156,7 @@ async def monthly_renewal_cron(
         .filter(
             GroupBuyMember.is_active.is_(True),
             GroupBuyTeam.is_active.is_(True),
+            GroupBuyTeam.subscription_end >= now_taipei,
         )
         .all()
     }

--- a/backend/routers/cron.py
+++ b/backend/routers/cron.py
@@ -21,6 +21,8 @@ from models import (
     Classroom,
     ClassroomStudent,
     StudentItemProgress,
+    GroupBuyTeam,
+    GroupBuyMember,
 )
 from services.email_service import email_service
 from services.tappay_service import TapPayService
@@ -141,6 +143,20 @@ async def monthly_renewal_cron(
         f"Found {len(teachers_with_auto_renew)} teachers with auto_renew enabled"
     )
 
+    # issue #862 §4.8 P1 雙保險：跳過「active 團購成員」的個人 auto_renew 扣款。
+    # 團購成員點數來自團隊年費、個人訂閱入團時已 paused；這裡在扣款前再攔一次，
+    # 即使某次 pause 漏關 auto_renew，也不會對團購成員重複收費（防 P1）。
+    active_gb_member_ids = {
+        row[0]
+        for row in db.query(GroupBuyMember.teacher_id)
+        .join(GroupBuyTeam, GroupBuyTeam.id == GroupBuyMember.team_id)
+        .filter(
+            GroupBuyMember.is_active.is_(True),
+            GroupBuyTeam.is_active.is_(True),
+        )
+        .all()
+    }
+
     results = {
         "status": "completed",
         "date": today_taipei.isoformat(),
@@ -174,6 +190,15 @@ async def monthly_renewal_cron(
 
     for teacher in teachers_with_auto_renew:
         try:
+            # issue #862 §4.8 P1：active 團購成員不對其個人訂閱扣款（雙保險）。
+            if teacher.id in active_gb_member_ids:
+                logger.info(
+                    f"Teacher {teacher.email} is an active group-buy member; "
+                    "skipping individual auto-renew charge"
+                )
+                results["skipped"] += 1
+                continue
+
             # 💳 檢查是否有儲存的信用卡 Token
             if not teacher.card_key or not teacher.card_token:
                 logger.info(

--- a/backend/routers/schools.py
+++ b/backend/routers/schools.py
@@ -26,7 +26,10 @@ from models import (
 )
 from auth import verify_token
 from services.casbin_service import get_casbin_service
-from services.group_buy import resume_member_on_group_buy_unbind
+from services.group_buy import (
+    pause_member_on_group_buy_bind,
+    resume_member_on_group_buy_unbind,
+)
 
 
 router = APIRouter(prefix="/api/schools", tags=["schools"])
@@ -684,6 +687,13 @@ async def add_teacher_to_school(
         )
         db.add(teacher_school)
 
+    # issue #862 §4.8 #1：把老師加進/重新啟用到團購 school（非 open/admin 流程）時，
+    # 對稱地立即暫停其個人訂閱、關 auto_renew（非團購 / 無個人訂閱為 no-op），
+    # 補上 P1 雙保險在通用 join 端點的缺口。
+    pause_member_on_group_buy_bind(
+        request.teacher_id, school_id, db, now=datetime.now(timezone.utc)
+    )
+
     db.commit()
     db.refresh(teacher_school)
 
@@ -761,10 +771,15 @@ async def update_teacher_school_roles(
     # Update is_active if provided
     if request.is_active is not None:
         teacher_school.is_active = request.is_active
-    # issue #862 §4.8 A：把團購成員從團購 school 停用（退團）時，立即恢復其暫停的
-    # 個人訂閱殘值（非團購 school / 非 paused 為 no-op）。
-    if teacher_school.is_active is False:
+    # issue #862 §4.8：對團購 school 的成員綁定啟停做對稱的 pause/resume（非團購
+    # school / 非 paused / 無個人訂閱為 no-op）。停用→退團→恢復殘值；重新啟用→
+    # 入團→暫停個人訂閱（補 P1 雙保險在通用 join 端點的缺口）。
+    if request.is_active is False:
         resume_member_on_group_buy_unbind(
+            teacher_id, school_id, db, now=datetime.now(timezone.utc)
+        )
+    elif request.is_active is True:
+        pause_member_on_group_buy_bind(
             teacher_id, school_id, db, now=datetime.now(timezone.utc)
         )
     db.commit()

--- a/backend/routers/schools.py
+++ b/backend/routers/schools.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import func, or_
 from pydantic import BaseModel, Field
 from typing import List, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 import uuid
 
 from database import get_db
@@ -26,6 +26,7 @@ from models import (
 )
 from auth import verify_token
 from services.casbin_service import get_casbin_service
+from services.group_buy import resume_member_on_group_buy_unbind
 
 
 router = APIRouter(prefix="/api/schools", tags=["schools"])
@@ -760,6 +761,12 @@ async def update_teacher_school_roles(
     # Update is_active if provided
     if request.is_active is not None:
         teacher_school.is_active = request.is_active
+    # issue #862 §4.8 A：把團購成員從團購 school 停用（退團）時，立即恢復其暫停的
+    # 個人訂閱殘值（非團購 school / 非 paused 為 no-op）。
+    if teacher_school.is_active is False:
+        resume_member_on_group_buy_unbind(
+            teacher_id, school_id, db, now=datetime.now(timezone.utc)
+        )
     db.commit()
     db.refresh(teacher_school)
 
@@ -811,6 +818,10 @@ async def remove_teacher_from_school(
 
     # Soft delete
     teacher_school.is_active = False
+    # issue #862 §4.8 A：退團即恢復暫停的個人訂閱殘值（非團購 / 非 paused 為 no-op）。
+    resume_member_on_group_buy_unbind(
+        teacher_id, school_id, db, now=datetime.now(timezone.utc)
+    )
     db.commit()
 
     # Sync Casbin roles for this teacher (will remove inactive roles)

--- a/backend/services/group_buy.py
+++ b/backend/services/group_buy.py
@@ -693,11 +693,25 @@ def resume_individual_for_member(
         p.start_date = now
         p.end_date = now + timedelta(seconds=member.paused_remaining_seconds or 0)
         p.status = "active"  # quota_used untouched → points residual preserved
-        if member.individual_auto_renew_suspended:
-            teacher = db.query(Teacher).filter(Teacher.id == member.teacher_id).first()
-            if teacher is not None:
-                teacher.subscription_auto_renew = True
         resumed = True
+    elif member.individual_auto_renew_suspended:
+        # Period gone / already-resumed elsewhere: residual is unrecoverable, but
+        # we must NOT leave the teacher permanently opted out of auto-renew. Flag
+        # for ops since the bookkeeping recording this is wiped just below.
+        logger.warning(
+            "group-buy resume: paused period %s for member %s missing or no "
+            "longer paused; restoring auto_renew, residual unrecoverable",
+            member.paused_period_id,
+            member.id,
+        )
+
+    # Restore auto_renew whenever WE suspended it — independent of whether the
+    # period could be resumed — so a lost/expired paused period can't strand the
+    # teacher with subscription_auto_renew=False forever.
+    if member.individual_auto_renew_suspended:
+        teacher = db.query(Teacher).filter(Teacher.id == member.teacher_id).first()
+        if teacher is not None:
+            teacher.subscription_auto_renew = True
 
     # Clear bookkeeping regardless, so a later trigger is a clean no-op.
     member.paused_period_id = None
@@ -780,6 +794,64 @@ def resume_member_on_group_buy_unbind(
     if member is None:
         return False
     return resume_individual_for_member(member, db, now=now)
+
+
+def pause_member_on_group_buy_bind(
+    teacher_id: int, school_id, db: Session, *, now: datetime
+) -> bool:
+    """Immediate pause trigger symmetric to ``resume_member_on_group_buy_unbind``
+    (§4.8 #1): when a teacher is added to / reactivated in a group-buy school via
+    the generic schools.py endpoints (which aren't group-buy-aware and skip the
+    payment/admin join flow), mirror the org so the GroupBuyMember row exists,
+    then pause that teacher's individual subscription right away. Closes the P1
+    double-charge gap on the non-payment join paths — otherwise the teacher keeps
+    auto-renewing their individual sub in parallel with the group-buy grant, and
+    the cron Phase-2 guard wouldn't even see them until the next monthly heal.
+
+    No-op for non-group-buy schools / teachers without an active individual sub.
+    Does NOT commit. Returns True if a pause was applied.
+    """
+    school = db.query(School).filter(School.id == school_id).first()
+    if school is None:
+        return False
+    org = (
+        db.query(Organization)
+        .filter(
+            Organization.id == school.organization_id,
+            Organization.org_type == "group_buy",
+        )
+        .first()
+    )
+    if org is None:
+        return False
+    # Ensure the just-added/reactivated TeacherSchool is visible, then mirror so
+    # the GroupBuyMember row exists (autoflush is off in this project).
+    db.flush()
+    mirror_group_buy_dual_write(org, db)
+    team = (
+        db.query(GroupBuyTeam)
+        .filter(
+            GroupBuyTeam.source_organization_id == org.id,
+            GroupBuyTeam.is_active.is_(True),
+        )
+        .first()
+    )
+    if team is None:
+        return False
+    member = (
+        db.query(GroupBuyMember)
+        .filter(
+            GroupBuyMember.team_id == team.id,
+            GroupBuyMember.teacher_id == teacher_id,
+        )
+        .first()
+    )
+    if member is None:
+        return False
+    teacher = db.query(Teacher).filter(Teacher.id == teacher_id).first()
+    if teacher is None:
+        return False
+    return pause_individual_for_member(teacher, member, db, now=now)
 
 
 def resume_ended_paused_memberships(db: Session, *, now: datetime) -> int:

--- a/backend/services/group_buy.py
+++ b/backend/services/group_buy.py
@@ -353,6 +353,11 @@ def grant_monthly_for_group_buy(today: datetime, db: Session) -> dict:
     # commit 前執行，heal 與發點同一交易原子提交）。
     resync_all_group_buy_teams(db)
 
+    # issue #862 §4.8 B：heal 之後（停用的 org/school 已把 team 翻 inactive）掃描
+    # 「會籍/團隊已結束但個人訂閱仍 paused」的成員 → 恢復殘值。涵蓋團購到期
+    # （subscription_end < now）、退團漏勾即時 hook、團隊/成員被停用。防 P2 吞權益。
+    resume_ended_paused_memberships(db, now=today_local)
+
     # 資格改讀新表 group_buy_members → group_buy_teams（取代舊 TeacherSchool→
     # School→Org join）。條件對齊舊語意：成員 active、team active 且訂閱未過期、
     # 方案 active 且為團購方案、老師 active。
@@ -609,3 +614,200 @@ def resync_all_group_buy_teams(db: Session) -> int:
                 "group-buy re-sync heal failed for org=%s: %s", org.id, sync_err
             )
     return synced
+
+
+# ---------- §4.8 pause + extend (residual preservation) ----------
+
+
+def pause_individual_for_member(
+    teacher: Teacher, member: GroupBuyMember, db: Session, *, now: datetime
+) -> bool:
+    """On group-buy join, pause the teacher's active INDIVIDUAL subscription and
+    record the frozen residual on the group_buy_member (issue #862 §4.8).
+
+    Freezes remaining time (`paused_remaining_seconds`) and the paused period id;
+    the period's `quota_used` is left untouched so unused points are preserved.
+    Flips the individual period `status='paused'` (drops it out of `current_period`
+    selection and out of cron Phase-1 expiry) and — critically — turns OFF
+    `subscription_auto_renew` so the monthly renewal cron can't re-charge and
+    create a fresh active individual period that would shadow the group-buy points.
+
+    Idempotent: no-op if the member is already paused. No-op (returns False) if the
+    teacher has no active, not-yet-expired individual period. Does NOT commit.
+    Returns True if a pause was applied.
+    """
+    if member.paused_period_id is not None:
+        return False  # already paused for this membership
+    ind = (
+        db.query(SubscriptionPeriod)
+        .filter(
+            SubscriptionPeriod.teacher_id == teacher.id,
+            SubscriptionPeriod.status == "active",
+            SubscriptionPeriod.payment_method != "group_buy",
+        )
+        .order_by(SubscriptionPeriod.start_date.desc())
+        .first()
+    )
+    if ind is None:
+        return False
+    end = _as_utc(ind.end_date)
+    now_utc = _as_utc(now)
+    if end <= now_utc:
+        return False  # already expired → nothing to preserve; treat as pure member
+
+    member.paused_period_id = ind.id
+    member.paused_remaining_seconds = int((end - now_utc).total_seconds())
+    member.paused_at = now
+    ind.status = "paused"
+    if teacher.subscription_auto_renew:
+        teacher.subscription_auto_renew = False
+        member.individual_auto_renew_suspended = True
+    db.flush()
+    return True
+
+
+def resume_individual_for_member(
+    member: GroupBuyMember, db: Session, *, now: datetime
+) -> bool:
+    """On leave / team-end, restore the paused individual subscription's residual
+    (issue #862 §4.8): shift the frozen period to start at `now` and run for the
+    frozen remaining seconds, with `quota_used` unchanged (unused points carry).
+    Re-enables `subscription_auto_renew` if it was suspended for this membership,
+    so the existing monthly cron takes over once the residual runs out.
+
+    Idempotent: no-op if the member isn't paused, or if the referenced period is
+    no longer `paused` (already resumed elsewhere). Always clears the member's
+    pause bookkeeping so a second trigger can't double-resume. Does NOT commit.
+    Returns True if a period was resumed.
+    """
+    if member.paused_period_id is None:
+        return False
+
+    resumed = False
+    p = (
+        db.query(SubscriptionPeriod)
+        .filter(SubscriptionPeriod.id == member.paused_period_id)
+        .first()
+    )
+    if p is not None and p.status == "paused":
+        p.start_date = now
+        p.end_date = now + timedelta(seconds=member.paused_remaining_seconds or 0)
+        p.status = "active"  # quota_used untouched → points residual preserved
+        if member.individual_auto_renew_suspended:
+            teacher = db.query(Teacher).filter(Teacher.id == member.teacher_id).first()
+            if teacher is not None:
+                teacher.subscription_auto_renew = True
+        resumed = True
+
+    # Clear bookkeeping regardless, so a later trigger is a clean no-op.
+    member.paused_period_id = None
+    member.paused_remaining_seconds = None
+    member.individual_auto_renew_suspended = False
+    member.paused_at = None
+    db.flush()
+    return resumed
+
+
+# ---------- §4.8 orchestration (join / leave / team-end / reconcile) ----------
+
+
+def pause_joining_teachers_for_org(
+    org: Organization, teachers: list, db: Session, *, now: datetime
+) -> int:
+    """After a group-buy open / add-member writes the old tables and the mirror
+    has created the group_buy_members rows, pause each joining teacher's active
+    individual subscription (issue #862 §4.8). Idempotent per member. Returns the
+    number actually paused. Does NOT commit.
+    """
+    team = (
+        db.query(GroupBuyTeam)
+        .filter(
+            GroupBuyTeam.source_organization_id == org.id,
+            GroupBuyTeam.is_active.is_(True),
+        )
+        .first()
+    )
+    if team is None:
+        return 0
+    paused = 0
+    for teacher in teachers:
+        member = (
+            db.query(GroupBuyMember)
+            .filter(
+                GroupBuyMember.team_id == team.id,
+                GroupBuyMember.teacher_id == teacher.id,
+            )
+            .first()
+        )
+        if member is not None and pause_individual_for_member(
+            teacher, member, db, now=now
+        ):
+            paused += 1
+    return paused
+
+
+def resume_member_on_group_buy_unbind(
+    teacher_id: int, school_id, db: Session, *, now: datetime
+) -> bool:
+    """Immediate resume trigger (§4.8 A): when a TeacherSchool under a group-buy
+    school is deactivated via the generic schools.py endpoints (which aren't
+    group-buy-aware), restore that member's paused individual subscription right
+    away instead of waiting for the monthly reconcile. No-op for non-group-buy
+    schools or non-paused members. Does NOT commit. Returns True if resumed.
+    """
+    school = db.query(School).filter(School.id == school_id).first()
+    if school is None:
+        return False
+    org = (
+        db.query(Organization)
+        .filter(
+            Organization.id == school.organization_id,
+            Organization.org_type == "group_buy",
+        )
+        .first()
+    )
+    if org is None:
+        return False
+    member = (
+        db.query(GroupBuyMember)
+        .join(GroupBuyTeam, GroupBuyTeam.id == GroupBuyMember.team_id)
+        .filter(
+            GroupBuyTeam.source_organization_id == org.id,
+            GroupBuyMember.teacher_id == teacher_id,
+        )
+        .first()
+    )
+    if member is None:
+        return False
+    return resume_individual_for_member(member, db, now=now)
+
+
+def resume_ended_paused_memberships(db: Session, *, now: datetime) -> int:
+    """Backstop resume sweep (§4.8 B + team-end): resume every still-paused member
+    whose group-buy benefit has ended — membership deactivated, team deactivated,
+    or team subscription window elapsed (發起人 didn't renew). Catches any leave
+    path that skipped the immediate hook, and the team-expiry case. Idempotent
+    (resume clears bookkeeping). Returns count resumed. Does NOT commit.
+
+    Run inside the monthly cron (after the re-sync heal, which flips teams of
+    deactivated orgs/schools to inactive so they get swept here too).
+    """
+    now_utc = _as_utc(now)
+    rows = (
+        db.query(GroupBuyMember)
+        .join(GroupBuyTeam, GroupBuyTeam.id == GroupBuyMember.team_id)
+        .filter(
+            GroupBuyMember.paused_period_id.isnot(None),
+            (
+                (GroupBuyMember.is_active.is_(False))
+                | (GroupBuyTeam.is_active.is_(False))
+                | (GroupBuyTeam.subscription_end < now_utc)
+            ),
+        )
+        .all()
+    )
+    resumed = 0
+    for member in rows:
+        if resume_individual_for_member(member, db, now=now):
+            resumed += 1
+    return resumed

--- a/backend/tests/test_admin_subscriptions_group_buy_branch.py
+++ b/backend/tests/test_admin_subscriptions_group_buy_branch.py
@@ -6,7 +6,7 @@ without going through TapPay. Covers validation, seat / duplicate
 checks, and the happy path.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -312,6 +312,80 @@ def test_admin_join_survives_mirror_failure(
         .count()
         >= 1
     )
+
+
+def _indiv_sub(db, teacher, *, days_left=120):
+    teacher.subscription_auto_renew = True
+    p = SubscriptionPeriod(
+        teacher_id=teacher.id,
+        plan_name="Tutor Teachers",
+        amount_paid=299,
+        quota_total=2000,
+        quota_used=100,
+        start_date=datetime.now(timezone.utc) - timedelta(days=3),
+        end_date=datetime.now(timezone.utc) + timedelta(days=days_left),
+        payment_method="manual",
+        payment_status="paid",
+        status="active",
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+def test_admin_join_pauses_target_existing_individual_sub(
+    test_client, admin, owner, target, opened_team, gb_plan_30, shared_test_session
+):
+    """§4.8：admin 加團時，target 既有個人訂閱應被暫停、auto_renew 關（端點級）。"""
+    ind = _indiv_sub(shared_test_session, target)
+
+    r = _post_create(
+        test_client,
+        admin,
+        {
+            "teacher_email": target.email,
+            "plan_name": gb_plan_30.name,
+            "group_owner_email": owner.email,
+            "reason": "join",
+        },
+    )
+    assert r.status_code == 200, r.json()
+    shared_test_session.expire_all()
+    shared_test_session.refresh(ind)
+    assert ind.status == "paused"
+    t2 = shared_test_session.query(Teacher).filter(Teacher.id == target.id).one()
+    assert t2.subscription_auto_renew is False
+
+
+def test_schools_add_teacher_to_group_buy_school_pauses_and_delete_resumes(
+    test_client, owner, target, opened_team, shared_test_session
+):
+    """§4.8 #1：經通用 schools 端點把有個人訂閱的老師加進團購 school → 暫停；
+    再 DELETE 移除 → 恢復殘值。驗證 router wiring（id / commit 順序）。"""
+    org, school = opened_team
+    ind = _indiv_sub(shared_test_session, target, days_left=120)
+
+    # 通用 join 端點（org_owner 有權限）
+    r = test_client.post(
+        f"/api/schools/{school.id}/teachers",
+        headers=_bearer(owner.id),
+        json={"teacher_id": target.id, "roles": ["teacher"]},
+    )
+    assert r.status_code in (200, 201), r.json()
+    shared_test_session.expire_all()
+    shared_test_session.refresh(ind)
+    assert ind.status == "paused"
+
+    # 通用 leave 端點 → 恢復
+    r = test_client.delete(
+        f"/api/schools/{school.id}/teachers/{target.id}",
+        headers=_bearer(owner.id),
+    )
+    assert r.status_code in (200, 204), getattr(r, "text", "")
+    shared_test_session.expire_all()
+    shared_test_session.refresh(ind)
+    assert ind.status == "active"
 
 
 # ---------- post-join guards ----------

--- a/backend/tests/test_group_buy_open_endpoint.py
+++ b/backend/tests/test_group_buy_open_endpoint.py
@@ -222,6 +222,52 @@ def test_happy_path_creates_org_school_binding_period(
     assert owner_member.is_active is True
 
 
+def test_open_pauses_leader_existing_individual_subscription(
+    test_client, auth_header, teacher, gb_plan, shared_test_session
+):
+    """issue #862 §4.8：發起人開團前若已有有效個人訂閱，開團後該個人 period 應被
+    暫停（status=paused）且 auto_renew 關掉（防 P1 重複收費）。端點級整合驗證。"""
+    from datetime import datetime, timedelta, timezone
+
+    teacher.subscription_auto_renew = True
+    ind = SubscriptionPeriod(
+        teacher_id=teacher.id,
+        plan_name="Tutor Teachers",
+        amount_paid=299,
+        quota_total=2000,
+        quota_used=300,
+        start_date=datetime.now(timezone.utc) - timedelta(days=5),
+        end_date=datetime.now(timezone.utc) + timedelta(days=90),
+        payment_method="manual",
+        payment_status="paid",
+        status="active",
+    )
+    shared_test_session.add(ind)
+    shared_test_session.commit()
+
+    mock_tappay = Mock()
+    mock_tappay.process_payment.return_value = {
+        "status": 0,
+        "rec_trade_id": "REC-PAUSE",
+        "card_secret": {},
+    }
+    with patch("routers.credit_packages.ENABLE_PAYMENT", True), patch(
+        "routers.credit_packages.TapPayService", return_value=mock_tappay
+    ):
+        r = test_client.post(
+            "/api/credit-packages/group-buy-open",
+            json={"prime": "prime-x", "plan_name": gb_plan.name},
+            headers=auth_header,
+        )
+    assert r.status_code == 200, r.json()
+
+    shared_test_session.expire_all()
+    shared_test_session.refresh(ind)
+    assert ind.status == "paused"  # 個人訂閱被暫停凍結
+    t2 = shared_test_session.query(Teacher).filter(Teacher.id == teacher.id).one()
+    assert t2.subscription_auto_renew is False  # 關掉月扣防 P1
+
+
 def test_open_survives_mirror_failure(
     test_client, auth_header, teacher, gb_plan, shared_test_session, monkeypatch
 ):

--- a/backend/tests/test_group_buy_pause_extend.py
+++ b/backend/tests/test_group_buy_pause_extend.py
@@ -1,0 +1,370 @@
+"""§4.8 暫停 + 延展（殘值保留）service 層測試（issue #862 PR4b）.
+
+覆蓋 pause_individual_for_member / resume_individual_for_member 的：
+  - 有個人訂閱 → 暫停（period status=paused、凍結殘值、關 auto_renew）
+  - 無/已過期個人訂閱 → no-op
+  - 冪等（重複 pause / resume）
+  - resume 殘值保留（時間 + 未用點數）、恢復 auto_renew
+  - pause→resume 往返
+  - paused period 不進 current_period（讀取路徑安全）
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from auth import get_password_hash
+from models import (
+    GroupBuyMember,
+    GroupBuyTeam,
+    Plan,
+    SubscriptionPeriod,
+    Teacher,
+)
+from datetime import timedelta as _td  # noqa: F401 (kept for clarity below)
+
+from models import Organization, School, TeacherOrganization, TeacherSchool
+from services.group_buy import (
+    pause_individual_for_member,
+    pause_joining_teachers_for_org,
+    resume_ended_paused_memberships,
+    resume_individual_for_member,
+    resume_member_on_group_buy_unbind,
+    sync_group_buy_team_from_org,
+)
+
+
+def _teacher(db, email, *, auto_renew=True):
+    t = Teacher(
+        email=email,
+        password_hash=get_password_hash("x"),
+        name=email.split("@")[0],
+        is_active=True,
+        email_verified=True,
+        subscription_auto_renew=auto_renew,
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+def _plan(db):
+    p = Plan(
+        name="團購-30席-pe",
+        price=None,
+        quota=1000,
+        teacher_seats=30,
+        annual_fee=1300,
+        is_active=True,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+def _member(db, plan, teacher):
+    team = GroupBuyTeam(
+        owner_teacher_id=teacher.id, plan_id=plan.id, seat_limit=30, is_active=True
+    )
+    db.add(team)
+    db.flush()
+    m = GroupBuyMember(
+        team_id=team.id, teacher_id=teacher.id, is_owner=False, is_active=True
+    )
+    db.add(m)
+    db.commit()
+    db.refresh(m)
+    return m
+
+
+def _indiv_period(db, teacher, *, days_left=100, quota_used=500):
+    now = datetime.now(timezone.utc)
+    p = SubscriptionPeriod(
+        teacher_id=teacher.id,
+        plan_name="Tutor Teachers",
+        amount_paid=299,
+        quota_total=2000,
+        quota_used=quota_used,
+        start_date=now - timedelta(days=10),
+        end_date=now + timedelta(days=days_left),
+        payment_method="manual",
+        payment_status="paid",
+        status="active",
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+# ---------- pause ----------
+
+
+def test_pause_freezes_period_and_disables_auto_renew(shared_test_session):
+    db = shared_test_session
+    t = _teacher(db, "pe1@d.com", auto_renew=True)
+    plan = _plan(db)
+    m = _member(db, plan, t)
+    ind = _indiv_period(db, t, days_left=100, quota_used=500)
+
+    now = datetime.now(timezone.utc)
+    applied = pause_individual_for_member(t, m, db, now=now)
+    db.commit()
+
+    assert applied is True
+    db.refresh(ind)
+    db.refresh(m)
+    db.refresh(t)
+    assert ind.status == "paused"
+    assert m.paused_period_id == ind.id
+    # ~100 days frozen (allow small delta from setup)
+    assert abs(m.paused_remaining_seconds - 100 * 86400) < 3600
+    assert t.subscription_auto_renew is False
+    assert m.individual_auto_renew_suspended is True
+
+
+def test_pause_noop_without_individual_period(shared_test_session):
+    db = shared_test_session
+    t = _teacher(db, "pe2@d.com")
+    plan = _plan(db)
+    m = _member(db, plan, t)
+
+    assert (
+        pause_individual_for_member(t, m, db, now=datetime.now(timezone.utc)) is False
+    )
+    db.refresh(m)
+    assert m.paused_period_id is None
+
+
+def test_pause_noop_when_period_expired(shared_test_session):
+    db = shared_test_session
+    t = _teacher(db, "pe3@d.com")
+    plan = _plan(db)
+    m = _member(db, plan, t)
+    _indiv_period(db, t, days_left=-1)  # already expired
+
+    assert (
+        pause_individual_for_member(t, m, db, now=datetime.now(timezone.utc)) is False
+    )
+    db.refresh(m)
+    assert m.paused_period_id is None
+
+
+def test_pause_idempotent(shared_test_session):
+    db = shared_test_session
+    t = _teacher(db, "pe4@d.com")
+    plan = _plan(db)
+    m = _member(db, plan, t)
+    _indiv_period(db, t)
+
+    now = datetime.now(timezone.utc)
+    assert pause_individual_for_member(t, m, db, now=now) is True
+    db.commit()
+    # second call → already paused → no-op
+    assert pause_individual_for_member(t, m, db, now=now) is False
+
+
+def test_pause_keeps_auto_renew_flag_when_already_off(shared_test_session):
+    db = shared_test_session
+    t = _teacher(db, "pe5@d.com", auto_renew=False)
+    plan = _plan(db)
+    m = _member(db, plan, t)
+    _indiv_period(db, t)
+
+    assert pause_individual_for_member(t, m, db, now=datetime.now(timezone.utc)) is True
+    db.refresh(m)
+    # auto_renew was already off → we did NOT suspend it (so resume won't wrongly
+    # turn it on)
+    assert m.individual_auto_renew_suspended is False
+
+
+# ---------- resume ----------
+
+
+def test_resume_restores_residual_and_auto_renew(shared_test_session):
+    db = shared_test_session
+    t = _teacher(db, "pe6@d.com", auto_renew=True)
+    plan = _plan(db)
+    m = _member(db, plan, t)
+    ind = _indiv_period(db, t, days_left=100, quota_used=500)
+
+    pause_at = datetime.now(timezone.utc)
+    pause_individual_for_member(t, m, db, now=pause_at)
+    db.commit()
+    frozen = m.paused_remaining_seconds
+
+    resume_at = pause_at + timedelta(days=200)  # 提早退團/團購結束
+    resumed = resume_individual_for_member(m, db, now=resume_at)
+    db.commit()
+
+    assert resumed is True
+    db.refresh(ind)
+    db.refresh(m)
+    db.refresh(t)
+    assert ind.status == "active"
+    # 殘值時間平移到 resume 之後
+    assert abs((_naive(ind.end_date) - _naive(resume_at)).total_seconds() - frozen) < 5
+    assert ind.quota_used == 500  # 未用點數殘值保留
+    assert t.subscription_auto_renew is True  # 恢復月扣
+    # 清掉 bookkeeping
+    assert m.paused_period_id is None
+    assert m.individual_auto_renew_suspended is False
+
+
+def test_resume_noop_when_not_paused(shared_test_session):
+    db = shared_test_session
+    t = _teacher(db, "pe7@d.com")
+    plan = _plan(db)
+    m = _member(db, plan, t)
+    assert resume_individual_for_member(m, db, now=datetime.now(timezone.utc)) is False
+
+
+def test_resume_idempotent(shared_test_session):
+    db = shared_test_session
+    t = _teacher(db, "pe8@d.com")
+    plan = _plan(db)
+    m = _member(db, plan, t)
+    _indiv_period(db, t)
+    pause_individual_for_member(t, m, db, now=datetime.now(timezone.utc))
+    db.commit()
+
+    assert resume_individual_for_member(m, db, now=datetime.now(timezone.utc)) is True
+    db.commit()
+    # second resume → already cleared → no-op
+    assert resume_individual_for_member(m, db, now=datetime.now(timezone.utc)) is False
+
+
+def test_paused_period_not_selected_as_current(shared_test_session):
+    """讀取路徑安全：paused 個人 period 不進 current_period。"""
+    db = shared_test_session
+    t = _teacher(db, "pe9@d.com")
+    plan = _plan(db)
+    m = _member(db, plan, t)
+    _indiv_period(db, t)
+    assert t.current_period is not None  # active 時是 current
+    pause_individual_for_member(t, m, db, now=datetime.now(timezone.utc))
+    db.commit()
+    db.refresh(t)
+    assert t.current_period is None  # paused 後不再被選為 current
+
+
+def _naive(dt):
+    return dt.replace(tzinfo=None) if dt and dt.tzinfo else dt
+
+
+# ---------- orchestration (join-pause / unbind-resume / ended-sweep) ----------
+
+
+def _full_group_buy(db, owner, plan, *, end_in_days=365):
+    """Build a real group_buy org+school+owner-binding and sync it into new
+    tables. Returns (org, school, team)."""
+    now = datetime.now(timezone.utc)
+    org = Organization(
+        name="gb-orch",
+        org_type="group_buy",
+        teacher_limit=30,
+        is_active=True,
+        subscription_start_date=now,
+        subscription_end_date=now + timedelta(days=end_in_days),
+    )
+    db.add(org)
+    db.flush()
+    school = School(
+        organization_id=org.id,
+        name="S",
+        plan_id=plan.id,
+        teacher_seat_limit=30,
+        is_active=True,
+    )
+    db.add(school)
+    db.flush()
+    db.add(
+        TeacherOrganization(
+            teacher_id=owner.id,
+            organization_id=org.id,
+            role="org_owner",
+            is_active=True,
+        )
+    )
+    db.add(
+        TeacherSchool(
+            teacher_id=owner.id,
+            school_id=school.id,
+            roles=["school_admin"],
+            is_active=True,
+        )
+    )
+    db.flush()
+    team = sync_group_buy_team_from_org(org, db)
+    db.commit()
+    return org, school, team
+
+
+def test_pause_joining_teachers_for_org(shared_test_session):
+    db = shared_test_session
+    owner = _teacher(db, "orch_owner@d.com", auto_renew=True)
+    plan = _plan(db)
+    org, school, team = _full_group_buy(db, owner, plan)
+    ind = _indiv_period(db, owner, days_left=80)
+
+    n = pause_joining_teachers_for_org(org, [owner], db, now=datetime.now(timezone.utc))
+    db.commit()
+    assert n == 1
+    db.refresh(ind)
+    assert ind.status == "paused"
+
+
+def test_resume_on_group_buy_unbind(shared_test_session):
+    db = shared_test_session
+    owner = _teacher(db, "orch_unbind@d.com")
+    plan = _plan(db)
+    org, school, team = _full_group_buy(db, owner, plan)
+    ind = _indiv_period(db, owner, days_left=80)
+    pause_joining_teachers_for_org(org, [owner], db, now=datetime.now(timezone.utc))
+    db.commit()
+
+    ok = resume_member_on_group_buy_unbind(
+        owner.id, school.id, db, now=datetime.now(timezone.utc)
+    )
+    db.commit()
+    assert ok is True
+    db.refresh(ind)
+    assert ind.status == "active"
+
+
+def test_resume_ended_sweep_by_team_expiry(shared_test_session):
+    """team subscription_end 過期 → sweep 恢復 paused 成員。"""
+    db = shared_test_session
+    owner = _teacher(db, "orch_end@d.com")
+    plan = _plan(db)
+    org, school, team = _full_group_buy(db, owner, plan, end_in_days=365)
+    ind = _indiv_period(db, owner, days_left=80)
+    pause_joining_teachers_for_org(org, [owner], db, now=datetime.now(timezone.utc))
+    db.commit()
+
+    # 團購年度已過（把 team.subscription_end 移到過去）
+    team.subscription_end = datetime.now(timezone.utc) - timedelta(days=1)
+    db.commit()
+
+    n = resume_ended_paused_memberships(db, now=datetime.now(timezone.utc))
+    db.commit()
+    assert n == 1
+    db.refresh(ind)
+    assert ind.status == "active"
+
+
+def test_resume_ended_sweep_skips_still_active_membership(shared_test_session):
+    """會籍仍有效（team active、未過期）→ sweep 不動 paused 成員。"""
+    db = shared_test_session
+    owner = _teacher(db, "orch_active@d.com")
+    plan = _plan(db)
+    org, school, team = _full_group_buy(db, owner, plan, end_in_days=365)
+    ind = _indiv_period(db, owner, days_left=80)
+    pause_joining_teachers_for_org(org, [owner], db, now=datetime.now(timezone.utc))
+    db.commit()
+
+    n = resume_ended_paused_memberships(db, now=datetime.now(timezone.utc))
+    db.commit()
+    assert n == 0
+    db.refresh(ind)
+    assert ind.status == "paused"

--- a/backend/tests/test_group_buy_pause_extend.py
+++ b/backend/tests/test_group_buy_pause_extend.py
@@ -19,12 +19,11 @@ from models import (
     SubscriptionPeriod,
     Teacher,
 )
-from datetime import timedelta as _td  # noqa: F401 (kept for clarity below)
-
 from models import Organization, School, TeacherOrganization, TeacherSchool
 from services.group_buy import (
     pause_individual_for_member,
     pause_joining_teachers_for_org,
+    pause_member_on_group_buy_bind,
     resume_ended_paused_memberships,
     resume_individual_for_member,
     resume_member_on_group_buy_unbind,
@@ -351,6 +350,62 @@ def test_resume_ended_sweep_by_team_expiry(shared_test_session):
     assert n == 1
     db.refresh(ind)
     assert ind.status == "active"
+
+
+def test_pause_member_on_group_buy_bind(shared_test_session):
+    """#1：老師經通用 join 端點被加進團購 school（非 open/admin）→ bind helper 應
+    mirror 出 member 列並暫停其個人訂閱。"""
+    db = shared_test_session
+    owner = _teacher(db, "bind_owner@d.com")
+    joiner = _teacher(db, "bind_joiner@d.com", auto_renew=True)
+    plan = _plan(db)
+    org, school, team = _full_group_buy(db, owner, plan)
+    ind = _indiv_period(db, joiner, days_left=90)
+    db.add(
+        TeacherSchool(
+            teacher_id=joiner.id, school_id=school.id, roles=["teacher"], is_active=True
+        )
+    )
+    db.commit()
+
+    ok = pause_member_on_group_buy_bind(
+        joiner.id, school.id, db, now=datetime.now(timezone.utc)
+    )
+    db.commit()
+    assert ok is True
+    db.refresh(ind)
+    assert ind.status == "paused"
+    joiner_db = _reload(db, joiner.id)
+    assert joiner_db.subscription_auto_renew is False
+
+
+def test_resume_restores_auto_renew_even_if_period_gone(shared_test_session):
+    """#2：paused period 不見了（p None），resume 仍要恢復 auto_renew、不可讓老師
+    永久卡在不續約。"""
+    db = shared_test_session
+    t = _teacher(db, "strand@d.com", auto_renew=True)
+    plan = _plan(db)
+    m = _member(db, plan, t)
+    ind = _indiv_period(db, t)
+    pause_individual_for_member(t, m, db, now=datetime.now(timezone.utc))
+    db.commit()
+    db.refresh(t)
+    assert t.subscription_auto_renew is False  # pause 關掉了
+
+    db.delete(ind)  # 模擬 period 消失
+    db.commit()
+
+    resumed = resume_individual_for_member(m, db, now=datetime.now(timezone.utc))
+    db.commit()
+    assert resumed is False  # period 沒了 → 沒 resume
+    db.refresh(t)
+    db.refresh(m)
+    assert t.subscription_auto_renew is True  # 但 auto_renew 已恢復（不卡死）
+    assert m.individual_auto_renew_suspended is False
+
+
+def _reload(db, teacher_id):
+    return db.query(Teacher).filter(Teacher.id == teacher_id).first()
 
 
 def test_resume_ended_sweep_skips_still_active_membership(shared_test_session):


### PR DESCRIPTION
## 方案 B — PR4b（§4.8，最敏感一塊：動個人訂閱/退款/發點）

Related to #862（PR1 #966 / PR2 #968 / PR3 #970 / PR4a #971 已 merge）

> **線上風險**：prod 現 **0 個團購 org**、新表 prod 尚未存在，§4.8 只在「個人訂閱者加入團購」情境啟動 → 對現有線上使用者實際影響 **0**。**無 schema 變更**（pause 欄位 PR1 已建、`status='paused'` 是純 String）。

### pause / resume 核心（`services/group_buy.py`，冪等、不 commit）
- `pause_individual_for_member`：入團凍結個人 period 剩餘時間+未用點數、`status='paused'`、關 `subscription_auto_renew`（防 P1 重複收費）。無/過期個人訂閱 → no-op。
- `resume_individual_for_member`：退團/團購結束平移殘值（`start=now`, `end=now+殘值`，`quota_used` 不動 → 點數殘值保留）、恢復 auto_renew、清 bookkeeping。冪等。

### 觸發點
| 事件 | 位置 | 行為 |
|------|------|------|
| 入團 | `credit_packages` 開團 / `admin_subscriptions` 加團 | mirror 建好 member 後 pause（主交易內，pause 是 P1 防線非 best-effort） |
| 退團即時（§4.8 A） | `schools.py` update/remove teacher_school | 限 group_buy school → 立即 resume（非團購/非 paused no-op） |
| 團購結束/漏勾（§4.8 B） | cron `grant_monthly_for_group_buy` | `resume_ended_paused_memberships` 掃 team 到期/停用/會籍失效 |
| P1 雙保險 | cron Phase 2 自動續訂 | 跳過 active 團購成員（即使 pause 漏關 auto_renew 也不重複收費） |

### 讀取安全
paused 個人 period 不進 `current_period`、不被 cron Phase 1 標 expired（測試鎖定）。

### 一個要 reviewer 確認的設計取捨
入團 pause 放在**主交易**（非 SAVEPOINT）：pause 是 P1 防重複收費的第一道防線，若失敗應連同退款補償一起（rare、且優於留下雙重收費狀態）；cron Phase 2 guard 為**執行期雙保險**。這是刻意的（vs mirror 的 best-effort）。

### 驗證
本機 **56 passed**（13 個 §4.8 service/orchestration + 既有全綠）、lint clean、2574 collect 無破壞。端點層（open/admin 入團 pause、schools.py resume、cron guard）由 CI Test Backend 驗證。

🤖 Generated with [Claude Code](https://claude.com/claude-code)