### PR TITLE
fix(#983): 團購 UI 修正 1–5（第 6 點留 #976）

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -21,6 +21,7 @@ from routers.teachers import get_current_teacher
 from services.tappay_service import TapPayService
 from services.email_service import email_service
 from services.subscription_calculator import SubscriptionCalculator
+from services.topup_discount import get_teacher_topup_discount
 from utils.bigquery_logger import (
     log_payment_attempt,
     log_payment_success,
@@ -1084,6 +1085,19 @@ async def get_subscription_status(
             # quota label, auto-renew banner visibility, and any
             # team-management CTAs.
             "plan_type": plan_type,
+            # issue #983-5：團購成員的點數包加購折扣（0.85/0.90/0.95），供
+            # 訂閱頁點數包 tab 顯示折後價。非團購 → None（原價）。折扣的實際
+            # 收費由 /credit-packages/purchase 伺服器端套用（此處僅供顯示）。
+            "topup_discount": (
+                float(_gb_topup_discount)
+                if (
+                    _gb_topup_discount := get_teacher_topup_discount(
+                        current_teacher, db
+                    )
+                )
+                is not None
+                else None
+            ),
             "end_date": (
                 effective_end_date.isoformat() if effective_end_date else None
             ),

--- a/backend/tests/test_subscription_status_group_buy.py
+++ b/backend/tests/test_subscription_status_group_buy.py
@@ -153,6 +153,8 @@ def test_group_buy_member_status_overrides_end_date_and_plan_type(
     body = r.json()
     assert body["plan_type"] == "group_buy_member"
     assert body["auto_renew"] is False
+    # issue #983-5：團購成員回傳團隊方案的加購折扣，供點數包 tab 顯示折後價
+    assert body["topup_discount"] == 0.95
     # Refresh from session so we compare the DB-persisted value (the
     # ORM may return tz-naive on a TIMESTAMP WITHOUT TIME ZONE column;
     # the in-memory fixture value is tz-aware via datetime.now(utc)).
@@ -185,6 +187,7 @@ def test_group_buy_owner_status_returns_group_buy_owner_plan_type(
     body = r.json()
     assert body["plan_type"] == "group_buy_owner"
     assert body["auto_renew"] is False
+    assert body["topup_discount"] == 0.95
 
 
 def test_individual_teacher_status_unaffected_by_group_buy_branch(
@@ -198,6 +201,7 @@ def test_individual_teacher_status_unaffected_by_group_buy_branch(
     assert r.status_code == 200
     body = r.json()
     assert body["plan_type"] == "individual"
+    assert body["topup_discount"] is None
     # auto_renew defaults to True per the existing endpoint behaviour
     # when the teacher has no explicit subscription_auto_renew flag.
     assert body["auto_renew"] is True

--- a/frontend/src/components/pricing/GroupBuyPlanCards.tsx
+++ b/frontend/src/components/pricing/GroupBuyPlanCards.tsx
@@ -147,7 +147,7 @@ export function GroupBuyPlanCards({ onSelectPlan }: Props) {
                   </span>
                 </div>
                 <div>
-                  加購折扣{" "}
+                  點數包加購{" "}
                   <span className="font-semibold">
                     {Math.round((1 - p.topup_discount) * 100)}% off
                   </span>

--- a/frontend/src/components/pricing/PointPackageCard.tsx
+++ b/frontend/src/components/pricing/PointPackageCard.tsx
@@ -19,6 +19,10 @@ interface PointPackageCardProps {
   disabled?: boolean;
   ctaText: string;
   baseUnitCost: number; // highest unit cost for discount calculation
+  // issue #983-5：團購成員的加購折扣（0.85/0.90/0.95）；有值時顯示折後價。
+  // 折後價 = round(price × groupBuyDiscount)，與後端 /credit-packages/purchase
+  // 的 ROUND_HALF_UP 一致（正數 Math.round 即 round-half-up）。null=原價。
+  groupBuyDiscount?: number | null;
 }
 
 export function PointPackageCard({
@@ -27,12 +31,24 @@ export function PointPackageCard({
   disabled,
   ctaText,
   baseUnitCost,
+  groupBuyDiscount,
 }: PointPackageCardProps) {
   const { t } = useTranslation();
   const discountPercent =
     baseUnitCost > pkg.unitCost
       ? Math.round(((baseUnitCost - pkg.unitCost) / baseUnitCost) * 100)
       : 0;
+
+  const hasGbDiscount =
+    typeof groupBuyDiscount === "number" &&
+    groupBuyDiscount > 0 &&
+    groupBuyDiscount < 1;
+  const discountedPrice = hasGbDiscount
+    ? Math.round(pkg.price * (groupBuyDiscount as number))
+    : pkg.price;
+  const gbOffPercent = hasGbDiscount
+    ? Math.round((1 - (groupBuyDiscount as number)) * 100)
+    : 0;
 
   const greenGradient =
     "linear-gradient(145deg, #15803d, #22c55e, #6ee7a0, #22c55e, #15803d)";
@@ -85,12 +101,32 @@ export function PointPackageCard({
 
         {/* Price */}
         <div className="bg-gray-50 rounded-lg p-3 mb-3">
-          <div className="text-2xl font-bold text-gray-900">
-            NT$ {pkg.price.toLocaleString()}
-          </div>
-          <div className="text-xs text-gray-500 mt-1">
-            {pkg.unitCost.toFixed(2)} {t("pricing.pointPackages.unitCost")}
-          </div>
+          {hasGbDiscount ? (
+            <>
+              <div className="text-2xl font-bold text-blue-600">
+                NT$ {discountedPrice.toLocaleString()}
+              </div>
+              <div className="text-xs text-gray-400 mt-1">
+                <span className="line-through">
+                  NT$ {pkg.price.toLocaleString()}
+                </span>{" "}
+                <span className="text-blue-600 font-medium">
+                  {t("pricing.pointPackages.groupBuyDiscount", {
+                    percent: gbOffPercent,
+                  })}
+                </span>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="text-2xl font-bold text-gray-900">
+                NT$ {pkg.price.toLocaleString()}
+              </div>
+              <div className="text-xs text-gray-500 mt-1">
+                {pkg.unitCost.toFixed(2)} {t("pricing.pointPackages.unitCost")}
+              </div>
+            </>
+          )}
         </div>
 
         {/* Discount Badge */}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -493,7 +493,8 @@
       "studentCannotSubscribe": "Students Cannot Subscribe",
       "loginRequired": "Please login to subscribe",
       "studentAccountWarning": "Student accounts cannot subscribe to teacher plans, please use a teacher account",
-      "logoutFirst": "Please logout first and login with a teacher account to subscribe"
+      "logoutFirst": "Please logout first and login with a teacher account to subscribe",
+      "groupBuyActive": "Group-buy plan active"
     },
     "tabs": {
       "subscription": "Monthly Plans",
@@ -511,6 +512,7 @@
       "bonusPoints": "+{{count, number}} bonus pts",
       "unitCost": "NTD/pt",
       "discount": "Save {{percent}}%",
+      "groupBuyDiscount": "Group-buy {{percent}}% off",
       "validity": "Valid for 1 year",
       "purchaseSuccess": "Successfully purchased {{points}} point package! Transaction ID: {{transactionId}}",
       "purchaseTitle": "Purchase {{points}} Point Package"

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -638,7 +638,8 @@
       "studentCannotSubscribe": "學生無法訂閱",
       "loginRequired": "請先登入才能訂閱方案",
       "studentAccountWarning": "學生帳號無法訂閱教師方案，請使用教師帳號登入",
-      "logoutFirst": "請先登出，使用教師帳號登入才能訂閱"
+      "logoutFirst": "請先登出，使用教師帳號登入才能訂閱",
+      "groupBuyActive": "團購方案進行中"
     },
     "tabs": {
       "subscription": "月訂閱方案",
@@ -656,6 +657,7 @@
       "bonusPoints": "+{{count, number}} 點贈送",
       "unitCost": "元/點",
       "discount": "省 {{percent}}%",
+      "groupBuyDiscount": "團購 {{percent}}% off",
       "validity": "有效期限：1 年",
       "purchaseSuccess": "成功購買 {{points}} 點數包！交易編號：{{transactionId}}",
       "purchaseTitle": "購買 {{points}} 點數包"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2060,6 +2060,8 @@ class ApiClient {
       // issue #862：後端由 group_buy_teams/members 推導的方案身分，供前端分流
       // 顯示（個人 / 團購發起人 / 團購團員）。
       plan_type?: "individual" | "group_buy_owner" | "group_buy_member";
+      // issue #983：團購成員的點數包加購折扣（0.85/0.90/0.95）；非團購為 null。
+      topup_discount?: number | null;
       days_remaining: number | null;
       is_active: boolean;
       quota_used: number;

--- a/frontend/src/pages/teacher/GroupBuyOpenPage.tsx
+++ b/frontend/src/pages/teacher/GroupBuyOpenPage.tsx
@@ -718,15 +718,17 @@ export default function GroupBuyOpenPage() {
                 className="flex flex-wrap items-center gap-2 border-b border-gray-100 pb-2"
               >
                 <span className="w-8 text-sm text-gray-500">{idx + 1}.</span>
-                <span className="w-20 text-xs text-gray-600">
-                  {idx === 0 ? "發起人" : "團員"}
-                </span>
+                <span className="w-20 text-xs text-gray-600">團員</span>
                 <Input
                   type="email"
+                  // issue #983-2：每個 input 給唯一 name + autoComplete off，
+                  // 避免瀏覽器 email 自動填入時把所有欄位一起填滿。
+                  name={`gb-roster-email-${idx}`}
+                  autoComplete="off"
                   className="flex-1 min-w-[200px]"
                   placeholder={
                     idx === 0
-                      ? "發起人 email（可改填別人）"
+                      ? "預設帶入你自己，可改填團員 email"
                       : `team-member-${idx}@example.com`
                   }
                   value={row.email}
@@ -800,7 +802,8 @@ export default function GroupBuyOpenPage() {
               <DialogDescription>
                 檔案格式：第一列為英文欄位名 <code>Email</code>，下方每列一個
                 email。最多會匯入 {selectedPlan.teacher_seats - 1} 筆，覆蓋第 2
-                ~ 第 {selectedPlan.teacher_seats} 列；發起人那一列不會被動到。
+                ~ 第 {selectedPlan.teacher_seats} 列；第 1
+                列（預設帶你自己）不會被動到。
                 <br />
                 <span className="text-xs text-gray-500">
                   ⚠ 請使用 <strong>UTF-8</strong> 編碼存檔（Excel

--- a/frontend/src/pages/teacher/TeacherSubscription.tsx
+++ b/frontend/src/pages/teacher/TeacherSubscription.tsx
@@ -87,6 +87,8 @@ interface SubscriptionInfo {
   status: string;
   plan: string | null;
   plan_type?: SubscriptionPlanType;
+  // issue #983：團購成員點數包加購折扣（0.85/0.90/0.95）；非團購為 null。
+  topup_discount?: number | null;
   end_date: string | null;
   days_remaining: number;
   is_active: boolean;
@@ -497,7 +499,13 @@ export default function TeacherSubscription() {
                   let onSelect: ((plan: SubscriptionPlan) => void) | undefined =
                     handleSelectPlan;
 
-                  if (!isAuthenticated) {
+                  if (isGroupBuyPlan) {
+                    // issue #983-3：團購方案進行中，個人方案按鈕一律停用，
+                    // 直到團購方案結束（避免團購成員又去訂個人方案）。
+                    ctaText = t("pricing.actions.groupBuyActive");
+                    disabled = true;
+                    onSelect = undefined;
+                  } else if (!isAuthenticated) {
                     // Not logged in
                     if (plan.id === "free") {
                       ctaText = t("pricing.actions.freeRegister");
@@ -579,6 +587,8 @@ export default function TeacherSubscription() {
                   onSelect={handleSelectPointPackage}
                   ctaText={t("pricing.pointPackages.buy")}
                   baseUnitCost={BASE_UNIT_COST}
+                  // issue #983-5：團購成員顯示折後價（實際收費由後端套用）。
+                  groupBuyDiscount={subscription?.topup_discount ?? null}
                 />
               ))}
             </div>


### PR DESCRIPTION
修正 #983 的第 1～5 點。**第 6 點**（發起人找不到團購紀錄/管理區）與 **#976** 重疊，留 #976 處理（issue 已備註）。

| # | 問題 | 修正 |
|---|------|------|
| 1 | 開團頁名冊第一列 label「發起人」易誤解（團主開多團想把第一列填別人） | label →「團員」、placeholder →「預設帶入你自己，可改填團員 email」、CSV 說明同步 |
| 2 | 瀏覽器自動填入 email 時所有欄位一起被填滿 | 每個 input 加唯一 `name` + `autoComplete="off"` |
| 3 | 團購成功後訂閱頁「方案」tab 按鈕應 disable 直到團購結束 | 團購 owner/member 期間個人方案按鈕一律 disable（「團購方案進行中」） |
| 4 | pricing「加購折扣 5% off」看不出是點數包 | 文案 →「點數包加購 X% off」 |
| 5 | 訂閱頁「點數包」tab 未依折扣顯示團員折後價 | 後端 `/subscription/status` 加 `topup_discount`；`PointPackageCard` 顯示折後價（原價刪除線 + 折後價 + 團購 X% off），折後價與後端 `ROUND_HALF_UP` 一致 |

### 技術
- 後端：`payment.py` get_subscription_status 回 `topup_discount`（`get_teacher_topup_discount`，非團購為 null）。折扣**實際收費**由 `/credit-packages/purchase` 伺服器端套用，前端僅供顯示且用相同 round。
- 前端：`api.ts`/`SubscriptionInfo` 加 `topup_discount`；i18n 新增 `pricing.actions.groupBuyActive`、`pricing.pointPackages.groupBuyDiscount`（zh-TW + en；ja/ko 無此區塊，fallback）。

### 驗證
frontend `tsc --noEmit` + prettier `--check` clean；backend black/flake8/import clean；`test_topup_discount` 7 passed；2584 tests collect（3 errors 為 pre-existing playwright/freezegun）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)