### PR TITLE
chore(#947): 移除 OpenAI fallback 程式碼分支，AI 統一走 Vertex AI (PR1)

### DIFF
--- a/backend/routers/cron.py
+++ b/backend/routers/cron.py
@@ -852,7 +852,7 @@ async def recording_error_report_cron(
             "success_count": success_count_24h,
         }
 
-        # 使用 AI 生成摘要（如果有錯誤）- 支援 Vertex AI 或 OpenAI
+        # 使用 Vertex AI (Gemini) 生成摘要（如果有錯誤）
         ai_summary = ""
         if total_errors_24h > 0:
             try:
@@ -885,32 +885,17 @@ async def recording_error_report_cron(
 請用專業但易懂的語言，不要使用 Markdown 格式。
 """
 
-                use_vertex_ai = os.getenv("USE_VERTEX_AI", "false").lower() == "true"
+                # Use Vertex AI (Gemini)
+                from services.vertex_ai import get_vertex_ai_service
 
-                if use_vertex_ai:
-                    # Use Vertex AI (Gemini)
-                    from services.vertex_ai import get_vertex_ai_service
-
-                    vertex_ai = get_vertex_ai_service()
-                    ai_summary = vertex_ai.generate_text_sync(
-                        prompt=prompt,
-                        model_type="flash",
-                        max_tokens=300,
-                        temperature=0.7,
-                        system_instruction="你是 Duotopia 英語學習平台的技術顧問，擅長分析錄音播放錯誤。用繁體中文、專業但易懂的語言回覆，不要使用 Markdown 格式。",
-                    )
-                else:
-                    # Use OpenAI
-                    import openai
-
-                    openai.api_key = os.getenv("OPENAI_API_KEY")
-                    response = openai.chat.completions.create(
-                        model="gpt-4o-mini",
-                        messages=[{"role": "user", "content": prompt}],
-                        max_tokens=300,
-                        temperature=0.7,
-                    )
-                    ai_summary = response.choices[0].message.content.strip()
+                vertex_ai = get_vertex_ai_service()
+                ai_summary = vertex_ai.generate_text_sync(
+                    prompt=prompt,
+                    model_type="flash",
+                    max_tokens=300,
+                    temperature=0.7,
+                    system_instruction="你是 Duotopia 英語學習平台的技術顧問，擅長分析錄音播放錯誤。用繁體中文、專業但易懂的語言回覆，不要使用 Markdown 格式。",
+                )
 
             except Exception as e:
                 logger.warning(f"Failed to generate AI summary: {str(e)}")

--- a/backend/services/billing_analysis_service.py
+++ b/backend/services/billing_analysis_service.py
@@ -1,11 +1,6 @@
-"""GCP Billing AI 分析服務
-
-Supports switching between OpenAI and Vertex AI via USE_VERTEX_AI environment variable.
-"""
-import os
+"""GCP Billing AI 分析服務（Vertex AI / Gemini）"""
 import logging
 from typing import Dict, Any, List
-from openai import AsyncOpenAI
 
 logger = logging.getLogger(__name__)
 
@@ -14,26 +9,12 @@ class BillingAnalysisService:
     """帳單 AI 分析服務"""
 
     def __init__(self):
-        self.use_vertex_ai = os.getenv("USE_VERTEX_AI", "false").lower() == "true"
+        # Use Vertex AI (Gemini)
+        from services.vertex_ai import get_vertex_ai_service
 
-        if self.use_vertex_ai:
-            # Use Vertex AI (Gemini)
-            from services.vertex_ai import get_vertex_ai_service
-
-            self.vertex_ai = get_vertex_ai_service()
-            self.use_ai = True
-            self.client = None
-            logger.info("BillingAnalysisService: Using Vertex AI (Gemini)")
-        else:
-            # Use OpenAI
-            self.openai_api_key = os.getenv("OPENAI_API_KEY")
-            self.use_ai = bool(self.openai_api_key)
-            self.vertex_ai = None
-            if self.use_ai:
-                self.client = AsyncOpenAI(api_key=self.openai_api_key)
-                logger.info("BillingAnalysisService: Using OpenAI")
-            else:
-                self.client = None
+        self.vertex_ai = get_vertex_ai_service()
+        self.use_ai = True
+        logger.info("BillingAnalysisService: Using Vertex AI (Gemini)")
 
     async def analyze_billing_data(
         self,
@@ -234,7 +215,7 @@ class BillingAnalysisService:
         trend: str,
         trend_percent: float,
     ) -> str:
-        """使用 AI (Vertex AI or OpenAI) 生成分析摘要"""
+        """使用 Vertex AI (Gemini) 生成分析摘要"""
         try:
             # 構建 prompt
             prompt = f"""你是一位 GCP 費用分析專家。請根據以下數據生成一份簡潔的分析摘要（2-3 句話）：
@@ -258,29 +239,15 @@ class BillingAnalysisService:
 
             system_instruction = "你是一位專業的 GCP 費用分析專家，擅長用簡潔易懂的語言解釋複雜的帳單數據。"
 
-            # Use Vertex AI or OpenAI based on configuration
-            if self.use_vertex_ai:
-                # Use Gemini Pro for complex analysis (equivalent to gpt-4)
-                summary = await self.vertex_ai.generate_text(
-                    prompt=prompt,
-                    model_type="pro",  # Use pro for complex analysis
-                    max_tokens=300,
-                    temperature=0.7,
-                    system_instruction=system_instruction,
-                )
-                summary = summary.strip()
-            else:
-                # Use OpenAI API
-                response = await self.client.chat.completions.create(
-                    model="gpt-4",
-                    messages=[
-                        {"role": "system", "content": system_instruction},
-                        {"role": "user", "content": prompt},
-                    ],
-                    max_tokens=300,
-                    temperature=0.7,
-                )
-                summary = response.choices[0].message.content.strip()
+            # Use Gemini Pro for complex analysis
+            summary = await self.vertex_ai.generate_text(
+                prompt=prompt,
+                model_type="pro",  # Use pro for complex analysis
+                max_tokens=300,
+                temperature=0.7,
+                system_instruction=system_instruction,
+            )
+            summary = summary.strip()
 
             logger.info("✅ AI summary generated successfully")
             return summary

--- a/backend/services/translation.py
+++ b/backend/services/translation.py
@@ -1,19 +1,13 @@
 """
-Translation service using OpenAI API or Vertex AI (Gemini)
-
-Supports switching between OpenAI and Vertex AI via USE_VERTEX_AI environment variable.
+Translation service using Vertex AI (Gemini)
 """
 
-import os
-import re
 import json as json_module
 import asyncio
 import logging
 from pathlib import Path
 from typing import List, Dict, Optional  # noqa: F401
-from openai import OpenAI, AsyncOpenAI
 from dotenv import load_dotenv
-from utils.http_client import get_http_client
 
 # 載入文法規則（按 CEFR 級別）
 _grammar_rules_path = Path(__file__).parent.parent / "config" / "grammar_by_level.json"
@@ -27,31 +21,15 @@ logger = logging.getLogger(__name__)
 
 class TranslationService:
     def __init__(self):
-        self.use_vertex_ai = os.getenv("USE_VERTEX_AI", "false").lower() == "true"
-        self.client = None  # OpenAI client (lazy init)
         self.vertex_ai = None  # Vertex AI service (lazy init)
-        self.model = "gpt-4o-mini"  # OpenAI model (for fallback)
 
     def _ensure_client(self):
-        """Lazy initialization of AI client (OpenAI or Vertex AI)"""
-        if self.use_vertex_ai:
-            if self.vertex_ai is None:
-                from services.vertex_ai import get_vertex_ai_service
+        """Lazy initialization of Vertex AI (Gemini) client"""
+        if self.vertex_ai is None:
+            from services.vertex_ai import get_vertex_ai_service
 
-                self.vertex_ai = get_vertex_ai_service()
-                logger.info("Using Vertex AI (Gemini) for translation")
-        else:
-            if self.client is None:
-                api_key = os.getenv("OPENAI_API_KEY")
-                if not api_key:
-                    raise ValueError(
-                        "OPENAI_API_KEY not found in environment variables"
-                    )
-                # Use shared http_client for connection pooling
-                self.client = AsyncOpenAI(
-                    api_key=api_key, http_client=get_http_client()
-                )
-                logger.info("Using OpenAI for translation")
+            self.vertex_ai = get_vertex_ai_service()
+            logger.info("Using Vertex AI (Gemini) for translation")
 
     async def translate_text(self, text: str, target_lang: str = "zh-TW") -> str:
         """
@@ -139,28 +117,15 @@ class TranslationService:
             # 英英釋義需要更多 tokens（最多 3 個定義 + 詞性標記）
             token_limit = 200 if target_lang == "en" else 100
 
-            # Use Vertex AI or OpenAI based on configuration
-            if self.use_vertex_ai:
-                result = await self.vertex_ai.generate_text(
-                    prompt=prompt,
-                    model_type="flash",
-                    max_tokens=token_limit,
-                    temperature=0.3,
-                    system_instruction=system_instruction,
-                    disable_thinking=True,
-                )
-                return result.strip()
-            else:
-                response = await self.client.chat.completions.create(
-                    model=self.model,
-                    messages=[
-                        {"role": "system", "content": system_instruction},
-                        {"role": "user", "content": prompt},
-                    ],
-                    temperature=0.3,  # 降低隨機性以獲得更一致的翻譯
-                    max_tokens=token_limit,
-                )
-                return response.choices[0].message.content.strip()
+            result = await self.vertex_ai.generate_text(
+                prompt=prompt,
+                model_type="flash",
+                max_tokens=token_limit,
+                temperature=0.3,
+                system_instruction=system_instruction,
+                disable_thinking=True,
+            )
+            return result.strip()
 
         except Exception as e:
             logger.error("Translation error: %s", e)
@@ -258,81 +223,28 @@ Required: Return format must be ["translation1", "translation2", ...]"""
                 "NOT Simplified Chinese."
             )
 
-            # Use Vertex AI or OpenAI based on configuration
-            if self.use_vertex_ai:
-                translations = await self.vertex_ai.generate_json(
-                    prompt=prompt,
-                    model_type="flash",
-                    max_tokens=3500,
-                    temperature=0.3,
-                    system_instruction=system_instruction,
-                    disable_thinking=True,
-                )
-                # Ensure it's a list
-                if isinstance(translations, str):
-                    translations = translations.split("---")
-            else:
-                response = await self.client.chat.completions.create(
-                    model=self.model,
-                    messages=[
-                        {"role": "system", "content": system_instruction},
-                        {"role": "user", "content": prompt},
-                    ],
-                    temperature=0.3,
-                    max_tokens=3500,  # 提高上限以支持更多句子的批次翻译
-                )
-
-                # 解析 JSON 回應
-                import re
-
-                content = response.choices[0].message.content.strip()
-
-                # 移除可能的 markdown 代碼塊標記
-                content = re.sub(r"^```json\s*", "", content)
-                content = re.sub(r"\s*```$", "", content)
-                content = content.strip()
-
-                # Try JSON parse; handle legacy separator when JSON decode fails
-                try:
-                    translations = json.loads(content)
-                except Exception:
-                    # If not JSON, fall back to separator or raw string
-                    if "---" in content:
-                        translations = [
-                            seg.strip() for seg in content.split("---") if seg.strip()
-                        ]
-                    else:
-                        translations = [content.strip()] if content else []
-                if isinstance(translations, str):
-                    translations = translations.split("---")
+            translations = await self.vertex_ai.generate_json(
+                prompt=prompt,
+                model_type="flash",
+                max_tokens=3500,
+                temperature=0.3,
+                system_instruction=system_instruction,
+                disable_thinking=True,
+            )
+            # Ensure it's a list
+            if isinstance(translations, str):
+                translations = translations.split("---")
 
             # 確保返回的翻譯數量與輸入相同
             if len(translations) != len(texts):
-                # Try manual split on separator if present
-                if isinstance(content, str) and "---" in content:
-                    manual = [
-                        seg.strip() for seg in content.split("---") if seg.strip()
-                    ]
-                    if len(manual) == len(texts):
-                        translations = manual
-                    else:
-                        logger.warning(
-                            "Batch translation count mismatch "
-                            "(expected %d, got %d), "
-                            "falling back to individual translation.",
-                            len(texts),
-                            len(translations),
-                        )
-                        return texts
-                else:
-                    logger.warning(
-                        "Batch translation count mismatch "
-                        "(expected %d, got %d), "
-                        "falling back to individual translation.",
-                        len(texts),
-                        len(translations),
-                    )
-                    return texts
+                logger.warning(
+                    "Batch translation count mismatch "
+                    "(expected %d, got %d), "
+                    "falling back to individual translation.",
+                    len(texts),
+                    len(translations),
+                )
+                return texts
 
             return translations
         except Exception as e:
@@ -447,36 +359,14 @@ Only reply with JSON array, no other text."""
                 "NOT Simplified Chinese. Always respond with valid JSON array only."
             )
 
-            # Use Vertex AI or OpenAI based on configuration
-            if self.use_vertex_ai:
-                results = await self.vertex_ai.generate_json(
-                    prompt=prompt,
-                    model_type="flash",
-                    max_tokens=2000,
-                    temperature=0.2,
-                    system_instruction=system_instruction,
-                    disable_thinking=True,
-                )
-            else:
-                response = await self.client.chat.completions.create(
-                    model=self.model,
-                    messages=[
-                        {"role": "system", "content": system_instruction},
-                        {"role": "user", "content": prompt},
-                    ],
-                    temperature=0.2,  # Lower temperature for more consistent POS detection
-                    max_tokens=2000,
-                )
-
-                # 解析 JSON 回應
-                import re
-
-                content = response.choices[0].message.content.strip()
-                content = re.sub(r"^```json\s*", "", content)
-                content = re.sub(r"\s*```$", "", content)
-                content = content.strip()
-
-                results = json.loads(content)
+            results = await self.vertex_ai.generate_json(
+                prompt=prompt,
+                model_type="flash",
+                max_tokens=2000,
+                temperature=0.2,
+                system_instruction=system_instruction,
+                disable_thinking=True,
+            )
 
             # 確保返回數量正確
             if len(results) != len(texts):
@@ -783,36 +673,14 @@ IMPORTANT: Each English sentence MUST contain the exact target word."""
             # 動態計算 max_tokens：分塊後每批 ≤5 字，最低 1000 tokens
             dynamic_max_tokens = max(1000, len(words) * self.TOKENS_PER_WORD)
 
-            # Use Vertex AI or OpenAI based on configuration
-            if self.use_vertex_ai:
-                sentences = await self.vertex_ai.generate_json(
-                    prompt=user_prompt,
-                    model_type="flash",
-                    max_tokens=dynamic_max_tokens,
-                    temperature=0.7,  # Match GPT temperature for consistent quality
-                    system_instruction=system_prompt,
-                    disable_thinking=True,
-                )
-            else:
-                response = await self.client.chat.completions.create(
-                    model=self.model,
-                    messages=[
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt},
-                    ],
-                    temperature=0.7,  # 稍高一點讓例句更有變化
-                    max_tokens=dynamic_max_tokens,
-                )
-
-                # 解析回應
-                content = response.choices[0].message.content.strip()
-
-                # 移除可能的 markdown 代碼塊標記
-                content = re.sub(r"^```json\s*", "", content)
-                content = re.sub(r"\s*```$", "", content)
-                content = content.strip()
-
-                sentences = json_module.loads(content)
+            sentences = await self.vertex_ai.generate_json(
+                prompt=user_prompt,
+                model_type="flash",
+                max_tokens=dynamic_max_tokens,
+                temperature=0.7,  # Match GPT temperature for consistent quality
+                system_instruction=system_prompt,
+                disable_thinking=True,
+            )
 
             # 確保返回數量正確並添加 word 欄位以防止陣列錯位
             if len(sentences) != len(words):
@@ -949,37 +817,14 @@ JSON 陣列，只包含 {count} 個干擾項：
                 "4) All in Traditional Chinese. JSON array only."
             )
 
-            # Use Vertex AI or OpenAI based on configuration
-            if self.use_vertex_ai:
-                distractors = await self.vertex_ai.generate_json(
-                    prompt=prompt,
-                    model_type="flash",
-                    max_tokens=200,
-                    temperature=0.2,  # Very low temperature to strictly follow prompt rules
-                    system_instruction=system_instruction,
-                    disable_thinking=True,
-                )
-            else:
-                response = await self.client.chat.completions.create(
-                    model=self.model,
-                    messages=[
-                        {"role": "system", "content": system_instruction},
-                        {"role": "user", "content": prompt},
-                    ],
-                    temperature=0.2,  # Very low temperature to strictly follow prompt rules
-                    max_tokens=200,
-                )
-
-                # Parse JSON response
-                import re
-
-                content = response.choices[0].message.content.strip()
-                # Remove markdown code block markers if present
-                content = re.sub(r"^```json\s*", "", content)
-                content = re.sub(r"\s*```$", "", content)
-                content = content.strip()
-
-                distractors = json.loads(content)
+            distractors = await self.vertex_ai.generate_json(
+                prompt=prompt,
+                model_type="flash",
+                max_tokens=200,
+                temperature=0.2,  # Very low temperature to strictly follow prompt rules
+                system_instruction=system_instruction,
+                disable_thinking=True,
+            )
 
             # Filter: remove duplicates (case-insensitive) and correct answer
             seen = {translation.lower().strip()}
@@ -1081,36 +926,14 @@ JSON 陣列，每個元素是一個包含 {count} 個干擾項的陣列。
                 "5) All in Traditional Chinese. JSON array only."
             )
 
-            # Use Vertex AI or OpenAI based on configuration
-            if self.use_vertex_ai:
-                all_distractors = await self.vertex_ai.generate_json(
-                    prompt=prompt,
-                    model_type="flash",
-                    max_tokens=1000,
-                    temperature=0.2,  # Very low temperature to strictly follow prompt rules
-                    system_instruction=system_instruction,
-                    disable_thinking=True,
-                )
-            else:
-                response = await self.client.chat.completions.create(
-                    model=self.model,
-                    messages=[
-                        {"role": "system", "content": system_instruction},
-                        {"role": "user", "content": prompt},
-                    ],
-                    temperature=0.2,  # Very low temperature to strictly follow prompt rules
-                    max_tokens=1000,
-                )
-
-                # Parse JSON response
-                import re
-
-                content = response.choices[0].message.content.strip()
-                content = re.sub(r"^```json\s*", "", content)
-                content = re.sub(r"\s*```$", "", content)
-                content = content.strip()
-
-                all_distractors = json.loads(content)
+            all_distractors = await self.vertex_ai.generate_json(
+                prompt=prompt,
+                model_type="flash",
+                max_tokens=1000,
+                temperature=0.2,  # Very low temperature to strictly follow prompt rules
+                system_instruction=system_instruction,
+                disable_thinking=True,
+            )
 
             # Verify count matches
             if len(all_distractors) != len(words):

--- a/backend/tests/test_sentence_generation_misalignment.py
+++ b/backend/tests/test_sentence_generation_misalignment.py
@@ -6,15 +6,28 @@ This test file validates that the generate_sentences method:
 2. Each sentence object contains the original word field
 3. Handles array misalignment scenarios correctly
 4. Maintains 1:1 correspondence even when AI fails partially
+
+All AI generation now goes through Vertex AI (Gemini), so these tests mock
+``TranslationService.vertex_ai.generate_json`` which returns already-parsed
+Python objects (not raw JSON strings).
 """
 import os
 import sys
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import pytest  # noqa: E402
 from services.translation import TranslationService  # noqa: E402
+
+
+def _make_vertex_service():
+    """Create a TranslationService wired to a mocked Vertex AI client."""
+    service = TranslationService()
+    service.vertex_ai = AsyncMock()
+    # _ensure_client() must not try to (re)initialise the real client
+    service._ensure_client = lambda: None
+    return service
 
 
 @pytest.mark.unit
@@ -24,36 +37,24 @@ class TestSentenceGenerationMisalignment:
     @pytest.fixture
     def service(self):
         """Create test service instance"""
-        return TranslationService()
+        return _make_vertex_service()
 
     @pytest.mark.asyncio
     async def test_generate_sentences_returns_matching_array_length(self, service):
         """Test that generate_sentences returns array matching input word count"""
         words = ["apple", "banana", "cherry", "date", "elderberry"]
 
-        # Mock OpenAI response with correct number of sentences
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[
-            0
-        ].message.content = """[
-            {"sentence": "I eat an apple every day.", "word": "apple"},
-            {"sentence": "The banana is yellow.", "word": "banana"},
-            {"sentence": "I love cherry pie.", "word": "cherry"},
-            {"sentence": "A date is a sweet fruit.", "word": "date"},
-            {"sentence": "Elderberry is good for health.", "word": "elderberry"}
-        ]"""
+        service.vertex_ai.generate_json = AsyncMock(
+            return_value=[
+                {"sentence": "I eat an apple every day.", "word": "apple"},
+                {"sentence": "The banana is yellow.", "word": "banana"},
+                {"sentence": "I love cherry pie.", "word": "cherry"},
+                {"sentence": "A date is a sweet fruit.", "word": "date"},
+                {"sentence": "Elderberry is good for health.", "word": "elderberry"},
+            ]
+        )
 
-        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
-            with patch("services.translation.OpenAI") as mock_openai:
-                mock_client = Mock()
-                mock_client.chat.completions.create = AsyncMock(
-                    return_value=mock_response
-                )
-                mock_openai.return_value = mock_client
-
-                service._ensure_client()
-                results = await service.generate_sentences(words=words, level="A1")
+        results = await service.generate_sentences(words=words, level="A1")
 
         # Verify length matches
         assert len(results) == len(
@@ -72,26 +73,15 @@ class TestSentenceGenerationMisalignment:
         """Test that each sentence object contains the original word field for verification"""
         words = ["like", "change", "run"]
 
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[
-            0
-        ].message.content = """[
-            {"sentence": "I like to read books.", "word": "like"},
-            {"sentence": "Change is inevitable.", "word": "change"},
-            {"sentence": "I run every morning.", "word": "run"}
-        ]"""
+        service.vertex_ai.generate_json = AsyncMock(
+            return_value=[
+                {"sentence": "I like to read books.", "word": "like"},
+                {"sentence": "Change is inevitable.", "word": "change"},
+                {"sentence": "I run every morning.", "word": "run"},
+            ]
+        )
 
-        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
-            with patch("services.translation.OpenAI") as mock_openai:
-                mock_client = Mock()
-                mock_client.chat.completions.create = AsyncMock(
-                    return_value=mock_response
-                )
-                mock_openai.return_value = mock_client
-
-                service._ensure_client()
-                results = await service.generate_sentences(words=words)
+        results = await service.generate_sentences(words=words)
 
         # Each result must have word field matching input
         for i, result in enumerate(results):
@@ -104,27 +94,16 @@ class TestSentenceGenerationMisalignment:
         """Test array misalignment scenario when AI returns fewer sentences than words"""
         words = ["word1", "word2", "word3", "word4", "word5"]
 
-        # Mock OpenAI returning only 3 sentences instead of 5
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[
-            0
-        ].message.content = """[
-            {"sentence": "This is word1 example."},
-            {"sentence": "This is word2 example."},
-            {"sentence": "This is word3 example."}
-        ]"""
+        # AI returns only 3 sentences instead of 5
+        service.vertex_ai.generate_json = AsyncMock(
+            return_value=[
+                {"sentence": "This is word1 example."},
+                {"sentence": "This is word2 example."},
+                {"sentence": "This is word3 example."},
+            ]
+        )
 
-        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
-            with patch("services.translation.OpenAI") as mock_openai:
-                mock_client = Mock()
-                mock_client.chat.completions.create = AsyncMock(
-                    return_value=mock_response
-                )
-                mock_openai.return_value = mock_client
-
-                service._ensure_client()
-                results = await service.generate_sentences(words=words)
+        results = await service.generate_sentences(words=words)
 
         # Must still return 5 results with fallback for missing ones
         assert len(results) == len(
@@ -143,28 +122,17 @@ class TestSentenceGenerationMisalignment:
         """Test when AI returns more sentences than requested"""
         words = ["cat", "dog"]
 
-        # Mock OpenAI returning 4 sentences instead of 2
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[
-            0
-        ].message.content = """[
-            {"sentence": "The cat is sleeping.", "word": "cat"},
-            {"sentence": "The dog is barking.", "word": "dog"},
-            {"sentence": "Extra sentence 1."},
-            {"sentence": "Extra sentence 2."}
-        ]"""
+        # AI returns 4 sentences instead of 2
+        service.vertex_ai.generate_json = AsyncMock(
+            return_value=[
+                {"sentence": "The cat is sleeping.", "word": "cat"},
+                {"sentence": "The dog is barking.", "word": "dog"},
+                {"sentence": "Extra sentence 1."},
+                {"sentence": "Extra sentence 2."},
+            ]
+        )
 
-        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
-            with patch("services.translation.OpenAI") as mock_openai:
-                mock_client = Mock()
-                mock_client.chat.completions.create = AsyncMock(
-                    return_value=mock_response
-                )
-                mock_openai.return_value = mock_client
-
-                service._ensure_client()
-                results = await service.generate_sentences(words=words)
+        results = await service.generate_sentences(words=words)
 
         # Should truncate to match input length
         assert len(results) == len(
@@ -176,17 +144,10 @@ class TestSentenceGenerationMisalignment:
         """Test that fallback mechanism maintains 1:1 word correspondence on error"""
         words = ["test1", "test2", "test3"]
 
-        # Mock exception to trigger fallback
-        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
-            with patch("services.translation.OpenAI") as mock_openai:
-                mock_client = Mock()
-                mock_client.chat.completions.create = AsyncMock(
-                    side_effect=Exception("API Error")
-                )
-                mock_openai.return_value = mock_client
+        # Exception triggers fallback
+        service.vertex_ai.generate_json = AsyncMock(side_effect=Exception("API Error"))
 
-                service._ensure_client()
-                results = await service.generate_sentences(words=words)
+        results = await service.generate_sentences(words=words)
 
         # Fallback should still return correct length
         assert len(results) == len(
@@ -204,27 +165,22 @@ class TestSentenceGenerationMisalignment:
         """Test that translations are preserved with word correspondence"""
         words = ["hello", "world"]
 
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[
-            0
-        ].message.content = """[
-            {"sentence": "Hello everyone!", "translation": "大家好！", "word": "hello"},
-            {"sentence": "The world is beautiful.", "translation": "世界很美麗。", "word": "world"}
-        ]"""
+        service.vertex_ai.generate_json = AsyncMock(
+            return_value=[
+                {
+                    "sentence": "Hello everyone!",
+                    "translation": "大家好！",
+                    "word": "hello",
+                },
+                {
+                    "sentence": "The world is beautiful.",
+                    "translation": "世界很美麗。",
+                    "word": "world",
+                },
+            ]
+        )
 
-        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
-            with patch("services.translation.OpenAI") as mock_openai:
-                mock_client = Mock()
-                mock_client.chat.completions.create = AsyncMock(
-                    return_value=mock_response
-                )
-                mock_openai.return_value = mock_client
-
-                service._ensure_client()
-                results = await service.generate_sentences(
-                    words=words, translate_to="zh-TW"
-                )
+        results = await service.generate_sentences(words=words, translate_to="zh-TW")
 
         assert len(results) == len(words)
         for i, result in enumerate(results):
@@ -236,26 +192,15 @@ class TestSentenceGenerationMisalignment:
         """Test backend adds word field when AI response doesn't include it"""
         words = ["apple", "banana"]
 
-        # Mock AI returning sentences WITHOUT word field
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[
-            0
-        ].message.content = """[
-            {"sentence": "I like apples."},
-            {"sentence": "Bananas are yellow."}
-        ]"""
+        # AI returns sentences WITHOUT word field
+        service.vertex_ai.generate_json = AsyncMock(
+            return_value=[
+                {"sentence": "I like apples."},
+                {"sentence": "Bananas are yellow."},
+            ]
+        )
 
-        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
-            with patch("services.translation.OpenAI") as mock_openai:
-                mock_client = Mock()
-                mock_client.chat.completions.create = AsyncMock(
-                    return_value=mock_response
-                )
-                mock_openai.return_value = mock_client
-
-                service._ensure_client()
-                results = await service.generate_sentences(words=words)
+        results = await service.generate_sentences(words=words)
 
         # Backend should add word field even if AI didn't include it
         assert len(results) == len(words)
@@ -272,10 +217,8 @@ class TestSentenceGenerationChunking:
 
     @pytest.fixture
     def service(self):
-        """Create test service instance with mocked client"""
-        svc = TranslationService()
-        svc.use_vertex_ai = False
-        return svc
+        """Create test service instance with mocked Vertex client"""
+        return _make_vertex_service()
 
     @pytest.mark.asyncio
     async def test_large_batch_is_chunked(self, service):
@@ -284,24 +227,14 @@ class TestSentenceGenerationChunking:
 
         call_count = 0
 
-        async def mock_create(**kwargs):
+        async def mock_generate_json(**kwargs):
             nonlocal call_count
             call_count += 1
-            import json
+            prompt = kwargs.get("prompt", "")
+            chunk_words = [w for w in words if f'"word": "{w}"' in prompt]
+            return [{"sentence": f"Example with {w}.", "word": w} for w in chunk_words]
 
-            prompt_content = kwargs["messages"][1]["content"]
-            chunk_words = [w for w in words if f'"word": "{w}"' in prompt_content]
-            sentences = [
-                {"sentence": f"Example with {w}.", "word": w} for w in chunk_words
-            ]
-            mock_resp = Mock()
-            mock_resp.choices = [Mock()]
-            mock_resp.choices[0].message.content = json.dumps(sentences)
-            return mock_resp
-
-        mock_client = Mock()
-        mock_client.chat.completions.create = AsyncMock(side_effect=mock_create)
-        service.client = mock_client
+        service.vertex_ai.generate_json = AsyncMock(side_effect=mock_generate_json)
 
         results = await service.generate_sentences(words=words, level="A1")
 
@@ -315,24 +248,18 @@ class TestSentenceGenerationChunking:
         """3 words should NOT be chunked (under SENTENCE_CHUNK_SIZE)"""
         words = ["cat", "dog", "bird"]
 
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[
-            0
-        ].message.content = """[
-            {"sentence": "The cat is sleeping.", "word": "cat"},
-            {"sentence": "The dog is barking.", "word": "dog"},
-            {"sentence": "The bird is singing.", "word": "bird"}
-        ]"""
-
-        mock_client = Mock()
-        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
-        service.client = mock_client
+        service.vertex_ai.generate_json = AsyncMock(
+            return_value=[
+                {"sentence": "The cat is sleeping.", "word": "cat"},
+                {"sentence": "The dog is barking.", "word": "dog"},
+                {"sentence": "The bird is singing.", "word": "bird"},
+            ]
+        )
 
         results = await service.generate_sentences(words=words, level="A1")
 
         assert len(results) == 3
-        assert mock_client.chat.completions.create.call_count == 1
+        assert service.vertex_ai.generate_json.call_count == 1
 
     @pytest.mark.asyncio
     async def test_chunk_failure_isolation(self, service):
@@ -341,26 +268,18 @@ class TestSentenceGenerationChunking:
 
         call_number = 0
 
-        async def mock_create(**kwargs):
+        async def mock_generate_json(**kwargs):
             nonlocal call_number
             call_number += 1
             if call_number == 2:
                 raise Exception("API rate limit exceeded")
-            import json
-
-            prompt_content = kwargs["messages"][1]["content"]
-            chunk_words = [w for w in words if f'"word": "{w}"' in prompt_content]
-            sentences = [
+            prompt = kwargs.get("prompt", "")
+            chunk_words = [w for w in words if f'"word": "{w}"' in prompt]
+            return [
                 {"sentence": f"Good sentence for {w}.", "word": w} for w in chunk_words
             ]
-            mock_resp = Mock()
-            mock_resp.choices = [Mock()]
-            mock_resp.choices[0].message.content = json.dumps(sentences)
-            return mock_resp
 
-        mock_client = Mock()
-        mock_client.chat.completions.create = AsyncMock(side_effect=mock_create)
-        service.client = mock_client
+        service.vertex_ai.generate_json = AsyncMock(side_effect=mock_generate_json)
 
         results = await service.generate_sentences(words=words, level="A1")
 
@@ -380,8 +299,7 @@ class TestSentenceGenerationChunking:
     @pytest.mark.asyncio
     async def test_large_batch_chunked_vertex_ai(self):
         """Vertex AI path: 10 words should be chunked into 2 batches"""
-        svc = TranslationService()
-        svc.use_vertex_ai = True
+        svc = _make_vertex_service()
 
         words = [f"word{i}" for i in range(10)]
         call_count = 0
@@ -396,9 +314,7 @@ class TestSentenceGenerationChunking:
                 for w in chunk_words
             ]
 
-        mock_vertex = Mock()
-        mock_vertex.generate_json = AsyncMock(side_effect=mock_generate_json)
-        svc.vertex_ai = mock_vertex
+        svc.vertex_ai.generate_json = AsyncMock(side_effect=mock_generate_json)
 
         results = await svc.generate_sentences(words=words, level="A1")
 
@@ -421,9 +337,7 @@ class TestSentenceTranslationBackfill:
 
     @pytest.fixture
     def service(self):
-        svc = TranslationService()
-        svc.use_vertex_ai = False
-        return svc
+        return _make_vertex_service()
 
     @pytest.mark.asyncio
     async def test_missing_translation_is_backfilled(self, service):
@@ -431,18 +345,16 @@ class TestSentenceTranslationBackfill:
         words = ["grape", "passionfruit"]
 
         # AI response: first sentence has NO translation, second one does.
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[
-            0
-        ].message.content = """[
-            {"sentence": "I ate a grape.", "word": "grape"},
-            {"sentence": "Passionfruit is sweet.", "translation": "百香果很甜。", "word": "passionfruit"}
-        ]"""
-
-        mock_client = Mock()
-        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
-        service.client = mock_client
+        service.vertex_ai.generate_json = AsyncMock(
+            return_value=[
+                {"sentence": "I ate a grape.", "word": "grape"},
+                {
+                    "sentence": "Passionfruit is sweet.",
+                    "translation": "百香果很甜。",
+                    "word": "passionfruit",
+                },
+            ]
+        )
 
         # Mock the fallback single-sentence translator.
         service.translate_text = AsyncMock(return_value="我吃了一顆葡萄。")
@@ -461,17 +373,11 @@ class TestSentenceTranslationBackfill:
         """A present-but-empty translation is also treated as missing."""
         words = ["grape"]
 
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[
-            0
-        ].message.content = """[
-            {"sentence": "I ate a grape.", "translation": "  ", "word": "grape"}
-        ]"""
-
-        mock_client = Mock()
-        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
-        service.client = mock_client
+        service.vertex_ai.generate_json = AsyncMock(
+            return_value=[
+                {"sentence": "I ate a grape.", "translation": "  ", "word": "grape"}
+            ]
+        )
         service.translate_text = AsyncMock(return_value="我吃了一顆葡萄。")
 
         results = await service.generate_sentences(words=words, translate_to="zh-TW")
@@ -484,18 +390,12 @@ class TestSentenceTranslationBackfill:
         """When no translation is requested, no fallback runs and no translation key is added."""
         words = ["grape", "passionfruit"]
 
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[
-            0
-        ].message.content = """[
-            {"sentence": "I ate a grape.", "word": "grape"},
-            {"sentence": "Passionfruit is sweet.", "word": "passionfruit"}
-        ]"""
-
-        mock_client = Mock()
-        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
-        service.client = mock_client
+        service.vertex_ai.generate_json = AsyncMock(
+            return_value=[
+                {"sentence": "I ate a grape.", "word": "grape"},
+                {"sentence": "Passionfruit is sweet.", "word": "passionfruit"},
+            ]
+        )
         service.translate_text = AsyncMock(return_value="should-not-be-used")
 
         results = await service.generate_sentences(words=words, translate_to=None)
@@ -510,17 +410,9 @@ class TestSentenceTranslationBackfill:
         rather than propagating the error."""
         words = ["grape"]
 
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[
-            0
-        ].message.content = """[
-            {"sentence": "I ate a grape.", "word": "grape"}
-        ]"""
-
-        mock_client = Mock()
-        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
-        service.client = mock_client
+        service.vertex_ai.generate_json = AsyncMock(
+            return_value=[{"sentence": "I ate a grape.", "word": "grape"}]
+        )
         service.translate_text = AsyncMock(side_effect=Exception("translate down"))
 
         results = await service.generate_sentences(words=words, translate_to="zh-TW")

--- a/backend/tests/test_vertex_disable_thinking.py
+++ b/backend/tests/test_vertex_disable_thinking.py
@@ -29,7 +29,6 @@ class TestVertexDisableThinking:
     def vertex_service(self):
         """Service forced into Vertex AI mode with a mocked vertex client."""
         service = TranslationService()
-        service.use_vertex_ai = True
         service.vertex_ai = AsyncMock()
         # _ensure_client() must not try to (re)initialise the real client
         service._ensure_client = lambda: None

--- a/backend/tests/unit/test_translation_service.py
+++ b/backend/tests/unit/test_translation_service.py
@@ -1,10 +1,13 @@
 """
-Translation service 單元測試 - 目標覆蓋率 80%
+TranslationService 單元測試（Vertex AI / Gemini 路徑）
+
+Issue #947: OpenAI fallback 已移除，所有 AI 呼叫統一走 Vertex AI。
+這些測試 mock ``TranslationService.vertex_ai`` 的 generate_text / generate_json，
+它們回傳的是已解析的 Python 物件（不是原始 JSON 字串）。
 """
 import os
 import sys
-import asyncio
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
@@ -17,209 +20,139 @@ class TestTranslationService:
 
     @pytest.fixture
     def service(self):
-        """創建測試用 service"""
-        return TranslationService()
-
-    @pytest.fixture
-    def mock_openai_response(self):
-        """Mock OpenAI 回應"""
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[0].message.content = "翻譯結果"
-        return mock_response
+        """創建測試用 service，vertex_ai 以 mock 注入（避免真實初始化）"""
+        svc = TranslationService()
+        svc.vertex_ai = AsyncMock()
+        return svc
 
     def test_init(self):
-        """測試初始化"""
+        """測試初始化：vertex_ai 延遲初始化為 None"""
         service = TranslationService()
-        assert service.client is None
-        assert service.model == "gpt-4o-mini"
+        assert service.vertex_ai is None
 
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    @patch("services.translation.OpenAI")
-    def test_ensure_client_success(self, mock_openai):
-        """測試 client 初始化成功"""
+    def test_ensure_client_initializes_vertex(self):
+        """測試 _ensure_client 會初始化 Vertex AI service（延遲初始化）
+
+        重置 module 級 singleton 並 mock VertexAIService，避免建立真實
+        client 或污染其他測試（test_vertex_ai_service）。
+        """
+        import services.vertex_ai as vertex_module
+
+        vertex_module._vertex_ai_service = None
+        try:
+            with patch.object(vertex_module, "VertexAIService") as MockVertex:
+                service = TranslationService()
+                assert service.vertex_ai is None
+
+                service._ensure_client()
+
+                assert service.vertex_ai is MockVertex.return_value
+                MockVertex.assert_called_once()
+        finally:
+            # 還原 singleton，避免快取到 mock 影響後續測試
+            vertex_module._vertex_ai_service = None
+
+    def test_ensure_client_cached(self):
+        """測試 client 快取機制：已初始化則不重複建立"""
+        import services.vertex_ai as vertex_module
+
         service = TranslationService()
-        service._ensure_client()
+        existing = Mock()
+        service.vertex_ai = existing
 
-        assert service.client is not None
-        mock_openai.assert_called_once_with(api_key="test-key")
-
-    @patch.dict(os.environ, {}, clear=True)
-    def test_ensure_client_no_api_key(self):
-        """測試沒有 API key 時的錯誤"""
-        service = TranslationService()
-
-        with pytest.raises(ValueError, match="OPENAI_API_KEY not found"):
+        with patch.object(vertex_module, "VertexAIService") as MockVertex:
             service._ensure_client()
 
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    @patch("services.translation.OpenAI")
-    def test_ensure_client_cached(self, mock_openai):
-        """測試 client 快取機制"""
-        service = TranslationService()
-        mock_client = Mock()
-        service.client = mock_client
-
-        service._ensure_client()
-
-        # 不應該再次創建 client
-        mock_openai.assert_not_called()
-        assert service.client == mock_client
+        MockVertex.assert_not_called()
+        assert service.vertex_ai is existing
 
     @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    async def test_translate_text_zh_tw(self, service, mock_openai_response):
+    async def test_translate_text_zh_tw(self, service):
         """測試翻譯至繁體中文"""
-        service.client = Mock()
-        service.client.chat.completions.create = Mock(return_value=mock_openai_response)
+        service.vertex_ai.generate_text = AsyncMock(return_value="翻譯結果")
 
         result = await service.translate_text("Hello", "zh-TW")
 
         assert result == "翻譯結果"
-        service.client.chat.completions.create.assert_called_once()
+        service.vertex_ai.generate_text.assert_awaited_once()
 
         # 檢查呼叫參數
-        call_args = service.client.chat.completions.create.call_args
-        assert call_args.kwargs["model"] == "gpt-4o-mini"
-        assert call_args.kwargs["temperature"] == 0.3
-        assert call_args.kwargs["max_tokens"] == 100
-
-        # 檢查 messages
-        messages = call_args.kwargs["messages"]
-        assert len(messages) == 2
-        assert "professional translator" in messages[0]["content"]
-        assert "繁體中文" in messages[1]["content"]
-        assert "Hello" in messages[1]["content"]
+        kwargs = service.vertex_ai.generate_text.call_args.kwargs
+        assert kwargs["model_type"] == "flash"
+        assert kwargs["temperature"] == 0.3
+        assert kwargs["max_tokens"] == 100
+        assert kwargs["disable_thinking"] is True
+        assert "繁體中文" in kwargs["prompt"]
+        assert "Hello" in kwargs["prompt"]
 
     @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
     async def test_translate_text_english_definition(self, service):
-        """測試英英釋義"""
-        service.client = Mock()
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[0].message.content = "A common greeting"
-        service.client.chat.completions.create = Mock(return_value=mock_response)
+        """測試英英釋義（更高 token 上限）"""
+        service.vertex_ai.generate_text = AsyncMock(return_value="a common greeting")
 
         result = await service.translate_text("Hello", "en")
 
-        assert result == "A common greeting"
-
-        # 檢查呼叫參數
-        call_args = service.client.chat.completions.create.call_args
-        messages = call_args.kwargs["messages"]
-        assert "simple English definition" in messages[1]["content"]
-        assert "language learners" in messages[1]["content"]
+        assert result == "a common greeting"
+        kwargs = service.vertex_ai.generate_text.call_args.kwargs
+        assert kwargs["max_tokens"] == 200
+        assert "English definitions" in kwargs["prompt"]
 
     @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
     async def test_translate_text_other_language(self, service):
         """測試翻譯至其他語言"""
-        service.client = Mock()
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[0].message.content = "Hola"
-        service.client.chat.completions.create = Mock(return_value=mock_response)
+        service.vertex_ai.generate_text = AsyncMock(return_value="Hola")
 
         result = await service.translate_text("Hello", "Spanish")
 
         assert result == "Hola"
-
-        # 檢查呼叫參數
-        call_args = service.client.chat.completions.create.call_args
-        messages = call_args.kwargs["messages"]
-        assert "translate the following text to Spanish" in messages[1]["content"]
+        kwargs = service.vertex_ai.generate_text.call_args.kwargs
+        assert "translate the following text to Spanish" in kwargs["prompt"]
 
     @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
     async def test_translate_text_strip_whitespace(self, service):
         """測試移除空白字元"""
-        service.client = Mock()
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[0].message.content = "  翻譯結果  \n\t"
-        service.client.chat.completions.create = Mock(return_value=mock_response)
+        service.vertex_ai.generate_text = AsyncMock(return_value="  翻譯結果  \n\t")
 
         result = await service.translate_text("Hello", "zh-TW")
 
         assert result == "翻譯結果"
 
     @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
     async def test_translate_text_error_handling(self, service):
-        """測試錯誤處理"""
-        service.client = Mock()
-        service.client.chat.completions.create = Mock(
-            side_effect=Exception("API Error")
-        )
+        """測試錯誤處理：失敗時返回原文"""
+        service.vertex_ai.generate_text = AsyncMock(side_effect=Exception("API Error"))
 
         result = await service.translate_text("Hello", "zh-TW")
 
-        # 錯誤時返回原文
         assert result == "Hello"
 
     @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
     async def test_translate_text_error_logging(self, service, caplog):
         """測試錯誤記錄"""
-        service.client = Mock()
-        service.client.chat.completions.create = Mock(
-            side_effect=Exception("API Error")
-        )
+        service.vertex_ai.generate_text = AsyncMock(side_effect=Exception("API Error"))
 
         await service.translate_text("Hello", "zh-TW")
 
-        # Check that error was logged
         assert "Translation error: API Error" in caplog.text
 
     @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
     async def test_batch_translate_zh_tw(self, service):
-        """測試批次翻譯至繁體中文（小批量使用 cache）"""
-        service.client = Mock()
-
-        # Mock different responses for different texts
-        def mock_create(**kwargs):
-            mock_resp = Mock()
-            mock_resp.choices = [Mock()]
-            messages = kwargs["messages"]
-            content = messages[1]["content"]
-            if "Hello" in content:
-                mock_resp.choices[0].message.content = "你好"
-            elif "Goodbye" in content:
-                mock_resp.choices[0].message.content = "再見"
-            elif "Thank you" in content:
-                mock_resp.choices[0].message.content = "謝謝"
-            return mock_resp
-
-        service.client.chat.completions.create = Mock(side_effect=mock_create)
+        """測試批次翻譯至繁體中文（單次 generate_json 呼叫）"""
+        service.vertex_ai.generate_json = AsyncMock(return_value=["你好", "再見", "謝謝"])
 
         texts = ["Hello", "Goodbye", "Thank you"]
         result = await service.batch_translate(texts, "zh-TW")
 
         assert result == ["你好", "再見", "謝謝"]
+        kwargs = service.vertex_ai.generate_json.call_args.kwargs
+        assert kwargs["disable_thinking"] is True
 
     @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
     async def test_batch_translate_english_definitions(self, service):
-        """測試批次英英釋義（小批量使用 cache）"""
-        service.client = Mock()
-
-        # Mock different responses for different texts
-        def mock_create(**kwargs):
-            mock_resp = Mock()
-            mock_resp.choices = [Mock()]
-            messages = kwargs["messages"]
-            content = messages[1]["content"]
-            if "Hello" in content:
-                mock_resp.choices[0].message.content = "A greeting"
-            elif "Goodbye" in content:
-                mock_resp.choices[0].message.content = "A farewell"
-            elif "Thank you" in content:
-                mock_resp.choices[0].message.content = "Expression of gratitude"
-            return mock_resp
-
-        service.client.chat.completions.create = Mock(side_effect=mock_create)
+        """測試批次英英釋義"""
+        service.vertex_ai.generate_json = AsyncMock(
+            return_value=["A greeting", "A farewell", "Expression of gratitude"]
+        )
 
         texts = ["Hello", "Goodbye", "Thank you"]
         result = await service.batch_translate(texts, "en")
@@ -227,163 +160,41 @@ class TestTranslationService:
         assert result == ["A greeting", "A farewell", "Expression of gratitude"]
 
     @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    async def test_batch_translate_other_language(self, service):
-        """測試批次翻譯至其他語言（小批量使用 cache）"""
-        service.client = Mock()
-
-        def mock_create(**kwargs):
-            mock_resp = Mock()
-            mock_resp.choices = [Mock()]
-            messages = kwargs["messages"]
-            content = messages[1]["content"]
-            if "Hello" in content:
-                mock_resp.choices[0].message.content = "Hola"
-            elif "Goodbye" in content:
-                mock_resp.choices[0].message.content = "Adiós"
-            return mock_resp
-
-        service.client.chat.completions.create = Mock(side_effect=mock_create)
-
-        texts = ["Hello", "Goodbye"]
-        result = await service.batch_translate(texts, "Spanish")
-
-        assert result == ["Hola", "Adiós"]
-
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    async def test_batch_translate_strip_whitespace(self, service):
-        """測試批次翻譯移除空白（小批量使用 cache）"""
-        service.client = Mock()
-
-        def mock_create(**kwargs):
-            mock_resp = Mock()
-            mock_resp.choices = [Mock()]
-            messages = kwargs["messages"]
-            content = messages[1]["content"]
-            if "Hello" in content:
-                mock_resp.choices[0].message.content = "  你好  "
-            elif "Goodbye" in content:
-                mock_resp.choices[0].message.content = "  再見  "
-            elif "Thank you" in content:
-                mock_resp.choices[0].message.content = "  謝謝  "
-            return mock_resp
-
-        service.client.chat.completions.create = Mock(side_effect=mock_create)
-
-        texts = ["Hello", "Goodbye", "Thank you"]
-        result = await service.batch_translate(texts, "zh-TW")
-
-        assert result == ["你好", "再見", "謝謝"]
-
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    async def test_batch_translate_empty_segments(self, service):
-        """測試處理空白片段（小批量使用 cache）"""
-        service.client = Mock()
-
-        def mock_create(**kwargs):
-            mock_resp = Mock()
-            mock_resp.choices = [Mock()]
-            messages = kwargs["messages"]
-            content = messages[1]["content"]
-            if "Hello" in content:
-                mock_resp.choices[0].message.content = "你好"
-            elif "Goodbye" in content:
-                mock_resp.choices[0].message.content = "再見"
-            return mock_resp
-
-        service.client.chat.completions.create = Mock(side_effect=mock_create)
-
-        texts = ["Hello", "Goodbye"]
-        result = await service.batch_translate(texts, "zh-TW")
-
-        assert result == ["你好", "再見"]
-
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
     async def test_batch_translate_count_mismatch(self, service):
-        """測試翻譯數量不匹配（小批量使用 cache，自動逐個翻譯）"""
-        service.client = Mock()
-
-        def mock_create(**kwargs):
-            mock_resp = Mock()
-            mock_resp.choices = [Mock()]
-            messages = kwargs["messages"]
-            content = messages[1]["content"]
-            if "Hello" in content:
-                mock_resp.choices[0].message.content = "你好"
-            elif "Goodbye" in content:
-                mock_resp.choices[0].message.content = "再見"
-            elif "Thank you" in content:
-                mock_resp.choices[0].message.content = "謝謝"
-            return mock_resp
-
-        service.client.chat.completions.create = Mock(side_effect=mock_create)
+        """測試翻譯數量不匹配時返回原文列表"""
+        # AI 只回傳 2 個，但輸入 3 個
+        service.vertex_ai.generate_json = AsyncMock(return_value=["你好", "再見"])
 
         texts = ["Hello", "Goodbye", "Thank you"]
         result = await service.batch_translate(texts, "zh-TW")
 
-        # Small batches use individual translation, so all succeed
-        assert result == ["你好", "再見", "謝謝"]
-
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    async def test_batch_translate_error_handling(self, service):
-        """測試批次翻譯錯誤處理"""
-        service.client = Mock()
-        service.client.chat.completions.create = Mock(
-            side_effect=Exception("API Error")
-        )
-
-        texts = ["Hello", "Goodbye"]
-        result = await service.batch_translate(texts, "zh-TW")
-
-        # 錯誤時返回原文列表
         assert result == texts
 
     @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    async def test_batch_translate_error_logging(self, service, caplog):
-        """測試批次翻譯錯誤記錄"""
-        service.client = Mock()
-        service.client.chat.completions.create = Mock(
-            side_effect=Exception("API Error")
-        )
+    async def test_batch_translate_error_handling(self, service):
+        """測試批次翻譯錯誤處理：失敗時返回原文列表"""
+        service.vertex_ai.generate_json = AsyncMock(side_effect=Exception("API Error"))
 
         texts = ["Hello", "Goodbye"]
-        await service.batch_translate(texts, "zh-TW")
+        result = await service.batch_translate(texts, "zh-TW")
 
-        # Check that error was logged (will appear in individual translate_text calls)
-        assert "Translation error: API Error" in caplog.text
+        assert result == texts
 
     @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
     async def test_batch_translate_single_text(self, service):
         """測試批次翻譯單一文本"""
-        service.client = Mock()
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[0].message.content = "你好"
-        service.client.chat.completions.create = Mock(return_value=mock_response)
+        service.vertex_ai.generate_json = AsyncMock(return_value=["你好"])
 
-        texts = ["Hello"]
-        result = await service.batch_translate(texts, "zh-TW")
+        result = await service.batch_translate(["Hello"], "zh-TW")
 
         assert result == ["你好"]
 
     @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
     async def test_batch_translate_empty_list(self, service):
         """測試批次翻譯空列表"""
-        service.client = Mock()
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[0].message.content = ""
-        service.client.chat.completions.create = Mock(return_value=mock_response)
+        service.vertex_ai.generate_json = AsyncMock(return_value=[])
 
-        texts = []
-        result = await service.batch_translate(texts, "zh-TW")
+        result = await service.batch_translate([], "zh-TW")
 
         assert result == []
 
@@ -392,182 +203,3 @@ class TestTranslationService:
         from services.translation import translation_service
 
         assert isinstance(translation_service, TranslationService)
-        assert translation_service.model == "gpt-4o-mini"
-
-    # ===== Cache Tests (Issue #88) =====
-
-    def test_cache_initialization(self, service):
-        """測試 cache 初始化"""
-        assert service._cache_hits == 0
-        assert service._cache_misses == 0
-
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    async def test_translate_text_cache_miss(self, service, mock_openai_response):
-        """測試 cache miss"""
-        service.client = Mock()
-        service.client.chat.completions.create = Mock(return_value=mock_openai_response)
-
-        result1 = await service.translate_text("Hello", "zh-TW")
-
-        assert result1 == "翻譯結果"
-        assert service._cache_misses == 1
-        assert service._cache_hits == 0
-        # API should be called once
-        assert service.client.chat.completions.create.call_count == 1
-
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    async def test_translate_text_cache_hit(self, service, mock_openai_response):
-        """測試 cache hit - 相同文本不应重复调用 API"""
-        service.client = Mock()
-        service.client.chat.completions.create = Mock(return_value=mock_openai_response)
-
-        # First call - cache miss
-        result1 = await service.translate_text("Hello", "zh-TW")
-        assert service._cache_misses == 1
-
-        # Second call - should hit cache
-        result2 = await service.translate_text("Hello", "zh-TW")
-        assert result2 == result1
-        assert service._cache_hits == 1
-        # API should only be called ONCE (second call uses cache)
-        assert service.client.chat.completions.create.call_count == 1
-
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    async def test_translate_text_cache_different_lang(self, service):
-        """測試不同語言使用不同 cache key"""
-        service.client = Mock()
-
-        # Mock different responses for different languages
-        def mock_create(**kwargs):
-            mock_resp = Mock()
-            mock_resp.choices = [Mock()]
-            messages = kwargs["messages"]
-            if "繁體中文" in messages[1]["content"]:
-                mock_resp.choices[0].message.content = "你好"
-            elif "simple English definition" in messages[1]["content"]:
-                mock_resp.choices[0].message.content = "A greeting"
-            else:
-                mock_resp.choices[0].message.content = "Hola"
-            return mock_resp
-
-        service.client.chat.completions.create = Mock(side_effect=mock_create)
-
-        # Different languages should not share cache
-        result_zh = await service.translate_text("Hello", "zh-TW")
-        result_en = await service.translate_text("Hello", "en")
-        result_es = await service.translate_text("Hello", "Spanish")
-
-        assert result_zh == "你好"
-        assert result_en == "A greeting"
-        assert result_es == "Hola"
-        # All should be cache misses (different keys)
-        assert service._cache_misses == 3
-        assert service._cache_hits == 0
-        assert service.client.chat.completions.create.call_count == 3
-
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    async def test_batch_translate_uses_cache(self, service):
-        """測試 batch_translate 使用 cache（小批量或有重复）"""
-        service.client = Mock()
-
-        def mock_create(**kwargs):
-            mock_resp = Mock()
-            mock_resp.choices = [Mock()]
-            mock_resp.choices[0].message.content = "你好"
-            return mock_resp
-
-        service.client.chat.completions.create = Mock(side_effect=mock_create)
-
-        # Small batch should use individual translation (which uses cache)
-        texts = ["Hello", "Hello", "Hi"]  # Has duplicates
-        result = await service.batch_translate(texts, "zh-TW")
-
-        assert len(result) == 3
-        # Should have called individual translate_text which uses cache
-        # "Hello" appears twice, so second time should hit cache
-        assert service._cache_hits >= 1
-
-    def test_get_cache_stats(self, service):
-        """測試 cache 统计信息"""
-        service._cache_hits = 10
-        service._cache_misses = 5
-
-        stats = service.get_cache_stats()
-
-        assert stats["cache_hits"] == 10
-        assert stats["cache_misses"] == 5
-        assert stats["total_calls"] == 15
-        assert stats["hit_rate_percent"] == 66.67
-        assert stats["cache_maxsize"] == 5000
-        assert stats["cache_ttl_seconds"] == 3600
-
-    def test_get_cache_stats_no_calls(self, service):
-        """測試初始 cache 统计（无调用）"""
-        stats = service.get_cache_stats()
-
-        assert stats["cache_hits"] == 0
-        assert stats["cache_misses"] == 0
-        assert stats["total_calls"] == 0
-        assert stats["hit_rate_percent"] == 0
-
-    def test_clear_cache(self, service):
-        """測試清空 cache"""
-        service._cache_hits = 10
-        service._cache_misses = 5
-        service._cache.set(("key", "zh-TW", "model", 0.3), "value")
-
-        service.clear_cache()
-
-        assert service._cache_hits == 0
-        assert service._cache_misses == 0
-        stats = service.get_cache_stats()
-        assert stats["cache_size"] == 0
-
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    async def test_cache_size_limit(self, service, mock_openai_response):
-        """測試 cache 大小限制（maxsize=5000）"""
-        service.client = Mock()
-        service.client.chat.completions.create = Mock(return_value=mock_openai_response)
-
-        # Cache should work within limit
-        for i in range(100):
-            await service.translate_text(f"text_{i}", "zh-TW")
-
-        stats = service.get_cache_stats()
-        assert stats["cache_size"] == 100
-        assert stats["cache_size"] <= stats["cache_maxsize"]
-
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    async def test_cache_ttl_expiry(self, mock_openai_response):
-        """測試 cache TTL 到期後不應命中"""
-        # Use short TTL for test
-        service = TranslationService(cache_ttl_seconds=0)
-        service.client = Mock()
-
-        # First response
-        first_resp = Mock()
-        first_resp.choices = [Mock()]
-        first_resp.choices[0].message.content = "翻譯1"
-        # Second response after expiry
-        second_resp = Mock()
-        second_resp.choices = [Mock()]
-        second_resp.choices[0].message.content = "翻譯2"
-
-        service.client.chat.completions.create = Mock(
-            side_effect=[first_resp, second_resp]
-        )
-
-        result1 = await service.translate_text("Hello", "zh-TW")
-        await asyncio.sleep(0.01)
-        result2 = await service.translate_text("Hello", "zh-TW")
-
-        assert result1 == "翻譯1"
-        assert result2 == "翻譯2"  # cache expired, so second call hits API
-        assert service.client.chat.completions.create.call_count == 2
-        assert service._cache_hits == 0


### PR DESCRIPTION
## PR1：僅移除 OpenAI fallback 程式碼分支

後端所有 AI 呼叫原本是「`if USE_VERTEX_AI:` 走 Vertex，`else:` 走 OpenAI」雙供應商結構。四個環境的旗標（prod / staging / develop / preview）全部為 `true`，OpenAI 分支已是死碼。本 PR 移除死碼分支，直接呼叫 Vertex AI。

### 變更檔案
- **`backend/services/translation.py`** — 移除 6 處雙分支（`translate_text` / `batch_translate` / `_batch_translate_with_pos_single` / `generate_sentences` batch / `generate_distractors` / `batch_generate_distractors`）與 `__init__`、`_ensure_client` 的 `use_vertex_ai` 判斷；清掉不再使用的 import（`openai`、`os`、`re`、`get_http_client`）。函式簽名、回傳格式、fallback／例外處理皆不變。
- **`backend/services/billing_analysis_service.py`** — `__init__` 與 `_generate_ai_summary` 移除 OpenAI 分支；`use_ai` 恆為 `True`（Vertex 恆可用），保留 basic summary 作為例外 fallback。
- **`backend/routers/cron.py`** — 錄音錯誤摘要 cron 移除 OpenAI 分支與 `import openai`。

### 測試
- 將受影響測試改為 mock Vertex 路徑（`vertex_ai.generate_text` / `generate_json` 回傳已解析物件）：
  - `test_sentence_generation_misalignment.py`（原 15 tests 走 OpenAI mock，已全數轉為 Vertex，18 通過含 disable_thinking）
  - `test_translation_service.py` 重寫為 Vertex 路徑精簡版（原檔在 main 上即已大量失敗——測試的是已被移除的 cache 功能與 OpenAI 內部細節；移除死測、保留現存行為覆蓋）
  - `test_vertex_disable_thinking.py` 移除已無意義的 `use_vertex_ai` 設定行
- 本機通過：translation / billing / vertex_ai service 層測試 + Black + Flake8。
- 需 DB/casbin 或缺 `googletrans` 套件的端點/整合測試本機無法執行，交由 CI 驗證。

### 不在本 PR 範圍（PR2，人工手動處理）
- ❌ 移除 `openai` 套件依賴（requirements/pyproject 不動）
- ❌ 移除／輪換 `OPENAI_API_KEY`
- ❌ 清理 `USE_VERTEX_AI*` GH 變數、workflow 映射、Cloud Run env
- ❌ 任何 `.github/workflows` 或部署設定

### 注意事項
- issue 列出的第 4 個檔案 `backend/services/magic_paste_service.py` **尚未合入 `main`**（仍在未合併的 `fix/issue-891-magic-paste-content` 分支），故不在本 PR。待該分支合併後，其 OpenAI 分支需一併清理（PR2 或後續）。

Refs #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)