### PR TITLE
fix: Pricing 頁移除已登入自動跳轉 /teacher/subscription

### DIFF
--- a/frontend/src/pages/PricingPage.tsx
+++ b/frontend/src/pages/PricingPage.tsx
@@ -36,7 +36,6 @@ import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import LineContactButton, {
   LINE_FRIEND_URL,
 } from "@/components/LineContactButton";
-import { apiClient } from "@/lib/api";
 import { GroupBuyPlanCards } from "@/components/pricing/GroupBuyPlanCards";
 import { ENABLE_GROUP_BUY } from "@/config/featureFlags";
 
@@ -203,7 +202,6 @@ export default function PricingPage() {
   useEffect(() => {
     window.scrollTo(0, 0);
     checkUserStatus();
-    checkSubscriptionStatus();
   }, []);
 
   const checkUserStatus = () => {
@@ -231,25 +229,6 @@ export default function PricingPage() {
       });
     } else {
       setUserInfo({ isLoggedIn: false });
-    }
-  };
-
-  const checkSubscriptionStatus = async () => {
-    const teacherAuth = useTeacherAuthStore.getState();
-    if (!teacherAuth.isAuthenticated || !teacherAuth.token) return;
-
-    try {
-      const data = await apiClient.get<{ is_active: boolean }>(
-        "/api/subscription/status",
-      );
-      if (data.is_active) {
-        toast.info(t("pricing.payment.hasSubscription"));
-        setTimeout(() => {
-          navigate("/teacher/subscription");
-        }, 1000);
-      }
-    } catch (error) {
-      console.error("Error checking subscription:", error);
     }
   };
 


### PR DESCRIPTION
## 問題
已登入且有 active 訂閱的老師開啟 Pricing 頁時，`checkSubscriptionStatus()` 會在 mount 時打 `/api/subscription/status`，若 `is_active` 就 toast「已有訂閱」並在 1 秒後**自動跳轉** `/teacher/subscription` —— 使用者無法停留在 Pricing 頁瀏覽/比較方案（含團購方案）。

## 修改
- 移除 `checkSubscriptionStatus()` 及其在 mount `useEffect` 的呼叫。
- 連帶移除因此不再使用的 `apiClient` import。
- **保留** `checkUserStatus()`（登入狀態顯示 / 已登入的按鈕），不影響其他行為。

純刪除 21 行；本機 `tsc --noEmit` clean、prettier `--check` clean。

## 驗證
- 已登入（有訂閱）老師開 Pricing 頁 → **停留在 Pricing**，不再自動跳轉。
- 未登入 / 已登入無訂閱 → 行為不變。
- Pricing 頁其他功能（登入按鈕、選方案、團購 CTA）不受影響。

🤖 Generated with [Claude Code](https://claude.com/claude-code)