### PR TITLE
feat(#862): PR6 — 前端對齊團購新語意（cleanup）

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1925,31 +1925,6 @@ class ApiClient {
     >("/api/credit-packages/group-buy-plans", { method: "GET" });
   }
 
-  // ===== Phase 5-2 (issue #768): group-buy open =====
-  async openGroupBuy(body: {
-    prime: string;
-    plan_name: string;
-    cardholder?: { name?: string; email?: string; phone_number?: string };
-    // issue #768 comment #3 roster flow: leader supplies all member emails
-    // up-front. Length must equal plan.teacher_seats - 1; backend rejects
-    // payment if any is not_registered / not_verified / in_group_buy_team.
-    member_emails?: string[];
-  }) {
-    return this.request<{
-      success: boolean;
-      message: string;
-      transaction_id?: string;
-      organization_id?: string;
-      school_id?: string;
-      subscription_end_date?: string;
-      teacher_seat_limit?: number;
-      members_bound?: number;
-    }>("/api/credit-packages/group-buy-open", {
-      method: "POST",
-      body: JSON.stringify(body),
-    });
-  }
-
   // ===== Phase 5-2 (issue #768 comment #3): roster email validation =====
   async validateTeamEmails(emails: string[], signal?: AbortSignal) {
     return this.request<{
@@ -2082,6 +2057,9 @@ class ApiClient {
     return this.request<{
       status: string;
       plan: string | null;
+      // issue #862：後端由 group_buy_teams/members 推導的方案身分，供前端分流
+      // 顯示（個人 / 團購發起人 / 團購團員）。
+      plan_type?: "individual" | "group_buy_owner" | "group_buy_member";
       days_remaining: number | null;
       is_active: boolean;
       quota_used: number;

--- a/frontend/src/pages/teacher/TeacherSubscription.tsx
+++ b/frontend/src/pages/teacher/TeacherSubscription.tsx
@@ -584,9 +584,11 @@ export default function TeacherSubscription() {
                 existing individual subscribers. Hide for teachers already
                 on a group-buy plan — clicking through would hit R2-F2
                 single-org guard and 409.
-                TODO: replace prefix check with a backend-supplied flag
-                when SubscriptionInfo exposes teacher_seats or org_type. */}
-            {ENABLE_GROUP_BUY && !subscription?.plan?.startsWith("團購") && (
+                issue #862：改用後端 plan_type（group_buy_owner/member）判定，
+                與 plans-tab upsell 一致，取代舊的 plan 名稱前綴檢查。 */}
+            {ENABLE_GROUP_BUY &&
+              subscription?.plan_type !== "group_buy_owner" &&
+              subscription?.plan_type !== "group_buy_member" && (
               <Card className="mb-6 border-blue-200 bg-gradient-to-br from-blue-50 to-white">
                 <CardContent className="py-5">
                   <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">

--- a/frontend/src/pages/teacher/TeacherSubscription.tsx
+++ b/frontend/src/pages/teacher/TeacherSubscription.tsx
@@ -438,6 +438,12 @@ export default function TeacherSubscription() {
     );
   }
 
+  // issue #862：以後端 plan_type 判定是否已在團購方案（發起人或團員），供各處 upsell
+  // 一致隱藏，取代舊的 plan 名稱前綴檢查。
+  const isGroupBuyPlan =
+    subscription?.plan_type === "group_buy_owner" ||
+    subscription?.plan_type === "group_buy_member";
+
   return (
     <>
       <div>
@@ -584,11 +590,9 @@ export default function TeacherSubscription() {
                 existing individual subscribers. Hide for teachers already
                 on a group-buy plan — clicking through would hit R2-F2
                 single-org guard and 409.
-                issue #862：改用後端 plan_type（group_buy_owner/member）判定，
-                與 plans-tab upsell 一致，取代舊的 plan 名稱前綴檢查。 */}
-            {ENABLE_GROUP_BUY &&
-              subscription?.plan_type !== "group_buy_owner" &&
-              subscription?.plan_type !== "group_buy_member" && (
+                issue #862：改用後端 plan_type（isGroupBuyPlan）判定，與 plans-tab
+                upsell 一致，取代舊的 plan 名稱前綴檢查。 */}
+            {ENABLE_GROUP_BUY && !isGroupBuyPlan && (
               <Card className="mb-6 border-blue-200 bg-gradient-to-br from-blue-50 to-white">
                 <CardContent className="py-5">
                   <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">


### PR DESCRIPTION
## 方案 B — PR6（前端對齊，小 cleanup）

Related to #862（PR1–PR5 後端已 merge）

### 探勘結論：核心目標已零改動達成
issue #862 的痛點（團購老師個人模式自管班級/學生）在前端**已 just works**——團購老師拿到空 `organizations` → 走 personal 模式、org 切換器消失、`TeacherClassrooms` 新增/編輯鈕保持啟用。**沒有任何前端還假設團購老師有 org，也沒有前端打 org-owner 端點。**

### 本 PR 變更（cleanup）
- `TeacherSubscription.tsx` 管理 tab 的 group-buy upsell 改用後端 `plan_type`（`group_buy_owner/member`）判定，取代舊的 `plan?.startsWith("團購")` 名稱前綴（移除 TODO），與 plans-tab upsell 一致。
- `api.ts` `getSubscriptionStatus()` 型別補 `plan_type`（stale 契約對齊後端）。
- 移除 `api.ts` 死碼 `openGroupBuy()`（實際走 TapPay endpoint 字串，grep 確認無 caller）。

### 決策（已與 owner 確認）
- `group_buy_owner` 訂閱頁**維持靜態文字**（續約/加席走開團流程，符合 §4.8「發起人僅付款人」）。
- **獨立 admin 團購視圖留待收斂期**：過渡期團購 org 仍雙寫舊表、admin org 列表仍看得到；等收斂 PR 停舊寫、org 消失時再做（或另開 issue）。

### 驗證
frontend `tsc --noEmit` clean。formatting/eslint/build 由 CI 前端檢查驗證。

🤖 Generated with [Claude Code](https://claude.com/claude-code)